### PR TITLE
raft: introduce MsgHeartbeatResp.

### DIFF
--- a/raft/raftpb/raft.pb.go
+++ b/raft/raftpb/raft.pb.go
@@ -69,15 +69,16 @@ func (x *EntryType) UnmarshalJSON(data []byte) error {
 type MessageType int32
 
 const (
-	MsgHup       MessageType = 0
-	MsgBeat      MessageType = 1
-	MsgProp      MessageType = 2
-	MsgApp       MessageType = 3
-	MsgAppResp   MessageType = 4
-	MsgVote      MessageType = 5
-	MsgVoteResp  MessageType = 6
-	MsgSnap      MessageType = 7
-	MsgHeartbeat MessageType = 8
+	MsgHup           MessageType = 0
+	MsgBeat          MessageType = 1
+	MsgProp          MessageType = 2
+	MsgApp           MessageType = 3
+	MsgAppResp       MessageType = 4
+	MsgVote          MessageType = 5
+	MsgVoteResp      MessageType = 6
+	MsgSnap          MessageType = 7
+	MsgHeartbeat     MessageType = 8
+	MsgHeartbeatResp MessageType = 9
 )
 
 var MessageType_name = map[int32]string{
@@ -90,17 +91,19 @@ var MessageType_name = map[int32]string{
 	6: "MsgVoteResp",
 	7: "MsgSnap",
 	8: "MsgHeartbeat",
+	9: "MsgHeartbeatResp",
 }
 var MessageType_value = map[string]int32{
-	"MsgHup":       0,
-	"MsgBeat":      1,
-	"MsgProp":      2,
-	"MsgApp":       3,
-	"MsgAppResp":   4,
-	"MsgVote":      5,
-	"MsgVoteResp":  6,
-	"MsgSnap":      7,
-	"MsgHeartbeat": 8,
+	"MsgHup":           0,
+	"MsgBeat":          1,
+	"MsgProp":          2,
+	"MsgApp":           3,
+	"MsgAppResp":       4,
+	"MsgVote":          5,
+	"MsgVoteResp":      6,
+	"MsgSnap":          7,
+	"MsgHeartbeat":     8,
+	"MsgHeartbeatResp": 9,
 }
 
 func (x MessageType) Enum() *MessageType {

--- a/raft/raftpb/raft.proto
+++ b/raft/raftpb/raft.proto
@@ -32,15 +32,16 @@ message Snapshot {
 }
 
 enum MessageType {
-	MsgHup       = 0;
-	MsgBeat      = 1;
-	MsgProp      = 2;
-	MsgApp       = 3;
-	MsgAppResp   = 4;
-	MsgVote      = 5;
-	MsgVoteResp  = 6;
-	MsgSnap      = 7;
-	MsgHeartbeat = 8;
+	MsgHup           = 0;
+	MsgBeat          = 1;
+	MsgProp          = 2;
+	MsgApp           = 3;
+	MsgAppResp       = 4;
+	MsgVote          = 5;
+	MsgVoteResp      = 6;
+	MsgSnap          = 7;
+	MsgHeartbeat     = 8;
+	MsgHeartbeatResp = 9;
 }
 
 message Message {

--- a/raft/util.go
+++ b/raft/util.go
@@ -50,7 +50,9 @@ func max(a, b uint64) uint64 {
 
 func IsLocalMsg(m pb.Message) bool { return m.Type == pb.MsgHup || m.Type == pb.MsgBeat }
 
-func IsResponseMsg(m pb.Message) bool { return m.Type == pb.MsgAppResp || m.Type == pb.MsgVoteResp }
+func IsResponseMsg(m pb.Message) bool {
+	return m.Type == pb.MsgAppResp || m.Type == pb.MsgVoteResp || m.Type == pb.MsgHeartbeatResp
+}
 
 // DescribeMessage returns a concise human-readable description of a
 // Message for debugging.


### PR DESCRIPTION
Now that heartbeats are distinct from MsgApp{,Resp}, the retries
currently performed in stepLeader's MsgAppResp section are only
performed on an actual MsgAppResp (or a new MsgProp). This means
that it may take a long time to recover from a dropped MsgAppResp
in a quiet cluster.

This commit adds a dedicated heartbeat response message. This message
does not convey the follower's current log position because the
MsgHeartbeat does not include the leaders term and index. Upon receipt
of a heartbeat response, the leader may retry the latest MsgApp if it
believes the follower to be behind.