### PR TITLE
RFC: proxy: basic proxy status/stats

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -80,8 +80,6 @@ func (p *reverseProxy) proxyStats(w http.ResponseWriter, r *http.Request) {
 		stats.Endpoints[i] = &proxyEndpoint{
 			URL:       ep.URL.String(),
 			Available: ep.Available,
-			Requests:  ep.Requests,
-			Errors:    ep.Errors,
 		}
 	}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -65,7 +65,7 @@ type (
 
 	proxyEndpoint struct {
 		URL       string `json:"url"`
-		Available bool   `json:"availible"`
+		Available bool   `json:"available"`
 	}
 )
 


### PR DESCRIPTION
request for comment.

Simple start of proxy specific status/stats. Currently, just show the current endpoint the proxy is using. This may be useful as the list can change through the lifetime of the proxy.

We do not have a way to see the list of endpoints except by looking at the proxy's "state file". This is a rough start, but demonstrates the idea.  We could add some counters/timings which may be helpful to find a misbehaving proxy and/or server.