### PR TITLE
raftest: wait for network sending

### DIFF
--- a/raft/rafttest/network.go
+++ b/raft/rafttest/network.go
@@ -86,7 +86,11 @@ func (rn *raftNetwork) send(m raftpb.Message) {
 		time.Sleep(time.Duration(rd))
 	}
 
-	to <- m
+	select {
+	case to <- m:
+	default:
+		// drop messages when the receiver queue is full.
+	}
 }
 
 func (rn *raftNetwork) recvFrom(from uint64) chan raftpb.Message {

--- a/raft/rafttest/node.go
+++ b/raft/rafttest/node.go
@@ -49,11 +49,10 @@ func (n *node) start() {
 					n.storage.SetHardState(n.state)
 				}
 				n.storage.Append(rd.Entries)
-				go func() {
-					for _, m := range rd.Messages {
-						n.iface.send(m)
-					}
-				}()
+				// TODO: make send async, more like real world...
+				for _, m := range rd.Messages {
+					n.iface.send(m)
+				}
 				n.Advance()
 			case m := <-n.iface.recv():
 				n.Step(context.TODO(), m)


### PR DESCRIPTION
@yichengq @bdarnell 
When we stop the node, we need to ensure the sending routine is stopped.
We might want to move the sending stuff into a separate go routine.