### PR TITLE
etcd: add -etcd-binary-dir flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,9 @@ import (
 // The default location for the etcd configuration file.
 const DefaultSystemConfigPath = "/etc/etcd/etcd.conf"
 
+// The default location of the etcd internal directory.
+const DefaultInternalDir = "/usr/libexec/etcd/internal_versions/"
+
 // A lookup of deprecated flags to their new flag name.
 var newFlagNameLookup = map[string]string{
 	"C":                      "peers",
@@ -64,6 +67,7 @@ type Config struct {
 	KeyFile          string   `toml:"key_file" env:"ETCD_KEY_FILE"`
 	HTTPReadTimeout  float64  `toml:"http_read_timeout" env:"ETCD_HTTP_READ_TIMEOUT"`
 	HTTPWriteTimeout float64  `toml:"http_write_timeout" env:"ETCD_HTTP_WRITE_TIMEOUT"`
+	InternalDir      string   `toml:"internal_dir" env:"ETCD_INTERNAL_DIR"`
 	Peers            []string `toml:"peers" env:"ETCD_PEERS"`
 	PeersFile        string   `toml:"peers_file" env:"ETCD_PEERS_FILE"`
 	MaxResultBuffer  int      `toml:"max_result_buffer" env:"ETCD_MAX_RESULT_BUFFER"`
@@ -116,6 +120,7 @@ func New() *Config {
 	c.Cluster.ActiveSize = server.DefaultActiveSize
 	c.Cluster.RemoveDelay = server.DefaultRemoveDelay
 	c.Cluster.SyncInterval = server.DefaultSyncInterval
+	c.InternalDir = DefaultInternalDir
 	return c
 }
 
@@ -263,6 +268,7 @@ func (c *Config) LoadFlags(arguments []string) error {
 	f.Float64Var(&c.HTTPWriteTimeout, "http-write-timeout", c.HTTPReadTimeout, "")
 
 	f.StringVar(&c.DataDir, "data-dir", c.DataDir, "")
+	f.StringVar(&c.InternalDir, "internal-dir", c.InternalDir, "")
 	f.IntVar(&c.MaxResultBuffer, "max-result-buffer", c.MaxResultBuffer, "")
 	f.IntVar(&c.MaxRetryAttempts, "max-retry-attempts", c.MaxRetryAttempts, "")
 	f.Float64Var(&c.RetryInterval, "retry-interval", c.RetryInterval, "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,7 @@ func TestConfigTOML(t *testing.T) {
 		cpu_profile_file = "XXX"
 		data_dir = "/tmp/data"
 		discovery = "http://example.com/foobar"
+		internal_dir = "/tmp/etcd/internal_versions"
 		key_file = "/tmp/file.key"
 		bind_addr = "127.0.0.1:4003"
 		peers = ["coreos.com:4001", "coreos.com:4002"]
@@ -54,6 +55,7 @@ func TestConfigTOML(t *testing.T) {
 	assert.Equal(t, c.CorsOrigins, []string{"*"}, "")
 	assert.Equal(t, c.DataDir, "/tmp/data", "")
 	assert.Equal(t, c.Discovery, "http://example.com/foobar", "")
+	assert.Equal(t, c.InternalDir, "/tmp/etcd/internal_versions", "")
 	assert.Equal(t, c.HTTPReadTimeout, 2.34, "")
 	assert.Equal(t, c.HTTPWriteTimeout, 1.23, "")
 	assert.Equal(t, c.KeyFile, "/tmp/file.key", "")
@@ -86,6 +88,7 @@ func TestConfigEnv(t *testing.T) {
 	os.Setenv("ETCD_DISCOVERY", "http://example.com/foobar")
 	os.Setenv("ETCD_HTTP_READ_TIMEOUT", "2.34")
 	os.Setenv("ETCD_HTTP_WRITE_TIMEOUT", "1.23")
+	os.Setenv("ETCD_INTERNAL_DIR", "/tmp/etcd/internal_versions")
 	os.Setenv("ETCD_KEY_FILE", "/tmp/file.key")
 	os.Setenv("ETCD_BIND_ADDR", "127.0.0.1:4003")
 	os.Setenv("ETCD_PEERS", "coreos.com:4001,coreos.com:4002")
@@ -115,6 +118,7 @@ func TestConfigEnv(t *testing.T) {
 	assert.Equal(t, c.Discovery, "http://example.com/foobar", "")
 	assert.Equal(t, c.HTTPReadTimeout, 2.34, "")
 	assert.Equal(t, c.HTTPWriteTimeout, 1.23, "")
+	assert.Equal(t, c.InternalDir, "/tmp/etcd/internal_versions", "")
 	assert.Equal(t, c.KeyFile, "/tmp/file.key", "")
 	assert.Equal(t, c.BindAddr, "127.0.0.1:4003", "")
 	assert.Equal(t, c.Peers, []string{"coreos.com:4001", "coreos.com:4002"}, "")

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -309,7 +309,7 @@ func (e *Etcd) runServer() {
 	for {
 		if e.mode == PeerMode {
 			log.Infof("%v starting in peer mode", e.Config.Name)
-			go registerAvailableInternalVersions(e.Config.Name, e.Config.Addr, e.Config.EtcdTLSInfo())
+			go registerAvailableInternalVersions(e.Config.InternalDir, e.Config.Name, e.Config.Addr, e.Config.EtcdTLSInfo())
 			// Starting peer server should be followed close by listening on its port
 			// If not, it may leave many requests unaccepted, or cannot receive heartbeat from the cluster.
 			// One severe problem caused if failing receiving heartbeats is when the second node joins one-node cluster,

--- a/etcd/upgrade.go
+++ b/etcd/upgrade.go
@@ -1,9 +1,7 @@
 package etcd
 
 import (
-	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/coreos/etcd/log"
@@ -11,9 +9,7 @@ import (
 	"github.com/coreos/etcd/third_party/github.com/coreos/go-etcd/etcd"
 )
 
-var defaultEtcdBinaryDir = "/usr/libexec/etcd/internal_versions/"
-
-func registerAvailableInternalVersions(name string, addr string, tls *server.TLSInfo) {
+func registerAvailableInternalVersions(internalDir, name, addr string, tls *server.TLSInfo) {
 	var c *etcd.Client
 	if tls.Scheme() == "http" {
 		c = etcd.NewClient([]string{addr})
@@ -25,7 +21,7 @@ func registerAvailableInternalVersions(name string, addr string, tls *server.TLS
 		}
 	}
 
-	vers, err := getInternalVersions()
+	vers, err := getInternalVersions(internalDir)
 	if err != nil {
 		log.Infof("failed to get local etcd versions: %v", err)
 		return
@@ -42,15 +38,8 @@ func registerAvailableInternalVersions(name string, addr string, tls *server.TLS
 	log.Infof("%s: available_internal_versions %s is registered into key space successfully.", name, vers)
 }
 
-func getInternalVersions() ([]string, error) {
-	if runtime.GOOS != "linux" {
-		return nil, fmt.Errorf("unmatched os version %v", runtime.GOOS)
-	}
-	etcdBinaryDir := os.Getenv("ETCD_BINARY_DIR")
-	if etcdBinaryDir == "" {
-		etcdBinaryDir = defaultEtcdBinaryDir
-	}
-	dir, err := os.Open(etcdBinaryDir)
+func getInternalVersions(internalDir string) ([]string, error) {
+	dir, err := os.Open(internalDir)
 	if err != nil {
 		return nil, err
 	}

--- a/server/usage.go
+++ b/server/usage.go
@@ -15,15 +15,16 @@ Usage:
   etcd -version
 
 Options:
-  -h -help          Show this screen.
-  --version         Show version.
-  -f -force         Force a new configuration to be used.
-  -config=<path>    Path to configuration file.
-  -name=<name>      Name of this node in the etcd cluster.
-  -data-dir=<path>  Path to the data directory.
-  -cors=<origins>   Comma-separated list of CORS origins.
-  -v                Enabled verbose logging.
-  -vv               Enabled very verbose logging.
+  -h -help              Show this screen.
+  --version             Show version.
+  -f -force             Force a new configuration to be used.
+  -config=<path>        Path to configuration file.
+  -name=<name>          Name of this node in the etcd cluster.
+  -data-dir=<path>      Path to the data directory.
+  -internal-dir=<path>  Path to the etcd internal directory.
+  -cors=<origins>       Comma-separated list of CORS origins.
+  -v                    Enabled verbose logging.
+  -vv                   Enabled very verbose logging.
 
 Cluster Configuration Options:
   -discovery=<url>                Discovery service used to find a peer list.


### PR DESCRIPTION
etcd supports setting the path to the etcd binary directory used for
running legacy mode and upgrades.