### PR TITLE
snap: load should only return ErrNoSnapshot

### DIFF
--- a/snap/snapshotter.go
+++ b/snap/snapshotter.go
@@ -89,7 +89,10 @@ func (s *Snapshotter) Load() (*raftpb.Snapshot, error) {
 			break
 		}
 	}
-	return snap, err
+	if err != nil {
+		return nil, ErrNoSnapshot
+	}
+	return snap, nil
 }
 
 func loadSnap(dir, name string) (*raftpb.Snapshot, error) {


### PR DESCRIPTION
If there is no available snapshot, load should return
ErrNoSnapshot. etcdserver might recover from that error
if it still have complete WAL files.

Fix #2661 

I tested it with corrupted wal too.