### PR TITLE
client: add CreateWithOptions function to client.KeysAPI

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -103,8 +103,11 @@ type KeysAPI interface {
 	// conditions in an DeleteOptions object.
 	Delete(ctx context.Context, key string, opts *DeleteOptions) (*Response, error)
 
-	// Create is an alias for Set w/ PrevExist=false
+	// Create is an alias for CreateWithOptions(ctx, key, value, nil).
 	Create(ctx context.Context, key, value string) (*Response, error)
+
+	// CreateWithOptions is used to create a Node.
+	CreateWithOptions(ctx context.Context, key, value string, opts *CreateOptions) (*Response, error)
 
 	// Update is an alias for Set w/ PrevExist=true
 	Update(ctx context.Context, key, value string) (*Response, error)
@@ -131,6 +134,14 @@ type WatcherOptions struct {
 	// to false (default), events will be limited to those that
 	// occur for the exact key.
 	Recursive bool
+}
+
+type CreateOptions struct {
+	// TTL defines a period of time after-which the Node should
+	// expire and no longer exist. Values <= 0 are ignored. Given
+	// that the zero-value is ignored, TTL cannot be used to set
+	// a TTL of 0.
+	TTL time.Duration
 }
 
 type SetOptions struct {
@@ -291,7 +302,27 @@ func (k *httpKeysAPI) Set(ctx context.Context, key, val string, opts *SetOptions
 }
 
 func (k *httpKeysAPI) Create(ctx context.Context, key, val string) (*Response, error) {
-	return k.Set(ctx, key, val, &SetOptions{PrevExist: PrevNoExist})
+	return k.CreateWithOptions(ctx, key, val, nil)
+}
+
+func (k *httpKeysAPI) CreateWithOptions(ctx context.Context, key, val string, opts *CreateOptions) (*Response, error) {
+	act := &setAction{
+		Prefix:    k.prefix,
+		Key:       key,
+		Value:     val,
+		PrevExist: PrevNoExist,
+	}
+
+	if opts != nil {
+		act.TTL = opts.TTL
+	}
+
+	resp, body, err := k.client.Do(ctx, act)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalHTTPResponse(resp.StatusCode, resp.Header, body)
 }
 
 func (k *httpKeysAPI) Update(ctx context.Context, key, val string) (*Response, error) {

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -1176,17 +1176,38 @@ func TestHTTPKeysAPIDeleteResponse(t *testing.T) {
 }
 
 func TestHTTPKeysAPICreateAction(t *testing.T) {
-	act := &setAction{
-		Key:       "/foo",
-		Value:     "bar",
-		PrevExist: PrevNoExist,
-		PrevIndex: 0,
-		PrevValue: "",
-		TTL:       0,
+
+	tests := []struct {
+		opts       *CreateOptions
+		wantAction httpAction
+	}{
+		// nil CreateOptions
+		{
+			opts: nil,
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevExist: PrevNoExist,
+			},
+		},
+		{
+			opts: &CreateOptions{
+				TTL: 100,
+			},
+			wantAction: &setAction{
+				Key:       "/foo",
+				Value:     "bar",
+				PrevExist: PrevNoExist,
+				TTL:       100,
+			},
+		},
 	}
 
-	kAPI := httpKeysAPI{client: &actionAssertingHTTPClient{t: t, act: act}}
-	kAPI.Create(context.Background(), "/foo", "bar")
+	for i, tt := range tests {
+		client := &actionAssertingHTTPClient{t: t, num: i, act: tt.wantAction}
+		kAPI := httpKeysAPI{client: client}
+		kAPI.CreateWithOptions(context.Background(), "/foo", "bar", tt.opts)
+	}
 }
 
 func TestHTTPKeysAPIUpdateAction(t *testing.T) {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -414,6 +414,10 @@ type clientWithResp struct {
 }
 
 func (c *clientWithResp) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+	return c.CreateWithOptions(ctx, key, value, nil)
+}
+
+func (c *clientWithResp) CreateWithOptions(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	if len(c.rs) == 0 {
 		return &client.Response{}, nil
 	}
@@ -442,6 +446,10 @@ type clientWithErr struct {
 }
 
 func (c *clientWithErr) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+	return c.CreateWithOptions(ctx, key, value, nil)
+}
+
+func (c *clientWithErr) CreateWithOptions(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	return &client.Response{}, c.err
 }
 
@@ -483,11 +491,15 @@ type clientWithRetry struct {
 }
 
 func (c *clientWithRetry) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+	return c.CreateWithOptions(ctx, key, value, nil)
+}
+
+func (c *clientWithRetry) CreateWithOptions(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	if c.failCount < c.failTimes {
 		c.failCount++
 		return nil, context.DeadlineExceeded
 	}
-	return c.clientWithResp.Create(ctx, key, value)
+	return c.clientWithResp.CreateWithOptions(ctx, key, value, opts)
 }
 
 func (c *clientWithRetry) Get(ctx context.Context, key string, opts *client.GetOptions) (*client.Response, error) {


### PR DESCRIPTION
Allows you to optionally Create nodes with:
* A TTL
* Ignore existing node values

This Succeeds #2410