### PR TITLE
Fix alignment for 32 bit compilers

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -71,6 +71,7 @@ type apply struct {
 
 type raftNode struct {
 	// Cache of the latest raft index and raft term the server has seen
+	// uint64 should be aligned to the top of struct, used by 32-bit compilers
 	index uint64
 	term  uint64
 	lead  uint64

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -70,6 +70,11 @@ type apply struct {
 }
 
 type raftNode struct {
+	// Cache of the latest raft index and raft term the server has seen
+	index uint64
+	term  uint64
+	lead  uint64
+
 	raft.Node
 
 	// a chan to send out apply
@@ -89,11 +94,6 @@ type raftNode struct {
 	// clients should timeout and reissue their messages.
 	// If transport is nil, server will panic.
 	transport rafthttp.Transporter
-
-	// Cache of the latest raft index and raft term the server has seen
-	index uint64
-	term  uint64
-	lead  uint64
 }
 
 func (r *raftNode) run() {

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -110,10 +110,10 @@ type Server interface {
 
 // EtcdServer is the production implementation of the Server interface
 type EtcdServer struct {
-	cfg       *ServerConfig
 	snapCount uint64
 
-	r raftNode
+	r   raftNode
+	cfg *ServerConfig
 
 	w          wait.Wait
 	stop       chan struct{}

--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -31,9 +31,9 @@ import (
 // event happens between the end of the first watch command and the start
 // of the second command.
 type watcherHub struct {
+	count        int64 // current number of watchers.
 	mutex        sync.Mutex
 	watchers     map[string]*list.List
-	count        int64 // current number of watchers.
 	EventHistory *EventHistory
 }
 

--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -31,8 +31,9 @@ import (
 // event happens between the end of the first watch command and the start
 // of the second command.
 type watcherHub struct {
-	count        int64 // current number of watchers.
-	mutex        sync.Mutex
+	// count is placed on top of struct, for 32-bit compilers
+	count        int64      // current number of watchers.
+	mutex        sync.Mutex // protects "count"
 	watchers     map[string]*list.List
 	EventHistory *EventHistory
 }


### PR DESCRIPTION
I've managed to run etcd + fleet on odroid u3 (ARM) and wandboard (ARM). It seems to work correctly after these few alignments are changed. I believe this patch won't cause much harm? Anyway it work perfectly fine so far, I've expected more failures due frequent sync but I'm using emmc + ssd memory, so it is not so bad.

I'll make some stress tests in a while.