### PR TITLE
build: use posix shell

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/etcd"


### PR DESCRIPTION
seems clean of bash stuff:

```
$ checkbashisms -nfpx etcd-2.0.11/build 
$
```