### PR TITLE
fix context time-out failure on travis

### DIFF
--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -43,6 +43,9 @@ type ServerConfig struct {
 	NewCluster      bool
 	ForceNewCluster bool
 	Transport       *http.Transport
+
+	// Only for testing purpose
+	ElectionTimeoutTicks int
 }
 
 // VerifyBootstrapConfig sanity-checks the initial config and returns an error

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -308,8 +308,9 @@ func (c *cluster) RemoveMember(t *testing.T, id uint64) {
 			select {
 			case <-m.s.StopNotify():
 				m.Terminate(t)
-			case <-time.After(time.Second):
-				t.Fatalf("failed to remove member %s in one second", m.s.ID())
+			// stop delay / election timeout + 1s disk and network delay
+			case <-time.After(time.Duration(electionTicks)*tickDuration + time.Second):
+				t.Fatalf("failed to remove member %s in time", m.s.ID())
 			}
 		}
 	}

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -49,9 +50,18 @@ const (
 	requestTimeout = 2 * time.Second
 )
 
+var (
+	electionTicks = 10
+)
+
 func init() {
 	// open microsecond-level time log for integration test debugging
 	log.SetFlags(log.Ltime | log.Lmicroseconds | log.Lshortfile)
+	if t := os.Getenv("ETCD_ELECTION_TIMEOUT_TICKS"); t != "" {
+		if i, err := strconv.ParseInt(t, 10, 64); err == nil {
+			electionTicks = int(i)
+		}
+	}
 }
 
 func TestClusterOf1(t *testing.T) { testCluster(t, 1) }
@@ -431,6 +441,7 @@ func mustNewMember(t *testing.T, name string) *member {
 	}
 	m.NewCluster = true
 	m.Transport = mustNewTransport(t)
+	m.ElectionTimeoutTicks = electionTicks
 	return m
 }
 
@@ -460,6 +471,7 @@ func (m *member) Clone(t *testing.T) *member {
 		panic(err)
 	}
 	mm.Transport = mustNewTransport(t)
+	mm.ElectionTimeoutTicks = m.ElectionTimeoutTicks
 	return mm
 }
 

--- a/test
+++ b/test
@@ -39,7 +39,7 @@ split=(${TEST// / })
 TEST=${split[@]/#/${REPO_PATH}/}
 
 echo "Running tests..."
-go test -timeout 60s ${COVER} $@ ${TEST} --race
+go test -timeout 3m ${COVER} $@ ${TEST} --race
 
 echo "Checking gofmt..."
 fmtRes=$(gofmt -l $FMT)


### PR DESCRIPTION
fixes #1949 
It passes travis tests in 40 times.

I set `ETCD_ELECTION_TIMEOUT_TICKS` environment as 200 in travis to extend election timeout, which avoids unexpected leader election due to instability of travis.