### PR TITLE
wal: reduce allocation when encoding entries

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -387,6 +387,7 @@ func (w *WAL) Close() error {
 }
 
 func (w *WAL) saveEntry(e *raftpb.Entry) error {
+	// TODO: add MustMarshalTo to reduce one allocation.
 	b := pbutil.MustMarshal(e)
 	rec := &walpb.Record{Type: entryType, Data: b}
 	if err := w.encoder.encode(rec); err != nil {


### PR DESCRIPTION
before
```
BenchmarkWrite100EntryWithoutBatch	   10000	    106195 ns/op	     361 B/op	       7 allocs/op
BenchmarkWrite100EntryBatch10	  200000	     11103 ns/op	     321 B/op	       5 allocs/op
BenchmarkWrite100EntryBatch100	  500000	      3788 ns/op	     320 B/op	       5 allocs/op
BenchmarkWrite100EntryBatch500	 1000000	      2149 ns/op	     320 B/op	       5 allocs/op
BenchmarkWrite100EntryBatch1000	 1000000	      1583 ns/op	     320 B/op	       5 allocs/op
BenchmarkWrite1000EntryWithoutBatch	   10000	    120806 ns/op	    2145 B/op	       7 allocs/op
BenchmarkWrite1000EntryBatch10	  100000	     22244 ns/op	    2132 B/op	       5 allocs/op
BenchmarkWrite1000EntryBatch100	  200000	      8681 ns/op	    2132 B/op	       5 allocs/op
BenchmarkWrite1000EntryBatch500	  200000	      6952 ns/op	    2132 B/op	       5 allocs/op
BenchmarkWrite1000EntryBatch1000	  300000	      6716 ns/op	    2132 B/op	       5 allocs/op
ok  	github.com/coreos/etcd/wal	18.273s
```

after
```
BenchmarkWrite100EntryWithoutBatch	   10000	    112254 ns/op	     233 B/op	       6 allocs/op
BenchmarkWrite100EntryBatch10	  200000	     11131 ns/op	     193 B/op	       4 allocs/op
BenchmarkWrite100EntryBatch100	  500000	      3557 ns/op	     192 B/op	       4 allocs/op
BenchmarkWrite100EntryBatch500	 1000000	      1823 ns/op	     192 B/op	       4 allocs/op
BenchmarkWrite100EntryBatch1000	 1000000	      1750 ns/op	     192 B/op	       4 allocs/op
BenchmarkWrite1000EntryWithoutBatch	   10000	    114098 ns/op	    1121 B/op	       6 allocs/op
BenchmarkWrite1000EntryBatch10	  100000	     19193 ns/op	    1108 B/op	       4 allocs/op
BenchmarkWrite1000EntryBatch100	  200000	      8259 ns/op	    1108 B/op	       4 allocs/op
BenchmarkWrite1000EntryBatch500	  300000	      5725 ns/op	    1108 B/op	       4 allocs/op
BenchmarkWrite1000EntryBatch1000	  300000	      5659 ns/op	    1108 B/op	       4 allocs/op
```