### PR TITLE
build-aci: change 'val' abbreviation to 'value'

### DIFF
--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -11,9 +11,9 @@ cat <<DF > manifest
     "acKind": "ImageManifest",
     "name": "coreos.com/etcd",
     "labels": [
-        {"name": "os", "val": "linux"},
-        {"name": "arch", "val": "amd64"},
-        {"name": "version", "val": "${1}"}
+        {"name": "os", "value": "linux"},
+        {"name": "arch", "value": "amd64"},
+        {"name": "version", "value": "${1}"}
     ],
     "app": {
         "exec": [


### PR DESCRIPTION
The spec changed, so etcd must be updated to follow the new spec:
https://github.com/appc/spec/commit/12a9617c2fbd2d220ac63e028e0dee0113085bb3