### PR TITLE
rafthttp: pretty print connection error

### DIFF
--- a/rafthttp/peer_status.go
+++ b/rafthttp/peer_status.go
@@ -1,0 +1,67 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rafthttp
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/coreos/etcd/pkg/types"
+)
+
+type failureType struct {
+	source string
+	action string
+}
+
+type peerStatus struct {
+	id         types.ID
+	mu         sync.Mutex // protect active and failureMap
+	active     bool
+	failureMap map[failureType]string
+}
+
+func newPeerStatus(id types.ID) *peerStatus {
+	return &peerStatus{
+		id:         id,
+		failureMap: make(map[failureType]string),
+	}
+}
+
+func (s *peerStatus) activate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.active {
+		plog.Infof("the connection with %s became active", s.id)
+		s.active = true
+		s.failureMap = make(map[failureType]string)
+	}
+}
+
+func (s *peerStatus) deactivate(failure failureType, reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.active {
+		plog.Infof("the connection with %s became inactive", s.id)
+		s.active = false
+	}
+	logline := fmt.Sprintf("failed to %s %s on %s (%s)", failure.action, s.id, failure.source, reason)
+	if r, ok := s.failureMap[failure]; ok && r == reason {
+		plog.Debugf(logline)
+		return
+	}
+	s.failureMap[failure] = reason
+	plog.Errorf(logline)
+}

--- a/rafthttp/pipeline_test.go
+++ b/rafthttp/pipeline_test.go
@@ -36,7 +36,7 @@ func TestPipelineSend(t *testing.T) {
 	tr := &roundTripperRecorder{}
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
 	fs := &stats.FollowerStats{}
-	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), fs, &fakeRaft{}, nil)
+	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil)
 
 	p.msgc <- raftpb.Message{Type: raftpb.MsgApp}
 	testutil.ForceGosched()
@@ -56,7 +56,7 @@ func TestPipelineExceedMaximalServing(t *testing.T) {
 	tr := newRoundTripperBlocker()
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
 	fs := &stats.FollowerStats{}
-	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), fs, &fakeRaft{}, nil)
+	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil)
 
 	// keep the sender busy and make the buffer full
 	// nothing can go out as we block the sender
