### PR TITLE
etcdserver: internal request union

### DIFF
--- a/etcdserver/etcdserverpb/etcdserver.proto
+++ b/etcdserver/etcdserverpb/etcdserver.proto
@@ -31,3 +31,12 @@ message Metadata {
 	optional uint64 NodeID    = 1 [(gogoproto.nullable) = false];
 	optional uint64 ClusterID = 2 [(gogoproto.nullable) = false];
 }
+
+// An InternalRaftRequest is the union of all requests which can be
+// sent via raft.
+message InternalRaftRequest {
+  option (gogoproto.onlyone) = true;
+  oneof value {
+    Request v2 = 1;
+  }
+}

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -982,10 +982,11 @@ func TestPublish(t *testing.T) {
 		t.Fatalf("action = %s, want Propose", action[0].Name)
 	}
 	data := action[0].Params[0].([]byte)
-	var r pb.Request
-	if err := r.Unmarshal(data); err != nil {
+	var rr pb.InternalRaftRequest
+	if err := rr.Unmarshal(data); err != nil {
 		t.Fatalf("unmarshal request error: %v", err)
 	}
+	r := rr.V2
 	if r.Method != "PUT" {
 		t.Errorf("method = %s, want PUT", r.Method)
 	}
@@ -1062,10 +1063,11 @@ func TestUpdateVersion(t *testing.T) {
 		t.Fatalf("action = %s, want Propose", action[0].Name)
 	}
 	data := action[0].Params[0].([]byte)
-	var r pb.Request
-	if err := r.Unmarshal(data); err != nil {
+	var rr pb.InternalRaftRequest
+	if err := rr.Unmarshal(data); err != nil {
 		t.Fatalf("unmarshal request error: %v", err)
 	}
+	r := rr.V2
 	if r.Method != "PUT" {
 		t.Errorf("method = %s, want PUT", r.Method)
 	}

--- a/pkg/pbutil/pbutil.go
+++ b/pkg/pbutil/pbutil.go
@@ -42,6 +42,13 @@ func MustUnmarshal(um Unmarshaler, data []byte) {
 	}
 }
 
+func MaybeUnmarshal(um Unmarshaler, data []byte) bool {
+	if err := um.Unmarshal(data); err != nil {
+		return false
+	}
+	return true
+}
+
 func GetBool(v *bool) (vv bool, set bool) {
 	if v == nil {
 		return false, false


### PR DESCRIPTION
prepare for v3 api request

The wire types of Request and InternalRaftRequest are different. So we do not need the magic number.

/cc @yichengq @barakmich @philips 