### PR TITLE
store: support compare-and-delete on directories

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -721,7 +721,7 @@ func (s *EtcdServer) applyRequest(r pb.Request) Response {
 	case "DELETE":
 		switch {
 		case r.PrevIndex > 0 || r.PrevValue != "":
-			return f(s.store.CompareAndDelete(r.Path, r.PrevValue, r.PrevIndex))
+			return f(s.store.CompareAndDelete(r.Path, r.PrevValue, r.PrevIndex, r.Dir, r.Recursive))
 		default:
 			return f(s.store.Delete(r.Path, r.Dir, r.Recursive))
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -354,8 +354,10 @@ func (s *store) CompareAndDelete(nodePath string, prevValue string, prevIndex ui
 		s.WatcherHub.notifyWatchers(e, path, true)
 	}
 
-	// delete a key-value pair, no error should happen
-	n.Remove(false, false, callback)
+	err = n.Remove(dir, false, callback)
+	if err != nil {
+		return nil, err
+	}
 
 	s.WatcherHub.notify(e)
 	s.Stats.Inc(CompareAndDeleteSuccess)


### PR DESCRIPTION
This is a quick test to attempt to fix #556. Does this seem reasonable?
Essentially it removes the if statement to make deleting dirs impossible
and passes the dir and recursive params into compare-and-delete.