### PR TITLE
etcdhttp: version endpoint also returns cluster version.

### DIFF
--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -53,6 +53,8 @@ type Cluster interface {
 	// IsIDRemoved checks whether the given ID has been removed from this
 	// cluster at some point in the past
 	IsIDRemoved(id types.ID) bool
+	// ClusterVersion is the cluster-wide minimum major.minor version.
+	Version() *semver.Version
 }
 
 // Cluster is a list of Members that belong to the same raft cluster

--- a/etcdserver/etcdhttp/client_test.go
+++ b/etcdserver/etcdhttp/client_test.go
@@ -1326,11 +1326,18 @@ func TestServeVersion(t *testing.T) {
 		t.Fatalf("error creating request: %v", err)
 	}
 	rw := httptest.NewRecorder()
-	serveVersion(rw, req)
+	serveVersion(rw, req, "2.1.0")
 	if rw.Code != http.StatusOK {
 		t.Errorf("code=%d, want %d", rw.Code, http.StatusOK)
 	}
-	w := version.MarshalJSON()
+	vs := version.Versions{
+		Server:  version.Version,
+		Cluster: "2.1.0",
+	}
+	w, err := json.Marshal(&vs)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if g := rw.Body.String(); g != string(w) {
 		t.Fatalf("body = %q, want %q", g, string(w))
 	}
@@ -1345,7 +1352,7 @@ func TestServeVersionFails(t *testing.T) {
 			t.Fatalf("error creating request: %v", err)
 		}
 		rw := httptest.NewRecorder()
-		serveVersion(rw, req)
+		serveVersion(rw, req, "2.1.0")
 		if rw.Code != http.StatusMethodNotAllowed {
 			t.Errorf("method %s: code=%d, want %d", m, rw.Code, http.StatusMethodNotAllowed)
 		}

--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -48,6 +48,7 @@ func (c *fakeCluster) Members() []*etcdserver.Member {
 }
 func (c *fakeCluster) Member(id types.ID) *etcdserver.Member { return c.members[uint64(id)] }
 func (c *fakeCluster) IsIDRemoved(id types.ID) bool          { return false }
+func (c *fakeCluster) Version() *semver.Version              { return nil }
 
 // errServer implements the etcd.Server interface for testing.
 // It returns the given error from any Do/Process/AddMember/RemoveMember calls.

--- a/etcdserver/etcdhttp/peer.go
+++ b/etcdserver/etcdhttp/peer.go
@@ -38,7 +38,7 @@ func NewPeerHandler(cluster etcdserver.Cluster, raftHandler http.Handler) http.H
 	mux.Handle(rafthttp.RaftPrefix, raftHandler)
 	mux.Handle(rafthttp.RaftPrefix+"/", raftHandler)
 	mux.Handle(peerMembersPrefix, mh)
-	mux.HandleFunc(versionPath, serveVersion)
+	mux.HandleFunc(versionPath, versionHandler(cluster, serveVersion))
 	return mux
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -15,8 +15,6 @@
 package version
 
 import (
-	"encoding/json"
-	"log"
 	"os"
 	"path"
 
@@ -45,18 +43,9 @@ const (
 )
 
 type Versions struct {
-	Server string `json:"etcdserver"`
-	// TODO: etcdcluster version
+	Server  string `json:"etcdserver"`
+	Cluster string `json:"etcdcluster"`
 	// TODO: raft state machine version
-}
-
-// MarshalJSON returns the JSON encoding of Versions struct.
-func MarshalJSON() []byte {
-	b, err := json.Marshal(Versions{Server: Version})
-	if err != nil {
-		log.Panicf("version: cannot marshal versions to json (%v)", err)
-	}
-	return b
 }
 
 func DetectDataDir(dirpath string) (DataDirVersion, error) {


### PR DESCRIPTION
Papare for joining checking. A member can only join a cluster with lower or equal cluster version.