### PR TITLE
etcdmain: advertise-client-urls must be set if listen-client-urls is set

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -61,6 +61,7 @@ var (
 
 	ErrConflictBootstrapFlags = fmt.Errorf("multiple discovery or bootstrap flags are set" +
 		"Choose one of \"initial-cluster\", \"discovery\" or \"discovery-srv\"")
+	errUnsetAdvertiseClientURLsFlag = fmt.Errorf("-advertise-client-urls is required when -listen-client-urls is set explicitly")
 )
 
 type config struct {
@@ -263,6 +264,9 @@ func (cfg *config) Parse(arguments []string) error {
 	cfg.acurls, err = flags.URLsFromFlags(cfg.FlagSet, "advertise-client-urls", "addr", cfg.clientTLSInfo)
 	if err != nil {
 		return err
+	}
+	if flags.IsSet(cfg.FlagSet, "listen-client-urls") && !flags.IsSet(cfg.FlagSet, "advertise-client-urls") {
+		return errUnsetAdvertiseClientURLsFlag
 	}
 
 	if 5*cfg.TickMs > cfg.ElectionMs {

--- a/etcdmain/config_test.go
+++ b/etcdmain/config_test.go
@@ -29,6 +29,8 @@ func TestConfigParsingMemberFlags(t *testing.T) {
 		"-snapshot-count=10",
 		"-listen-peer-urls=http://localhost:8000,https://localhost:8001",
 		"-listen-client-urls=http://localhost:7000,https://localhost:7001",
+		// it should be set if -listen-client-urls is set
+		"-advertise-client-urls=http://localhost:7000,https://localhost:7001",
 	}
 	wcfg := &config{
 		dir:          "testdir",

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -60,7 +60,12 @@ func Main() {
 	cfg := NewConfig()
 	err := cfg.Parse(os.Args[1:])
 	if err != nil {
-		log.Fatalf("error verifying flags, %v. See 'etcd -help'.", err)
+		log.Printf("error verifying flags, %v. See 'etcd -help'.", err)
+		switch err {
+		case errUnsetAdvertiseClientURLsFlag:
+			log.Printf("When listening on specific address(es), this etcd process must advertise accessible url(s) to each connected client.")
+		}
+		os.Exit(1)
 	}
 	setupLogging(cfg)
 

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -56,7 +56,8 @@ clustering flags:
 	--initial-cluster-token 'etcd-cluster'
 		initial cluster token for the etcd cluster during bootstrap.
 	--advertise-client-urls 'http://localhost:2379,http://localhost:4001'
-		list of this member's client URLs to advertise to the rest of the cluster.
+		list of this member's client URLs to advertise to the public.
+		The client URLs advertised should be accessible to machines that talk to etcd cluster. etcd client libraries parse these URLs to connect to the cluster.
 	--discovery ''
 		discovery URL used to bootstrap the cluster.
 	--discovery-fallback 'proxy'


### PR DESCRIPTION
Before this PR, people can set listen-client-urls without setting
advertise-client-urls, and leaves advertise-client-urls as default
localhost value. The client libraries which sync the cluster info
fetch wrong advertise-client-urls and cannot connect to the cluster.
This PR avoids this case and provides better UX.

On the other hand, this change is safe because people always want to set
advertise-client-urls if listen-client-urls is set. The default localhost
advertise url cannot be accessed from the outside, and should always be
set except that etcd is bootstrapped with no flag.

This follows #2334 
This helps recent issues #2734 , #2694 

Before this PR:
```
unihorn@CoreOS ~/g/s/g/c/etcd> ./bin/etcd --listen-client-urls http://localhost:9999
2015/04/27 10:11:14 etcd: no data-dir provided, using default data-dir ./default.etcd
2015/04/27 10:11:14 etcd: already initialized as member before, starting as etcd member...
2015/04/27 10:11:14 etcd: listening for peers on http://localhost:2380
2015/04/27 10:11:14 etcd: listening for peers on http://localhost:7001
2015/04/27 10:11:14 etcd: listening for client requests on http://localhost:9999
2015/04/27 10:11:14 etcdserver: datadir is valid for the 2.0.1 format
2015/04/27 10:11:15 etcdserver: name = default
2015/04/27 10:11:15 etcdserver: data dir = default.etcd
2015/04/27 10:11:15 etcdserver: member dir = default.etcd/member
2015/04/27 10:11:15 etcdserver: heartbeat = 100ms
2015/04/27 10:11:15 etcdserver: election = 1000ms
2015/04/27 10:11:15 etcdserver: snapshot count = 10000
2015/04/27 10:11:15 etcdserver: advertise client URLs = http://localhost:2379,http://localhost:4001
2015/04/27 10:11:15 etcdserver: restart member ce2a822cea30bfca in cluster 7e27652122e8b2ae at commit index 13
2015/04/27 10:11:15 INFO: raft: ce2a822cea30bfca became follower at term 2
2015/04/27 10:11:15 INFO: raft: newRaft ce2a822cea30bfca [peers: [], term: 2, commit: 13, applied: 0, lastindex: 13, lastterm: 2]
2015/04/27 10:11:15 etcdserver: cannot monitor file descriptor usage (cannot get FDUsage on darwin)
2015/04/27 10:11:15 etcdserver: added local member ce2a822cea30bfca [http://localhost:2380 http://localhost:7001] to cluster 7e27652122e8b2ae
2015/04/27 10:11:16 INFO: raft: ce2a822cea30bfca is starting a new election at term 2
2015/04/27 10:11:16 INFO: raft: ce2a822cea30bfca became candidate at term 3
2015/04/27 10:11:16 INFO: raft: ce2a822cea30bfca received vote from ce2a822cea30bfca at term 3
2015/04/27 10:11:16 INFO: raft: ce2a822cea30bfca became leader at term 3
2015/04/27 10:11:16 INFO: raft.node: ce2a822cea30bfca elected leader ce2a822cea30bfca at term 3
2015/04/27 10:11:16 etcdserver: published {Name:default ClientURLs:[http://localhost:2379 http://localhost:4001]} to cluster 7e27652122e8b2ae
```

After this PR:
```
unihorn@CoreOS ~/g/s/g/c/etcd> ./bin/etcd --listen-client-urls http://localhost:9999
2015/04/27 22:28:44 etcd: error verifying flags, -advertise-client-urls is required when -listen-client-urls is set explicitly. See 'etcd -help'.
2015/04/27 22:28:44 When listening on specific address(es), this etcd process must advertise accessible url(s) to each connected client.
```

```
$ etcd -help
	--advertise-client-urls 'http://localhost:2379,http://localhost:4001'
		list of this member's client URLs to advertise to the public.
		The client URLs advertised should be accessible to machines that talk to etcd cluster. etcd client libraries parse these URLs to connect to the cluster.
```

/cc @barakmich 