### PR TITLE
etcdserver: stop raft node goroutine before stop server

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -341,7 +341,11 @@ func (s *EtcdServer) run() {
 	s.r.s = s
 	s.r.applyc = make(chan apply)
 	go s.r.run()
-	defer close(s.done)
+	defer func() {
+		s.r.stopped <- struct{}{}
+		<-s.r.done
+		close(s.done)
+	}()
 
 	var shouldstop bool
 	for {
@@ -404,7 +408,6 @@ func (s *EtcdServer) run() {
 			return
 		}
 	}
-	// TODO: wait for the stop of raft node routine?
 }
 
 // Stop stops the server gracefully, and shuts down the running goroutine.


### PR DESCRIPTION
Stop raftNode goroutine before stopping server goroutine, so
server.Stop does stop all underlying stuffs elegantly now. This fixes
the problem that previous-round lock on WAL may not be released when
etcd is restarted in integration test.