### PR TITLE
etcdctl:  prints name of key that changed when watching recursively

### DIFF
--- a/etcdctl/command/handle.go
+++ b/etcdctl/command/handle.go
@@ -147,7 +147,7 @@ func printKeyOnly(resp *etcd.Response, format string, prependKey bool) {
 	switch format {
 	case "simple":
 		if prependKey {
-			fmt.Println(fmt.Sprintf("%s: %s", resp.Node.Key, resp.Node.Value))
+			fmt.Printf("%s: %s\n", resp.Node.Key, resp.Node.Value)
 		} else {
 			fmt.Println(resp.Node.Value)
 		}

--- a/etcdctl/command/handle.go
+++ b/etcdctl/command/handle.go
@@ -122,7 +122,7 @@ func printKey(resp *etcd.Response, format string) {
 		fmt.Fprintln(os.Stderr, fmt.Sprintf("Cannot print key [%s: Is a directory]", resp.Node.Key))
 		os.Exit(1)
 	}
-	printKeyOnly(resp, format)
+	printKeyOnly(resp, format, false)
 }
 
 // printAll prints the etcd response in the given format in its best efforts.
@@ -130,15 +130,27 @@ func printAll(resp *etcd.Response, format string) {
 	if resp.Node.Dir == true {
 		return
 	}
-	printKeyOnly(resp, format)
+	printKeyOnly(resp, format, false)
+}
+
+// printAllPrependKey is just like printAll, but prepends the key name to the new value
+func printAllPrependKey(resp *etcd.Response, format string) {
+	if resp.Node.Dir == true {
+		return
+	}
+	printKeyOnly(resp, format, true)
 }
 
 // printKeyOnly only supports to print key correctly.
-func printKeyOnly(resp *etcd.Response, format string) {
+func printKeyOnly(resp *etcd.Response, format string, prependKey bool) {
 	// Format the result.
 	switch format {
 	case "simple":
-		fmt.Println(resp.Node.Value)
+		if prependKey {
+			fmt.Println(fmt.Sprintf("%s: %s", resp.Node.Key, resp.Node.Value))
+		} else {
+			fmt.Println(resp.Node.Value)
+		}
 	case "extended":
 		// Extended prints in a rfc2822 style format
 		fmt.Println("Key:", resp.Node.Key)

--- a/etcdctl/command/watch_command.go
+++ b/etcdctl/command/watch_command.go
@@ -53,6 +53,11 @@ func watchCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, erro
 		index = c.Int("after-index") + 1
 	}
 
+	printFn := printAll
+	if recursive {
+		printFn = printAllPrependKey
+	}
+
 	if forever {
 		sigch := make(chan os.Signal, 1)
 		signal.Notify(sigch, os.Interrupt)
@@ -74,7 +79,7 @@ func watchCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, erro
 		for {
 			select {
 			case resp := <-receiver:
-				printAll(resp, c.GlobalString("output"))
+				printFn(resp, c.GlobalString("output"))
 			case err := <-errCh:
 				handleError(-1, err)
 			}
@@ -92,7 +97,7 @@ func watchCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, erro
 		if err != nil {
 			return nil, err
 		}
-		printAll(resp, c.GlobalString("output"))
+		printFn(resp, c.GlobalString("output"))
 	}
 
 	return nil, nil


### PR DESCRIPTION
Previously 'etcdctl watch /DIR --recursive' would print only the new value
of any changed key, but not show which key actually changed.  Now it formats
its output as 'name_of_changed_key:  new_value'.  Only affects --recursive
watch; regular watches are not affected.  This matches the behavior of
'grep -r'.

Fixes issue #1520 in the manner suggested by philips