### PR TITLE
raft: add link to the paper raft_paper_test.go refers to

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -42,7 +42,7 @@ type raftLog struct {
 }
 
 // newLog returns log using the given storage. It recovers the log to the state
-// that it just commits and applies the lastest snapshot.
+// that it just commits and applies the latest snapshot.
 func newLog(storage Storage) *raftLog {
 	if storage == nil {
 		log.Panic("storage must not be nil")

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -16,14 +16,15 @@
 
 /*
 This file contains tests which verify that the scenarios described
-in raft paper are handled by the raft implementation correctly.
-Each test focuses on several sentences written in the paper. This could
-help us to prevent most implementation bugs.
+in the raft paper (https://ramcloud.stanford.edu/raft.pdf) are
+handled by the raft implementation correctly. Each test focuses on
+several sentences written in the paper. This could help us to prevent
+most implementation bugs.
 
 Each test is composed of three parts: init, test and check.
 Init part uses simple and understandable way to simulate the init state.
 Test part uses Step function to generate the scenario. Check part checks
-outgoint messages and state.
+outgoing messages and state.
 */
 package raft
 
@@ -32,7 +33,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-
 	"reflect"
 	"sort"
 	"testing"


### PR DESCRIPTION
There are two Raft papers in existence from its creator: the original paper linked to in this change, and the more up-to-date dissertation (https://ramcloud.stanford.edu/~ongaro/thesis.pdf). Make it clear which paper (and associated sections) are being referred to in `raft_paper_test.go`.