### PR TITLE
pkg/transport: set the maxIdleConnsPerHost to -1

### DIFF
--- a/pkg/transport/timeout_transport.go
+++ b/pkg/transport/timeout_transport.go
@@ -28,6 +28,9 @@ func NewTimeoutTransport(info TLSInfo, dialtimeoutd, rdtimeoutd, wtimeoutd time.
 	if err != nil {
 		return nil, err
 	}
+	// the timeouted connection will tiemout soon after it is idle.
+	// it should not be put back to http transport as an idle connection for future usage.
+	tr.MaxIdleConnsPerHost = -1
 	tr.Dial = (&rwTimeoutDialer{
 		Dialer: net.Dialer{
 			Timeout:   dialtimeoutd,


### PR DESCRIPTION
for transport that are using timeout connections, we set the
maxIdleConnsPerHost to -1. The default transport does not clear
the timeout for the connections when it sets the connections to be idle.
So the connections with timeout cannot be reused.