### PR TITLE
logging: add flag to disable timestamps on log messages

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -141,6 +141,12 @@ Be CAUTIOUS to use unsafe flags because it will break the guarantee given by con
 + Force to create a new one-member cluster. It commits configuration changes in force to remove all existing members in the cluster and add itself. It needs to be set to [restore a backup][restore].
 + default: false
 
+### Logging Flags
+
+#### -disable-log-timestamps
++ Disable writing timestamps in logs.
++ default: false
+
 ### Miscellaneous Flags
 
 ##### -version

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -99,6 +99,9 @@ type config struct {
 	// unsafe
 	forceNewCluster bool
 
+	// logging
+	disableLogTimestamps bool
+
 	printVersion bool
 
 	ignored []string
@@ -178,6 +181,9 @@ func NewConfig() *config {
 
 	// unsafe
 	fs.BoolVar(&cfg.forceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster")
+
+	// logging
+	fs.BoolVar(&cfg.disableLogTimestamps, "disable-log-timestamps", false, "Disable writing timestamps in logs.")
 
 	// version
 	fs.BoolVar(&cfg.printVersion, "version", false, "Print the version and exit")

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/etcdhttp"
 	"github.com/coreos/etcd/pkg/cors"
+	"github.com/coreos/etcd/pkg/logutil"
 	"github.com/coreos/etcd/pkg/osutil"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/pkg/types"
@@ -50,6 +51,8 @@ func Main() {
 		log.Printf("etcd: error verifying flags, %v", err)
 		os.Exit(2)
 	}
+
+	logutil.InitLogger(&logutil.Config{DisableTimestamps: cfg.disableLogTimestamps})
 
 	var stopped <-chan struct{}
 

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -96,5 +96,11 @@ by consensus protocol.
 	
 	--force-new-cluster 'false'
 		force to create a new one-member cluster.
+
+
+logging flags:
+
+	--disable-log-timestamps 'false'
+		disable writing timestamps in logs.	
 `
 )

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -1,0 +1,39 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import "log"
+
+// Config holds the logger config.
+type Config struct {
+	DisableTimestamps bool
+}
+
+// InitLogger initializes a Logger based on the specified config.
+func InitLogger(config *Config) {
+	flags := getFlags(config)
+	log.SetFlags(flags)
+}
+
+// getFlags returns logger output flags based on configuration.
+func getFlags(config *Config) int {
+	if config == nil {
+		return log.LstdFlags
+	}
+	if config.DisableTimestamps {
+		return 0
+	}
+	return log.LstdFlags
+}

--- a/pkg/logutil/logutil_test.go
+++ b/pkg/logutil/logutil_test.go
@@ -1,0 +1,61 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"log"
+	"testing"
+)
+
+func TestInitLogger(t *testing.T) {
+	initialFlags := log.Flags()
+	defer log.SetFlags(initialFlags)
+
+	tests := []struct {
+		config   *Config
+		expected int
+	}{
+		{&Config{DisableTimestamps: false}, log.LstdFlags},
+		{&Config{DisableTimestamps: true}, 0},
+		{nil, log.LstdFlags},
+	}
+
+	for _, tt := range tests {
+		InitLogger(tt.config)
+		flags := log.Flags()
+
+		if flags != tt.expected {
+			t.Errorf("expected: %v, got %v", tt.expected, flags)
+		}
+	}
+}
+
+func TestGetFlags(t *testing.T) {
+	tests := []struct {
+		config   *Config
+		expected int
+	}{
+		{&Config{DisableTimestamps: false}, log.LstdFlags},
+		{&Config{DisableTimestamps: true}, 0},
+		{nil, log.LstdFlags},
+	}
+
+	for _, tt := range tests {
+		got := getFlags(tt.config)
+		if got != tt.expected {
+			t.Errorf("expected: %v, got %v", tt.expected, got)
+		}
+	}
+}

--- a/test
+++ b/test
@@ -15,7 +15,7 @@ COVER=${COVER:-"-cover"}
 source ./build
 
 # Hack: gofmt ./ will recursively check the .git directory. So use *.go for gofmt.
-TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes migrate pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/osutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft snap store wal"
+TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes migrate pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/logutil pkg/netutil pkg/osutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft snap store wal"
 # TODO: add it to race testing when the issue is resolved
 # https://github.com/golang/go/issues/9946
 NO_RACE_TESTABLE="rafthttp"


### PR DESCRIPTION
Currently etcd includes timestamps on every log entry, which results
in multiple timestamps per log entry when running under systemd.
systemd prepends timestamps to log entries before they are written to
permanent storage.

It is now possible to disable timestamps on log messages by using the
`--disable-log-timestamps` flag.

    etcd --disable-log-timestamps

Fixes #2475.