### PR TITLE
README: remove doozer and zookeeper mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 ![etcd Logo](logos/etcd-horizontal-color.png)
 
-A highly-available key value store for shared configuration and service discovery.
-etcd is inspired by [Apache ZooKeeper][zookeeper] and [doozer][doozer], with a focus on being:
+etcd is a distributed, consistent key value store for shared configuration and service discovery with a focus on being:
 
 * *Simple*: curl'able user facing API (HTTP+JSON)
 * *Secure*: optional SSL client cert authentication


### PR DESCRIPTION
doozer in particular is rather confusing to mention since the project
hasn't been worked on in years. While we are at it it might simplify
people's understanding if we remove zookeeper too.