### PR TITLE
migrate/functional: fix `go build` failure

### DIFF
--- a/migrate/functional/member.go
+++ b/migrate/functional/member.go
@@ -28,6 +28,8 @@ import (
 	"time"
 )
 
+var binDir = ".versions"
+
 type Proc struct {
 	*exec.Cmd
 	Name    string

--- a/migrate/functional/upgrade_test.go
+++ b/migrate/functional/upgrade_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 var (
-	binDir         = ".versions"
 	v1BinPath      = path.Join(binDir, "1")
 	v2BinPath      = path.Join(binDir, "2")
 	etcdctlBinPath string


### PR DESCRIPTION
fixes #2310 