### PR TITLE
genproto assumes bash; specify bash

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 #
 # Generate all etcd protobuf bindings.
 # Run from repository root.


### PR DESCRIPTION
Specifically, line 21 assumes a bash-like shell (I believe):
```
go get github.com/gogo/protobuf/{proto,protoc-gen-gogo,gogoproto}
```