### PR TITLE
etcdmain: add readtimeout for http server

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/coreos/etcd/discovery"
 	"github.com/coreos/etcd/etcdserver"
@@ -174,13 +175,13 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 	// Start the peer server in a goroutine
 	for _, l := range plns {
 		go func(l net.Listener) {
-			log.Fatal(serveHTTP(l, ph))
+			log.Fatal(serveHTTP(l, ph, 5*time.Minute))
 		}(l)
 	}
 	// Start a client server goroutine for each listen address
 	for _, l := range clns {
 		go func(l net.Listener) {
-			log.Fatal(serveHTTP(l, ch))
+			log.Fatal(serveHTTP(l, ch, 30*time.Second))
 		}(l)
 	}
 	return s.StopNotify(), nil

--- a/etcdmain/http.go
+++ b/etcdmain/http.go
@@ -5,17 +5,19 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"time"
 )
 
 // serveHTTP accepts incoming HTTP connections on the listener l,
 // creating a new service goroutine for each. The service goroutines
 // read requests and then call handler to reply to them.
-func serveHTTP(l net.Listener, handler http.Handler) error {
+func serveHTTP(l net.Listener, handler http.Handler, readTimeout time.Duration) error {
 	logger := log.New(ioutil.Discard, "etcdhttp", 0)
 	// TODO: add debug flag; enable logging when debug flag is set
 	srv := &http.Server{
-		Handler:  handler,
-		ErrorLog: logger, // do not log user error
+		Handler:     handler,
+		ReadTimeout: readTimeout,
+		ErrorLog:    logger, // do not log user error
 	}
 	return srv.Serve(l)
 }


### PR DESCRIPTION
1. Add a 30 second read time out for the client api server. 30 second is reasonable, since client does not send large value to etcd. We should expect to read out all the request header and body within 30 seconds.

2. Add a 5 minutes read time out for the peer api server. Actually we do not need to recycle the peer handing routines aggressively. There should not be many anyway. We set it to 5 minutes since there might be a batch of entries or a snapshot inside the request body that need some time to transfere.
