### PR TITLE
rafthttp: only close streamMsgApp when updating term

### DIFF
--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -317,10 +317,12 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser) error {
 	}
 }
 
+// updateMsgAppTerm updates the term for MsgApp stream, and closes
+// the existing MsgApp stream if term is updated.
 func (cr *streamReader) updateMsgAppTerm(term uint64) {
 	cr.mu.Lock()
 	defer cr.mu.Unlock()
-	if cr.msgAppTerm == term {
+	if cr.msgAppTerm >= term {
 		return
 	}
 	cr.msgAppTerm = term

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -324,7 +324,9 @@ func (cr *streamReader) updateMsgAppTerm(term uint64) {
 		return
 	}
 	cr.msgAppTerm = term
-	cr.close()
+	if cr.t == streamTypeMsgApp {
+		cr.close()
+	}
 }
 
 // TODO: always cancel in-flight dial and decode


### PR DESCRIPTION
In all stream types, streamMsgApp needs to be closed when
updating term because its stream connection can only be used under
a certain term. But there is no need to close other streams, which
may waste time and reduce performance.