### PR TITLE
etcdctl: mark unstarted member

### DIFF
--- a/etcdctl/command/member_commands.go
+++ b/etcdctl/command/member_commands.go
@@ -104,7 +104,11 @@ func actionMemberList(c *cli.Context) {
 	}
 
 	for _, m := range members {
-		fmt.Printf("%s: name=%s peerURLs=%s clientURLs=%s\n", m.ID, m.Name, strings.Join(m.PeerURLs, ","), strings.Join(m.ClientURLs, ","))
+		if len(m.Name) == 0 {
+			fmt.Printf("%s[unstarted]: peerURLs=%s\n", m.ID, strings.Join(m.PeerURLs, ","))
+		} else {
+			fmt.Printf("%s: name=%s peerURLs=%s clientURLs=%s\n", m.ID, m.Name, strings.Join(m.PeerURLs, ","), strings.Join(m.ClientURLs, ","))
+		}
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/2251

after add a member infra4 and before it is started.

before the fix:
```
6e3bd23ae5f1eae0: name=infra2 peerURLs=http://localhost:7002 clientURLs=http://localhost:4002
924e2e83e93f2560: name=infra3 peerURLs=http://localhost:7003 clientURLs=http://localhost:4003
a1855f305e50a3bc: name= peerURLs=http://localhost:7004 clientURLs=
a8266ecf031671f3: name=infra1 peerURLs=http://localhost:7001 clientURLs=http://localhost:4001
```

after the fix:
```
6e3bd23ae5f1eae0: name=infra2 peerURLs=http://localhost:7002 clientURLs=http://localhost:4002
924e2e83e93f2560: name=infra3 peerURLs=http://localhost:7003 clientURLs=http://localhost:4003
a1855f305e50a3bc[unstarted]: peerURLs=http://localhost:7004
a8266ecf031671f3: name=infra1 peerURLs=http://localhost:7001 clientURLs=http://localhost:4001
```

after we start infra4:
```
6e3bd23ae5f1eae0: name=infra2 peerURLs=http://localhost:7002 clientURLs=http://localhost:4002
924e2e83e93f2560: name=infra3 peerURLs=http://localhost:7003 clientURLs=http://localhost:4003
a1855f305e50a3bc: name=infra4 peerURLs=http://localhost:7004 clientURLs=http://localhost:4004
a8266ecf031671f3: name=infra1 peerURLs=http://localhost:7001 clientURLs=http://localhost:4001
```