### PR TITLE
pkg/wait: fix TestWaitTestStress

### DIFF
--- a/pkg/wait/wait_time_test.go
+++ b/pkg/wait/wait_time_test.go
@@ -53,6 +53,8 @@ func TestWaitTestStress(t *testing.T) {
 	wt := NewTimeList()
 	for i := 0; i < 10000; i++ {
 		chs = append(chs, wt.Wait(time.Now()))
+		// sleep one nanosecond before waiting on the next event
+		time.Sleep(time.Nanosecond)
 	}
 	wt.Trigger(time.Now())
 


### PR DESCRIPTION
The test may fail if two consequent time.Now() returns the same value.
Sleep 1ns to avoid this situation.

The failure always happened if I ran 100 times `./test`
After this PR, 100 times `./test` works fine.

/cc @xiang90 @barakmich 