@@ -96,7 +96,7 @@ func TestPipelineExceedMaximalServing(t *testing.T) {
 func TestPipelineSendFailed(t *testing.T) {
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
 	fs := &stats.FollowerStats{}
-	p := newPipeline(newRespRoundTripper(0, errors.New("blah")), picker, types.ID(2), types.ID(1), types.ID(1), fs, &fakeRaft{}, nil)
+	p := newPipeline(newRespRoundTripper(0, errors.New("blah")), picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil)
 
 	p.msgc <- raftpb.Message{Type: raftpb.MsgApp}
 	testutil.ForceGosched()
@@ -112,7 +112,7 @@ func TestPipelineSendFailed(t *testing.T) {
 func TestPipelinePost(t *testing.T) {
 	tr := &roundTripperRecorder{}
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
-	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), nil, &fakeRaft{}, nil)
+	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, nil)
 	if err := p.post([]byte("some data")); err != nil {
 		t.Fatalf("unexpect post error: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestPipelinePostBad(t *testing.T) {
 	}
 	for i, tt := range tests {
 		picker := mustNewURLPicker(t, []string{tt.u})
-		p := newPipeline(newRespRoundTripper(tt.code, tt.err), picker, types.ID(2), types.ID(1), types.ID(1), nil, &fakeRaft{}, make(chan error))
+		p := newPipeline(newRespRoundTripper(tt.code, tt.err), picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, make(chan error))
 		err := p.post([]byte("some data"))
 		p.stop()
 
@@ -180,7 +180,7 @@ func TestPipelinePostErrorc(t *testing.T) {
 	for i, tt := range tests {
 		picker := mustNewURLPicker(t, []string{tt.u})
 		errorc := make(chan error, 1)
-		p := newPipeline(newRespRoundTripper(tt.code, tt.err), picker, types.ID(2), types.ID(1), types.ID(1), nil, &fakeRaft{}, errorc)
+		p := newPipeline(newRespRoundTripper(tt.code, tt.err), picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, errorc)
 		p.post([]byte("some data"))
 		p.stop()
 		select {
@@ -193,7 +193,7 @@ func TestPipelinePostErrorc(t *testing.T) {
 
 func TestStopBlockedPipeline(t *testing.T) {
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
-	p := newPipeline(newRoundTripperBlocker(), picker, types.ID(2), types.ID(1), types.ID(1), nil, &fakeRaft{}, nil)
+	p := newPipeline(newRoundTripperBlocker(), picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, nil)
 	// send many messages that most of them will be blocked in buffer
 	for i := 0; i < connPerPipeline*10; i++ {
 		p.msgc <- raftpb.Message{}

--- a/rafthttp/remote.go
+++ b/rafthttp/remote.go
@@ -30,7 +30,7 @@ func startRemote(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID,
 	picker := newURLPicker(urls)
 	return &remote{
 		id:       to,
-		pipeline: newPipeline(tr, picker, local, to, cid, nil, r, errorc),
+		pipeline: newPipeline(tr, picker, local, to, cid, newPeerStatus(to), nil, r, errorc),
 	}
 }
 

--- a/rafthttp/stream_test.go
+++ b/rafthttp/stream_test.go
@@ -21,7 +21,7 @@ import (
 // to streamWriter. After that, streamWriter can use it to send messages
 // continuously, and closes it when stopped.
 func TestStreamWriterAttachOutgoingConn(t *testing.T) {
-	sw := startStreamWriter(types.ID(1), &stats.FollowerStats{}, &fakeRaft{})
+	sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{})
 	// the expected initial state of streamWrite is not working
 	if _, ok := sw.writec(); ok != false {
 		t.Errorf("initial working status = %v, want false", ok)
@@ -67,7 +67,7 @@ func TestStreamWriterAttachOutgoingConn(t *testing.T) {
 // TestStreamWriterAttachBadOutgoingConn tests that streamWriter with bad
 // outgoingConn will close the outgoingConn and fall back to non-working status.
 func TestStreamWriterAttachBadOutgoingConn(t *testing.T) {
-	sw := startStreamWriter(types.ID(1), &stats.FollowerStats{}, &fakeRaft{})
+	sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{})
 	defer sw.stop()
 	wfc := &fakeWriteFlushCloser{err: errors.New("blah")}
 	sw.attach(&outgoingConn{t: streamTypeMessage, Writer: wfc, Flusher: wfc, Closer: wfc})
@@ -269,12 +269,12 @@ func TestStream(t *testing.T) {
 		srv := httptest.NewServer(h)
 		defer srv.Close()
 
-		sw := startStreamWriter(types.ID(1), &stats.FollowerStats{}, &fakeRaft{})
+		sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{})
 		defer sw.stop()
 		h.sw = sw
 
 		picker := mustNewURLPicker(t, []string{srv.URL})
-		sr := startStreamReader(&http.Transport{}, picker, tt.t, types.ID(1), types.ID(2), types.ID(1), recvc, propc, nil)
+		sr := startStreamReader(&http.Transport{}, picker, tt.t, types.ID(1), types.ID(2), types.ID(1), newPeerStatus(types.ID(1)), recvc, propc, nil)
 		defer sr.stop()
 		if tt.t == streamTypeMsgApp {
 			sr.updateMsgAppTerm(tt.term)

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -26,7 +26,7 @@ import (
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
-var plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "snap")
+var plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "rafthttp")
 
 type Raft interface {
 	Process(ctx context.Context, m raftpb.Message) error


### PR DESCRIPTION
The PR helps to log rafthttp event better. The changes are:
1. print out the status change of connection with peer
2. only print the first error for repeated ones
So users are aware of the status without being flooded by repeated log lines.

pending on #2911 
inherit from #2402 

The log still has verbose log from raft package about unreachable report. My plan is to change it in follow-up PR. (has been done)

example output when restart member infra3:

log from infra1:
```
2015/06/10 15:37:04 etcdserver: published {Name:infra1 ClientURLs:[http://localhost:4001]} to cluster e9c7614f68f35fb2
2015/06/10 15:37:08 rafthttp: the connection with 924e2e83e93f2560 became active
2015/06/10 15:37:12 rafthttp: the connection with 924e2e83e93f2560 became inactive
2015/06/10 15:37:12 rafthttp: failed to dial 924e2e83e93f2560 on stream Message (dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:12 rafthttp: failed to dial 924e2e83e93f2560 on stream MsgApp v2 (dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:12 rafthttp: failed to heartbeat 924e2e83e93f2560 on stream Message (write tcp 127.0.0.1:57752: broken pipe)
2015/06/10 15:37:12 rafthttp: failed to write 924e2e83e93f2560 on pipeline (dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:13 rafthttp: failed to write 924e2e83e93f2560 on stream MsgApp v2 (write tcp 127.0.0.1:57751: broken pipe)
2015/06/10 15:37:14 etcdserver: failed to reach the peerURL(http://localhost:7003) of member 924e2e83e93f2560 (Get http://localhost:7003/version: dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:14 etcdserver: cannot get the version of member 924e2e83e93f2560 (Get http://localhost:7003/version: dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:19 etcdserver: failed to reach the peerURL(http://localhost:7003) of member 924e2e83e93f2560 (Get http://localhost:7003/version: dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:19 etcdserver: cannot get the version of member 924e2e83e93f2560 (Get http://localhost:7003/version: dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:24 etcdserver: failed to reach the peerURL(http://localhost:7003) of member 924e2e83e93f2560 (Get http://localhost:7003/version: dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:24 etcdserver: cannot get the version of member 924e2e83e93f2560 (Get http://localhost:7003/version: dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:26 rafthttp: the connection with 924e2e83e93f2560 became active
```

log from infra2:
```
2015/06/10 15:37:04 etcdserver: published {Name:infra2 ClientURLs:[http://localhost:4002]} to cluster e9c7614f68f35fb2
2015/06/10 15:37:08 rafthttp: the connection with 924e2e83e93f2560 became active
2015/06/10 15:37:12 rafthttp: the connection with 924e2e83e93f2560 became inactive
2015/06/10 15:37:12 rafthttp: failed to dial 924e2e83e93f2560 on stream MsgApp v2 (dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:12 rafthttp: failed to dial 924e2e83e93f2560 on stream Message (dial tcp 127.0.0.1:7003: connection refused)
2015/06/10 15:37:19 rafthttp: failed to heartbeat 924e2e83e93f2560 on stream MsgApp v2 (write tcp 127.0.0.1:57749: broken pipe)
2015/06/10 15:37:19 rafthttp: failed to heartbeat 924e2e83e93f2560 on stream Message (write tcp 127.0.0.1:57750: broken pipe)
2015/06/10 15:37:26 rafthttp: the connection with 924e2e83e93f2560 became active
```

infra3 restart normally.