### PR TITLE
etcdserver: stop exposing Cluster struct

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -203,7 +203,7 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 		Handler: etcdhttp.NewClientHandler(s),
 		Info:    cfg.corsInfo,
 	}
-	ph := etcdhttp.NewPeerHandler(s.Cluster, s.RaftHandler())
+	ph := etcdhttp.NewPeerHandler(s.Cluster(), s.RaftHandler())
 	// Start the peer server in a goroutine
 	for _, l := range plns {
 		go func(l net.Listener) {

--- a/etcdserver/cluster_test.go
+++ b/etcdserver/cluster_test.go
@@ -470,7 +470,7 @@ func TestClusterAddMember(t *testing.T) {
 }
 
 func TestClusterMembers(t *testing.T) {
-	cls := &Cluster{
+	cls := &cluster{
 		members: map[types.ID]*Member{
 			1:   &Member{ID: 1},
 			20:  &Member{ID: 20},
@@ -521,8 +521,8 @@ func TestNodeToMember(t *testing.T) {
 	}
 }
 
-func newTestCluster(membs []*Member) *Cluster {
-	c := &Cluster{members: make(map[types.ID]*Member), removed: make(map[types.ID]bool)}
+func newTestCluster(membs []*Member) *cluster {
+	c := &cluster{members: make(map[types.ID]*Member), removed: make(map[types.ID]bool)}
 	for _, m := range membs {
 		c.members[m.ID] = m
 	}

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -30,7 +30,7 @@ import (
 
 // isMemberBootstrapped tries to check if the given member has been bootstrapped
 // in the given cluster.
-func isMemberBootstrapped(cl *Cluster, member string, tr *http.Transport) bool {
+func isMemberBootstrapped(cl *cluster, member string, tr *http.Transport) bool {
 	rcl, err := getClusterFromRemotePeers(getRemotePeerURLs(cl, member), false, tr)
 	if err != nil {
 		return false
@@ -51,12 +51,12 @@ func isMemberBootstrapped(cl *Cluster, member string, tr *http.Transport) bool {
 // these URLs. The first URL to provide a response is used. If no URLs provide
 // a response, or a Cluster cannot be successfully created from a received
 // response, an error is returned.
-func GetClusterFromRemotePeers(urls []string, tr *http.Transport) (*Cluster, error) {
+func GetClusterFromRemotePeers(urls []string, tr *http.Transport) (*cluster, error) {
 	return getClusterFromRemotePeers(urls, true, tr)
 }
 
 // If logerr is true, it prints out more error messages.
-func getClusterFromRemotePeers(urls []string, logerr bool, tr *http.Transport) (*Cluster, error) {
+func getClusterFromRemotePeers(urls []string, logerr bool, tr *http.Transport) (*cluster, error) {
 	cc := &http.Client{
 		Transport: tr,
 		Timeout:   time.Second,
@@ -90,14 +90,14 @@ func getClusterFromRemotePeers(urls []string, logerr bool, tr *http.Transport) (
 			}
 			continue
 		}
-		return NewClusterFromMembers("", id, membs), nil
+		return newClusterFromMembers("", id, membs), nil
 	}
 	return nil, fmt.Errorf("etcdserver: could not retrieve cluster information from the given urls")
 }
 
 // getRemotePeerURLs returns peer urls of remote members in the cluster. The
 // returned list is sorted in ascending lexicographical order.
-func getRemotePeerURLs(cl ClusterInfo, local string) []string {
+func getRemotePeerURLs(cl Cluster, local string) []string {
 	us := make([]string, 0)
 	for _, m := range cl.Members() {
 		if m.Name == local {
@@ -113,7 +113,7 @@ func getRemotePeerURLs(cl ClusterInfo, local string) []string {
 // The key of the returned map is the member's ID. The value of the returned map
 // is the semver version string. If it fails to get the version of a member, the key
 // will be an empty string.
-func getVersions(cl ClusterInfo, tr *http.Transport) map[string]string {
+func getVersions(cl Cluster, tr *http.Transport) map[string]string {
 	members := cl.Members()
 	vers := make(map[string]string)
 	for _, m := range members {

--- a/etcdserver/etcdhttp/client_security.go
+++ b/etcdserver/etcdhttp/client_security.go
@@ -28,8 +28,8 @@ import (
 )
 
 type securityHandler struct {
-	sec         *security.Store
-	clusterInfo etcdserver.ClusterInfo
+	sec     *security.Store
+	cluster etcdserver.Cluster
 }
 
 func hasWriteRootAccess(sec *security.Store, r *http.Request) bool {
@@ -140,7 +140,7 @@ func (sh *securityHandler) baseRoles(w http.ResponseWriter, r *http.Request) {
 		writeNoAuth(w)
 		return
 	}
-	w.Header().Set("X-Etcd-Cluster-ID", sh.clusterInfo.ID().String())
+	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
 	w.Header().Set("Content-Type", "application/json")
 	var rolesCollections struct {
 		Roles []string `json:"roles"`
@@ -185,7 +185,7 @@ func (sh *securityHandler) forRole(w http.ResponseWriter, r *http.Request, role 
 		writeNoAuth(w)
 		return
 	}
-	w.Header().Set("X-Etcd-Cluster-ID", sh.clusterInfo.ID().String())
+	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
 
 	switch r.Method {
 	case "GET":
@@ -245,7 +245,7 @@ func (sh *securityHandler) baseUsers(w http.ResponseWriter, r *http.Request) {
 		writeNoAuth(w)
 		return
 	}
-	w.Header().Set("X-Etcd-Cluster-ID", sh.clusterInfo.ID().String())
+	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
 	w.Header().Set("Content-Type", "application/json")
 	var usersCollections struct {
 		Users []string `json:"users"`
@@ -290,7 +290,7 @@ func (sh *securityHandler) forUser(w http.ResponseWriter, r *http.Request, user 
 		writeNoAuth(w)
 		return
 	}
-	w.Header().Set("X-Etcd-Cluster-ID", sh.clusterInfo.ID().String())
+	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
 
 	switch r.Method {
 	case "GET":
@@ -360,7 +360,7 @@ func (sh *securityHandler) enableDisable(w http.ResponseWriter, r *http.Request)
 		writeNoAuth(w)
 		return
 	}
-	w.Header().Set("X-Etcd-Cluster-ID", sh.clusterInfo.ID().String())
+	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
 	w.Header().Set("Content-Type", "application/json")
 	isEnabled := sh.sec.SecurityEnabled()
 	switch r.Method {

--- a/etcdserver/etcdhttp/peer.go
+++ b/etcdserver/etcdhttp/peer.go
@@ -28,9 +28,9 @@ const (
 )
 
 // NewPeerHandler generates an http.Handler to handle etcd peer (raft) requests.
-func NewPeerHandler(clusterInfo etcdserver.ClusterInfo, raftHandler http.Handler) http.Handler {
+func NewPeerHandler(cluster etcdserver.Cluster, raftHandler http.Handler) http.Handler {
 	mh := &peerMembersHandler{
-		clusterInfo: clusterInfo,
+		cluster: cluster,
 	}
 
 	mux := http.NewServeMux()
@@ -43,20 +43,20 @@ func NewPeerHandler(clusterInfo etcdserver.ClusterInfo, raftHandler http.Handler
 }
 
 type peerMembersHandler struct {
-	clusterInfo etcdserver.ClusterInfo
+	cluster etcdserver.Cluster
 }
 
 func (h *peerMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !allowMethod(w, r.Method, "GET") {
 		return
 	}
-	w.Header().Set("X-Etcd-Cluster-ID", h.clusterInfo.ID().String())
+	w.Header().Set("X-Etcd-Cluster-ID", h.cluster.ID().String())
 
 	if r.URL.Path != peerMembersPrefix {
 		http.Error(w, "bad path", http.StatusBadRequest)
 		return
 	}
-	ms := h.clusterInfo.Members()
+	ms := h.cluster.Members()
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(ms); err != nil {
 		log.Printf("etcdhttp: %v", err)

--- a/etcdserver/etcdhttp/peer_test.go
+++ b/etcdserver/etcdhttp/peer_test.go
@@ -76,7 +76,7 @@ func TestServeMembersFails(t *testing.T) {
 	}
 	for i, tt := range tests {
 		rw := httptest.NewRecorder()
-		h := &peerMembersHandler{clusterInfo: nil}
+		h := &peerMembersHandler{cluster: nil}
 		h.ServeHTTP(rw, &http.Request{Method: tt.method})
 		if rw.Code != tt.wcode {
 			t.Errorf("#%d: code=%d, want %d", i, rw.Code, tt.wcode)
@@ -91,7 +91,7 @@ func TestServeMembersGet(t *testing.T) {
 		id:      1,
 		members: map[uint64]*etcdserver.Member{1: &memb1, 2: &memb2},
 	}
-	h := &peerMembersHandler{clusterInfo: cluster}
+	h := &peerMembersHandler{cluster: cluster}
 	msb, err := json.Marshal([]etcdserver.Member{memb1, memb2})
 	if err != nil {
 		t.Fatal(err)

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -192,7 +192,7 @@ func (r *raftNode) resumeSending() {
 	p.Resume()
 }
 
-func startNode(cfg *ServerConfig, cl *Cluster, ids []types.ID) (id types.ID, n raft.Node, s *raft.MemoryStorage, w *wal.WAL) {
+func startNode(cfg *ServerConfig, cl *cluster, ids []types.ID) (id types.ID, n raft.Node, s *raft.MemoryStorage, w *wal.WAL) {
 	var err error
 	member := cl.MemberByName(cfg.Name)
 	metadata := pbutil.MustMarshal(
@@ -231,7 +231,7 @@ func startNode(cfg *ServerConfig, cl *Cluster, ids []types.ID) (id types.ID, n r
 	return
 }
 
-func restartNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *Cluster, raft.Node, *raft.MemoryStorage, *wal.WAL) {
+func restartNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *cluster, raft.Node, *raft.MemoryStorage, *wal.WAL) {
 	var walsnap walpb.Snapshot
 	if snapshot != nil {
 		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
@@ -260,7 +260,7 @@ func restartNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *Clust
 	return id, cl, n, s, w
 }
 
-func restartAsStandaloneNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *Cluster, raft.Node, *raft.MemoryStorage, *wal.WAL) {
+func restartAsStandaloneNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *cluster, raft.Node, *raft.MemoryStorage, *wal.WAL) {
 	var walsnap walpb.Snapshot
 	if snapshot != nil {
 		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -393,7 +393,7 @@ func TestApplyRequestOnAdminMemberAttributes(t *testing.T) {
 	cl := newTestCluster([]*Member{{ID: 1}})
 	srv := &EtcdServer{
 		store:   &storeRecorder{},
-		Cluster: cl,
+		cluster: cl,
 	}
 	req := pb.Request{
 		Method: "PUT",
@@ -453,7 +453,7 @@ func TestApplyConfChangeError(t *testing.T) {
 		n := &nodeRecorder{}
 		srv := &EtcdServer{
 			r:       raftNode{Node: n},
-			Cluster: cl,
+			cluster: cl,
 		}
 		_, err := srv.applyConfChange(tt.cc, nil)
 		if err != tt.werr {
@@ -484,7 +484,7 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 			Node:      &nodeRecorder{},
 			transport: &nopTransporter{},
 		},
-		Cluster: cl,
+		cluster: cl,
 	}
 	cc := raftpb.ConfChange{
 		Type:   raftpb.ConfChangeRemoveNode,
@@ -780,7 +780,7 @@ func TestRecvSnapshot(t *testing.T) {
 			raftStorage: raft.NewMemoryStorage(),
 		},
 		store:   st,
-		Cluster: cl,
+		cluster: cl,
 	}
 
 	s.start()
@@ -815,7 +815,7 @@ func TestApplySnapshotAndCommittedEntries(t *testing.T) {
 			transport:   &nopTransporter{},
 		},
 		store:   st,
-		Cluster: cl,
+		cluster: cl,
 	}
 
 	s.start()
@@ -859,7 +859,7 @@ func TestAddMember(t *testing.T) {
 			transport:   &nopTransporter{},
 		},
 		store:    st,
-		Cluster:  cl,
+		cluster:  cl,
 		reqIDGen: idutil.NewGenerator(0, time.Time{}),
 	}
 	s.start()
@@ -898,7 +898,7 @@ func TestRemoveMember(t *testing.T) {
 			transport:   &nopTransporter{},
 		},
 		store:    st,
-		Cluster:  cl,
+		cluster:  cl,
 		reqIDGen: idutil.NewGenerator(0, time.Time{}),
 	}
 	s.start()
@@ -936,7 +936,7 @@ func TestUpdateMember(t *testing.T) {
 			transport:   &nopTransporter{},
 		},
 		store:    st,
-		Cluster:  cl,
+		cluster:  cl,
 		reqIDGen: idutil.NewGenerator(0, time.Time{}),
 	}
 	s.start()
@@ -969,7 +969,7 @@ func TestPublish(t *testing.T) {
 		id:         1,
 		r:          raftNode{Node: n},
 		attributes: Attributes{Name: "node1", ClientURLs: []string{"http://a", "http://b"}},
-		Cluster:    &Cluster{},
+		cluster:    &cluster{},
 		w:          w,
 		reqIDGen:   idutil.NewGenerator(0, time.Time{}),
 	}
@@ -1010,7 +1010,7 @@ func TestPublishStopped(t *testing.T) {
 			Node:      &nodeRecorder{},
 			transport: &nopTransporter{},
 		},
-		Cluster:  &Cluster{},
+		cluster:  &cluster{},
 		w:        &waitRecorder{},
 		done:     make(chan struct{}),
 		stop:     make(chan struct{}),
@@ -1051,7 +1051,7 @@ func TestUpdateVersion(t *testing.T) {
 		id:         1,
 		r:          raftNode{Node: n},
 		attributes: Attributes{Name: "node1", ClientURLs: []string{"http://node1.com"}},
-		Cluster:    &Cluster{},
+		cluster:    &cluster{},
 		w:          w,
 		reqIDGen:   idutil.NewGenerator(0, time.Time{}),
 	}
@@ -1137,7 +1137,7 @@ func TestGetOtherPeerURLs(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		cl := NewClusterFromMembers("", types.ID(0), tt.membs)
+		cl := newClusterFromMembers("", types.ID(0), tt.membs)
 		urls := getRemotePeerURLs(cl, tt.self)
 		if !reflect.DeepEqual(urls, tt.wurls) {
 			t.Errorf("#%d: urls = %+v, want %+v", i, urls, tt.wurls)

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -695,7 +695,7 @@ func (m *member) Launch() error {
 	m.s.SyncTicker = time.Tick(500 * time.Millisecond)
 	m.s.Start()
 
-	m.raftHandler = &testutil.PauseableHandler{Next: etcdhttp.NewPeerHandler(m.s.Cluster, m.s.RaftHandler())}
+	m.raftHandler = &testutil.PauseableHandler{Next: etcdhttp.NewPeerHandler(m.s.Cluster(), m.s.RaftHandler())}
 
 	for _, ln := range m.PeerListeners {
 		hs := &httptest.Server{


### PR DESCRIPTION
After this PR, only cluster's interface Cluster is exposed, which makes
code much cleaner. And it avoids external packages to rely on cluster
struct in the future.