### PR TITLE
integration: fix upgrade test

### DIFF
--- a/integration/migration_test.go
+++ b/integration/migration_test.go
@@ -15,8 +15,6 @@
 package integration
 
 import (
-	"github.com/coreos/etcd/pkg/types"
-	"net"
 	"os/exec"
 	"testing"
 )
@@ -24,25 +22,16 @@ import (
 func TestUpgradeMember(t *testing.T) {
 	defer afterTest(t)
 	m := mustNewMember(t, "integration046")
-	newPeerListeners := make([]net.Listener, 0)
-	newPeerListeners = append(newPeerListeners, newListenerWithAddr(t, "127.0.0.1:59892"))
-	m.PeerListeners = newPeerListeners
-	urls, err := types.NewURLs([]string{"http://127.0.0.1:59892"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	m.PeerURLs = urls
-	m.NewCluster = true
-	c := &cluster{}
-	c.Members = []*member{m}
-	fillClusterForMembers(c.Members, "etcd-cluster")
 	cmd := exec.Command("cp", "-r", "testdata/integration046_data/conf", "testdata/integration046_data/log", "testdata/integration046_data/snapshot", m.DataDir)
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := m.Launch(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Terminate(t)
+	m.WaitOK(t)
 
-	c.Launch(t)
-	defer c.Terminate(t)
-	clusterMustProgress(t, c.Members)
+	clusterMustProgress(t, []*member{m})
 }


### PR DESCRIPTION
Upgrade test listens on a fixed port, which may fail with 'bind address
already in use' if the port was just used to send tcp sockets.

The commit makes it listen on a random available port to avoid this.

/cc @barakmich 