### PR TITLE
raft: remove wrong invariant

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -31,7 +31,6 @@ type raftLog struct {
 
 	// committed is the highest log position that is known to be in
 	// stable storage on a quorum of nodes.
-	// Invariant: committed < unstable
 	committed uint64
 	// applied is the highest log position that the application has
 	// been instructed to apply to its state machine.


### PR DESCRIPTION
The commit > unstable might not true for follower. The leader only need
to ensure the entry is stored on the majority of nodes to commit an
entry. So the minority of the cluster might receive commit > unstable
append request. This is normal.

/cc @yichengq @bdarnell 