### PR TITLE
WIP: store: stream watching with an outdated index returns a list of events

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -101,7 +101,7 @@ func (s *store) Version() int {
 	return s.CurrentVersion
 }
 
-// Retrieves current of the store
+// Retrieves current index of the store
 func (s *store) Index() uint64 {
 	s.worldLock.RLock()
 	defer s.worldLock.RUnlock()

--- a/store/store.go
+++ b/store/store.go
@@ -28,8 +28,14 @@ import (
 	"github.com/coreos/etcd/pkg/types"
 )
 
-// The default version to set when the store is first initialized.
-const defaultVersion = 2
+const (
+	// Size of the watch window.
+	// TODO: Expose as a cmd line parameter?
+	WatchWindowSize = 1000
+
+	// The default version to set when the store is first initialized.
+	defaultVersion = 2
+)
 
 var minExpireTime time.Time
 
@@ -90,7 +96,7 @@ func newStore(namespaces ...string) *store {
 		s.Root.Add(newDir(s, namespace, s.CurrentIndex, s.Root, Permanent))
 	}
 	s.Stats = newStats()
-	s.WatcherHub = newWatchHub(1000)
+	s.WatcherHub = newWatchHub(WatchWindowSize)
 	s.ttlKeyHeap = newTtlKeyHeap()
 	s.readonlySet = types.NewUnsafeSet(append(namespaces, "/")...)
 	return s

--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -53,6 +53,8 @@ func newWatchHub(capacity int) *watcherHub {
 // If recursive is false, the first change after index at key will be sent to the event channel of the watcher.
 // If index is zero, watch will start from the current index + 1.
 func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeIndex uint64) (Watcher, *etcdErr.Error) {
+	wh.mutex.Lock()
+	defer wh.mutex.Unlock()
 	events, err := wh.EventHistory.scan(key, recursive, index, stream)
 
 	if err != nil {
@@ -61,7 +63,9 @@ func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeInde
 	}
 
 	w := &watcher{
-		eventChan:  make(chan *Event, 100), // use a buffered channel
+		// The eventChan needs to be at least as big as the event history to support streaming
+		// events from an outdated index.
+		eventChan:  make(chan *Event, wh.EventHistory.Queue.Capacity),
 		recursive:  recursive,
 		stream:     stream,
 		sinceIndex: index,
@@ -69,8 +73,6 @@ func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeInde
 		hub:        wh,
 	}
 
-	wh.mutex.Lock()
-	defer wh.mutex.Unlock()
 	// If the events exists in the known history, append the EtcdIndex and return immediately unless
 	// stream=true, in which case we find all matching events, and add this watcher to the notify list.
 	if len(events) > 0 {
@@ -78,7 +80,9 @@ func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeInde
 			event.EtcdIndex = storeIndex
 			w.eventChan <- event
 		}
-		return w, nil
+		if !stream {
+			return w, nil
+		}
 	}
 
 	l, ok := wh.watchers[key]


### PR DESCRIPTION
A watch with `stream=true` and an outdated `waitIndex` returns all events from the outdated index till current index and closes the watch, with the first commit. The watch is kept open for subsequent events with the second commit. 

I've only tested this lightly. Looking for opinions before I proceed.
/cc @xiang90 
 