### PR TITLE
rafthttp: add stream metrics

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -80,6 +80,7 @@ func NewClientHandler(server *etcdserver.EtcdServer) http.Handler {
 	mux.HandleFunc(statsPrefix+"/store", sh.serveStore)
 	mux.HandleFunc(statsPrefix+"/self", sh.serveSelf)
 	mux.HandleFunc(statsPrefix+"/leader", sh.serveLeader)
+	mux.HandleFunc(statsPrefix+"/transport", sh.serveTransport)
 	mux.Handle(membersPrefix, mh)
 	mux.Handle(membersPrefix+"/", mh)
 	mux.Handle(deprecatedMachinesPrefix, dmh)
@@ -279,6 +280,14 @@ func (h *statsHandler) serveLeader(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(stats)
+}
+
+func (h *statsHandler) serveTransport(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r.Method, "GET") {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(h.stats.TransportStats())
 }
 
 func serveVersion(w http.ResponseWriter, r *http.Request) {

--- a/etcdserver/etcdhttp/client_test.go
+++ b/etcdserver/etcdhttp/client_test.go
@@ -1220,10 +1220,10 @@ type dummyStats struct {
 	data []byte
 }
 
-func (ds *dummyStats) SelfStats() []byte                 { return ds.data }
-func (ds *dummyStats) LeaderStats() []byte               { return ds.data }
-func (ds *dummyStats) StoreStats() []byte                { return ds.data }
-func (ds *dummyStats) UpdateRecvApp(_ types.ID, _ int64) {}
+func (ds *dummyStats) SelfStats() []byte      { return ds.data }
+func (ds *dummyStats) LeaderStats() []byte    { return ds.data }
+func (ds *dummyStats) StoreStats() []byte     { return ds.data }
+func (ds *dummyStats) TransportStats() []byte { return ds.data }
 
 func TestServeSelfStats(t *testing.T) {
 	wb := []byte("some statistics")

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -535,6 +535,8 @@ func (s *EtcdServer) LeaderStats() []byte {
 
 func (s *EtcdServer) StoreStats() []byte { return s.store.JsonStats() }
 
+func (s *EtcdServer) TransportStats() []byte { return s.transport.Stats() }
+
 func (s *EtcdServer) AddMember(ctx context.Context, memb Member) error {
 	// TODO: move Member to protobuf type
 	b, err := json.Marshal(memb)

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1365,6 +1365,7 @@ func (n *readyNode) Ready() <-chan raft.Ready { return n.readyc }
 type nopTransporter struct{}
 
 func (s *nopTransporter) Handler() http.Handler               { return nil }
+func (s *nopTransporter) Stats() []byte                       { return nil }
 func (s *nopTransporter) Send(m []raftpb.Message)             {}
 func (s *nopTransporter) AddPeer(id types.ID, us []string)    {}
 func (s *nopTransporter) RemovePeer(id types.ID)              {}

--- a/etcdserver/stats/stats.go
+++ b/etcdserver/stats/stats.go
@@ -8,4 +8,6 @@ type Stats interface {
 	LeaderStats() []byte
 	// StoreStats returns statistics of the store backing this EtcdServer
 	StoreStats() []byte
+	// TransportStats returns statistics of the raft transport.
+	TransportStats() []byte
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,98 @@
+/*
+   Copyright 2014 CoreOS, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package metrics provides minimalist instrumentation for client side in
+// pull-based monitoring.
+package metrics
+
+import (
+	"expvar"
+	"fmt"
+	"net/http"
+)
+
+// Counter is a number that increases over time monotonically.
+type Counter interface {
+	Add(delta int64)
+	String() string
+}
+
+// Gauge returns instantaneous value that is expected to fluctuate over time.
+type Gauge interface {
+	Set(value int64)
+	String() string
+}
+
+// Group aggregates counters, gauges and sub-groups.
+// It implements http.Handler, which exposes the registered metrics in JSON format.
+type Group struct {
+	m *expvar.Map
+}
+
+func NewGroup() *Group {
+	return &Group{
+		m: new(expvar.Map).Init(),
+	}
+}
+
+func (g *Group) Counter(key string) Counter {
+	c := &counter{
+		i: new(expvar.Int),
+	}
+	g.m.Set(key, c)
+	return c
+}
+
+func (g *Group) Gauge(key string) Gauge {
+	gg := &gauge{
+		i: new(expvar.Int),
+	}
+	g.m.Set(key, gg)
+	return gg
+}
+
+func (g *Group) Group(key string) *Group {
+	gg := NewGroup()
+	g.m.Set(key, gg)
+	return gg
+}
+
+func (g *Group) Clear() { g.m.Init() }
+
+func (g *Group) String() string { return g.m.String() }
+
+func (g *Group) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintf(w, "%s\n", g)
+}
+
+func (g *Group) Handler() http.Handler { return g }
+
+type counter struct {
+	i *expvar.Int
+}
+
+func (c *counter) Add(delta int64) { c.i.Add(delta) }
+
+func (c *counter) String() string { return c.i.String() }
+
+type gauge struct {
+	i *expvar.Int
+}
+
+func (g *gauge) Set(value int64) { g.i.Set(value) }
+
+func (g *gauge) String() string { return g.i.String() }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -92,6 +92,10 @@ func (g *Group) String() string {
 	fmt.Fprintf(&b, "{")
 	first := true
 	g.m.Do(func(kv expvar.KeyValue) {
+		// expvar returns all old keys even if Map is inited
+		if kv.Value == nil {
+			return
+		}
 		v := kv.Value.String()
 		// omit the empty group
 		if v == "{}" {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,7 +39,6 @@ type Gauge interface {
 
 // Group aggregates counters, gauges and sub-groups.
 type Group struct {
-	// clear operation needs exclusive access to map
 	mu sync.RWMutex
 	m  *expvar.Map
 }
@@ -108,17 +107,13 @@ func (g *Group) String() string {
 	return b.String()
 }
 
-type counter struct {
-	i *expvar.Int
-}
+type counter struct{ i *expvar.Int }
 
 func (c *counter) Add(delta int64) { c.i.Add(delta) }
 
 func (c *counter) String() string { return c.i.String() }
 
-type gauge struct {
-	i *expvar.Int
-}
+type gauge struct{ i *expvar.Int }
 
 func (g *gauge) Set(value int64) { g.i.Set(value) }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,43 @@
+/*
+   Copyright 2014 CoreOS, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metrics
+
+import "testing"
+
+// TestMetrics tests the basic usage of metrics group.
+func TestMetrics(t *testing.T) {
+	group := NewGroup()
+	// use counter
+	counter := group.Counter("Number")
+	counter.Add(1234)
+	// use sub-group
+	subgroup := group.Group("shares")
+	// use gauge
+	subgroup.Gauge("alice").Set(30)
+	subgroup.Gauge("bob").Set(50)
+
+	wstr := `{"Number": 1234, "shares": {"alice": 30, "bob": 50}}`
+	if str := group.String(); str != wstr {
+		t.Errorf("group = %v, want %v", str, wstr)
+	}
+
+	// clear group
+	group.Clear()
+	if g := group.String(); g != "{}" {
+		t.Errorf("group = %v, want {}", g)
+	}
+}

--- a/rafthttp/entry_test.go
+++ b/rafthttp/entry_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/etcd/pkg/metrics"
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
@@ -45,12 +46,12 @@ func TestEntsWriteAndRead(t *testing.T) {
 	}
 	for i, tt := range tests {
 		b := &bytes.Buffer{}
-		ew := &entryWriter{w: b}
+		ew := newEntryWriter(b, metrics.NewGroup())
 		if err := ew.writeEntries(tt); err != nil {
 			t.Errorf("#%d: unexpected write ents error: %v", i, err)
 			continue
 		}
-		er := &entryReader{r: b}
+		er := newEntryReader(b, metrics.NewGroup())
 		ents, err := er.readEntries()
 		if err != nil {
 			t.Errorf("#%d: unexpected read ents error: %v", i, err)

--- a/rafthttp/entry_writer.go
+++ b/rafthttp/entry_writer.go
@@ -52,3 +52,12 @@ func (ew *entryWriter) writeEntry(ent *raftpb.Entry) error {
 	_, err = ew.w.Write(b)
 	return err
 }
+
+func entryTransferSize(ents []raftpb.Entry) int {
+	size := 8
+	for _, e := range ents {
+		size += 8
+		size += e.Size()
+	}
+	return size
+}

--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 
@@ -32,6 +33,11 @@ import (
 
 const (
 	ConnReadLimitByte = 64 * 1024
+)
+
+var (
+	RaftPrefix       = "/raft"
+	RaftStreamPrefix = path.Join(RaftPrefix, "stream")
 )
 
 func NewHandler(r Raft, cid types.ID) http.Handler {

--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"path"
 	"strconv"
 	"strings"
 
@@ -33,11 +32,6 @@ import (
 
 const (
 	ConnReadLimitByte = 64 * 1024
-)
-
-var (
-	RaftPrefix       = "/raft"
-	RaftStreamPrefix = path.Join(RaftPrefix, "stream")
 )
 
 func NewHandler(r Raft, cid types.ID) http.Handler {

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/etcdserver/stats"
+	"github.com/coreos/etcd/pkg/metrics"
 	"github.com/coreos/etcd/pkg/pbutil"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -55,6 +56,7 @@ type peer struct {
 	tr     http.RoundTripper
 	r      Raft
 	fs     *stats.FollowerStats
+	mg     *metrics.Group
 	errorc chan error
 
 	batcher     *Batcher
@@ -76,7 +78,7 @@ type peer struct {
 	stopped bool
 }
 
-func NewPeer(tr http.RoundTripper, u string, id types.ID, cid types.ID, r Raft, fs *stats.FollowerStats, errorc chan error) *peer {
+func NewPeer(tr http.RoundTripper, u string, id types.ID, cid types.ID, r Raft, fs *stats.FollowerStats, mg *metrics.Group, errorc chan error) *peer {
 	p := &peer{
 		id:          id,
 		active:      true,
@@ -85,7 +87,8 @@ func NewPeer(tr http.RoundTripper, u string, id types.ID, cid types.ID, r Raft, 
 		cid:         cid,
 		r:           r,
 		fs:          fs,
-		stream:      &stream{},
+		mg:          mg,
+		stream:      &stream{mg: mg.Group("stream")},
 		errorc:      errorc,
 		batcher:     NewBatcher(100, appRespBatchMs*time.Millisecond),
 		propBatcher: NewProposalBatcher(100, propBatchMs*time.Millisecond),
@@ -181,6 +184,7 @@ func (p *peer) Stop() {
 	p.Lock()
 	defer p.Unlock()
 	p.stream.stop()
+	p.mg.Clear()
 	p.stopped = true
 }
 
@@ -264,8 +268,6 @@ func (p *peer) attachStream(sw *streamWriter) error {
 	if p.stopped {
 		return errors.New("peer: stopped")
 	}
-
-	sw.fs = p.fs
 	return p.stream.attach(sw)
 }
 

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -184,7 +184,6 @@ func (p *peer) Stop() {
 	p.Lock()
 	defer p.Unlock()
 	p.stream.stop()
-	p.mg.Clear()
 	p.stopped = true
 }
 

--- a/rafthttp/streamer.go
+++ b/rafthttp/streamer.go
@@ -50,7 +50,7 @@ type stream struct {
 }
 
 func (s *stream) open(from, to, cid types.ID, term uint64, tr http.RoundTripper, u string, r Raft) error {
-	rd, err := newStreamReader(from, to, cid, term, tr, u, r, s.mg.Group("reader"))
+	rd, err := newStreamReader(from, to, cid, term, tr, u, r, s.mg)
 	if err != nil {
 		log.Printf("stream: error opening stream: %v", err)
 		return err
@@ -82,7 +82,7 @@ func (s *stream) attach(sw *streamWriter) error {
 		}
 		s.w.stop()
 	}
-	sw.mg = s.mg.Group("writer")
+	sw.mg = s.mg
 	go sw.handle()
 	s.w = sw
 	return nil

--- a/rafthttp/streamer.go
+++ b/rafthttp/streamer.go
@@ -137,6 +137,7 @@ func (s *stream) invalidate(term uint64) {
 
 func (s *stream) stop() {
 	s.invalidate(math.MaxUint64)
+	s.mg.Clear()
 }
 
 func (s *stream) isOpen() bool {

--- a/rafthttp/transport_test.go
+++ b/rafthttp/transport_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/etcdserver/stats"
+	"github.com/coreos/etcd/pkg/metrics"
 	"github.com/coreos/etcd/pkg/testutil"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -30,8 +31,9 @@ import (
 func TestTransportAdd(t *testing.T) {
 	ls := stats.NewLeaderStats("")
 	tr := &transport{
-		leaderStats: ls,
-		peers:       make(map[types.ID]*peer),
+		leaderStats:  ls,
+		metricsGroup: metrics.NewGroup(),
+		peers:        make(map[types.ID]*peer),
 	}
 	tr.AddPeer(1, []string{"http://a"})
 
@@ -53,8 +55,9 @@ func TestTransportAdd(t *testing.T) {
 
 func TestTransportRemove(t *testing.T) {
 	tr := &transport{
-		leaderStats: stats.NewLeaderStats(""),
-		peers:       make(map[types.ID]*peer),
+		leaderStats:  stats.NewLeaderStats(""),
+		metricsGroup: metrics.NewGroup(),
+		peers:        make(map[types.ID]*peer),
 	}
 	tr.AddPeer(1, []string{"http://a"})
 	tr.RemovePeer(types.ID(1))
@@ -69,6 +72,7 @@ func TestTransportErrorc(t *testing.T) {
 	tr := &transport{
 		roundTripper: newRespRoundTripper(http.StatusForbidden, nil),
 		leaderStats:  stats.NewLeaderStats(""),
+		metricsGroup: metrics.NewGroup(),
 		peers:        make(map[types.ID]*peer),
 		errorc:       errorc,
 	}


### PR DESCRIPTION
http endpoint: `/v2/stats/transport`
format:
```
unihorn@CoreOS ~/g/s/g/a/kafka> curl http://127.0.0.1:4002/v2/stats/transport | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   110    0   110    0     0  89576      0 --:--:-- --:--:-- --:--:--  107k
{
    "924e2e83e93f2560": {
        "stream": {
            "bytes_recieved": 385,
            "entries_received": 5,
            "last_index_received": 18307
        }
    }
}
unihorn@CoreOS ~/g/s/g/a/kafka> curl http://127.0.0.1:4003/v2/stats/transport | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   200    0   200    0     0   131k      0 --:--:-- --:--:-- --:--:--  195k
{
    "6e3bd23ae5f1eae0": {
        "stream": {
            "bytes_sent": 1078,
            "entries_sent": 14,
            "last_index_sent": 18316
        }
    },
    "a8266ecf031671f3": {
        "stream": {
            "bytes_sent": 1078,
            "entries_sent": 14,
            "last_index_sent": 18316
        }
    }
}
```