### PR TITLE
checking cluster version compatibility before joining the existing cluster

### DIFF
--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -226,6 +226,7 @@ func getVersion(m *Member, tr *http.Transport) (*version.Versions, error) {
 	for _, u := range m.PeerURLs {
 		resp, err = cc.Get(u + "/version")
 		if err != nil {
+			log.Printf("etcdserver: failed to reach the peerURL(%s) of member %s (%v)", u, m.ID, err)
 			continue
 		}
 		// etcd 2.0 does not have version endpoint on peer url.
@@ -237,10 +238,12 @@ func getVersion(m *Member, tr *http.Transport) (*version.Versions, error) {
 		b, err := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
+			log.Printf("etcdserver: failed to read out the response body from the peerURL(%s) of member %s (%v)", u, m.ID, err)
 			continue
 		}
 		var vers version.Versions
 		if err := json.Unmarshal(b, &vers); err != nil {
+			log.Printf("etcdserver: failed to unmarshal the response body got from the peerURL(%s) of member %s (%v)", u, m.ID, err)
 			continue
 		}
 		return &vers, nil

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -113,10 +113,14 @@ func getRemotePeerURLs(cl Cluster, local string) []string {
 // The key of the returned map is the member's ID. The value of the returned map
 // is the semver versions string, including server and cluster.
 // If it fails to get the version of a member, the key will be nil.
-func getVersions(cl Cluster, tr *http.Transport) map[string]*version.Versions {
+func getVersions(cl Cluster, local types.ID, tr *http.Transport) map[string]*version.Versions {
 	members := cl.Members()
 	vers := make(map[string]*version.Versions)
 	for _, m := range members {
+		if m.ID == local {
+			vers[m.ID.String()] = &version.Versions{Server: version.Version, Cluster: cl.Version().String()}
+			continue
+		}
 		ver, err := getVersion(m, tr)
 		if err != nil {
 			log.Printf("etcdserver: cannot get the version of member %s (%v)", m.ID, err)

--- a/etcdserver/cluster_util_test.go
+++ b/etcdserver/cluster_util_test.go
@@ -19,32 +19,33 @@ import (
 	"testing"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
+	"github.com/coreos/etcd/version"
 )
 
 func TestDecideClusterVersion(t *testing.T) {
 	tests := []struct {
-		vers  map[string]string
+		vers  map[string]*version.Versions
 		wdver *semver.Version
 	}{
 		{
-			map[string]string{"a": "2.0.0"},
+			map[string]*version.Versions{"a": &version.Versions{Server: "2.0.0"}},
 			semver.Must(semver.NewVersion("2.0.0")),
 		},
 		// unknow
 		{
-			map[string]string{"a": ""},
+			map[string]*version.Versions{"a": nil},
 			nil,
 		},
 		{
-			map[string]string{"a": "2.0.0", "b": "2.1.0", "c": "2.1.0"},
+			map[string]*version.Versions{"a": &version.Versions{Server: "2.0.0"}, "b": &version.Versions{Server: "2.1.0"}, "c": &version.Versions{Server: "2.1.0"}},
 			semver.Must(semver.NewVersion("2.0.0")),
 		},
 		{
-			map[string]string{"a": "2.1.0", "b": "2.1.0", "c": "2.1.0"},
+			map[string]*version.Versions{"a": &version.Versions{Server: "2.1.0"}, "b": &version.Versions{Server: "2.1.0"}, "c": &version.Versions{Server: "2.1.0"}},
 			semver.Must(semver.NewVersion("2.1.0")),
 		},
 		{
-			map[string]string{"a": "", "b": "2.1.0", "c": "2.1.0"},
+			map[string]*version.Versions{"a": nil, "b": &version.Versions{Server: "2.1.0"}, "c": &version.Versions{Server: "2.1.0"}},
 			nil,
 		},
 	}

--- a/etcdserver/cluster_util_test.go
+++ b/etcdserver/cluster_util_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
+	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/version"
 )
 
@@ -54,6 +55,77 @@ func TestDecideClusterVersion(t *testing.T) {
 		dver := decideClusterVersion(tt.vers)
 		if !reflect.DeepEqual(dver, tt.wdver) {
 			t.Errorf("#%d: ver = %+v, want %+v", i, dver, tt.wdver)
+		}
+	}
+}
+
+func TestIsCompatibleWithVers(t *testing.T) {
+	tests := []struct {
+		vers       map[string]*version.Versions
+		local      types.ID
+		minV, maxV *semver.Version
+		wok        bool
+	}{
+		// too low
+		{
+			map[string]*version.Versions{
+				"a": &version.Versions{Server: "2.0.0", Cluster: "not_decided"},
+				"b": &version.Versions{Server: "2.1.0", Cluster: "2.1.0"},
+				"c": &version.Versions{Server: "2.1.0", Cluster: "2.1.0"},
+			},
+			0xa,
+			semver.Must(semver.NewVersion("2.0.0")), semver.Must(semver.NewVersion("2.0.0")),
+			false,
+		},
+		{
+			map[string]*version.Versions{
+				"a": &version.Versions{Server: "2.1.0", Cluster: "not_decided"},
+				"b": &version.Versions{Server: "2.1.0", Cluster: "2.1.0"},
+				"c": &version.Versions{Server: "2.1.0", Cluster: "2.1.0"},
+			},
+			0xa,
+			semver.Must(semver.NewVersion("2.0.0")), semver.Must(semver.NewVersion("2.1.0")),
+			true,
+		},
+		// too high
+		{
+			map[string]*version.Versions{
+				"a": &version.Versions{Server: "2.2.0", Cluster: "not_decided"},
+				"b": &version.Versions{Server: "2.0.0", Cluster: "2.0.0"},
+				"c": &version.Versions{Server: "2.0.0", Cluster: "2.0.0"},
+			},
+			0xa,
+			semver.Must(semver.NewVersion("2.1.0")), semver.Must(semver.NewVersion("2.2.0")),
+			false,
+		},
+		// cannot get b's version, expect ok
+		{
+			map[string]*version.Versions{
+				"a": &version.Versions{Server: "2.1.0", Cluster: "not_decided"},
+				"b": nil,
+				"c": &version.Versions{Server: "2.1.0", Cluster: "2.1.0"},
+			},
+			0xa,
+			semver.Must(semver.NewVersion("2.0.0")), semver.Must(semver.NewVersion("2.1.0")),
+			true,
+		},
+		// cannot get b and c's version, expect not ok
+		{
+			map[string]*version.Versions{
+				"a": &version.Versions{Server: "2.1.0", Cluster: "not_decided"},
+				"b": nil,
+				"c": nil,
+			},
+			0xa,
+			semver.Must(semver.NewVersion("2.0.0")), semver.Must(semver.NewVersion("2.1.0")),
+			false,
+		},
+	}
+
+	for i, tt := range tests {
+		ok := isCompatibleWithVers(tt.vers, tt.local, tt.minV, tt.maxV)
+		if ok != tt.wok {
+			t.Errorf("#%d: ok = %+v, want %+v", i, ok, tt.wok)
 		}
 	}
 }

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -209,6 +209,10 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		if err := ValidateClusterAndAssignIDs(cl, existingCluster); err != nil {
 			return nil, fmt.Errorf("error validating peerURLs %s: %v", existingCluster, err)
 		}
+		if !isCompatibleWithCluster(cl, cl.MemberByName(cfg.Name).ID, cfg.Transport) {
+			return nil, fmt.Errorf("incomptible with current running cluster")
+		}
+
 		remotes = existingCluster.Members()
 		cl.SetID(existingCluster.id)
 		cl.SetStore(st)

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -942,7 +942,7 @@ func (s *EtcdServer) monitorVersions() {
 			continue
 		}
 
-		v := decideClusterVersion(getVersions(s.cluster, s.cfg.Transport))
+		v := decideClusterVersion(getVersions(s.cluster, s.id, s.cfg.Transport))
 		if v != nil {
 			// only keep major.minor version for comparasion
 			v = &semver.Version{


### PR DESCRIPTION
Check the cluster version with all other members before starting a new member in an existing cluster.

Do not start if there is one incompatibility or it cannot connect with all other members.

**Note**: we do a pre-checking of the liveness of all other members before the compatibility checking, there is nearly 0% that this member cannot connect all other members during compatibility checking.