### PR TITLE
etcdserver: support raft.status

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -16,6 +16,7 @@ package etcdserver
 
 import (
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -33,6 +34,7 @@ import (
 	"github.com/coreos/etcd/etcdserver/stats"
 	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/pkg/idutil"
+	"github.com/coreos/etcd/pkg/metrics"
 	"github.com/coreos/etcd/pkg/pbutil"
 	"github.com/coreos/etcd/pkg/timeutil"
 	"github.com/coreos/etcd/pkg/types"
@@ -266,6 +268,7 @@ func (s *EtcdServer) Start() {
 	s.start()
 	go s.publish(defaultPublishRetryInterval)
 	go s.purgeFile()
+	metrics.Publish("raft.status", expvar.Func(s.raftStatus))
 }
 
 // start prepares and starts server in a new goroutine. It is no longer safe to
@@ -512,6 +515,8 @@ func (s *EtcdServer) LeaderStats() []byte {
 }
 
 func (s *EtcdServer) StoreStats() []byte { return s.store.JsonStats() }
+
+func (s *EtcdServer) raftStatus() interface{} { return s.r.Status() }
 
 func (s *EtcdServer) AddMember(ctx context.Context, memb Member) error {
 	// TODO: move Member to protobuf type


### PR DESCRIPTION
@yichengq @bdarnell I really do not like to encode json ourselves... but i guess it is the best approach right now. 

go's json does not support map[uint64]string. and we want to print uint64(id) as hex encoded string. 