### PR TITLE
raft: add flow control for progress

### DIFF
--- a/raft/progress_test.go
+++ b/raft/progress_test.go
@@ -1,0 +1,175 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInflightsAdd(t *testing.T) {
+	// no rotating case
+	in := &inflights{
+		size:   10,
+		buffer: make([]uint64, 10),
+	}
+
+	for i := 0; i < 5; i++ {
+		in.add(uint64(i))
+	}
+
+	wantIn := &inflights{
+		start: 0,
+		count: 5,
+		size:  10,
+		//               ↓------------
+		buffer: []uint64{0, 1, 2, 3, 4, 0, 0, 0, 0, 0},
+	}
+
+	if !reflect.DeepEqual(in, wantIn) {
+		t.Fatalf("in = %+v, want %+v", in, wantIn)
+	}
+
+	for i := 5; i < 10; i++ {
+		in.add(uint64(i))
+	}
+
+	wantIn2 := &inflights{
+		start: 0,
+		count: 10,
+		size:  10,
+		//               ↓---------------------------
+		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+
+	if !reflect.DeepEqual(in, wantIn2) {
+		t.Fatalf("in = %+v, want %+v", in, wantIn2)
+	}
+
+	// rotating case
+	in2 := &inflights{
+		start:  5,
+		size:   10,
+		buffer: make([]uint64, 10),
+	}
+
+	for i := 0; i < 5; i++ {
+		in2.add(uint64(i))
+	}
+
+	wantIn21 := &inflights{
+		start: 5,
+		count: 5,
+		size:  10,
+		//                              ↓------------
+		buffer: []uint64{0, 0, 0, 0, 0, 0, 1, 2, 3, 4},
+	}
+
+	if !reflect.DeepEqual(in2, wantIn21) {
+		t.Fatalf("in = %+v, want %+v", in2, wantIn21)
+	}
+
+	for i := 5; i < 10; i++ {
+		in2.add(uint64(i))
+	}
+
+	wantIn22 := &inflights{
+		start: 5,
+		count: 10,
+		size:  10,
+		//               -------------- ↓------------
+		buffer: []uint64{5, 6, 7, 8, 9, 0, 1, 2, 3, 4},
+	}
+
+	if !reflect.DeepEqual(in2, wantIn22) {
+		t.Fatalf("in = %+v, want %+v", in2, wantIn22)
+	}
+}
+
+func TestInflightFreeTo(t *testing.T) {
+	// no rotating case
+	in := newInflights(10)
+	for i := 0; i < 10; i++ {
+		in.add(uint64(i))
+	}
+
+	in.freeTo(4)
+
+	wantIn := &inflights{
+		start: 5,
+		count: 5,
+		size:  10,
+		//                              ↓------------
+		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+
+	if !reflect.DeepEqual(in, wantIn) {
+		t.Fatalf("in = %+v, want %+v", in, wantIn)
+	}
+
+	in.freeTo(8)
+
+	wantIn2 := &inflights{
+		start: 9,
+		count: 1,
+		size:  10,
+		//                                          ↓
+		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+
+	if !reflect.DeepEqual(in, wantIn2) {
+		t.Fatalf("in = %+v, want %+v", in, wantIn2)
+	}
+
+	// rotating case
+	for i := 10; i < 15; i++ {
+		in.add(uint64(i))
+	}
+
+	in.freeTo(12)
+
+	wantIn3 := &inflights{
+		start: 3,
+		count: 2,
+		size:  10,
+		//                           ↓-----
+		buffer: []uint64{10, 11, 12, 13, 14, 5, 6, 7, 8, 9},
+	}
+
+	if !reflect.DeepEqual(in, wantIn3) {
+		t.Fatalf("in = %+v, want %+v", in, wantIn3)
+	}
+}
+
+func TestInflightFreeFirstOne(t *testing.T) {
+	in := newInflights(10)
+	for i := 0; i < 10; i++ {
+		in.add(uint64(i))
+	}
+
+	in.freeFirstOne()
+
+	wantIn := &inflights{
+		start: 1,
+		count: 9,
+		size:  10,
+		//                  ↓------------------------
+		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+
+	if !reflect.DeepEqual(in, wantIn) {
+		t.Fatalf("in = %+v, want %+v", in, wantIn)
+	}
+}

--- a/raft/raft_flow_control_test.go
+++ b/raft/raft_flow_control_test.go
@@ -1,0 +1,155 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"testing"
+
+	pb "github.com/coreos/etcd/raft/raftpb"
+)
+
+// TestMsgAppFlowControlFull ensures:
+// 1. msgApp can fill the sending window until full
+// 2. when the window is full, no more msgApp can be sent.
+func TestMsgAppFlowControlFull(t *testing.T) {
+	r := newRaft(1, []uint64{1, 2}, 5, 1, NewMemoryStorage(), 0)
+	r.becomeCandidate()
+	r.becomeLeader()
+
+	pr2 := r.prs[2]
+	// force the progress to be in replicate state
+	pr2.becomeReplicate()
+	// fill in the inflights window
+	for i := 0; i < r.maxInflight; i++ {
+		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
+		ms := r.readMessages()
+		if len(ms) != 1 {
+			t.Fatalf("#%d: len(ms) = %d, want 1", i, len(ms))
+		}
+	}
+
+	// ensure 1
+	if !pr2.ins.full() {
+		t.Fatalf("inflights.full = %t, want %t", pr2.ins.full(), true)
+	}
+
+	// ensure 2
+	for i := 0; i < 10; i++ {
+		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
+		ms := r.readMessages()
+		if len(ms) != 0 {
+			t.Fatalf("#%d: len(ms) = %d, want 0", i, len(ms))
+		}
+	}
+}
+
+// TestMsgAppFlowControlMoveForward ensures msgAppResp can move
+// forward the sending window correctly:
+// 1. vaild msgAppResp.index moves the windows to pass all smaller or equal index.
+// 2. out-of-dated msgAppResp has no effect on the silding window.
+func TestMsgAppFlowControlMoveForward(t *testing.T) {
+	r := newRaft(1, []uint64{1, 2}, 5, 1, NewMemoryStorage(), 0)
+	r.becomeCandidate()
+	r.becomeLeader()
+
+	pr2 := r.prs[2]
+	// force the progress to be in replicate state
+	pr2.becomeReplicate()
+	// fill in the inflights window
+	for i := 0; i < r.maxInflight; i++ {
+		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
+		r.readMessages()
+	}
+
+	// 1 is noop, 2 is the first proposal we just sent.
+	// so we start with 2.
+	for tt := 2; tt < r.maxInflight; tt++ {
+		// move forward the window
+		r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: uint64(tt)})
+		r.readMessages()
+
+		// fill in the inflights window again
+		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
+		ms := r.readMessages()
+		if len(ms) != 1 {
+			t.Fatalf("#%d: len(ms) = %d, want 1", tt, len(ms))
+		}
+
+		// ensure 1
+		if !pr2.ins.full() {
+			t.Fatalf("inflights.full = %t, want %t", pr2.ins.full(), true)
+		}
+
+		// ensure 2
+		for i := 0; i < tt; i++ {
+			r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: uint64(i)})
+			if !pr2.ins.full() {
+				t.Fatalf("#%d: inflights.full = %t, want %t", tt, pr2.ins.full(), true)
+			}
+		}
+	}
+}
+
+// TestMsgAppFlowControlRecvHeartbeat ensures a heartbeat response
+// frees one slot if the window is full.
+func TestMsgAppFlowControlRecvHeartbeat(t *testing.T) {
+	r := newRaft(1, []uint64{1, 2}, 5, 1, NewMemoryStorage(), 0)
+	r.becomeCandidate()
+	r.becomeLeader()
+
+	pr2 := r.prs[2]
+	// force the progress to be in replicate state
+	pr2.becomeReplicate()
+	// fill in the inflights window
+	for i := 0; i < r.maxInflight; i++ {
+		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
+		r.readMessages()
+	}
+
+	for tt := 1; tt < 5; tt++ {
+		if !pr2.ins.full() {
+			t.Fatalf("#%d: inflights.full = %t, want %t", tt, pr2.ins.full(), true)
+		}
+
+		// recv tt msgHeartbeatResp and expect one free slot
+		for i := 0; i < tt; i++ {
+			r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgHeartbeatResp})
+			r.readMessages()
+			if pr2.ins.full() {
+				t.Fatalf("#%d.%d: inflights.full = %t, want %t", tt, i, pr2.ins.full(), false)
+			}
+		}
+
+		// one slot
+		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
+		ms := r.readMessages()
+		if len(ms) != 1 {
+			t.Fatalf("#%d: free slot = 0, want 1", tt)
+		}
+
+		// and just one slot
+		for i := 0; i < 10; i++ {
+			r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
+			ms1 := r.readMessages()
+			if len(ms1) != 0 {
+				t.Fatalf("#%d.%d: len(ms) = %d, want 0", tt, i, len(ms1))
+			}
+		}
+
+		// clear all pending messages.
+		r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgHeartbeatResp})
+		r.readMessages()
+	}
+}


### PR DESCRIPTION
Each progress has a inflighs sliding window. When the progress
is in replicate state, inflights will control the sending speed
of the leader.

The leader can have at most maxInflight number of inflight
messages for each replicate progress. Receving a appResp will
move forward the sliding window. Heartbeat will clear the sliding
window.