### PR TITLE
client: fix test name typo

### DIFF
--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -923,7 +923,7 @@ func TestHTTPKeysAPIWatcherAction(t *testing.T) {
 	}
 }
 
-func TestHTTPKeysAPIcreateInOrderAction(t *testing.T) {
+func TestHTTPKeysAPISetAction(t *testing.T) {
 	tests := []struct {
 		key        string
 		value      string


### PR DESCRIPTION
This is introduced at d89a862

fixes https://github.com/coreos/etcd/pull/2673#discussion_r28611361