### PR TITLE
*: use namespace and subsystem in metrics

### DIFF
--- a/etcdserver/metrics.go
+++ b/etcdserver/metrics.go
@@ -25,23 +25,31 @@ import (
 var (
 	// TODO: with label in v3?
 	proposeDurations = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "etcdserver_proposal_durations_milliseconds",
-		Help: "The latency distributions of committing proposal.",
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "proposal_durations_milliseconds",
+		Help:      "The latency distributions of committing proposal.",
 	})
 	proposePending = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "etcdserver_pending_proposal_total",
-		Help: "The total number of pending proposals.",
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "pending_proposal_total",
+		Help:      "The total number of pending proposals.",
 	})
 	// This is number of proposal failed in client's view.
 	// The proposal might be later got committed in raft.
 	proposeFailed = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "etcdserver_proposal_failed_total",
-		Help: "The total number of failed proposals.",
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "proposal_failed_total",
+		Help:      "The total number of failed proposals.",
 	})
 
 	fileDescriptorUsed = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "file_descriptors_used",
-		Help: "The number of file descriptors used",
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "file_descriptors_used_totol",
+		Help:      "The total number of file descriptors used.",
 	})
 )
 

--- a/rafthttp/metrics.go
+++ b/rafthttp/metrics.go
@@ -25,15 +25,19 @@ import (
 var (
 	msgSentDuration = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name: "rafthttp_message_sent_latency_microseconds",
-			Help: "message sent latency distributions.",
+			Namespace: "etcd",
+			Subsystem: "rafthttp",
+			Name:      "message_sent_latency_microseconds",
+			Help:      "message sent latency distributions.",
 		},
 		[]string{"channel", "remoteID", "msgType"},
 	)
 
 	msgSentFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "rafthttp_message_sent_failed_total",
-		Help: "The total number of failed messages sent.",
+		Namespace: "etcd",
+		Subsystem: "rafthttp",
+		Name:      "message_sent_failed_total",
+		Help:      "The total number of failed messages sent.",
 	},
 		[]string{"channel", "remoteID", "msgType"},
 	)

--- a/wal/metrics.go
+++ b/wal/metrics.go
@@ -18,12 +18,16 @@ import "github.com/coreos/etcd/Godeps/_workspace/src/github.com/prometheus/clien
 
 var (
 	syncDurations = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "wal_fsync_durations_microseconds",
-		Help: "The latency distributions of fsync called by wal.",
+		Namespace: "etcd",
+		Subsystem: "wal",
+		Name:      "fsync_durations_microseconds",
+		Help:      "The latency distributions of fsync called by wal.",
 	})
 	lastIndexSaved = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "wal_last_index_saved",
-		Help: "The index of the last entry saved by wal",
+		Namespace: "etcd",
+		Subsystem: "wal",
+		Name:      "last_index_saved",
+		Help:      "The index of the last entry saved by wal.",
 	})
 )
 


### PR DESCRIPTION
Fix #2841.

From Prometheus developer:
```
the recommended way for etcd as an open source project and under
consideration of its size would be etcd_<subsystem>_<name>.
```

We made the naming change accordingly.