### PR TITLE
build: do not build internal debugging tool

### DIFF
--- a/build
+++ b/build
@@ -14,5 +14,3 @@ eval $(go env)
 # Static compilation is useful when etcd is run in a container
 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-s' -o bin/etcd ${REPO_PATH}
 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-s' -o bin/etcdctl ${REPO_PATH}/etcdctl
-go build -o bin/etcd-migrate ${REPO_PATH}/tools/etcd-migrate
-go build -o bin/etcd-dump-logs ${REPO_PATH}/tools/etcd-dump-logs

--- a/tools/etcd-migrate/README.md
+++ b/tools/etcd-migrate/README.md
@@ -15,7 +15,8 @@ etcd will detect 0.4.x data dir and update the data automatically (while leaving
 
 The tool can be run via:
 ```sh
-./bin/etcd-migrate --data-dir=<PATH TO YOUR DATA>
+./go build
+./etcd-migrate --data-dir=<PATH TO YOUR DATA>
 ```
 
 It should autodetect everything and convert the data-dir to be 2.0 compatible. It does not remove the 0.4.x data, and is safe to convert multiple times; the 2.0 data will be overwritten. Recovering the disk space once everything is settled is covered later in the document.


### PR DESCRIPTION
We are still playing around with the dump-log tool.
Stop building it publicly until we are happy with its
ux and functionality.

/cc @philips 