### PR TITLE
Unexpected dependency in build script

### DIFF
--- a/build
+++ b/build
@@ -11,7 +11,7 @@ ln -s ${PWD} $GOPATH/src/${REPO_PATH}
 
 eval $(go env)
 
-GIT_SHA=`git rev-parse --short HEAD`
+GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
 
 # Static compilation is useful when etcd is run in a container
 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-s -X ${REPO_PATH}/version.GitSHA ${GIT_SHA}" -o bin/etcd ${REPO_PATH}


### PR DESCRIPTION
This line: https://github.com/coreos/etcd/blob/v2.0.11/build#L14 introduced by https://github.com/coreos/etcd/commit/d30e764b2d20a783a0f569d2677a125da1832936 introduces an unexpected build-time dependency on git. This breaks any build where you ship the code to a remote machine to compile where you don't have, and don't want to have, git.

Is there any way we can get versioning information for that script without adding the extra dependency?
How about writing "N/A" or some other default in case git cannot be found?