### PR TITLE
etcdserver: omit updateattr on non-exist member in Cluster

### DIFF
--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -372,7 +372,9 @@ func (c *Cluster) RemoveMember(id types.ID, index uint64) {
 func (c *Cluster) UpdateAttributes(id types.ID, attr Attributes) {
 	c.Lock()
 	defer c.Unlock()
-	c.members[id].Attributes = attr
+	if m, ok := c.members[id]; ok {
+		m.Attributes = attr
+	}
 	// TODO: update store in this function
 }
 


### PR DESCRIPTION
The omission happens only when newly joined member catches up the
progress.

Its Cluster struct has a future view of members, which doesn't have
members that are removed between local index and future index.

The non-exist member should be removed from the cluster in further apply,
so it is ok to omit the updateattr in Cluster.

fixes #2681 