### PR TITLE
raft: Use <= instead of < for heartbeat ticks.

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -346,7 +346,7 @@ func (r *raft) tickElection() {
 // tickHeartbeat is run by leaders to send a MsgBeat after r.heartbeatTimeout.
 func (r *raft) tickHeartbeat() {
 	r.elapsed++
-	if r.elapsed > r.heartbeatTimeout {
+	if r.elapsed >= r.heartbeatTimeout {
 		r.elapsed = 0
 		r.Step(pb.Message{From: r.id, Type: pb.MsgBeat})
 	}

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -120,7 +120,7 @@ func TestLeaderBcastBeat(t *testing.T) {
 		r.appendEntry(pb.Entry{Index: uint64(i) + 1})
 	}
 
-	for i := 0; i <= hi; i++ {
+	for i := 0; i < hi; i++ {
 		r.tick()
 	}
 


### PR DESCRIPTION
In code outside the raft package, we cannot call raft.bcastHeartbeat
directly. Instead, to control heartbeats we set heartbeatInterval to 1
and call Tick().