### PR TITLE
migrate/starter: add tests that start only using name flag

### DIFF
--- a/migrate/functional/member.go
+++ b/migrate/functional/member.go
@@ -63,6 +63,12 @@ func NewProcWithDefaultFlags(path string) *Proc {
 	return p
 }
 
+func NewProcWithName(path, name string) *Proc {
+	p := NewProcWithDefaultFlags(path)
+	p.SetName(name)
+	return p
+}
+
 func NewProcWithV1Flags(path string) *Proc {
 	p := NewProcWithDefaultFlags(path)
 	p.SetV1PeerAddr("127.0.0.1:7001")

--- a/migrate/functional/upgrade_test.go
+++ b/migrate/functional/upgrade_test.go
@@ -43,6 +43,7 @@ func init() {
 func TestStartNewMember(t *testing.T) {
 	tests := []*Proc{
 		NewProcWithDefaultFlags(v2BinPath),
+		NewProcWithName(v2BinPath, "etcd"),
 		NewProcWithV1Flags(v2BinPath),
 		NewProcWithV2Flags(v2BinPath),
 	}
@@ -65,6 +66,7 @@ func TestStartNewMember(t *testing.T) {
 func TestStartV2Member(t *testing.T) {
 	tests := []*Proc{
 		NewProcWithDefaultFlags(v2BinPath),
+		NewProcWithName(v2BinPath, "etcd"),
 		NewProcWithV1Flags(v2BinPath),
 		NewProcWithV2Flags(v2BinPath),
 	}
@@ -94,6 +96,7 @@ func TestStartV2Member(t *testing.T) {
 func TestStartV1Member(t *testing.T) {
 	tests := []*Proc{
 		NewProcWithDefaultFlags(v2BinPath),
+		NewProcWithName(v2BinPath, "etcd"),
 		NewProcWithV1Flags(v2BinPath),
 		NewProcWithV2Flags(v2BinPath),
 	}


### PR DESCRIPTION
tests to ensure the change in #2534 works