### PR TITLE
docs: remove absolute links to other docs

### DIFF
--- a/Documentation/admin_guide.md
+++ b/Documentation/admin_guide.md
@@ -15,7 +15,7 @@ Using an out-of-date data directory can lead to inconsistency as the member had 
 For maximum safety, if an etcd member suffers any sort of data corruption or loss, it must be removed from the cluster.
 Once removed the member can be re-added with an empty data directory.
 
-[members-api]: https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md#members-api
+[members-api]: other_apis.md#members-api
 
 #### Contents
 
@@ -133,7 +133,7 @@ etcd -name node1 \
 -advertise-client-urls http://10.0.1.13:2379,http://127.0.0.1:2379
 ```
 
-[change peer url]: https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md#change-the-peer-urls-of-a-member
+[change peer url]: other_apis.md#change-the-peer-urls-of-a-member
 
 ### Disaster Recovery
 

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1046,4 +1046,4 @@ curl http://127.0.0.1:2379/v2/stats/store
 
 See the [other etcd APIs][other-apis] for details on the cluster management.
 
-[other-apis]: https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md
+[other-apis]: other_apis.md

--- a/Documentation/backward_compatibility.md
+++ b/Documentation/backward_compatibility.md
@@ -94,18 +94,18 @@ Standby mode was intended for large clusters that had a subset of the members ac
 
 Proxy mode in 2.0 will provide similar functionality, and with improved control over which machines act as proxies due to the operator specifically configuring them. Proxies also support read only or read/write modes for increased security and durability.
 
-[proxymode]: https://github.com/coreos/etcd/blob/master/Documentation/proxy.md
+[proxymode]: proxy.md
 
 ## Discovery Service
 
 A size key needs to be provided inside a [discovery token][discoverytoken].
-[discoverytoken]: https://github.com/coreos/etcd/blob/master/Documentation/clustering.md#custom-etcd-discovery-service
+[discoverytoken]: clustering.md#custom-etcd-discovery-service
 
 ## HTTP Admin API
 
 `v2/admin` on peer url and `v2/keys/_etcd` are unified under the new [v2/member API][memberapi] to better explain which machines are part of an etcd cluster, and to simplify the keyspace for all your use cases.
 
-[memberapi]: https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md
+[memberapi]: other_apis.md
 
 ## HTTP Key Value API
 - The follower can now transparently proxy write equests to the leader. Clients will no longer see 307 redirections to the leader from etcd.

--- a/Documentation/clustering.md
+++ b/Documentation/clustering.md
@@ -116,7 +116,7 @@ A discovery URL identifies a unique etcd cluster. Instead of reusing a discovery
 
 Moreover, discovery URLs should ONLY be used for the initial bootstrapping of a cluster. To change cluster membership after the cluster is already running, see the [runtime reconfiguration][runtime] guide.
 
-[runtime]: https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md
+[runtime]: runtime-configuration.md
 
 #### Custom etcd Discovery Service
 

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -165,9 +165,9 @@ Follow the instructions when using these flags.
 + Print the version and exit.
 + default: false
 
-[build-cluster]: https://github.com/coreos/etcd/blob/master/Documentation/clustering.md#static
-[reconfig]: https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md
-[discovery]: https://github.com/coreos/etcd/blob/master/Documentation/clustering.md#discovery
-[proxy]: https://github.com/coreos/etcd/blob/master/Documentation/proxy.md
-[security]: https://github.com/coreos/etcd/blob/master/Documentation/security.md
-[restore]: https://github.com/coreos/etcd/blob/master/Documentation/admin_guide.md#restoring-a-backup
+[build-cluster]: clustering.md#static
+[reconfig]: runtime-configuration.md
+[discovery]: clustering.md#discovery
+[proxy]: proxy.md
+[security]: security.md
+[restore]: admin_guide.md#restoring-a-backup

--- a/Documentation/proxy.md
+++ b/Documentation/proxy.md
@@ -31,4 +31,4 @@ etcd -proxy on -listen-client-urls 127.0.0.1:8080  -discovery https://discovery.
 #### Fallback to proxy mode with discovery service
 If you bootstrap a etcd cluster using [discovery service][discovery-service] with more than the expected number of etcd members, the extra etcd processes will fall back to being `readwrite` proxies by default. They will forward the requests to the cluster as described above. For example, if you create a discovery url with `size=5`, and start ten etcd processes using that same discovery url, the result will be a cluster with five etcd members and five proxies. Note that this behaviour can be disabled with the `proxy-fallback` flag.
 
-[discovery-service]: https://github.com/coreos/etcd/blob/master/Documentation/clustering.md#discovery
+[discovery-service]: clustering.md#discovery

--- a/Documentation/runtime-configuration.md
+++ b/Documentation/runtime-configuration.md
@@ -57,7 +57,7 @@ To increase from 3 to 5 members you will make two add operations
 To decrease from 5 to 3 you will make two remove operations
 
 All of these examples will use the `etcdctl` command line tool that ships with etcd.
-If you want to use the member API directly you can find the documentation [here](https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md).
+If you want to use the member API directly you can find the documentation [here](other_apis.md).
 
 ### Remove a Member
 
@@ -90,7 +90,7 @@ It is safe to remove the leader, however the cluster will be inactive while a ne
 
 Adding a member is a two step process:
 
- * Add the new member to the cluster via the [members API](https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md#post-v2members) or the `etcdctl member add` command.
+ * Add the new member to the cluster via the [members API](other_apis.md#post-v2members) or the `etcdctl member add` command.
  * Start the new member with the new cluster configuration, including a list of the updated members (existing members + the new member).
 
 Using `etcdctl` let's add the new member to the cluster by specifing its [name](configuration.md#-name) and [advertised peer URLs](configuration.md#-initial-advertise-peer-urls):


### PR DESCRIPTION
Having these absolute links means that users reading docs on coreos.com/etcd will jump over to github and linking directly to master will break any versioning of docs.