### PR TITLE
etcdmain: let user provide a name w/o initial-cluster update

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -62,6 +62,10 @@ func Main() {
 
 	var stopped <-chan struct{}
 
+	if cfg.name != defaultName && cfg.initialCluster == initialClusterFromName(defaultName) {
+		cfg.initialCluster = initialClusterFromName(cfg.name)
+	}
+
 	if cfg.dir == "" {
 		cfg.dir = fmt.Sprintf("%v.etcd", cfg.name)
 		log.Printf("etcd: no data-dir provided, using default data-dir ./%s", cfg.dir)


### PR DESCRIPTION
Currently this doesn't work if a user wants to try out a single machine
cluster but change the name for whatever reason. This is because the
name is always "default" and the

```
./bin/etcd -name 'baz'
```

This solves our problem on CoreOS where the default is `ETCD_NAME=%m`.