### PR TITLE
etcdctl: update the ls subcommand help to match behavior

### DIFF
--- a/etcdctl/command/ls_command.go
+++ b/etcdctl/command/ls_command.go
@@ -27,7 +27,7 @@ func NewLsCommand() cli.Command {
 		Usage: "retrieve a directory",
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "sort", Usage: "returns result in sorted order"},
-			cli.BoolFlag{Name: "recursive", Usage: "returns all values for key and child keys"},
+			cli.BoolFlag{Name: "recursive", Usage: "returns all key names recursively for the given path"},
 			cli.BoolFlag{Name: "p", Usage: "append slash (/) to directories"},
 		},
 		Action: func(c *cli.Context) {


### PR DESCRIPTION
Currently the `etcdctl ls` subcommand help output is a bit misleading.
It mentions that using the `--recursive` flag will output all keys and
values for a given path:

    --recursive  returns all values for key and child keys

This is inaccurate. The `--recursive` will only output the key names
under the given path. Fix the issue by updating the help string for
the `--recursive` flag.

    --recursive  returns all key names recursively for the given path

Fixes #2379.