### PR TITLE
not print unhelpful info when connecting to etcd 2.1

### DIFF
--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -121,7 +121,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fromStr := strings.TrimPrefix(r.URL.Path, RaftStreamPrefix+"/")
 	from, err := types.IDFromString(fromStr)
 	if err != nil {
-		log.Printf("rafthttp: path %s cannot be parsed", fromStr)
 		http.Error(w, "invalid path", http.StatusNotFound)
 		return
 	}


### PR DESCRIPTION
fix part 2 in #2793 

When running 2.0 and 2.1 mixed cluster, there is no error log line on etcd 2.0 side.

When running mixed cluster and etcd 2.0 becomes the leader, there is still some performance issue. will dig into it more in #2793 