### PR TITLE
client: add CreateOptions to client.KeysAPI

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -103,8 +103,8 @@ type KeysAPI interface {
 	// conditions in an DeleteOptions object.
 	Delete(ctx context.Context, key string, opts *DeleteOptions) (*Response, error)
 
-	// Create is an alias for Set w/ PrevExist=false
-	Create(ctx context.Context, key, value string) (*Response, error)
+	// Used to Create a Node
+	Create(ctx context.Context, key, value string, opts *CreateOptions) (*Response, error)
 
 	// Update is an alias for Set w/ PrevExist=true
 	Update(ctx context.Context, key, value string) (*Response, error)
@@ -131,6 +131,25 @@ type WatcherOptions struct {
 	// to false (default), events will be limited to those that
 	// occur for the exact key.
 	Recursive bool
+}
+
+type CreateOptions struct {
+
+	// TTL defines a period of time after-which the Node should
+	// expire and no longer exist. Values <= 0 are ignored. Given
+	// that the zero-value is ignored, TTL cannot be used to set
+	// a TTL of 0.
+	TTL time.Duration
+
+	// InOrder specifices whether or not the the keys are created
+	// with key names that are in-order.   Generated Key names use
+	// the global etcd index, so the next key can be more than
+	// previous + 1
+	InOrder bool
+
+	// if PrevIgnore is set to true, then the create operation
+	// will ignore if the node already exists.
+	PrevIgnore bool
 }
 
 type SetOptions struct {
@@ -281,8 +300,28 @@ func (k *httpKeysAPI) Set(ctx context.Context, key, val string, opts *SetOptions
 	return unmarshalHTTPResponse(resp.StatusCode, resp.Header, body)
 }
 
-func (k *httpKeysAPI) Create(ctx context.Context, key, val string) (*Response, error) {
-	return k.Set(ctx, key, val, &SetOptions{PrevExist: PrevNoExist})
+func (k *httpKeysAPI) Create(ctx context.Context, key, val string, opts *CreateOptions) (*Response, error) {
+	act := &setAction{
+		Prefix:    k.prefix,
+		Key:       key,
+		Value:     val,
+		PrevExist: PrevNoExist,
+	}
+
+	if opts != nil {
+		act.TTL = opts.TTL
+		act.InOrder = opts.InOrder
+		if opts.PrevIgnore {
+			act.PrevExist = PrevIgnore
+		}
+	}
+
+	resp, body, err := k.client.Do(ctx, act)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalHTTPResponse(resp.StatusCode, resp.Header, body)
 }
 
 func (k *httpKeysAPI) Update(ctx context.Context, key, val string) (*Response, error) {
@@ -422,6 +461,7 @@ type setAction struct {
 	Value     string
 	PrevValue string
 	PrevIndex uint64
+	InOrder   bool
 	PrevExist PrevExistType
 	TTL       time.Duration
 }
@@ -448,7 +488,11 @@ func (a *setAction) HTTPRequest(ep url.URL) *http.Request {
 	}
 	body := strings.NewReader(form.Encode())
 
-	req, _ := http.NewRequest("PUT", u.String(), body)
+	method := "PUT"
+	if a.InOrder {
+		method = "POST"
+	}
+	req, _ := http.NewRequest(method, u.String(), body)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	return req

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -1153,17 +1153,59 @@ func TestHTTPKeysAPIDeleteResponse(t *testing.T) {
 }
 
 func TestHTTPKeysAPICreateAction(t *testing.T) {
-	act := &setAction{
-		Key:       "/foo",
-		Value:     "bar",
-		PrevExist: PrevNoExist,
-		PrevIndex: 0,
-		PrevValue: "",
-		TTL:       0,
+
+	tests := []struct {
+		opts       *CreateOptions
+		wantAction httpAction
+	}{
+		// nil CreateOptions
+		{
+			opts: nil,
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevExist: PrevNoExist,
+			},
+		},
+		{
+			opts: &CreateOptions{
+				InOrder: true,
+			},
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevExist: PrevNoExist,
+				InOrder:   true,
+			},
+		},
+		{
+			opts: &CreateOptions{
+				PrevIgnore: true,
+			},
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevExist: PrevIgnore,
+			},
+		},
+		{
+			opts: &CreateOptions{
+				TTL: 100,
+			},
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevExist: PrevNoExist,
+				TTL:       100,
+			},
+		},
 	}
 
-	kAPI := httpKeysAPI{client: &actionAssertingHTTPClient{t: t, act: act}}
-	kAPI.Create(context.Background(), "/foo", "bar")
+	for i, tt := range tests {
+		client := &actionAssertingHTTPClient{t: t, num: i, act: tt.wantAction}
+		kAPI := httpKeysAPI{client: client}
+		kAPI.Create(context.Background(), "/foo", "bar", tt.opts)
+	}
 }
 
 func TestHTTPKeysAPIUpdateAction(t *testing.T) {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -180,7 +180,7 @@ func (d *discovery) getCluster() (string, error) {
 
 func (d *discovery) createSelf(contents string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
-	resp, err := d.c.Create(ctx, d.selfKey(), contents)
+	resp, err := d.c.Create(ctx, d.selfKey(), contents, nil)
 	cancel()
 	if err != nil {
 		if eerr, ok := err.(*client.Error); ok && eerr.Code == client.ErrorCodeNodeExist {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -413,7 +413,7 @@ type clientWithResp struct {
 	client.KeysAPI
 }
 
-func (c *clientWithResp) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+func (c *clientWithResp) Create(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	if len(c.rs) == 0 {
 		return &client.Response{}, nil
 	}
@@ -441,7 +441,7 @@ type clientWithErr struct {
 	client.KeysAPI
 }
 
-func (c *clientWithErr) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+func (c *clientWithErr) Create(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	return &client.Response{}, c.err
 }
 
@@ -482,12 +482,12 @@ type clientWithRetry struct {
 	failTimes int
 }
 
-func (c *clientWithRetry) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+func (c *clientWithRetry) Create(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	if c.failCount < c.failTimes {
 		c.failCount++
 		return nil, context.DeadlineExceeded
 	}
-	return c.clientWithResp.Create(ctx, key, value)
+	return c.clientWithResp.Create(ctx, key, value, opts)
 }
 
 func (c *clientWithRetry) Get(ctx context.Context, key string, opts *client.GetOptions) (*client.Response, error) {

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -84,7 +84,7 @@ func testClusterUsingDiscovery(t *testing.T, size int) {
 	dcc := mustNewHTTPClient(t, dc.URLs())
 	dkapi := client.NewKeysAPI(dcc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	if _, err := dkapi.Create(ctx, "/_config/size", fmt.Sprintf("%d", size)); err != nil {
+	if _, err := dkapi.Create(ctx, "/_config/size", fmt.Sprintf("%d", size), nil); err != nil {
 		t.Fatal(err)
 	}
 	cancel()
@@ -134,7 +134,7 @@ func TestForceNewCluster(t *testing.T) {
 	cc := mustNewHTTPClient(t, []string{c.Members[0].URL()})
 	kapi := client.NewKeysAPI(cc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	resp, err := kapi.Create(ctx, "/foo", "bar")
+	resp, err := kapi.Create(ctx, "/foo", "bar", nil)
 	if err != nil {
 		t.Fatalf("unexpected create error: %v", err)
 	}
@@ -177,7 +177,7 @@ func clusterMustProgress(t *testing.T, membs []*member) {
 	kapi := client.NewKeysAPI(cc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	key := fmt.Sprintf("foo%d", rand.Int())
-	resp, err := kapi.Create(ctx, "/"+key, "bar")
+	resp, err := kapi.Create(ctx, "/"+key, "bar", nil)
 	if err != nil {
 		t.Fatalf("create on %s error: %v", membs[0].URL(), err)
 	}


### PR DESCRIPTION
Allows you to optionally Create nodes with:
* A TTL
* In order generated keys
* Ignore existing node values