### PR TITLE
etcdctl/cluster_health: improve output if failed to get leader stats

### DIFF
--- a/etcdctl/command/cluster_health.go
+++ b/etcdctl/command/cluster_health.go
@@ -46,9 +46,10 @@ func handleClusterHealth(c *cli.Context) {
 	}
 
 	// do we have a leader?
-	ep, ls0, err := getLeaderStats(tr, client.GetCluster())
+	cl := client.GetCluster()
+	ep, ls0, err := getLeaderStats(tr, cl)
 	if err != nil {
-		fmt.Println("cluster is unhealthy")
+		fmt.Println("cluster may be unhealthy: failed to connect", cl)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
When failing to get leader stats, it said 'cluster is unhealthy' before.
This is confusing when it cannot get stats because advertised client urls
are set wrong and the cluster is healthy.

I set wrong client urls intentionally and get this when failed to get leader stats:
```
cluster may be unhealthy: failed to connect [http://localhost:4001 http://localhost:4001 http://localhost:4001]
```

fixes the problem of #2650 