### PR TITLE
raft: node bench matches reality

### DIFF
--- a/raft/rafttest/node_bench_test.go
+++ b/raft/rafttest/node_bench_test.go
@@ -1,0 +1,39 @@
+package rafttest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/raft"
+)
+
+func BenchmarkProposal3Nodes(b *testing.B) {
+	peers := []raft.Peer{{1, nil}, {2, nil}, {3, nil}}
+	nt := newRaftNetwork(1, 2, 3)
+
+	nodes := make([]*node, 0)
+
+	for i := 1; i <= 3; i++ {
+		n := startNode(uint64(i), peers, nt.nodeNetwork(uint64(i)))
+		nodes = append(nodes, n)
+	}
+	// get ready and warm up
+	time.Sleep(50 * time.Millisecond)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nodes[0].Propose(context.TODO(), []byte("somedata"))
+	}
+
+	for _, n := range nodes {
+		if n.state.Commit != uint64(b.N+4) {
+			continue
+		}
+	}
+	b.StopTimer()
+
+	for _, n := range nodes {
+		n.stop()
+	}
+}

--- a/raft/rafttest/node_test.go
+++ b/raft/rafttest/node_test.go
@@ -19,16 +19,17 @@ func TestBasicProgress(t *testing.T) {
 		nodes = append(nodes, n)
 	}
 
-	time.Sleep(50 * time.Millisecond)
-	for i := 0; i < 1000; i++ {
+	time.Sleep(10 * time.Millisecond)
+
+	for i := 0; i < 10000; i++ {
 		nodes[0].Propose(context.TODO(), []byte("somedata"))
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	for _, n := range nodes {
 		n.stop()
-		if n.state.Commit != 1006 {
-			t.Errorf("commit = %d, want = 1006", n.state.Commit)
+		if n.state.Commit != 10006 {
+			t.Errorf("commit = %d, want = 10006", n.state.Commit)
 		}
 	}
 }
@@ -63,7 +64,7 @@ func TestRestart(t *testing.T) {
 	nodes[1].restart()
 
 	// give some time for nodes to catch up with the raft leader
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	for _, n := range nodes {
 		n.stop()
 		if n.state.Commit != 1206 {


### PR DESCRIPTION
one node:
```
 300000	      3702 ns/op	     655 B/op	       5 allocs/op
```

About 250k req/second and 1.1ms latency.

disk latency actually helps improving throughput due to batch.
 
I roughly tested a three nodes raft with in-mem transport (without encoding/decoding), the result is at the same level.

3 nodes:
```
  300000	      5885 ns/op	    1897 B/op	       5 allocs/op
```