### PR TITLE
raft: print out data and time in log

### DIFF
--- a/raft/logger.go
+++ b/raft/logger.go
@@ -44,7 +44,7 @@ type Logger interface {
 func SetLogger(l Logger) { raftLogger = l }
 
 var (
-	defaultLogger = &DefaultLogger{Logger: log.New(os.Stderr, "", 0)}
+	defaultLogger = &DefaultLogger{Logger: log.New(os.Stderr, "", log.LstdFlags)}
 	discardLogger = &DefaultLogger{Logger: log.New(ioutil.Discard, "", 0)}
 	raftLogger    = Logger(defaultLogger)
 )


### PR DESCRIPTION
Keep the default log setting consistent with other packages. 