### PR TITLE
store: fix skewed watchers count in hub.

### DIFF
--- a/store/watcher.go
+++ b/store/watcher.go
@@ -91,6 +91,7 @@ func (w *watcher) Remove() {
 	w.remove()
 }
 
+// remove is the internal remove method for which the hub lock must be held.
 func (w *watcher) remove() {
 	w.removeOnce.Do(func() {
 		close(w.eventChan)

--- a/store/watcher.go
+++ b/store/watcher.go
@@ -14,6 +14,10 @@
 
 package store
 
+import (
+	"sync"
+)
+
 type Watcher interface {
 	EventChan() chan *Event
 	StartIndex() uint64 // The EtcdIndex at which the Watcher was created
@@ -27,8 +31,8 @@ type watcher struct {
 	sinceIndex uint64
 	startIndex uint64
 	hub        *watcherHub
-	removed    bool
-	remove     func()
+	removeOnce sync.Once
+	removeFunc func()
 }
 
 func (w *watcher) EventChan() chan *Event {
@@ -64,6 +68,10 @@ func (w *watcher) notify(e *Event, originalPath bool, deleted bool) bool {
 		// If this happens, we close the channel.
 		select {
 		case w.eventChan <- e:
+			if !w.stream { // do not remove the stream watcher
+				// if watcher has successfully been notified, we can remove it
+				w.remove()
+			}
 		default:
 			// We have missed a notification. Remove the watcher.
 			// Removing the watcher also closes the eventChan.
@@ -80,8 +88,14 @@ func (w *watcher) Remove() {
 	w.hub.mutex.Lock()
 	defer w.hub.mutex.Unlock()
 
-	close(w.eventChan)
-	if w.remove != nil {
-		w.remove()
-	}
+	w.remove()
+}
+
+func (w *watcher) remove() {
+	w.removeOnce.Do(func() {
+		close(w.eventChan)
+		if w.removeFunc != nil {
+			w.removeFunc()
+		}
+	})
 }

--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -143,21 +143,12 @@ func (wh *watcherHub) notifyWatchers(e *Event, nodePath string, deleted bool) {
 			originalPath := (e.Node.Key == nodePath)
 			if (originalPath || !isHidden(nodePath, e.Node.Key)) && w.notify(e, originalPath, deleted) {
 				if !w.stream { // do not remove the stream watcher
-					// if we successfully notify a watcher
-					// we need to remove the watcher from the list
-					// and decrease the counter
-					l.Remove(curr)
-					atomic.AddInt64(&wh.count, -1)
+					// if we successfully notify a watcher, we can remove it
+					w.remove()
 				}
 			}
 
 			curr = next // update current to the next element in the list
-		}
-
-		if l.Len() == 0 {
-			// if we have notified all watcher in the list
-			// we can delete the list
-			delete(wh.watchers, nodePath)
 		}
 	}
 }

--- a/store/watcher_hub_test.go
+++ b/store/watcher_hub_test.go
@@ -67,6 +67,7 @@ func TestIsHidden(t *testing.T) {
 
 func TestWatchersCount(t *testing.T) {
 	wh := newWatchHub(10)
+
 	w, err := wh.watch("/foo", true, false, 1, 1)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -75,10 +76,48 @@ func TestWatchersCount(t *testing.T) {
 		t.Fatalf("watchers count was %d, expected %d", wh.count, 1)
 	}
 
+	wr, err := wh.watch("/foo", true, true, 1, 1)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if wh.count != 2 {
+		t.Fatalf("watchers count was %d, expected %d", wh.count, 2)
+	}
+	wr2, err := wh.watch("/foo", true, true, 1, 1)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if wh.count != 3 {
+		t.Fatalf("watchers count was %d, expected %d", wh.count, 3)
+	}
+
 	e := newEvent(Set, "/foo", 1, 1)
 	wh.notify(e)
 
+	// watcher hub's internal remove must reduce the count for the
+	// non-streaming watcher
+	if wh.count != 2 {
+		t.Fatalf("watchers count was %d, expected %d", wh.count, 2)
+	}
+	// removing the non-streaming watcher manually must not reduce the
+	// count again
 	w.Remove()
+	if wh.count != 2 {
+		t.Fatalf("watchers count was %d, expected %d", wh.count, 2)
+	}
+	// removing first streaming watcher externally
+	wr.Remove()
+	if wh.count != 1 {
+		t.Fatalf("watchers count was %d, expected %d", wh.count, 1)
+	}
+	// removing second streaming watcher by missing event
+	c := wr2.EventChan()
+	i := uint64(1)
+	for int(i) <= cap(c)+1 {
+		e = newEvent(Create, "/foo", i, i)
+		wh.notify(e)
+		i++
+	}
 	if wh.count != 0 {
 		t.Fatalf("watchers count was %d, expected %d", wh.count, 0)
 	}

--- a/store/watcher_hub_test.go
+++ b/store/watcher_hub_test.go
@@ -64,3 +64,22 @@ func TestIsHidden(t *testing.T) {
 		t.Fatalf("%v should not be hidden to %v\n", key, watch)
 	}
 }
+
+func TestWatchersCount(t *testing.T) {
+	wh := newWatchHub(10)
+	w, err := wh.watch("/foo", true, false, 1, 1)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if wh.count != 1 {
+		t.Fatalf("watchers count was %d, expected %d", wh.count, 1)
+	}
+
+	e := newEvent(Set, "/foo", 1, 1)
+	wh.notify(e)
+
+	w.Remove()
+	if wh.count != 0 {
+		t.Fatalf("watchers count was %d, expected %d", wh.count, 0)
+	}
+}

--- a/store/watcher_test.go
+++ b/store/watcher_test.go
@@ -35,20 +35,20 @@ func TestWatcher(t *testing.T) {
 	}
 
 	e := newEvent(Create, "/foo/bar", 1, 1)
-
 	wh.notify(e)
 
 	re := <-c
-
 	if e != re {
 		t.Fatal("recv != send")
 	}
 
-	w, _ = wh.watch("/foo", false, false, 2, 1)
+	w, err = wh.watch("/foo", false, false, 3, 1)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	c = w.EventChan()
 
 	e = newEvent(Create, "/foo/bar", 2, 2)
-
 	wh.notify(e)
 
 	select {
@@ -59,17 +59,50 @@ func TestWatcher(t *testing.T) {
 	}
 
 	e = newEvent(Create, "/foo", 3, 3)
-
 	wh.notify(e)
 
 	re = <-c
-
 	if e != re {
 		t.Fatal("recv != send")
 	}
 
+	// should not receive another event if not streaming
+	e = newEvent(Create, "/foo", 4, 4)
+	wh.notify(e)
+
+	select {
+	case _, ok := <-c:
+		if ok {
+			t.Fatal("should not receive more than once from non-streaming watcher ", re)
+		}
+	default:
+	}
+
+	// test streaming watcher
+	w, err = wh.watch("/bar", true, true, 1, 1)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	c = w.EventChan()
+
+	for i := uint64(1); int(i) < cap(c); i++ {
+		e = newEvent(Create, "/bar", i, i)
+		wh.notify(e)
+
+		re, ok := <-c
+		if !ok {
+			t.Fatal("streaming channel should receive")
+		}
+		if re != e {
+			t.Fatal("recv != send")
+		}
+	}
+
 	// ensure we are doing exact matching rather than prefix matching
-	w, _ = wh.watch("/fo", true, false, 1, 1)
+	w, err = wh.watch("/fo", true, false, 1, 1)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	c = w.EventChan()
 
 	select {
@@ -80,13 +113,53 @@ func TestWatcher(t *testing.T) {
 	}
 
 	e = newEvent(Create, "/fo/bar", 3, 3)
-
 	wh.notify(e)
 
 	re = <-c
-
 	if e != re {
 		t.Fatal("recv != send")
 	}
+}
 
+func TestWatcherRemoval(t *testing.T) {
+	s := newStore()
+	wh := s.WatcherHub
+
+	// ensure the watcher receives no further events after removing itself
+	w, err := wh.watch("/foo", false, false, 1, 1)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	c := w.EventChan()
+
+	w.Remove()
+
+	e := newEvent(Create, "/foo/bar", 1, 1)
+	wh.notify(e)
+
+	select {
+	case re, ok := <-c:
+		if ok {
+			t.Fatal("should not receive from channel after removing our watch ", re)
+		}
+	default:
+		t.Fatal("event channel blocking, should be closed")
+	}
+
+	// removal on missed notifcation
+	w, err = wh.watch("/spam", true, true, 1, 1)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	c = w.EventChan()
+
+	i := uint64(1)
+	for int(i) <= cap(c)+1 {
+		e = newEvent(Create, "/spam", i, i)
+		wh.notify(e)
+		i++
+	}
+	for range c {
+		// drain must exit
+	}
 }


### PR DESCRIPTION
Issue #2225 describes how a removed watcher decrements the count
of watchers twice. This fixes the issue by using the watcher's
`remove` function.