### PR TITLE
etcdct: adopt new client port by default

### DIFF
--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -65,7 +65,7 @@ func getPeersFlagValue(c *cli.Context) []string {
 
 	// If we still don't have peers, use a default
 	if peerstr == "" {
-		peerstr = "127.0.0.1:4001"
+		peerstr = "127.0.0.1:4001,127.0.0.1:2379"
 	}
 
 	return strings.Split(peerstr, ",")


### PR DESCRIPTION
etcdserver uses both 4001 and 2379 for serving client requests by
default. etcdctl supports both ports by default.

/cc @yichengq @barakmich 