### PR TITLE
wal: change io.EOF returned by readFull to io.ErrUnexpectedEOF

### DIFF
--- a/wal/decoder.go
+++ b/wal/decoder.go
@@ -54,6 +54,11 @@ func (d *decoder) decode(rec *walpb.Record) error {
 	}
 	data := make([]byte, l)
 	if _, err = io.ReadFull(d.br, data); err != nil {
+		// ReadFull returns io.EOF only if no bytes were read
+		// the decoder should treat this as an ErrUnexpectedEOF instead.
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
 		return err
 	}
 	if err := rec.Unmarshal(data); err != nil {

--- a/wal/record_test.go
+++ b/wal/record_test.go
@@ -42,6 +42,7 @@ func TestReadRecord(t *testing.T) {
 	}{
 		{infoRecord, &walpb.Record{Type: 1, Crc: crc32.Checksum(infoData, crcTable), Data: infoData}, nil},
 		{[]byte(""), &walpb.Record{}, io.EOF},
+		{infoRecord[:8], &walpb.Record{}, io.ErrUnexpectedEOF},
 		{infoRecord[:len(infoRecord)-len(infoData)-8], &walpb.Record{}, io.ErrUnexpectedEOF},
 		{infoRecord[:len(infoRecord)-len(infoData)], &walpb.Record{}, io.ErrUnexpectedEOF},
 		{infoRecord[:len(infoRecord)-8], &walpb.Record{}, io.ErrUnexpectedEOF},


### PR DESCRIPTION
Fix #2736

Decoder should return error for any broken block including the
one that only contains the length field. We should change io.EOF
to io.ErrUnexpectedEOF before return the error.