### PR TITLE
etcdmain: deprecate --ca-file and --peer-ca-file

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -109,7 +109,7 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 
 The security flags help to [build a secure etcd cluster][security].
 
-##### -ca-file
+##### -ca-file [DEPRECATED]
 + Path to the client server TLS CA file.
 + default: none
 
@@ -121,7 +121,15 @@ The security flags help to [build a secure etcd cluster][security].
 + Path to the client server TLS key file.
 + default: none
 
-##### -peer-ca-file
+##### -client-cert-auth
++ Enable client cert authentication.
++ default: false
+
+##### -trusted-ca-file
++ Path to the client server TLS trusted CA key file.
++ default: none
+
+##### -peer-ca-file [DEPRECATED]
 + Path to the peer server TLS CA file.
 + default: none
 
@@ -131,6 +139,14 @@ The security flags help to [build a secure etcd cluster][security].
 
 ##### -peer-key-file
 + Path to the peer server TLS key file.
++ default: none
+
+##### -peer-client-cert-auth
++ Enable peer client cert authentication.
++ default: false
+
+##### -peer-trusted-ca-file
++ Path to the peer server TLS trusted CA file.
 + default: none
 
 ### Unsafe Flags

--- a/Documentation/security.md
+++ b/Documentation/security.md
@@ -18,7 +18,9 @@ etcd takes several certificate related configuration options, either through com
 
 `--key-file=<path>`: Key for the certificate. Must be unencrypted.
 
-`--ca-file=<path>`: When this is set etcd will check all incoming HTTPS requests for a client certificate signed by the supplied CA, requests that don't supply a valid client certificate will fail.
+`--client-cert-auth`: When this is set etcd will check all incoming HTTPS requests for a client certificate signed by the trusted CA, requests that don't supply a valid client certificate will fail.
+
+`--trusted-ca-file=<path>`: Trusted certificate authority.
 
 **Peer (server-to-server / cluster) communication:**
 
@@ -28,7 +30,9 @@ The peer options work the same way as the client-to-server options:
 
 `--peer-key-file=<path>`: Key for the certificate. Must be unencrypted.
 
-`--peer-ca-file=<path>`: When set, etcd will check all incoming peer requests from the cluster for valid client certificates signed by the supplied CA.
+`--peer-client-cert-auth`: When set, etcd will check all incoming peer requests from the cluster for valid client certificates signed by the supplied CA.
+
+`--peer-trusted-ca-file=<path>`: Trusted certificate authority.
 
 If either a client-to-server or peer certificate is supplied the key must also be set. All of these configuration options are also available through the environment variables, `ETCD_CA_FILE`, `ETCD_PEER_CA_FILE` and so on.
 
@@ -68,11 +72,9 @@ You need the same files mentioned in the first example for this, as well as a ke
 
 ```sh
 $ etcd -name infra0 -data-dir infra0 \
-  -ca-file=/path/to/ca.crt -cert-file=/path/to/server.crt -key-file=/path/to/server.key \
+  -client-cert-auth -trusted-ca-file=/path/to/ca.crt -cert-file=/path/to/server.crt -key-file=/path/to/server.key \
   -advertise-client-urls https://127.0.0.1:2379 -listen-client-urls https://127.0.0.1:2379
 ```
-
-Notice that the addition of the `-ca-file` option automatically enables client certificate checking.
 
 Now try the same request as above to this server:
 
@@ -130,13 +132,13 @@ DISCOVERY_URL=... # from https://discovery.etcd.io/new
 
 # member1
 $ etcd -name infra1 -data-dir infra1 \
-  -peer-ca-file=/path/to/ca.crt -peer-cert-file=/path/to/member1.crt -peer-key-file=/path/to/member1.key \
+  -peer-client-cert-auth -peer-trusted-ca-file=/path/to/ca.crt -peer-cert-file=/path/to/member1.crt -peer-key-file=/path/to/member1.key \
   -initial-advertise-peer-urls=https://10.0.1.10:2380 -listen-peer-urls=https://10.0.1.10:2380 \
   -discovery ${DISCOVERY_URL}
 
 # member2
 $ etcd -name infra2 -data-dir infra2 \
-  -peer-ca-file=/path/to/ca.crt -peer-cert-file=/path/to/member2.crt -peer-key-file=/path/to/member2.key \
+  -peer-client-cert-atuh -peer-trusted-ca-file=/path/to/ca.crt -peer-cert-file=/path/to/member2.crt -peer-key-file=/path/to/member2.key \
   -initial-advertise-peer-urls=https://10.0.1.11:2380 -listen-peer-urls=https://10.0.1.11:2380 \
   -discovery ${DISCOVERY_URL}
 ```

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -171,12 +171,12 @@ func NewConfig() *config {
 	}
 
 	// security
-	fs.StringVar(&cfg.clientTLSInfo.CAFile, "ca-file", "", "Path to the client server TLS CA file.")
+	fs.StringVar(&cfg.clientTLSInfo.CAFile, "ca-file", "", "DEPRECATED: Path to the client server TLS CA file.")
 	fs.StringVar(&cfg.clientTLSInfo.CertFile, "cert-file", "", "Path to the client server TLS cert file.")
 	fs.StringVar(&cfg.clientTLSInfo.KeyFile, "key-file", "", "Path to the client server TLS key file.")
 	fs.BoolVar(&cfg.clientTLSInfo.ClientCertAuth, "client-cert-auth", false, "Enable client cert authentication.")
 	fs.StringVar(&cfg.clientTLSInfo.TrustedCAFile, "trusted-ca-file", "", "Path to the client server TLS trusted CA key file.")
-	fs.StringVar(&cfg.peerTLSInfo.CAFile, "peer-ca-file", "", "Path to the peer server TLS CA file.")
+	fs.StringVar(&cfg.peerTLSInfo.CAFile, "peer-ca-file", "", "DEPRECATED: Path to the peer server TLS CA file.")
 	fs.StringVar(&cfg.peerTLSInfo.CertFile, "peer-cert-file", "", "Path to the peer server TLS cert file.")
 	fs.StringVar(&cfg.peerTLSInfo.KeyFile, "peer-key-file", "", "Path to the peer server TLS key file.")
 	fs.BoolVar(&cfg.peerTLSInfo.ClientCertAuth, "peer-client-cert-auth", false, "Enable peer client cert authentication.")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -75,7 +75,7 @@ proxy flags:
 
 security flags:
 
-	--ca-file ''
+	--ca-file '' [DEPRECATED]
 		path to the client server TLS CA file.
 	--cert-file ''
 		path to the client server TLS cert file.
@@ -85,7 +85,7 @@ security flags:
 		enable client cert authentication.
 	--trusted-ca-file ''
 		path to the client server TLS trusted CA key file.
-	--peer-ca-file ''
+	--peer-ca-file '' [DEPRECATED]
 		path to the peer server TLS CA file.
 	--peer-cert-file ''
 		path to the peer server TLS cert file.


### PR DESCRIPTION
1. Print out DEPRECATE warning when people are still using it.
2. Remove it from help message.

for #2609 
/cc @kelseyhightower @barakmich 