### PR TITLE
Only use the EntryFormatter for normal entries.

### DIFF
--- a/raft/util.go
+++ b/raft/util.go
@@ -84,10 +84,10 @@ func DescribeMessage(m pb.Message, f EntryFormatter) string {
 // Entry for debugging.
 func DescribeEntry(e pb.Entry, f EntryFormatter) string {
 	var formatted string
-	if f == nil {
-		formatted = fmt.Sprintf("%q", e.Data)
-	} else {
+	if e.Type == pb.EntryNormal && f != nil {
 		formatted = f(e.Data)
+	} else {
+		formatted = fmt.Sprintf("%q", e.Data)
 	}
 	return fmt.Sprintf("%d/%d %s %s", e.Term, e.Index, e.Type, formatted)
 }


### PR DESCRIPTION
ConfChange entries also have a Data field but the application-supplied
formatter won't know what to do with them.

@xiang90 @yichengq 