### PR TITLE
rafthttp: print out log when clusterID mismatch instead of exiting

### DIFF
--- a/rafthttp/pipeline.go
+++ b/rafthttp/pipeline.go
@@ -148,12 +148,9 @@ func (p *pipeline) post(data []byte) error {
 
 	switch resp.StatusCode {
 	case http.StatusPreconditionFailed:
-		err := fmt.Errorf("conflicting cluster ID with the target cluster (%s != %s)", resp.Header.Get("X-Etcd-Cluster-ID"), p.cid)
-		select {
-		case p.errorc <- err:
-		default:
-		}
-		return nil
+		log.Printf("rafthttp: request sent was ignored due to cluster ID mismatch (remote[%s]:%s, local:%s)",
+			uu.Host, resp.Header.Get("X-Etcd-Cluster-ID"), p.cid)
+		return fmt.Errorf("cluster ID mismatch")
 	case http.StatusForbidden:
 		err := fmt.Errorf("the member has been permanently removed from the cluster")
 		select {

--- a/rafthttp/pipeline_test.go
+++ b/rafthttp/pipeline_test.go
@@ -165,7 +165,6 @@ func TestPipelinePostErrorc(t *testing.T) {
 		err  error
 	}{
 		{"http://localhost:2380", http.StatusForbidden, nil},
-		{"http://localhost:2380", http.StatusPreconditionFailed, nil},
 	}
 	for i, tt := range tests {
 		picker := mustNewURLPicker(t, []string{tt.u})

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -424,6 +424,11 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 	case http.StatusNotFound:
 		resp.Body.Close()
 		return nil, fmt.Errorf("local member has not been added to the peer list of member %s", cr.to)
+	case http.StatusPreconditionFailed:
+		resp.Body.Close()
+		log.Printf("rafthttp: request sent was ignored due to cluster ID mismatch (remote[%s]:%s, local:%s)",
+			uu.Host, resp.Header.Get("X-Etcd-Cluster-ID"), cr.cid)
+		return nil, fmt.Errorf("cluster ID mismatch")
 	default:
 		resp.Body.Close()
 		return nil, fmt.Errorf("unhandled http status %d", resp.StatusCode)


### PR DESCRIPTION
We have heard from several users that they do not expect a clusterID
mismatch to kill the cluster.

https://github.com/coreos/etcd/issues/2836

/cc @jedsmith @mariusgrigaitis