### PR TITLE
rafthttp: add test and bench

### DIFF
--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -42,11 +42,15 @@ func NewHandler(r Raft, cid types.ID) http.Handler {
 	}
 }
 
-func newStreamHandler(tr *transport, id, cid types.ID) http.Handler {
+type peerGetter interface {
+	Peer(id types.ID) Peer
+}
+
+func newStreamHandler(peerGetter peerGetter, id, cid types.ID) http.Handler {
 	return &streamHandler{
-		tr:  tr,
-		id:  id,
-		cid: cid,
+		peerGetter: peerGetter,
+		id:         id,
+		cid:        cid,
 	}
 }
 
@@ -105,9 +109,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type streamHandler struct {
-	tr  *transport
-	id  types.ID
-	cid types.ID
+	peerGetter peerGetter
+	id         types.ID
+	cid        types.ID
 }
 
 func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -139,7 +143,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid from", http.StatusNotFound)
 		return
 	}
-	p := h.tr.Peer(from)
+	p := h.peerGetter.Peer(from)
 	if p == nil {
 		log.Printf("rafthttp: fail to find sender %s", from)
 		http.Error(w, "error sender not found", http.StatusNotFound)

--- a/rafthttp/http_test.go
+++ b/rafthttp/http_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/pkg/pbutil"
@@ -154,6 +155,162 @@ func TestServeRaftPrefix(t *testing.T) {
 	}
 }
 
+func TestServeRaftStreamPrefix(t *testing.T) {
+	tests := []struct {
+		path  string
+		wtype streamType
+	}{
+		{
+			RaftStreamPrefix + "/message/1",
+			streamTypeMessage,
+		},
+		{
+			RaftStreamPrefix + "/msgapp/1",
+			streamTypeMsgApp,
+		},
+		// backward compatibility
+		{
+			RaftStreamPrefix + "/1",
+			streamTypeMsgApp,
+		},
+	}
+	for i, tt := range tests {
+		req, err := http.NewRequest("GET", "http://localhost:7001"+tt.path, nil)
+		if err != nil {
+			t.Fatalf("#%d: could not create request: %#v", i, err)
+		}
+		req.Header.Set("X-Etcd-Cluster-ID", "1")
+		req.Header.Set("X-Raft-To", "2")
+		req.Header.Set("X-Raft-Term", "1")
+		rw := httptest.NewRecorder()
+		peer := newPeerRecorder()
+		peerGetter := &resPeerGetter{peers: map[types.ID]Peer{types.ID(1): peer}}
+		h := newStreamHandler(peerGetter, types.ID(2), types.ID(1))
+		go h.ServeHTTP(rw, req)
+
+		var conn *outgoingConn
+		select {
+		case conn = <-peer.connc:
+		case <-time.After(time.Second):
+			t.Fatalf("#%d: failed to attach outgoingConn", i)
+		}
+		if conn.t != tt.wtype {
+			t.Errorf("$%d: type = %s, want %s", i, conn.t, tt.wtype)
+		}
+		if conn.termStr != "1" {
+			t.Errorf("$%d: term = %s, want 1", i, conn.termStr)
+		}
+		conn.Close()
+	}
+}
+
+func TestServeRaftStreamPrefixBad(t *testing.T) {
+	tests := []struct {
+		method    string
+		path      string
+		clusterID string
+		remote    string
+
+		wcode int
+	}{
+		// bad method
+		{
+			"PUT",
+			RaftStreamPrefix + "/message/1",
+			"1",
+			"1",
+			http.StatusMethodNotAllowed,
+		},
+		// bad method
+		{
+			"POST",
+			RaftStreamPrefix + "/message/1",
+			"1",
+			"1",
+			http.StatusMethodNotAllowed,
+		},
+		// bad method
+		{
+			"DELETE",
+			RaftStreamPrefix + "/message/1",
+			"1",
+			"1",
+			http.StatusMethodNotAllowed,
+		},
+		// bad path
+		{
+			"GET",
+			RaftStreamPrefix + "/strange/1",
+			"1",
+			"1",
+			http.StatusNotFound,
+		},
+		// bad path
+		{
+			"GET",
+			RaftStreamPrefix + "/strange",
+			"1",
+			"1",
+			http.StatusNotFound,
+		},
+		// non-existant peer
+		{
+			"GET",
+			RaftStreamPrefix + "/message/2",
+			"1",
+			"1",
+			http.StatusNotFound,
+		},
+		// wrong cluster ID
+		{
+			"GET",
+			RaftStreamPrefix + "/message/1",
+			"2",
+			"1",
+			http.StatusPreconditionFailed,
+		},
+		// wrong remote id
+		{
+			"GET",
+			RaftStreamPrefix + "/message/1",
+			"1",
+			"2",
+			http.StatusPreconditionFailed,
+		},
+	}
+	for i, tt := range tests {
+		req, err := http.NewRequest(tt.method, "http://localhost:7001"+tt.path, nil)
+		if err != nil {
+			t.Fatalf("#%d: could not create request: %#v", i, err)
+		}
+		req.Header.Set("X-Etcd-Cluster-ID", tt.clusterID)
+		req.Header.Set("X-Raft-To", tt.remote)
+		rw := httptest.NewRecorder()
+		peerGetter := &resPeerGetter{peers: map[types.ID]Peer{types.ID(1): newPeerRecorder()}}
+		h := newStreamHandler(peerGetter, types.ID(1), types.ID(1))
+		h.ServeHTTP(rw, req)
+
+		if rw.Code != tt.wcode {
+			t.Errorf("#%d: code = %d, want %d", i, rw.Code, tt.wcode)
+		}
+	}
+}
+
+func TestCloseNotifier(t *testing.T) {
+	c := newCloseNotifier()
+	select {
+	case <-c.closeNotify():
+		t.Fatalf("unexpected close notify")
+	default:
+	}
+	c.Close()
+	select {
+	case <-c.closeNotify():
+	default:
+		t.Fatalf("failed to get close notify")
+	}
+}
+
 // errReader implements io.Reader to facilitate a broken request.
 type errReader struct{}
 
