### PR TITLE
test: run integration tests in verbose mode

### DIFF
--- a/test
+++ b/test
@@ -50,7 +50,7 @@ go test -timeout 3m ${COVER} $@ ${NO_RACE_TEST}
 
 if [ -n "$INTEGRATION" ]; then
 	echo "Running integration tests..."
-	go test -timeout 3m $@ ${REPO_PATH}/integration
+	go test -timeout 3m $@ ${REPO_PATH}/integration -v
 fi
 
 echo "Checking gofmt..."


### PR DESCRIPTION
Travis doesn't print out the final result of integration tests
sometimes, and verbose mode helps us debug.