### PR TITLE
rafthttp: move mu to the top in urlPicker struct

### DIFF
--- a/rafthttp/urlpick.go
+++ b/rafthttp/urlpick.go
@@ -22,8 +22,8 @@ import (
 )
 
 type urlPicker struct {
+	mu     sync.Mutex // guards urls and picked
 	urls   types.URLs
-	mu     sync.Mutex
 	picked int
 }
 


### PR DESCRIPTION
mutex protects all the fields.