@@ -175,3 +332,24 @@ type resWriterToError struct {
 
 func (e *resWriterToError) Error() string                 { return "" }
 func (e *resWriterToError) WriteTo(w http.ResponseWriter) { w.WriteHeader(e.code) }
+
+type resPeerGetter struct {
+	peers map[types.ID]Peer
+}
+
+func (pg *resPeerGetter) Peer(id types.ID) Peer { return pg.peers[id] }
+
+type peerRecorder struct {
+	connc chan *outgoingConn
+}
+
+func newPeerRecorder() *peerRecorder {
+	return &peerRecorder{
+		connc: make(chan *outgoingConn, 1),
+	}
+}
+
+func (pr *peerRecorder) Send(m raftpb.Message)                 {}
+func (pr *peerRecorder) Update(u string)                       {}
+func (pr *peerRecorder) attachOutgoingConn(conn *outgoingConn) { pr.connc <- conn }
+func (pr *peerRecorder) Stop()                                 {}

--- a/rafthttp/http_test.go
+++ b/rafthttp/http_test.go
@@ -340,6 +340,8 @@ type resPeerGetter struct {
 func (pg *resPeerGetter) Peer(id types.ID) Peer { return pg.peers[id] }
 
 type peerRecorder struct {
+	msgs  []raftpb.Message
+	u     string
 	connc chan *outgoingConn
 }
 
@@ -349,7 +351,7 @@ func newPeerRecorder() *peerRecorder {
 	}
 }
 
-func (pr *peerRecorder) Send(m raftpb.Message)                 {}
-func (pr *peerRecorder) Update(u string)                       {}
+func (pr *peerRecorder) Send(m raftpb.Message)                 { pr.msgs = append(pr.msgs, m) }
+func (pr *peerRecorder) Update(u string)                       { pr.u = u }
 func (pr *peerRecorder) attachOutgoingConn(conn *outgoingConn) { pr.connc <- conn }
 func (pr *peerRecorder) Stop()                                 {}

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -33,6 +33,13 @@ const (
 	recvBufSize = 4096
 )
 
+type Peer interface {
+	Send(m raftpb.Message)
+	Update(u string)
+	attachOutgoingConn(conn *outgoingConn)
+	Stop()
+}
+
 // peer is the representative of a remote raft node. Local raft node sends
 // messages to the remote through peer.
 // Each peer has two underlying mechanisms to send out a message: stream and

--- a/rafthttp/peer_test.go
+++ b/rafthttp/peer_test.go
@@ -1,0 +1,87 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rafthttp
+
+import (
+	"testing"
+
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+func TestPeerPick(t *testing.T) {
+	tests := []struct {
+		msgappWorking  bool
+		messageWorking bool
+		m              raftpb.Message
+		wname          string
+	}{
+		{
+			true, true,
+			raftpb.Message{Type: raftpb.MsgApp, Term: 1, LogTerm: 1},
+			"msgapp stream",
+		},
+		{
+			true, true,
+			raftpb.Message{Type: raftpb.MsgProp},
+			"general stream",
+		},
+		{
+			true, true,
+			raftpb.Message{Type: raftpb.MsgSnap},
+			"general stream",
+		},
+		{
+			true, true,
+			raftpb.Message{Type: raftpb.MsgHeartbeat},
+			"general stream",
+		},
+		{
+			false, true,
+			raftpb.Message{Type: raftpb.MsgApp, Term: 1, LogTerm: 1},
+			"general stream",
+		},
+		{
+			false, false,
+			raftpb.Message{Type: raftpb.MsgApp, Term: 1, LogTerm: 1},
+			"pipeline",
+		},
+		{
+			false, false,
+			raftpb.Message{Type: raftpb.MsgProp},
+			"pipeline",
+		},
+		{
+			false, false,
+			raftpb.Message{Type: raftpb.MsgSnap},
+			"pipeline",
+		},
+		{
+			false, false,
+			raftpb.Message{Type: raftpb.MsgHeartbeat},
+			"pipeline",
+		},
+	}
+	for i, tt := range tests {
+		peer := &peer{
+			msgAppWriter: &streamWriter{working: tt.msgappWorking},
+			writer:       &streamWriter{working: tt.messageWorking},
+			pipeline:     &pipeline{},
+		}
+		_, name, _ := peer.pick(tt.m)
+		if name != tt.wname {
+			t.Errorf("#%d: name = %v, want %v", i, name, tt.wname)
+		}
+	}
+}

--- a/rafthttp/stream_test.go
+++ b/rafthttp/stream_test.go
@@ -1,0 +1,191 @@
+package rafthttp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/coreos/etcd/etcdserver/stats"
+	"github.com/coreos/etcd/pkg/testutil"
+	"github.com/coreos/etcd/pkg/types"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+// TestStreamWriterAttachOutgoingConn tests that outgoingConn can be attached
+// to streamWriter. After that, streamWriter can use it to send messages
+// continuously, and closes it when stopped.
+func TestStreamWriterAttachOutgoingConn(t *testing.T) {
+	sw := startStreamWriter(&stats.FollowerStats{})
+	// it is not in working status now
+	if g := sw.isWorking(); g != false {
+		t.Errorf("working = %v, want false", g)
+	}
+
+	wfc := &nopWriteFlushCloser{}
+	sw.attach(&outgoingConn{t: streamTypeMessage, Writer: wfc, Flusher: wfc, Closer: wfc})
+	// starts to working
+	if g := sw.isWorking(); g != true {
+		t.Errorf("working = %v, want true", g)
+	}
+
+	sw.msgc <- raftpb.Message{}
+	testutil.ForceGosched()
+	// still working
+	if g := sw.isWorking(); g != true {
+		t.Errorf("working = %v, want true", g)
+	}
+	if wfc.written != true {
+		t.Errorf("failed to write to the underlying connection")
+	}
+
+	sw.stop()
+	// no longer in working status now
+	if g := sw.isWorking(); g != false {
+		t.Errorf("working = %v, want false", g)
+	}
+	if wfc.closed != true {
+		t.Errorf("failed to close the underlying connection")
+	}
+}
+
+// TestStreamWriterAttachBadOutgoingConn tests that streamWriter with bad
+// outgoingConn will close the outgoingConn and fall back to non-working status.
+func TestStreamWriterAttachBadOutgoingConn(t *testing.T) {
+	sw := startStreamWriter(&stats.FollowerStats{})
+	defer sw.stop()
+	wfc := &errWriteFlushCloser{err: errors.New("blah")}
+	sw.attach(&outgoingConn{t: streamTypeMessage, Writer: wfc, Flusher: wfc, Closer: wfc})
+
+	sw.msgc <- raftpb.Message{}
+	testutil.ForceGosched()
+	// no longer working
+	if g := sw.isWorking(); g != false {
+		t.Errorf("working = %v, want false", g)
+	}
+	if wfc.closed != true {
+		t.Errorf("failed to close the underlying connection")
+	}
+}
+
+func TestStreamReaderRoundtrip(t *testing.T) {
+	tr := &roundTripperRecorder{}
+	sr := &streamReader{
+		tr:   tr,
+		u:    "http://localhost:7001",
+		t:    streamTypeMessage,
+		from: types.ID(1),
+		to:   types.ID(2),
+		cid:  types.ID(1),
+	}
+	sr.roundtrip()
+
+	req := tr.Request()
+	if w := "http://localhost:7001/raft/stream/message/1"; req.URL.String() != w {
+		t.Errorf("url = %s, want %s", req.URL.String(), w)
+	}
+	if w := "GET"; req.Method != w {
+		t.Errorf("method = %s, want %s", req.Method, w)
+	}
+	if g := req.Header.Get("X-Etcd-Cluster-ID"); g != "1" {
+		t.Errorf("header X-Etcd-Cluster-ID = %s, want 1", g)
+	}
+	if g := req.Header.Get("X-Raft-To"); g != "2" {
+		t.Errorf("header X-Raft-To = %s, want 2", g)
+	}
+}
+
+// TestStream tests that streamReader and streamWriter can build stream to
+// send messages between each other.
+func TestStream(t *testing.T) {
+	tests := []struct {
+		t    streamType
+		term uint64
+		m    raftpb.Message
+	}{
+		{
+			streamTypeMessage,
+			0,
+			raftpb.Message{Type: raftpb.MsgProp, To: 2},
+		},
+		{
+			streamTypeMsgApp,
+			1,
+			raftpb.Message{
+				Type:    raftpb.MsgApp,
+				From:    2,
+				To:      1,
+				Term:    1,
+				LogTerm: 1,
+				Index:   3,
+				Entries: []raftpb.Entry{{Term: 1, Index: 4}},
+			},
+		},
+	}
+	for i, tt := range tests {
+		h := &fakeStreamHandler{t: tt.t}
+		srv := httptest.NewServer(h)
+		defer srv.Close()
+		sw := startStreamWriter(&stats.FollowerStats{})
+		defer sw.stop()
+		h.sw = sw
+		recvc := make(chan raftpb.Message)
+		sr := startStreamReader(&http.Transport{}, srv.URL, tt.t, types.ID(1), types.ID(2), types.ID(1), recvc)
+		defer sr.stop()
+		if tt.t == streamTypeMsgApp {
+			sr.updateMsgAppTerm(tt.term)
+		}
+
+		sw.msgc <- tt.m
+		m := <-recvc
+		if !reflect.DeepEqual(m, tt.m) {
+			t.Errorf("#%d: message = %+v, want %+v", i, m, tt.m)
+		}
+	}
+}
+
+type nopWriteFlushCloser struct {
+	written bool
+	closed  bool
+}
+
+func (wfc *nopWriteFlushCloser) Write(p []byte) (n int, err error) {
+	wfc.written = true
+	return len(p), nil
+}
+func (wfc *nopWriteFlushCloser) Flush() {}
+func (wfc *nopWriteFlushCloser) Close() error {
+	wfc.closed = true
+	return nil
+}
+
+type errWriteFlushCloser struct {
+	err    error
+	closed bool
+}
+
+func (wfc *errWriteFlushCloser) Write(p []byte) (n int, err error) { return 0, wfc.err }
+func (wfc *errWriteFlushCloser) Flush()                            {}
+func (wfc *errWriteFlushCloser) Close() error {
+	wfc.closed = true
+	return wfc.err
+}
+
+type fakeStreamHandler struct {
+	t  streamType
+	sw *streamWriter
+}
+
+func (h *fakeStreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.(http.Flusher).Flush()
+	c := newCloseNotifier()
+	h.sw.attach(&outgoingConn{
+		t:       h.t,
+		termStr: r.Header.Get("X-Raft-Term"),
+		Writer:  w,
+		Flusher: w.(http.Flusher),
+		Closer:  c,
+	})
+	<-c.closeNotify()
+}

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -75,7 +75,7 @@ func (t *transport) Handler() http.Handler {
 	return mux
 }
 
-func (t *transport) Peer(id types.ID) *peer {
+func (t *transport) Peer(id types.ID) Peer {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.peers[id]

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -48,8 +48,8 @@ type transport struct {
 	serverStats  *stats.ServerStats
 	leaderStats  *stats.LeaderStats
 
-	mu     sync.RWMutex       // protect the peer map
-	peers  map[types.ID]*peer // remote peers
+	mu     sync.RWMutex      // protect the peer map
+	peers  map[types.ID]Peer // remote peers
 	errorc chan error
 }
 
@@ -61,7 +61,7 @@ func NewTransporter(rt http.RoundTripper, id, cid types.ID, r Raft, errorc chan 
 		raft:         r,
 		serverStats:  ss,
 		leaderStats:  ls,
-		peers:        make(map[types.ID]*peer),
+		peers:        make(map[types.ID]Peer),
 		errorc:       errorc,
 	}
 }
@@ -159,12 +159,12 @@ type Pausable interface {
 // for testing
 func (t *transport) Pause() {
 	for _, p := range t.peers {
-		p.Pause()
+		p.(Pausable).Pause()
 	}
 }
 
 func (t *transport) Resume() {
 	for _, p := range t.peers {
-		p.Resume()
+		p.(Pausable).Resume()
 	}
 }

--- a/rafthttp/transport_bench_test.go
+++ b/rafthttp/transport_bench_test.go
@@ -1,0 +1,70 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rafthttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/etcdserver/stats"
+	"github.com/coreos/etcd/pkg/types"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+func BenchmarkStandaloneTransport(b *testing.B) {
+	p := &countProcessor{}
+	ss := &stats.ServerStats{}
+	ss.Initialize()
+	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), p, nil, ss, stats.NewLeaderStats("1"))
+	srv := httptest.NewServer(tr.Handler())
+	defer srv.Close()
+	tr.AddPeer(types.ID(1), []string{srv.URL})
+	defer tr.Stop()
+	time.Sleep(time.Second)
+
+	data := make([]byte, 64)
+	b.ReportAllocs()
+	b.SetBytes(64)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tr.Send([]raftpb.Message{{Type: raftpb.MsgApp, To: 1, Entries: []raftpb.Entry{{Data: data}}}})
+	}
+	for p.count() != b.N {
+		time.Sleep(time.Millisecond)
+	}
+	b.StopTimer()
+}
+
+type countProcessor struct {
+	mu  sync.Mutex
+	cnt int
+}
+
+func (p *countProcessor) Process(ctx context.Context, m raftpb.Message) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cnt++
+	return nil
+}
+
+func (p *countProcessor) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.cnt
+}

