### PR TITLE
docs: expand description of -initial-cluster-state

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -68,8 +68,10 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 + default: "default=http://localhost:2380,default=http://localhost:7001"
 
 ##### -initial-cluster-state
-+ Initial cluster state ("new" or "existing").
++ Initial cluster state ("new" or "existing"). Set to `new` for all members present during initial static or DNS bootstrapping. If this option is set to `existing`, etcd will attempt to join the existing cluster. If the wrong value is set, etcd will attempt to start but fail safely.
 + default: "new"
+
+[static bootstrap]: clustering.md#static
 
 ##### -initial-cluster-token
 + Initial cluster token for the etcd cluster during bootstrap.


### PR DESCRIPTION
Expand description to address #2179. Proactively state that using the wrong value won't kill your cluster or anything. etcd does the right thing.