### PR TITLE
etcdserver: remove unnecessary around detect datadir

### DIFF
--- a/etcdserver/storage.go
+++ b/etcdserver/storage.go
@@ -127,7 +127,6 @@ func upgradeDataDir(baseDataDir string, name string, ver version.DataDirVersion)
 	case version.DataDir2_0_1:
 		fallthrough
 	default:
-		log.Printf("etcdserver: datadir is valid for the 2.0.1 format")
 	}
 	return nil
 }


### PR DESCRIPTION
The log is super unhelpful. When I have a 2.1.0 etcd, it prints out
`2.0.1 vaild dir`. I have no idea why the data dir of a 2.1.0 etcd is
2.0.1.