### PR TITLE
rafthttp/transport.go: Fix nil pointer dereference in RemovePeer

### DIFF
--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -132,7 +132,11 @@ func (t *transport) AddPeer(id types.ID, urls []string) {
 func (t *transport) RemovePeer(id types.ID) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.peers[id].Stop()
+	if peer, ok := t.peers[id]; ok {
+		peer.Stop()
+	} else {
+		log.Panicf("rafthttp: unexpected removal of unknown peer '%d'", id)
+	}
 	delete(t.peers, id)
 	delete(t.leaderStats.Followers, id.String())
 }


### PR DESCRIPTION
This behaviour has been observed when removing a couple nodes from
a cluster and then restarting another node. The restarting server
panics immediately, retrying to start the server a little later
then works fine.

See 'Cloud Foundry Diego' backlog tracker:
https://www.pivotaltracker.com/story/show/88199788
[#88199788]

Signed-off-by: Amit Gupta <agupta@pivotal.io>