### PR TITLE
rafthttp: refactor streamtype

### DIFF
--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -153,17 +153,9 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var t streamType
-	switch path.Dir(r.URL.Path) {
-	// backward compatibility
-	case RaftStreamPrefix:
-		t = streamTypeMsgApp
-	case path.Join(RaftStreamPrefix, string(streamTypeMsgApp)):
-		t = streamTypeMsgAppV2
-	case path.Join(RaftStreamPrefix, string(streamTypeMessage)):
-		t = streamTypeMessage
-	default:
-		log.Printf("rafthttp: ignored unexpected streaming request path %s", r.URL.Path)
+	t, err := parseStreamType(path.Dir(r.URL.Path))
+	if err != nil {
+		log.Printf("rafthttp: ignored streaming request path %s (%v)", r.URL.Path, err)
 		http.Error(w, "invalid path", http.StatusNotFound)
 		return
 	}


### PR DESCRIPTION
1. Add String() func to represent streamtype better
2. Add parse func to let convertion between endpoint and streamtype
clean

I do this for log cleanup and backoff work.
There doesn't exist an official way to represent stream type well, so i introduce this one.