### PR TITLE
Revert "migrate/starter: unset discovery when setting initial-cluster"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 sudo: false
 go:
-  - 1.4
+  - 1.3
 
 install:
- - go get golang.org/x/tools/cmd/cover
- - go get golang.org/x/tools/cmd/vet
+ - go get code.google.com/p/go.tools/cmd/cover
+ - go get code.google.com/p/go.tools/cmd/vet
 
 script:
  - INTEGRATION=y ./test

--- a/migrate/starter/starter.go
+++ b/migrate/starter/starter.go
@@ -123,7 +123,6 @@ func checkInternalVersion(fs *flag.FlagSet) version {
 				return internalV1
 			}
 			if ver == internalV2 {
-				os.Unsetenv("ETCD_DISCOVERY")
 				os.Args = append(os.Args, "-initial-cluster", standbyInfo.InitialCluster())
 				return internalV2Proxy
 			}


### PR DESCRIPTION
Reverts coreos/etcd#2222