### PR TITLE
etcdmain: verify heartbeat and election flag

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -255,6 +255,10 @@ func (cfg *config) Parse(arguments []string) error {
 		return errors.New("cannot resolve DNS hostnames.")
 	}
 
+	if 5*cfg.TickMs > cfg.ElectionMs {
+		return fmt.Errorf("-election-timeout[%vms] should be at least as 5 times as -heartbeat-interval[%vms]", cfg.ElectionMs, cfg.TickMs)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
etcdsever/raft requires the election leader timeout to be much greater than heartbeat-interval.

Output as 

```
2015/03/12 17:45:06 etcd: error verifying flags, -election-timeout[1000ms] should be at least as 5 times as -heartbeat-interval[1000ms]
```
instead of just panic.

Fix https://github.com/coreos/etcd/issues/2487