### PR TITLE
raft: fix raft node start bug

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -243,7 +243,7 @@ func (n *node) run(r *raft) {
 
 	lead := None
 	prevSoftSt := r.softState()
-	prevHardSt := r.HardState
+	prevHardSt := emptyState
 
 	for {
 		if advancec != nil {

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -362,7 +362,7 @@ func TestNodeRestart(t *testing.T) {
 	st := raftpb.HardState{Term: 1, Commit: 1}
 
 	want := Ready{
-		HardState: emptyState,
+		HardState: st,
 		// commit up to index commit index in st
 		CommittedEntries: entries[:st.Commit],
 	}
@@ -405,7 +405,7 @@ func TestNodeRestartFromSnapshot(t *testing.T) {
 	st := raftpb.HardState{Term: 1, Commit: 3}
 
 	want := Ready{
-		HardState: emptyState,
+		HardState: st,
 		// commit up to index commit index in st
 		CommittedEntries: entries,
 	}


### PR DESCRIPTION
raft node should set initial prev hard state to empty.
Or it will not send the first hard coded state to application
until the state changes again.

This commit fixes the issue. It introduce a small overhead, that
the same state might send to application twice when restarting.
But this is fine.

Fix #2877

/cc @bdarnell Does multiNode have the same issue? 