### PR TITLE
Fix test for existence of go-nyet.

### DIFF
--- a/test
+++ b/test
@@ -60,7 +60,7 @@ if [ -n "${vetRes}" ]; then
 	exit 255
 fi
 
-if [ -f `which go-nyet` ]; then
+if command -v go-nyet >/dev/null 2>&1; then
   echo "Checking go-nyet..."
   nyetRes=$(go-nyet -exitWith 0 $FMT)
   if [ -n "${nyetRes}" ]; then


### PR DESCRIPTION
When the file is not found, `which` returns an empty string,
which passes the -f test. `command -v` is the most portable alternative
to `which` per
http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script/677212#677212

@barakmich 