### PR TITLE
store: fix watcher removal

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -140,7 +140,6 @@ func (h *keysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-
 	switch {
 	case resp.Event != nil:
 		if err := writeKeyEvent(w, resp.Event, h.timer); err != nil {

--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -84,7 +84,6 @@ func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeInde
 
 	if ok { // add the new watcher to the back of the list
 		elem = l.PushBack(w)
-
 	} else { // create a new list and add the new watcher
 		l = list.New()
 		elem = l.PushBack(w)
@@ -146,6 +145,7 @@ func (wh *watcherHub) notifyWatchers(e *Event, nodePath string, deleted bool) {
 					// if we successfully notify a watcher
 					// we need to remove the watcher from the list
 					// and decrease the counter
+					w.removed = true
 					l.Remove(curr)
 					atomic.AddInt64(&wh.count, -1)
 				}


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/kubernetes/issues/6059#issuecomment-89273218

Originally, we never remove watcher twice. But due to a misuse of w.remove at https://github.com/coreos/etcd/blob/master/etcdserver/etcdhttp/client.go#L532
, we might remove watcher twice externally.

This commit "fix" the internal store to allow duplicate external removals, since we already have internal protection mechanism to use.

/cc @wojtek-t @lavalamp 