### PR TITLE
pkg/transport: tests always listen on 127.0.0.1

### DIFF
--- a/pkg/transport/keepalive_listener_test.go
+++ b/pkg/transport/keepalive_listener_test.go
@@ -25,7 +25,7 @@ import (
 // that accepts connections.
 // TODO: verify the keepalive option is set correctly
 func TestNewKeepAliveListener(t *testing.T) {
-	ln, err := NewKeepAliveListener(":0", "http", TLSInfo{})
+	ln, err := NewKeepAliveListener("127.0.0.1:0", "http", TLSInfo{})
 	if err != nil {
 		t.Fatalf("unexpected NewKeepAliveListener error: %v", err)
 	}

--- a/pkg/transport/listener_test.go
+++ b/pkg/transport/listener_test.go
@@ -55,7 +55,7 @@ func TestNewListenerTLSInfo(t *testing.T) {
 	defer os.Remove(tmp)
 	tlsInfo := TLSInfo{CertFile: tmp, KeyFile: tmp}
 	tlsInfo.parseFunc = fakeCertificateParserFunc(tls.Certificate{}, nil)
-	ln, err := NewListener(":0", "https", tlsInfo)
+	ln, err := NewListener("127.0.0.1:0", "https", tlsInfo)
 	if err != nil {
 		t.Fatalf("unexpected NewListener error: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestNewListenerTLSInfo(t *testing.T) {
 
 func TestNewListenerTLSInfoNonexist(t *testing.T) {
 	tlsInfo := TLSInfo{CertFile: "@badname", KeyFile: "@badname"}
-	_, err := NewListener(":0", "https", tlsInfo)
+	_, err := NewListener("127.0.0.1:0", "https", tlsInfo)
 	werr := &os.PathError{
 		Op:   "open",
 		Path: "@badname",

--- a/pkg/transport/timeout_listener_test.go
+++ b/pkg/transport/timeout_listener_test.go
@@ -25,7 +25,7 @@ import (
 // TestNewTimeoutListener tests that NewTimeoutListener returns a
 // rwTimeoutListener struct with timeouts set.
 func TestNewTimeoutListener(t *testing.T) {
-	l, err := NewTimeoutListener(":0", "http", TLSInfo{}, time.Hour, time.Hour)
+	l, err := NewTimeoutListener("127.0.0.1:0", "http", TLSInfo{}, time.Hour, time.Hour)
 	if err != nil {
 		t.Fatalf("unexpected NewTimeoutListener error: %v", err)
 	}


### PR DESCRIPTION
This avoids firewall prompts when running tests on OSX.