--- a/test
+++ b/test
@@ -15,12 +15,16 @@ COVER=${COVER:-"-cover"}
 source ./build
 
 # Hack: gofmt ./ will recursively check the .git directory. So use *.go for gofmt.
-TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes migrate pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft rafthttp snap store wal"
-FORMATTABLE="$TESTABLE_AND_FORMATTABLE *.go etcdctl/ integration"
+TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes migrate pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft snap store wal"
+# TODO: add it to race testing when the issue is resolved
+# https://github.com/golang/go/issues/9946
+NO_RACE_TESTABLE="rafthttp"
+FORMATTABLE="$TESTABLE_AND_FORMATTABLE $NO_RACE_TESTABLE *.go etcdctl/ integration"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then
 	TEST=$TESTABLE_AND_FORMATTABLE
+	NO_RACE_TEST=$NO_RACE_TESTABLE
 	FMT=$FORMATTABLE
 
 # user has provided PKG override
@@ -37,9 +41,12 @@ fi
 # split TEST into an array and prepend REPO_PATH to each local package
 split=(${TEST// / })
 TEST=${split[@]/#/${REPO_PATH}/}
+split=(${NO_RACE_TEST// / })
+NO_RACE_TEST=${split[@]/#/${REPO_PATH}/}
 
 echo "Running tests..."
 go test -timeout 3m ${COVER} $@ ${TEST} --race
+go test -timeout 3m ${COVER} $@ ${NO_RACE_TEST}
 
 if [ -n "$INTEGRATION" ]; then
 	echo "Running integration tests..."


### PR DESCRIPTION
The result of benchmark to send 64-byte-data msgapp to itself:
```
BenchmarkStandaloneTransport	  100000	     12916 ns/op	   4.95 MB/s	     840 B/op	      18 allocs/op
```