### PR TITLE
rafttest: fix build error

### DIFF
--- a/raft/rafttest/node.go
+++ b/raft/rafttest/node.go
@@ -59,7 +59,7 @@ func (n *node) start() {
 				n.Step(context.TODO(), m)
 			case <-n.stopc:
 				n.Stop()
-				raftLogger.Infof("raft.%d: stop", n.id)
+				log.Printf("raft.%d: stop", n.id)
 				n.Node = nil
 				close(n.stopc)
 				return


### PR DESCRIPTION
raftLogger is not exported so we can't access it from here. Go back to
using log.