### PR TITLE
etcdtcl: fix etcdctl cluster-health ignores SSL settings

### DIFF
--- a/etcdctl/command/cluster_health.go
+++ b/etcdctl/command/cluster_health.go
@@ -54,6 +54,7 @@ func handleClusterHealth(c *cli.Context) {
 
 	// is raft stable and making progress?
 	client = etcd.NewClient([]string{ep})
+	client.SetTransport(tr)
 	resp, err := client.Get("/", false, false)
 	if err != nil {
 		fmt.Println("cluster is unhealthy")


### PR DESCRIPTION
etcdctl reconnects to the leader, but was not picking up ssl settings in this
case, which causes it to show unhealthy when this is not the case.

Fixes #2373