### PR TITLE
Stop resolving advertise-client-urls

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -264,7 +264,7 @@ func (cfg *config) Parse(arguments []string) error {
 }
 
 func (cfg *config) resolveUrls() error {
-	return netutil.ResolveTCPAddrs(cfg.lpurls, cfg.apurls, cfg.lcurls, cfg.acurls)
+	return netutil.ResolveTCPAddrs(cfg.lpurls, cfg.apurls, cfg.lcurls)
 }
 
 func (cfg config) isNewCluster() bool          { return cfg.clusterState.String() == clusterStateFlagNew }


### PR DESCRIPTION
We're not validating acurls right now. And, resolving acurls may lead TLS verification failure, by having different hostname.