### PR TITLE
rafthttp: improve error printout

### DIFF
--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -165,6 +165,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	c := newCloseNotifier()
 	conn := &outgoingConn{
+		addr:    r.RemoteAddr,
 		t:       t,
 		termStr: r.Header.Get("X-Raft-Term"),
 		Writer:  w,

--- a/rafthttp/pipeline.go
+++ b/rafthttp/pipeline.go
@@ -17,7 +17,6 @@ package rafthttp
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -38,8 +37,9 @@ const (
 )
 
 type pipeline struct {
-	id  types.ID
-	cid types.ID
+	local  types.ID
+	remote types.ID
+	cid    types.ID
 
 	tr http.RoundTripper
 	// the url this pipeline sends to
@@ -57,9 +57,10 @@ type pipeline struct {
 	errored error
 }
 
-func newPipeline(tr http.RoundTripper, u string, id, cid types.ID, fs *stats.FollowerStats, errorc chan error) *pipeline {
+func newPipeline(tr http.RoundTripper, u string, local, remote, cid types.ID, fs *stats.FollowerStats, errorc chan error) *pipeline {
 	p := &pipeline{
-		id:     id,
+		local:  local,
+		remote: remote,
 		cid:    cid,
 		tr:     tr,
 		u:      u,
@@ -89,30 +90,16 @@ func (p *pipeline) handle() {
 		err := p.post(pbutil.MustMarshal(&m))
 		end := time.Now()
 
-		p.Lock()
 		if err != nil {
-			if p.errored == nil || p.errored.Error() != err.Error() {
-				log.Printf("pipeline: error posting to %s: %v", p.id, err)
-				p.errored = err
-			}
-			if p.active {
-				log.Printf("pipeline: the connection with %s became inactive", p.id)
-				p.active = false
-			}
+			reportOpError(p.local, p.remote, "pipeline", newOpError("post", p.u, err))
 			if m.Type == raftpb.MsgApp {
 				p.fs.Fail()
 			}
 		} else {
-			if !p.active {
-				log.Printf("pipeline: the connection with %s became active", p.id)
-				p.active = true
-				p.errored = nil
-			}
 			if m.Type == raftpb.MsgApp {
 				p.fs.Succ(end.Sub(start))
 			}
 		}
-		p.Unlock()
 	}
 }
 

--- a/rafthttp/pipeline_test.go
+++ b/rafthttp/pipeline_test.go
@@ -32,7 +32,7 @@ import (
 func TestPipelineSend(t *testing.T) {
 	tr := &roundTripperRecorder{}
 	fs := &stats.FollowerStats{}
-	p := newPipeline(tr, "http://10.0.0.1", types.ID(1), types.ID(1), fs, nil)
+	p := newPipeline(tr, "http://10.0.0.1", types.ID(2), types.ID(1), types.ID(1), fs, nil)
 
 	p.msgc <- raftpb.Message{Type: raftpb.MsgApp}
 	p.stop()
@@ -50,7 +50,7 @@ func TestPipelineSend(t *testing.T) {
 func TestPipelineExceedMaximalServing(t *testing.T) {
 	tr := newRoundTripperBlocker()
 	fs := &stats.FollowerStats{}
-	p := newPipeline(tr, "http://10.0.0.1", types.ID(1), types.ID(1), fs, nil)
+	p := newPipeline(tr, "http://10.0.0.1", types.ID(2), types.ID(1), types.ID(1), fs, nil)
 
 	// keep the sender busy and make the buffer full
 	// nothing can go out as we block the sender
@@ -89,7 +89,7 @@ func TestPipelineExceedMaximalServing(t *testing.T) {
 // it increases fail count in stats.
 func TestPipelineSendFailed(t *testing.T) {
 	fs := &stats.FollowerStats{}
-	p := newPipeline(newRespRoundTripper(0, errors.New("blah")), "http://10.0.0.1", types.ID(1), types.ID(1), fs, nil)
+	p := newPipeline(newRespRoundTripper(0, errors.New("blah")), "http://10.0.0.1", types.ID(2), types.ID(1), types.ID(1), fs, nil)
 
 	p.msgc <- raftpb.Message{Type: raftpb.MsgApp}
 	p.stop()
@@ -103,7 +103,7 @@ func TestPipelineSendFailed(t *testing.T) {
 
 func TestPipelinePost(t *testing.T) {
 	tr := &roundTripperRecorder{}
-	p := newPipeline(tr, "http://10.0.0.1", types.ID(1), types.ID(1), nil, nil)
+	p := newPipeline(tr, "http://10.0.0.1", types.ID(2), types.ID(1), types.ID(1), nil, nil)
 	if err := p.post([]byte("some data")); err != nil {
 		t.Fatalf("unexpect post error: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestPipelinePostBad(t *testing.T) {
 		{"http://10.0.0.1", http.StatusCreated, nil},
 	}
 	for i, tt := range tests {
-		p := newPipeline(newRespRoundTripper(tt.code, tt.err), tt.u, types.ID(1), types.ID(1), nil, make(chan error))
+		p := newPipeline(newRespRoundTripper(tt.code, tt.err), tt.u, types.ID(2), types.ID(1), types.ID(1), nil, make(chan error))
 		err := p.post([]byte("some data"))
 		p.stop()
 
@@ -166,7 +166,7 @@ func TestPipelinePostErrorc(t *testing.T) {
 	}
 	for i, tt := range tests {
 		errorc := make(chan error, 1)
-		p := newPipeline(newRespRoundTripper(tt.code, tt.err), tt.u, types.ID(1), types.ID(1), nil, errorc)
+		p := newPipeline(newRespRoundTripper(tt.code, tt.err), tt.u, types.ID(2), types.ID(1), types.ID(1), nil, errorc)
 		p.post([]byte("some data"))
 		p.stop()
 		select {

--- a/rafthttp/report.go
+++ b/rafthttp/report.go
@@ -50,7 +50,7 @@ func reportOpError(local, remote types.ID, worker string, err *opError) {
 	now := time.Now()
 	if !err.equal(linkErrMap[name].err) || now.Sub(linkErrMap[name].last) > errBackoffTime {
 		linkErrMap[name] = linkErr{err: err, last: now}
-		log.Printf("rafthttp: encountered error sending messages in %s from %s to %s: %v", worker, local, remote, err)
+		log.Printf("rafthttp: failed to %s %s in %s: %v", err.op, remote, worker, err)
 	}
 }
 

--- a/rafthttp/report.go
+++ b/rafthttp/report.go
@@ -1,0 +1,86 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rafthttp
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/coreos/etcd/pkg/types"
+)
+
+const (
+	errBackoffTime = 10 * time.Second
+)
+
+var (
+	linkErrMapMu sync.Mutex
+	linkErrMap   = make(map[linkName]linkErr)
+)
+
+type linkName struct {
+	local, remote types.ID
+	worker        string
+}
+
+type linkErr struct {
+	err  *opError
+	last time.Time
+}
+
+func reportOpError(local, remote types.ID, worker string, err *opError) {
+	linkErrMapMu.Lock()
+	defer linkErrMapMu.Unlock()
+	name := linkName{local: local, remote: remote, worker: worker}
+	now := time.Now()
+	if !err.equal(linkErrMap[name].err) || now.Sub(linkErrMap[name].last) > errBackoffTime {
+		linkErrMap[name] = linkErr{err: err, last: now}
+		log.Printf("rafthttp: encountered error sending messages in %s from %s to %s: %v", worker, local, remote, err)
+	}
+}
+
+// opError is the error type passed in the package that describing the
+// operation, worker type, remote id and address of an error.
+type opError struct {
+	// op is the operation which caused the error, such as
+	// "read" or "write".
+	op string
+	// addr is the network address on which this error occurred.
+	addr string
+	// err is the error that occurred during the operation.
+	err error
+}
+
+func newOpError(op string, addr string, err error) *opError {
+	return &opError{
+		op:   op,
+		addr: addr,
+		err:  err,
+	}
+}
+
+func (e *opError) Error() string {
+	if netErr, ok := e.err.(*net.OpError); ok {
+		return netErr.Error()
+	}
+	return fmt.Sprintf("%s %s: %s", e.op, e.addr, e.err)
+}
+
+func (e *opError) equal(ee *opError) bool {
+	return ee != nil && e.op == ee.op && e.addr == ee.addr && e.err.Error() == ee.err.Error()
+}

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -149,6 +149,7 @@ func (cw *streamWriter) run() {
 			cw.closer = conn.Closer
 			cw.working = true
 			cw.mu.Unlock()
+			log.Printf("rafthttp: start sending messages in %s to %s", cw.name(), cw.remote)
 			heartbeatc, msgc = tickc, cw.msgc
 		case <-cw.stopc:
 			cw.resetCloser()
@@ -229,6 +230,7 @@ func (cr *streamReader) run() {
 		if err != nil {
 			reportOpError(cr.local, cr.remote, cr.name(), newOpError("connect", cr.u, err))
 		} else {
+			log.Printf("rafthttp: start receiving messages in %s from %s", cr.name(), cr.remote)
 			err := cr.decodeLoop(rc)
 			if err != io.EOF && !isClosedConnectionError(err) {
 				reportOpError(cr.local, cr.remote, cr.name(), newOpError("decode", cr.u, err))

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -52,6 +52,7 @@ func isLinkHeartbeatMessage(m raftpb.Message) bool {
 }
 
 type outgoingConn struct {
+	addr    string
 	t       streamType
 	termStr string
 	io.Writer
@@ -62,7 +63,10 @@ type outgoingConn struct {
 // streamWriter is a long-running worker that writes messages into the
 // attached outgoingConn.
 type streamWriter struct {
-	fs *stats.FollowerStats
+	local  types.ID
+	remote types.ID
+	t      streamType
+	fs     *stats.FollowerStats
 
 	mu      sync.Mutex // guard field working and closer
 	closer  io.Closer
@@ -74,13 +78,16 @@ type streamWriter struct {
 	done  chan struct{}
 }
 
-func startStreamWriter(fs *stats.FollowerStats) *streamWriter {
+func startStreamWriter(local, remote types.ID, t streamType, fs *stats.FollowerStats) *streamWriter {
 	w := &streamWriter{
-		fs:    fs,
-		msgc:  make(chan raftpb.Message, streamBufSize),
-		connc: make(chan *outgoingConn),
-		stopc: make(chan struct{}),
-		done:  make(chan struct{}),
+		local:  local,
+		remote: remote,
+		t:      t,
+		fs:     fs,
+		msgc:   make(chan raftpb.Message, streamBufSize),
+		connc:  make(chan *outgoingConn),
+		stopc:  make(chan struct{}),
+		done:   make(chan struct{}),
 	}
 	go w.run()
 	return w
@@ -89,7 +96,7 @@ func startStreamWriter(fs *stats.FollowerStats) *streamWriter {
 func (cw *streamWriter) run() {
 	var msgc chan raftpb.Message
 	var heartbeatc <-chan time.Time
-	var t streamType
+	var addr string
 	var msgAppTerm uint64
 	var enc encoder
 	var flusher http.Flusher
@@ -99,14 +106,14 @@ func (cw *streamWriter) run() {
 		select {
 		case <-heartbeatc:
 			if err := enc.encode(linkHeartbeatMessage); err != nil {
-				log.Printf("rafthttp: failed to heartbeat on stream %s due to %v. waiting for a new stream to be established.", t, err)
 				cw.resetCloser()
+				reportOpError(cw.local, cw.remote, cw.name(), newOpError("heartbeat", addr, err))
 				heartbeatc, msgc = nil, nil
 				continue
 			}
 			flusher.Flush()
 		case m := <-msgc:
-			if t == streamTypeMsgApp && m.Term != msgAppTerm {
+			if cw.t == streamTypeMsgApp && m.Term != msgAppTerm {
 				// TODO: reasonable retry logic
 				if m.Term > msgAppTerm {
 					cw.resetCloser()
@@ -115,16 +122,16 @@ func (cw *streamWriter) run() {
 				continue
 			}
 			if err := enc.encode(m); err != nil {
-				log.Printf("rafthttp: failed to send message on stream %s due to %v. waiting for a new stream to be established.", t, err)
 				cw.resetCloser()
+				reportOpError(cw.local, cw.remote, cw.name(), newOpError("encode", addr, err))
 				heartbeatc, msgc = nil, nil
 				continue
 			}
 			flusher.Flush()
 		case conn := <-cw.connc:
 			cw.resetCloser()
-			t = conn.t
-			switch conn.t {
+			addr = conn.addr
+			switch cw.t {
 			case streamTypeMsgApp:
 				var err error
 				msgAppTerm, err = strconv.ParseUint(conn.termStr, 10, 64)
@@ -135,7 +142,7 @@ func (cw *streamWriter) run() {
 			case streamTypeMessage:
 				enc = &messageEncoder{w: conn.Writer}
 			default:
-				log.Panicf("rafthttp: unhandled stream type %s", conn.t)
+				log.Panicf("rafthttp: unhandled stream type %s", cw.t)
 			}
 			flusher = conn.Flusher
 			cw.mu.Lock()
@@ -180,15 +187,17 @@ func (cw *streamWriter) stop() {
 	<-cw.done
 }
 
+func (cw *streamWriter) name() string { return "stream " + string(cw.t) }
+
 // streamReader is a long-running go-routine that dials to the remote stream
 // endponit and reads messages from the response body returned.
 type streamReader struct {
-	tr       http.RoundTripper
-	u        string
-	t        streamType
-	from, to types.ID
-	cid      types.ID
-	recvc    chan<- raftpb.Message
+	tr            http.RoundTripper
+	u             string
+	t             streamType
+	local, remote types.ID
+	cid           types.ID
+	recvc         chan<- raftpb.Message
 
 	mu         sync.Mutex
 	msgAppTerm uint64
@@ -198,17 +207,17 @@ type streamReader struct {
 	done       chan struct{}
 }
 
-func startStreamReader(tr http.RoundTripper, u string, t streamType, from, to, cid types.ID, recvc chan<- raftpb.Message) *streamReader {
+func startStreamReader(tr http.RoundTripper, u string, t streamType, local, remote, cid types.ID, recvc chan<- raftpb.Message) *streamReader {
 	r := &streamReader{
-		tr:    tr,
-		u:     u,
-		t:     t,
-		from:  from,
-		to:    to,
-		cid:   cid,
-		recvc: recvc,
-		stopc: make(chan struct{}),
-		done:  make(chan struct{}),
+		tr:     tr,
+		u:      u,
+		t:      t,
+		local:  local,
+		remote: remote,
+		cid:    cid,
+		recvc:  recvc,
+		stopc:  make(chan struct{}),
+		done:   make(chan struct{}),
 	}
 	go r.run()
 	return r
@@ -218,11 +227,11 @@ func (cr *streamReader) run() {
 	for {
 		rc, err := cr.roundtrip()
 		if err != nil {
-			log.Printf("rafthttp: roundtripping error: %v", err)
+			reportOpError(cr.local, cr.remote, cr.name(), newOpError("connect", cr.u, err))
 		} else {
 			err := cr.decodeLoop(rc)
 			if err != io.EOF && !isClosedConnectionError(err) {
-				log.Printf("rafthttp: failed to read message on stream %s due to %v", cr.t, err)
+				reportOpError(cr.local, cr.remote, cr.name(), newOpError("decode", cr.u, err))
 			}
 		}
 		select {
@@ -241,7 +250,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser) error {
 	cr.mu.Lock()
 	switch cr.t {
 	case streamTypeMsgApp:
-		dec = &msgAppDecoder{r: rc, local: cr.from, remote: cr.to, term: cr.msgAppTerm}
+		dec = &msgAppDecoder{r: rc, local: cr.local, remote: cr.remote, term: cr.msgAppTerm}
 	case streamTypeMessage:
 		dec = &messageDecoder{r: rc}
 	default:
@@ -312,23 +321,23 @@ func (cr *streamReader) roundtrip() (io.ReadCloser, error) {
 
 	uu, err := url.Parse(u)
 	if err != nil {
-		return nil, fmt.Errorf("parse url %s error: %v", u, err)
+		return nil, err
 	}
 	switch cr.t {
 	case streamTypeMsgApp:
 		// for backward compatibility of v2.0
-		uu.Path = path.Join(RaftStreamPrefix, cr.from.String())
+		uu.Path = path.Join(RaftStreamPrefix, cr.local.String())
 	case streamTypeMessage:
-		uu.Path = path.Join(RaftStreamPrefix, string(streamTypeMessage), cr.from.String())
+		uu.Path = path.Join(RaftStreamPrefix, string(streamTypeMessage), cr.local.String())
 	default:
 		log.Panicf("rafthttp: unhandled stream type %v", cr.t)
 	}
 	req, err := http.NewRequest("GET", uu.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("new request to %s error: %v", u, err)
+		return nil, err
 	}
 	req.Header.Set("X-Etcd-Cluster-ID", cr.cid.String())
-	req.Header.Set("X-Raft-To", cr.to.String())
+	req.Header.Set("X-Raft-To", cr.remote.String())
 	if cr.t == streamTypeMsgApp {
 		req.Header.Set("X-Raft-Term", strconv.FormatUint(term, 10))
 	}
@@ -337,7 +346,7 @@ func (cr *streamReader) roundtrip() (io.ReadCloser, error) {
 	cr.mu.Unlock()
 	resp, err := cr.tr.RoundTrip(req)
 	if err != nil {
-		return nil, fmt.Errorf("error roundtripping to %s: %v", req.URL, err)
+		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
@@ -358,6 +367,8 @@ func (cr *streamReader) resetCloser() {
 	}
 	cr.closer = nil
 }
+
+func (cr *streamReader) name() string { return "stream " + string(cr.t) }
 
 func canUseMsgAppStream(m raftpb.Message) bool {
 	return m.Type == raftpb.MsgApp && m.Term == m.LogTerm


### PR DESCRIPTION
1. use uniform log format
2. improve log in stream
3. not print duplicate log line

The log to start 2 members in 3-member cluster:
```
13:30:47 etcd1 | 2015/02/25 13:30:47 rafthttp: encountered error in stream msgapp from a8266ecf031671f3 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:30:47 etcd2 | 2015/02/25 13:30:47 rafthttp: encountered error in stream msgapp from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:30:47 etcd2 | 2015/02/25 13:30:47 rafthttp: encountered error in stream message from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:30:49 etcd2 | 2015/02/25 13:30:49 rafthttp: encountered error in pipeline from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:30:57 etcd1 | 2015/02/25 13:30:57 rafthttp: encountered error in stream msgapp from a8266ecf031671f3 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:30:57 etcd1 | 2015/02/25 13:30:57 rafthttp: encountered error in stream message from a8266ecf031671f3 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:30:57 etcd2 | 2015/02/25 13:30:57 rafthttp: encountered error in stream message from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:30:57 etcd2 | 2015/02/25 13:30:57 rafthttp: encountered error in stream msgapp from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:30:59 etcd2 | 2015/02/25 13:30:59 rafthttp: encountered error in pipeline from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:07 etcd1 | 2015/02/25 13:31:07 rafthttp: encountered error in stream message from a8266ecf031671f3 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:07 etcd1 | 2015/02/25 13:31:07 rafthttp: encountered error in stream msgapp from a8266ecf031671f3 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:08 etcd2 | 2015/02/25 13:31:08 rafthttp: encountered error in stream msgapp from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:08 etcd2 | 2015/02/25 13:31:08 rafthttp: encountered error in stream message from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:09 etcd2 | 2015/02/25 13:31:09 rafthttp: encountered error in pipeline from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:17 etcd1 | 2015/02/25 13:31:17 rafthttp: encountered error in stream msgapp from a8266ecf031671f3 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:17 etcd1 | 2015/02/25 13:31:17 rafthttp: encountered error in stream message from a8266ecf031671f3 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:18 etcd2 | 2015/02/25 13:31:18 rafthttp: encountered error in stream message from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:18 etcd2 | 2015/02/25 13:31:18 rafthttp: encountered error in stream msgapp from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
13:31:19 etcd2 | 2015/02/25 13:31:19 rafthttp: encountered error in pipeline from 6e3bd23ae5f1eae0 to 924e2e83e93f2560: dial tcp 127.0.0.1:7003: connection refused
```