### PR TITLE
docs: fix link to etcd-migrate in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Now it's time to dig into the full etcd API and other guides.
 [libraries-and-tools]: ./Documentation/libraries-and-tools.md
 [security]: ./Documentation/security.md
 [tuning]: ./Documentation/tuning.md
-[upgrade]: ./Documentation/0_4_migration_tool.md
+[upgrade]: ./tools/etcd-migrate/README.md
 
 ## Contact
 


### PR DESCRIPTION
This fixes the link in README, but [this PR](https://github.com/coreos/etcd/pull/2735) suggests that moving docs outside of /Documentation causes issues. It may be better to restore the etcd-migrate doc to its previous location if practical?