### PR TITLE
etcdserver: User peerTLSInfo to get cluster member

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -213,11 +213,16 @@ func startProxy(cfg *config) error {
 		return err
 	}
 
+	tr, err := transport.NewTransport(cfg.peerTLSInfo)
+	if err != nil {
+		return err
+	}
+
 	// TODO(jonboulle): update peerURLs dynamically (i.e. when updating
 	// clientURLs) instead of just using the initial fixed list here
 	peerURLs := cls.PeerURLs()
 	uf := func() []string {
-		cls, err := etcdserver.GetClusterFromPeers(peerURLs)
+		cls, err := etcdserver.GetClusterFromPeers(peerURLs, tr)
 		if err != nil {
 			log.Printf("proxy: %v", err)
 			return []string{}


### PR DESCRIPTION
`peerTLSInfo` is not used to retrieve cluster members, so boot process fails due to CA verification error: `x509: certificate signed by unknown authority`.