### PR TITLE
integration: extend timeout to wait

### DIFF
--- a/integration/v2_http_kv_test.go
+++ b/integration/v2_http_kv_test.go
@@ -883,7 +883,10 @@ func TestV2WatchKeyInDir(t *testing.T) {
 
 	select {
 	case <-c:
-	case <-time.After(time.Millisecond * 1500):
+	// 1s ttl + 0.5s sync delay + 1.5s disk and network delay
+	// We set that long disk and network delay because travis may be slow
+	// when do system calls.
+	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for watch result")
 	}
 


### PR DESCRIPTION
fixes #2024 

Based on the log of this replay https://travis-ci.org/coreos/etcd/builds/45564798, it did watch and didn't get the response until it timed out. So i think it needs more time.

travis environment can be slow in fsync.