### PR TITLE
docs: clarify reconfig options

### DIFF
--- a/Documentation/admin_guide.md
+++ b/Documentation/admin_guide.md
@@ -55,6 +55,10 @@ It is recommended to have an odd number of members in a cluster. Having an odd c
 
 As you can see, adding another member to bring the size of cluster up to an odd size is always worth it. During a network partition, an odd number of members also guarantees that there will almost always be a majority of the cluster that can continue to operate and be the source of truth when the partition ends.
 
+#### Changing Cluster Size
+
+After your cluster is up and running, adding or removing members is done via [runtime reconfiguration](runtime-configuration.md), which allows the cluster to be modified without downtime. The `etcdctl` tool has a `member list`, `member add` and `member remove` commands to complete this process.
+
 ### Member Migration
 
 When there is a scheduled machine maintenance or retirement, you might want to migrate an etcd member to another machine without losing the data and changing the member ID. 

--- a/Documentation/clustering.md
+++ b/Documentation/clustering.md
@@ -4,6 +4,8 @@
 
 Starting an etcd cluster statically requires that each member knows another in the cluster. In a number of cases, you might not know the IPs of your cluster members ahead of time. In these cases, you can bootstrap an etcd cluster with the help of a discovery service.
 
+Once an etcd cluster is up and running, adding or removing members is done via [runtime reconfiguration](runtime-configuration.md).
+
 This guide willcover the following mechanisms for bootstrapping an etcd cluster:
 
 * [Static](#static)


### PR DESCRIPTION
Wanted to get some thoughts down on paper to help clarify #2179. The basic idea is to have some snippets that steer users towards the runtime docs where it makes sense, and have use-cases that explain the combinations of operations needed. This is normally a remove/add and sometimes a member migration.

cc: @philips @xiang90 