### PR TITLE
discovery: do not return raw error from etcd store

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -183,7 +183,7 @@ func (d *discovery) createSelf(contents string) error {
 	resp, err := d.c.Create(ctx, d.selfKey(), contents)
 	cancel()
 	if err != nil {
-		if eerr, ok := err.(*client.Error); ok && eerr.Code == client.ErrorCodeNodeExist {
+		if eerr, ok := err.(client.Error); ok && eerr.Code == client.ErrorCodeNodeExist {
 			return ErrDuplicateID
 		}
 		return err

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -318,6 +318,7 @@ func TestCreateSelf(t *testing.T) {
 
 	c := &clientWithResp{rs: rs, w: w}
 	errc := &clientWithErr{err: errors.New("create err"), w: w}
+	errdupc := &clientWithErr{err: client.Error{Code: client.ErrorCodeNodeExist}}
 	errwc := &clientWithResp{rs: rs, w: errw}
 
 	tests := []struct {
@@ -330,6 +331,8 @@ func TestCreateSelf(t *testing.T) {
 		{errc, errc.err},
 		// watcher.next retuens an error
 		{errwc, errw.err},
+		// parse key exist error to duplciate ID error
+		{errdupc, ErrDuplicateID},
 	}
 
 	for i, tt := range tests {

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -99,8 +99,10 @@ func Main() {
 	if err != nil {
 		switch err {
 		case discovery.ErrDuplicateID:
-			log.Fatalf("member %s has previously registered with discovery service (%s), but the data-dir (%s) on disk cannot be found.",
-				cfg.name, cfg.durl, cfg.dir)
+			log.Printf("member %q has previously registered with discovery service token (%s).", cfg.name, cfg.durl)
+			log.Printf("But etcd could not find vaild cluster configuration in the given data dir (%s).", cfg.dir)
+			log.Printf("Please check the given data dir path if the previous bootstrap succeeded")
+			log.Printf("or use a new discovery token if the previous bootstrap failed.")
 		default:
 			log.Fatalf("%v", err)
 		}


### PR DESCRIPTION
We used to return `key not found` directly to the
user due to a bug. We fixed the bug and added a test
case in this commit.

Fix https://github.com/coreos/etcd/issues/2710