### PR TITLE
etcdserver: not update attr if cluster is ahead of store index

### DIFF
--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -369,11 +369,13 @@ func (c *Cluster) RemoveMember(id types.ID, index uint64) {
 	}
 }
 
-func (c *Cluster) UpdateAttributes(id types.ID, attr Attributes) {
+func (c *Cluster) UpdateAttributes(id types.ID, attr Attributes, index uint64) {
 	c.Lock()
 	defer c.Unlock()
-	c.members[id].Attributes = attr
-	// TODO: update store in this function
+	if index > c.index {
+		c.members[id].Attributes = attr
+		// TODO: update store in this function
+	}
 }
 
 // UpdateRaftAttributes updates the raft attributes of the given id.

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -671,7 +671,7 @@ func (s *EtcdServer) apply(es []raftpb.Entry, confState *raftpb.ConfState) (uint
 		case raftpb.EntryNormal:
 			var r pb.Request
 			pbutil.MustUnmarshal(&r, e.Data)
-			s.w.Trigger(r.ID, s.applyRequest(r))
+			s.w.Trigger(r.ID, s.applyRequest(r, e.Index))
 		case raftpb.EntryConfChange:
 			var cc raftpb.ConfChange
 			pbutil.MustUnmarshal(&cc, e.Data)
@@ -689,7 +689,7 @@ func (s *EtcdServer) apply(es []raftpb.Entry, confState *raftpb.ConfState) (uint
 
 // applyRequest interprets r as a call to store.X and returns a Response interpreted
 // from store.Event
-func (s *EtcdServer) applyRequest(r pb.Request) Response {
+func (s *EtcdServer) applyRequest(r pb.Request, index uint64) Response {
 	f := func(ev *store.Event, err error) Response {
 		return Response{Event: ev, err: err}
 	}
@@ -714,7 +714,7 @@ func (s *EtcdServer) applyRequest(r pb.Request) Response {
 				if err := json.Unmarshal([]byte(r.Val), &attr); err != nil {
 					log.Panicf("unmarshal %s should never fail: %v", r.Val, err)
 				}
-				s.Cluster.UpdateAttributes(id, attr)
+				s.Cluster.UpdateAttributes(id, attr, index)
 			}
 			return f(s.store.Set(r.Path, r.Dir, r.Val, expr))
 		}

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -379,7 +379,7 @@ func TestApplyRequest(t *testing.T) {
 	for i, tt := range tests {
 		st := &storeRecorder{}
 		srv := &EtcdServer{store: st}
-		resp := srv.applyRequest(tt.req)
+		resp := srv.applyRequest(tt.req, 0)
 
 		if !reflect.DeepEqual(resp, tt.wresp) {
 			t.Errorf("#%d: resp = %+v, want %+v", i, resp, tt.wresp)
@@ -403,7 +403,9 @@ func TestApplyRequestOnAdminMemberAttributes(t *testing.T) {
 		Path:   path.Join(storeMembersPrefix, strconv.FormatUint(1, 16), attributesSuffix),
 		Val:    `{"Name":"abc","ClientURLs":["http://127.0.0.1:2379"]}`,
 	}
-	srv.applyRequest(req)
+	// req is committed at index 1
+	index := uint64(1)
+	srv.applyRequest(req, index)
 	w := Attributes{Name: "abc", ClientURLs: []string{"http://127.0.0.1:2379"}}
 	if g := cl.Member(1).Attributes; !reflect.DeepEqual(g, w) {
 		t.Errorf("attributes = %v, want %v", g, w)


### PR DESCRIPTION
If the cluster is ahead of current store index, it should not make changes
for committed requests because they have been applied.

fix most of #2681 