### PR TITLE
etcdserver: create member directory #2504

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"os"
 	"path"
 	"regexp"
 	"sync/atomic"
@@ -198,6 +199,10 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 
 		if err := fileutil.IsDirWriteable(cfg.DataDir); err != nil {
 			return nil, fmt.Errorf("cannot write to data directory: %v", err)
+		}
+
+		if err := os.MkdirAll(cfg.MemberDir(), 0700); err != nil {
+			return nil, fmt.Errorf("cannot create the member directory: %v", err)
 		}
 
 		if err := fileutil.IsDirWriteable(cfg.MemberDir()); err != nil {


### PR DESCRIPTION
The member directory is not created when etcd fallback to proxy if the cluster is full.

etcd output:

```
etcd: listening for client requests on https://0.0.0.0:2379
datadir is valid for the 2.0.1 format
etcd: stopping listening for client requests on https://0.0.0.0:2379
etcd: stopping listening for peers on https://0.0.0.0:2380
etcd: cannot write to member directory: open /root/etcd/member/.touch: no such file or directory