### PR TITLE
pkg/osutil: add Unsetenv

### DIFF
--- a/migrate/starter/starter.go
+++ b/migrate/starter/starter.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coreos/etcd/migrate"
 	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/pkg/flags"
+	"github.com/coreos/etcd/pkg/osutil"
 	"github.com/coreos/etcd/pkg/types"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
@@ -123,7 +124,7 @@ func checkInternalVersion(fs *flag.FlagSet) version {
 				return internalV1
 			}
 			if ver == internalV2 {
-				os.Unsetenv("ETCD_DISCOVERY")
+				osutil.Unsetenv("ETCD_DISCOVERY")
 				os.Args = append(os.Args, "-initial-cluster", standbyInfo.InitialCluster())
 				return internalV2Proxy
 			}

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -1,0 +1,35 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package osutil
+
+import (
+	"os"
+	"strings"
+)
+
+func Unsetenv(key string) error {
+	envs := os.Environ()
+	os.Clearenv()
+	for _, e := range envs {
+		strs := strings.SplitN(e, "=", 2)
+		if strs[0] == key {
+			continue
+		}
+		if err := os.Setenv(strs[0], strs[1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -1,0 +1,45 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package osutil
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestUnsetenv(t *testing.T) {
+	tests := []string{
+		"data",
+		"space data",
+		"equal=data",
+	}
+	for i, tt := range tests {
+		key := "ETCD_UNSETENV_TEST"
+		if os.Getenv(key) != "" {
+			t.Fatalf("#%d: cannot get empty %s", i, key)
+		}
+		env := os.Environ()
+		if err := os.Setenv(key, tt); err != nil {
+			t.Fatalf("#%d: cannot set %s: %v", i, key, err)
+		}
+		if err := Unsetenv(key); err != nil {
+			t.Errorf("#%d: unsetenv %s error: %v", i, key, err)
+		}
+		if g := os.Environ(); !reflect.DeepEqual(g, env) {
+			t.Errorf("#%d: env = %+v, want %+v", i, g, env)
+		}
+	}
+}

--- a/test
+++ b/test
@@ -15,7 +15,7 @@ COVER=${COVER:-"-cover"}
 source ./build
 
 # Hack: gofmt ./ will recursively check the .git directory. So use *.go for gofmt.
-TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes migrate pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft rafthttp snap store wal"
+TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes migrate pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/osutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft rafthttp snap store wal"
 FORMATTABLE="$TESTABLE_AND_FORMATTABLE *.go etcdctl/ integration"
 
 # user has not provided PKG override


### PR DESCRIPTION
go1.4 doesn't support static link well, so we stay in go1.3 for a while.
Implement Unsetenv in go1.3 way.