### PR TITLE
etcdmain: print error when non-flag args remain

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -212,6 +212,9 @@ func (cfg *config) Parse(arguments []string) error {
 	default:
 		os.Exit(2)
 	}
+	if len(cfg.FlagSet.Args()) != 0 {
+		return fmt.Errorf("'%s' is not a valid flag", cfg.FlagSet.Arg(0))
+	}
 
 	if cfg.printVersion {
 		fmt.Println("etcd version", version.Version)

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -56,7 +56,7 @@ func Main() {
 	cfg := NewConfig()
 	err := cfg.Parse(os.Args[1:])
 	if err != nil {
-		log.Printf("etcd: error verifying flags, %v", err)
+		log.Printf("etcd: error verifying flags, %v. See 'etcd -help'.", err)
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
current master ignores the flags and start:
```
$ ./bin/etcd name etcd
2015/03/23 10:10:45 etcd: no data-dir provided, using default data-dir ./default.etcd
2015/03/23 10:10:45 etcd: listening for peers on http://localhost:2380
2015/03/23 10:10:45 etcd: listening for peers on http://localhost:7001
2015/03/23 10:10:45 etcd: listening for client requests on http://localhost:2379
2015/03/23 10:10:45 etcd: listening for client requests on http://localhost:4001
2015/03/23 10:10:45 etcdserver: name = default
2015/03/23 10:10:45 etcdserver: data dir = default.etcd
2015/03/23 10:10:45 etcdserver: member dir = default.etcd/member
2015/03/23 10:10:45 etcdserver: heartbeat = 100ms
2015/03/23 10:10:45 etcdserver: election = 1000ms
2015/03/23 10:10:45 etcdserver: snapshot count = 10000
2015/03/23 10:10:45 etcdserver: advertise client URLs = http://localhost:2379,http://localhost:4001
2015/03/23 10:10:45 etcdserver: initial advertise peer URLs = http://localhost:2380,http://localhost:7001
2015/03/23 10:10:45 etcdserver: initial cluster = default=http://localhost:2380,default=http://localhost:7001
2015/03/23 10:10:45 etcdserver: start member ce2a822cea30bfca in cluster 7e27652122e8b2ae
2015/03/23 10:10:45 INFO: raft: ce2a822cea30bfca became follower at term 0
2015/03/23 10:10:45 INFO: raft: newRaft ce2a822cea30bfca [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
2015/03/23 10:10:45 INFO: raft: ce2a822cea30bfca became follower at term 1
2015/03/23 10:10:45 etcdserver: added local member ce2a822cea30bfca [http://localhost:2380 http://localhost:7001] to cluster 7e27652122e8b2ae
2015/03/23 10:10:46 INFO: raft: ce2a822cea30bfca is starting a new election at term 1
2015/03/23 10:10:46 INFO: raft: ce2a822cea30bfca became candidate at term 2
2015/03/23 10:10:46 INFO: raft: ce2a822cea30bfca received vote from ce2a822cea30bfca at term 2
2015/03/23 10:10:46 INFO: raft: ce2a822cea30bfca became leader at term 2
2015/03/23 10:10:46 INFO: raft.node: ce2a822cea30bfca elected leader ce2a822cea30bfca at term 2
2015/03/23 10:10:46 etcdserver: published {Name:default ClientURLs:[http://localhost:2379 http://localhost:4001]} to cluster 7e27652122e8b2ae
```

after change:
```
$ ./bin/etcd name etcd
2015/03/23 10:09:19 etcd: error verifying flags, unsupported non-flag arguments [name etcd]
```