### PR TITLE
travis: stop install tools cover and vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ go:
   - 1.4
 
 install:
- - go get golang.org/x/tools/cmd/cover
- - go get golang.org/x/tools/cmd/vet
  - go get github.com/barakmich/go-nyet
 
 script:


### PR DESCRIPTION
There is no need to install them separately because they have been
downloaded in the default go root directory.