### PR TITLE
wal: report throughput in wal bench

### DIFF
--- a/wal/wal_bench_test.go
+++ b/wal/wal_bench_test.go
@@ -53,6 +53,7 @@ func benchmarkWriteEntry(b *testing.B, size int, batch int) {
 
 	b.ResetTimer()
 	n := 0
+	b.SetBytes(int64(e.Size()))
 	for i := 0; i < b.N; i++ {
 		err := w.saveEntry(e)
 		if err != nil {


### PR DESCRIPTION
macair with ssd

```
BenchmarkWrite100EntryWithoutBatch	   10000	    113497 ns/op	   0.95 MB/s
BenchmarkWrite100EntryBatch10	  200000	     12419 ns/op	   8.70 MB/s
BenchmarkWrite100EntryBatch100	  500000	      2815 ns/op	  38.36 MB/s
BenchmarkWrite100EntryBatch500	 1000000	      1600 ns/op	  67.48 MB/s
BenchmarkWrite100EntryBatch1000	 1000000	      1317 ns/op	  81.95 MB/s
BenchmarkWrite1000EntryWithoutBatch	   10000	    113797 ns/op	   8.87 MB/s
BenchmarkWrite1000EntryBatch10	  100000	     19267 ns/op	  52.37 MB/s
BenchmarkWrite1000EntryBatch100	  200000	      7747 ns/op	 130.24 MB/s
BenchmarkWrite1000EntryBatch500	  200000	      5745 ns/op	 175.62 MB/s
BenchmarkWrite1000EntryBatch1000	  300000	      5530 ns/op	 182.43 MB/s
ok  	github.com/coreos/etcd/wal	16.053s
```