### PR TITLE
raft: fix freeTo fails to free

### DIFF
--- a/raft/progress_test.go
+++ b/raft/progress_test.go
@@ -151,6 +151,20 @@ func TestInflightFreeTo(t *testing.T) {
 	if !reflect.DeepEqual(in, wantIn3) {
 		t.Fatalf("in = %+v, want %+v", in, wantIn3)
 	}
+
+	in.freeTo(14)
+
+	wantIn4 := &inflights{
+		start: 5,
+		count: 0,
+		size:  10,
+		//                                   ↓
+		buffer: []uint64{10, 11, 12, 13, 14, 5, 6, 7, 8, 9},
+	}
+
+	if !reflect.DeepEqual(in, wantIn4) {
+		t.Fatalf("in = %+v, want %+v", in, wantIn4)
+	}
 }
 
 func TestInflightFreeFirstOne(t *testing.T) {


### PR DESCRIPTION
If freeTo is called when to is set to the lastest inflight, freeTo
fails to free the slots.

/cc @bdarnell @xiang90 