### PR TITLE
scripts: not put etcd-migrate into release dir

### DIFF
--- a/scripts/build-release
+++ b/scripts/build-release
@@ -39,7 +39,7 @@ function package {
 	if [ ${GOOS} == "windows" ]; then
 		ext=".exe"
 	fi
-	for bin in etcd etcdctl etcd-migrate; do
+	for bin in etcd etcdctl; do
 		cp ${srcdir}/${bin} ${target}/${bin}${ext}
 	done
 


### PR DESCRIPTION
etcd-migrate has been integrated with etcd, and there is no need to put
it into release dir any more.