### PR TITLE
raft: limit the size of msgApp

### DIFF
--- a/raft/multinode_test.go
+++ b/raft/multinode_test.go
@@ -140,7 +140,7 @@ func TestMultiNodePropose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entries, err := s.Entries(lastIndex, lastIndex+1)
+	entries, err := s.Entries(lastIndex, lastIndex+1, noLimit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestMultiNodeProposeConfig(t *testing.T) {
 	}
 	mn.Stop()
 
-	entries, err := s.Entries(lastIndex, lastIndex+1)
+	entries, err := s.Entries(lastIndex, lastIndex+1, noLimit)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -1629,7 +1629,7 @@ func TestStepIgnoreConfig(t *testing.T) {
 	pendingConf := r.pendingConf
 	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
 	wents := []pb.Entry{{Type: pb.EntryNormal, Term: 1, Index: 3, Data: nil}}
-	if ents := r.raftLog.entries(index + 1); !reflect.DeepEqual(ents, wents) {
+	if ents := r.raftLog.entries(index+1, noLimit); !reflect.DeepEqual(ents, wents) {
 		t.Errorf("ents = %+v, want %+v", ents, wents)
 	}
 	if r.pendingConf != pendingConf {

--- a/raft/util.go
+++ b/raft/util.go
@@ -93,3 +93,18 @@ func DescribeEntry(e pb.Entry, f EntryFormatter) string {
 	}
 	return fmt.Sprintf("%d/%d %s %s", e.Term, e.Index, e.Type, formatted)
 }
+
+func limitSize(ents []pb.Entry, maxSize uint64) []pb.Entry {
+	if len(ents) == 0 {
+		return ents
+	}
+	size := ents[0].Size()
+	var limit int
+	for limit = 1; limit < len(ents); limit++ {
+		size += ents[limit].Size()
+		if uint64(size) > maxSize {
+			break
+		}
+	}
+	return ents[:limit]
+}


### PR DESCRIPTION
limit the max size of entries sent per message.
Lower the cost at probing state as we limit the size per message;
lower the penalty when aggressively decrease to a too low next.