### PR TITLE
etcdmain: increase maxIdleConnsPerHost in proxy transport

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -248,6 +248,7 @@ func startProxy(cfg *config) error {
 	}
 
 	pt, err := transport.NewTransport(cfg.clientTLSInfo)
+	pt.MaxIdleConnsPerHost = proxy.DefaultMaxIdleConnsPerHost
 	if err != nil {
 		return err
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,6 +18,17 @@ import (
 	"net/http"
 )
 
+const (
+	// DefaultMaxIdleConnsPerHost indicates the default maximal idle connections
+	// maintained between proxy and each member. We set it to 128 to
+	// let proxy handle 128 concurrent requests in long term smoothly.
+	// If the number of concurrent requests is bigger than this value,
+	// proxy needs to create one new connection when handling each request in
+	// the delta, which is bad because the creation consumes resource and
+	// may eat up ephemeral ports.
+	DefaultMaxIdleConnsPerHost = 128
+)
+
 // GetProxyURLs is a function which should return the current set of URLs to
 // which client requests should be proxied. This function will be queried
 // periodically by the proxy Handler to refresh the set of available


### PR DESCRIPTION
This PR set maxIdleConnsPerHost to 128 to let proxy handle 128 concurrent
requests in long term smoothly.
If the number of concurrent requests is bigger than this value,
proxy needs to create one new connection when handling each request in
the delta, which is bad because the creation consumes resource and may
eat up your ephemeral port.