### PR TITLE
rafthttp: fix panic on receiving empty ents

### DIFF
--- a/rafthttp/entry_reader.go
+++ b/rafthttp/entry_reader.go
@@ -54,7 +54,9 @@ func (er *entryReader) readEntries() ([]raftpb.Entry, error) {
 		}
 		er.ents.Add()
 	}
-	er.lastIndex.Set(int64(ents[l-1].Index))
+	if l > 0 {
+		er.lastIndex.Set(int64(ents[l-1].Index))
+	}
 	return ents, nil
 }
 

--- a/rafthttp/streamer.go
+++ b/rafthttp/streamer.go
@@ -295,6 +295,9 @@ func (s *streamReader) handle(r io.Reader) {
 			}
 			return
 		}
+		if len(ents) == 0 {
+			continue
+		}
 		// The commit index field in appendEntry message is not recovered.
 		// The follower updates its commit index through heartbeat.
 		msg := raftpb.Message{


### PR DESCRIPTION
2.0 rc may send empty ents. Fix it for backward compatibility.

follow ups for #2270 