### PR TITLE
test: do not run integration tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
  - go get code.google.com/p/go.tools/cmd/vet
 
 script:
- - ./test
+ - INTEGRATION=y ./test

--- a/test
+++ b/test
@@ -15,8 +15,8 @@ COVER=${COVER:-"-cover"}
 source ./build
 
 # Hack: gofmt ./ will recursively check the .git directory. So use *.go for gofmt.
-TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes integration migrate pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft rafthttp snap store wal"
-FORMATTABLE="$TESTABLE_AND_FORMATTABLE *.go etcdctl/"
+TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes migrate pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft rafthttp snap store wal"
+FORMATTABLE="$TESTABLE_AND_FORMATTABLE *.go etcdctl/ integration"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then
@@ -40,6 +40,11 @@ TEST=${split[@]/#/${REPO_PATH}/}
 
 echo "Running tests..."
 go test -timeout 3m ${COVER} $@ ${TEST} --race
+
+if [ -n "$INTEGRATION" ]; then
+	echo "Running integration tests..."
+	go test -timeout 3m $@ ${REPO_PATH}/integration
+fi
 
 echo "Checking gofmt..."
 fmtRes=$(gofmt -l $FMT)


### PR DESCRIPTION
The ./test script will no longer run the integration tests. To run the
integration test, set the INTEGRATION env var to a nonzero value. For
example, `INTEGRATION=y ./test`.

I'm proposing this as the integration tests take way too long and they discourage developers from running `./test` during their normal workflow.