### PR TITLE
etcd: add -internal-dir flag

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -44,6 +44,7 @@ The full documentation is contained in the [API docs](https://github.com/coreos/
 * `-cors` - A comma separated white list of origins for cross-origin resource sharing.
 * `-cpuprofile` - The path to a file to output CPU profile data. Enables CPU profiling when present.
 * `-data-dir` - The directory to store log and snapshot. Defaults to the current working directory.
+* `-internal-binary-dir` - The path to the etcd internal binary directory. Defaults to `/usr/libexec/etcd/internal_versions/`.
 * `-max-result-buffer` - The max size of result buffer. Defaults to `1024`.
 * `-max-retry-attempts` - The max retry attempts when trying to join a cluster. Defaults to `3`.
 * `-peer-addr` - The advertised public hostname:port for server communication. Defaults to `127.0.0.1:7001`.
@@ -115,6 +116,7 @@ sync_interval = 5.0
  * `ETCD_CLUSTER_HTTP_READ_TIMEOUT`
  * `ETCD_CLUSTER_HTTP_WRITE_TIMEOUT`
  * `ETCD_KEY_FILE`
+ * `ETCD_INTERNAL_BINARY_DIR`
  * `ETCD_PEERS`
  * `ETCD_PEERS_FILE`
  * `ETCD_MAX_CLUSTER_SIZE`

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,9 @@ import (
 // The default location for the etcd configuration file.
 const DefaultSystemConfigPath = "/etc/etcd/etcd.conf"
 
+// The default location of the etcd internal binary directory.
+const DefaultInternalBinaryDir = "/usr/libexec/etcd/internal_versions/"
+
 // A lookup of deprecated flags to their new flag name.
 var newFlagNameLookup = map[string]string{
 	"C":                      "peers",
@@ -52,32 +55,33 @@ var newFlagNameLookup = map[string]string{
 type Config struct {
 	SystemPath string
 
-	Addr             string `toml:"addr" env:"ETCD_ADDR"`
-	BindAddr         string `toml:"bind_addr" env:"ETCD_BIND_ADDR"`
-	CAFile           string `toml:"ca_file" env:"ETCD_CA_FILE"`
-	CertFile         string `toml:"cert_file" env:"ETCD_CERT_FILE"`
-	CPUProfileFile   string
-	CorsOrigins      []string `toml:"cors" env:"ETCD_CORS"`
-	DataDir          string   `toml:"data_dir" env:"ETCD_DATA_DIR"`
-	Discovery        string   `toml:"discovery" env:"ETCD_DISCOVERY"`
-	Force            bool
-	KeyFile          string   `toml:"key_file" env:"ETCD_KEY_FILE"`
-	HTTPReadTimeout  float64  `toml:"http_read_timeout" env:"ETCD_HTTP_READ_TIMEOUT"`
-	HTTPWriteTimeout float64  `toml:"http_write_timeout" env:"ETCD_HTTP_WRITE_TIMEOUT"`
-	Peers            []string `toml:"peers" env:"ETCD_PEERS"`
-	PeersFile        string   `toml:"peers_file" env:"ETCD_PEERS_FILE"`
-	MaxResultBuffer  int      `toml:"max_result_buffer" env:"ETCD_MAX_RESULT_BUFFER"`
-	MaxRetryAttempts int      `toml:"max_retry_attempts" env:"ETCD_MAX_RETRY_ATTEMPTS"`
-	RetryInterval    float64  `toml:"retry_interval" env:"ETCD_RETRY_INTERVAL"`
-	Name             string   `toml:"name" env:"ETCD_NAME"`
-	Snapshot         bool     `toml:"snapshot" env:"ETCD_SNAPSHOT"`
-	SnapshotCount    int      `toml:"snapshot_count" env:"ETCD_SNAPSHOTCOUNT"`
-	ShowHelp         bool
-	ShowVersion      bool
-	Verbose          bool `toml:"verbose" env:"ETCD_VERBOSE"`
-	VeryVerbose      bool `toml:"very_verbose" env:"ETCD_VERY_VERBOSE"`
-	VeryVeryVerbose  bool `toml:"very_very_verbose" env:"ETCD_VERY_VERY_VERBOSE"`
-	Peer             struct {
+	Addr              string `toml:"addr" env:"ETCD_ADDR"`
+	BindAddr          string `toml:"bind_addr" env:"ETCD_BIND_ADDR"`
+	CAFile            string `toml:"ca_file" env:"ETCD_CA_FILE"`
+	CertFile          string `toml:"cert_file" env:"ETCD_CERT_FILE"`
+	CPUProfileFile    string
+	CorsOrigins       []string `toml:"cors" env:"ETCD_CORS"`
+	DataDir           string   `toml:"data_dir" env:"ETCD_DATA_DIR"`
+	Discovery         string   `toml:"discovery" env:"ETCD_DISCOVERY"`
+	Force             bool
+	KeyFile           string   `toml:"key_file" env:"ETCD_KEY_FILE"`
+	HTTPReadTimeout   float64  `toml:"http_read_timeout" env:"ETCD_HTTP_READ_TIMEOUT"`
+	HTTPWriteTimeout  float64  `toml:"http_write_timeout" env:"ETCD_HTTP_WRITE_TIMEOUT"`
+	InternalBinaryDir string   `toml:"internal_binary_dir" env:"ETCD_INTERNAL_BINARY_DIR"`
+	Peers             []string `toml:"peers" env:"ETCD_PEERS"`
+	PeersFile         string   `toml:"peers_file" env:"ETCD_PEERS_FILE"`
+	MaxResultBuffer   int      `toml:"max_result_buffer" env:"ETCD_MAX_RESULT_BUFFER"`
+	MaxRetryAttempts  int      `toml:"max_retry_attempts" env:"ETCD_MAX_RETRY_ATTEMPTS"`
+	RetryInterval     float64  `toml:"retry_interval" env:"ETCD_RETRY_INTERVAL"`
+	Name              string   `toml:"name" env:"ETCD_NAME"`
+	Snapshot          bool     `toml:"snapshot" env:"ETCD_SNAPSHOT"`
+	SnapshotCount     int      `toml:"snapshot_count" env:"ETCD_SNAPSHOTCOUNT"`
+	ShowHelp          bool
+	ShowVersion       bool
+	Verbose           bool `toml:"verbose" env:"ETCD_VERBOSE"`
+	VeryVerbose       bool `toml:"very_verbose" env:"ETCD_VERY_VERBOSE"`
+	VeryVeryVerbose   bool `toml:"very_very_verbose" env:"ETCD_VERY_VERY_VERBOSE"`
+	Peer              struct {
 		Addr              string `toml:"addr" env:"ETCD_PEER_ADDR"`
 		BindAddr          string `toml:"bind_addr" env:"ETCD_PEER_BIND_ADDR"`
 		CAFile            string `toml:"ca_file" env:"ETCD_PEER_CA_FILE"`
@@ -116,6 +120,7 @@ func New() *Config {
 	c.Cluster.ActiveSize = server.DefaultActiveSize
 	c.Cluster.RemoveDelay = server.DefaultRemoveDelay
 	c.Cluster.SyncInterval = server.DefaultSyncInterval
+	c.InternalBinaryDir = DefaultInternalBinaryDir
 	return c
 }
 
@@ -263,6 +268,7 @@ func (c *Config) LoadFlags(arguments []string) error {
 	f.Float64Var(&c.HTTPWriteTimeout, "http-write-timeout", c.HTTPReadTimeout, "")
 
 	f.StringVar(&c.DataDir, "data-dir", c.DataDir, "")
+	f.StringVar(&c.InternalBinaryDir, "internal-binary-dir", c.InternalBinaryDir, "")
 	f.IntVar(&c.MaxResultBuffer, "max-result-buffer", c.MaxResultBuffer, "")
 	f.IntVar(&c.MaxRetryAttempts, "max-retry-attempts", c.MaxRetryAttempts, "")
 	f.Float64Var(&c.RetryInterval, "retry-interval", c.RetryInterval, "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,7 @@ func TestConfigTOML(t *testing.T) {
 		cpu_profile_file = "XXX"
 		data_dir = "/tmp/data"
 		discovery = "http://example.com/foobar"
+		internal_binary_dir = "/tmp/etcd/internal_versions"
 		key_file = "/tmp/file.key"
 		bind_addr = "127.0.0.1:4003"
 		peers = ["coreos.com:4001", "coreos.com:4002"]
@@ -54,6 +55,7 @@ func TestConfigTOML(t *testing.T) {
 	assert.Equal(t, c.CorsOrigins, []string{"*"}, "")
 	assert.Equal(t, c.DataDir, "/tmp/data", "")
 	assert.Equal(t, c.Discovery, "http://example.com/foobar", "")
+	assert.Equal(t, c.InternalBinaryDir, "/tmp/etcd/internal_versions", "")
 	assert.Equal(t, c.HTTPReadTimeout, 2.34, "")
 	assert.Equal(t, c.HTTPWriteTimeout, 1.23, "")
 	assert.Equal(t, c.KeyFile, "/tmp/file.key", "")
@@ -86,6 +88,7 @@ func TestConfigEnv(t *testing.T) {
 	os.Setenv("ETCD_DISCOVERY", "http://example.com/foobar")
 	os.Setenv("ETCD_HTTP_READ_TIMEOUT", "2.34")
 	os.Setenv("ETCD_HTTP_WRITE_TIMEOUT", "1.23")
+	os.Setenv("ETCD_INTERNAL_BINARY_DIR", "/tmp/etcd/internal_versions")
 	os.Setenv("ETCD_KEY_FILE", "/tmp/file.key")
 	os.Setenv("ETCD_BIND_ADDR", "127.0.0.1:4003")
 	os.Setenv("ETCD_PEERS", "coreos.com:4001,coreos.com:4002")
@@ -115,6 +118,7 @@ func TestConfigEnv(t *testing.T) {
 	assert.Equal(t, c.Discovery, "http://example.com/foobar", "")
 	assert.Equal(t, c.HTTPReadTimeout, 2.34, "")
 	assert.Equal(t, c.HTTPWriteTimeout, 1.23, "")
+	assert.Equal(t, c.InternalBinaryDir, "/tmp/etcd/internal_versions", "")
 	assert.Equal(t, c.KeyFile, "/tmp/file.key", "")
 	assert.Equal(t, c.BindAddr, "127.0.0.1:4003", "")
 	assert.Equal(t, c.Peers, []string{"coreos.com:4001", "coreos.com:4002"}, "")

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -309,7 +309,7 @@ func (e *Etcd) runServer() {
 	for {
 		if e.mode == PeerMode {
 			log.Infof("%v starting in peer mode", e.Config.Name)
-			go registerAvailableInternalVersions(e.Config.Name, e.Config.Addr, e.Config.EtcdTLSInfo())
+			go registerAvailableInternalVersions(e.Config.InternalBinaryDir, e.Config.Name, e.Config.Addr, e.Config.EtcdTLSInfo())
 			// Starting peer server should be followed close by listening on its port
 			// If not, it may leave many requests unaccepted, or cannot receive heartbeat from the cluster.
 			// One severe problem caused if failing receiving heartbeats is when the second node joins one-node cluster,

--- a/etcd/upgrade.go
+++ b/etcd/upgrade.go
@@ -1,9 +1,7 @@
 package etcd
 
 import (
-	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/coreos/etcd/log"
@@ -11,9 +9,7 @@ import (
 	"github.com/coreos/etcd/third_party/github.com/coreos/go-etcd/etcd"
 )
 
-var defaultEtcdBinaryDir = "/usr/libexec/etcd/internal_versions/"
-
-func registerAvailableInternalVersions(name string, addr string, tls *server.TLSInfo) {
+func registerAvailableInternalVersions(internalBinaryDir, name, addr string, tls *server.TLSInfo) {
 	var c *etcd.Client
 	if tls.Scheme() == "http" {
 		c = etcd.NewClient([]string{addr})
@@ -25,7 +21,7 @@ func registerAvailableInternalVersions(name string, addr string, tls *server.TLS
 		}
 	}
 
-	vers, err := getInternalVersions()
+	vers, err := getInternalVersions(internalBinaryDir)
 	if err != nil {
 		log.Infof("failed to get local etcd versions: %v", err)
 		return
@@ -42,15 +38,8 @@ func registerAvailableInternalVersions(name string, addr string, tls *server.TLS
 	log.Infof("%s: available_internal_versions %s is registered into key space successfully.", name, vers)
 }
 
-func getInternalVersions() ([]string, error) {
-	if runtime.GOOS != "linux" {
-		return nil, fmt.Errorf("unmatched os version %v", runtime.GOOS)
-	}
-	etcdBinaryDir := os.Getenv("ETCD_BINARY_DIR")
-	if etcdBinaryDir == "" {
-		etcdBinaryDir = defaultEtcdBinaryDir
-	}
-	dir, err := os.Open(etcdBinaryDir)
+func getInternalVersions(internalBinaryDir string) ([]string, error) {
+	dir, err := os.Open(internalBinaryDir)
 	if err != nil {
 		return nil, err
 	}

--- a/server/usage.go
+++ b/server/usage.go
@@ -15,15 +15,16 @@ Usage:
   etcd -version
 
 Options:
-  -h -help          Show this screen.
-  --version         Show version.
-  -f -force         Force a new configuration to be used.
-  -config=<path>    Path to configuration file.
-  -name=<name>      Name of this node in the etcd cluster.
-  -data-dir=<path>  Path to the data directory.
-  -cors=<origins>   Comma-separated list of CORS origins.
-  -v                Enabled verbose logging.
-  -vv               Enabled very verbose logging.
+  -h -help                     Show this screen.
+  --version                    Show version.
+  -f -force                    Force a new configuration to be used.
+  -config=<path>               Path to configuration file.
+  -name=<name>                 Name of this node in the etcd cluster.
+  -data-dir=<path>             Path to the data directory.
+  -internal-binary-dir=<path>  Path to the etcd internal binary directory.
+  -cors=<origins>              Comma-separated list of CORS origins.
+  -v                           Enabled verbose logging.
+  -vv                          Enabled very verbose logging.
 
 Cluster Configuration Options:
   -discovery=<url>                Discovery service used to find a peer list.


### PR DESCRIPTION
etcd supports setting the path to the etcd binary directory used for
running legacy mode and upgrades.