### PR TITLE
storage: initial snapshot and restore

### DIFF
--- a/storage/key_index.go
+++ b/storage/key_index.go
@@ -187,6 +187,25 @@ func (a *keyIndex) Less(b btree.Item) bool {
 	return bytes.Compare(a.key, b.(*keyIndex).key) == -1
 }
 
+func (a *keyIndex) equal(b *keyIndex) bool {
+	if !bytes.Equal(a.key, b.key) {
+		return false
+	}
+	if a.rev != b.rev {
+		return false
+	}
+	if len(a.generations) != len(b.generations) {
+		return false
+	}
+	for i := range a.generations {
+		ag, bg := a.generations[i], b.generations[i]
+		if !ag.equal(bg) {
+			return false
+		}
+	}
+	return true
+}
+
 func (ki *keyIndex) String() string {
 	var s string
 	for _, g := range ki.generations {
@@ -220,4 +239,21 @@ func (g *generation) walk(f func(rev reversion) bool) int {
 
 func (g *generation) String() string {
 	return fmt.Sprintf("g: ver[%d], revs %#v\n", g.ver, g.revs)
+}
+
+func (a generation) equal(b generation) bool {
+	if a.ver != b.ver {
+		return false
+	}
+	if len(a.revs) != len(b.revs) {
+		return false
+	}
+
+	for i := range a.revs {
+		ar, br := a.revs[i], b.revs[i]
+		if ar != br {
+			return false
+		}
+	}
+	return true
 }

--- a/storage/kv.go
+++ b/storage/kv.go
@@ -1,6 +1,10 @@
 package storage
 
-import "github.com/coreos/etcd/storage/storagepb"
+import (
+	"io"
+
+	"github.com/coreos/etcd/storage/storagepb"
+)
 
 type KV interface {
 	// Range gets the keys in the range at rangeRev.
@@ -35,4 +39,10 @@ type KV interface {
 	TnxDeleteRange(tnxID int64, key, end []byte) (n, rev int64, err error)
 
 	Compact(rev int64) error
+
+	// Write a snapshot to the given io writer
+	Snapshot(w io.Writer) (int64, error)
+
+	Restore() error
+	Close() error
 }

--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -320,6 +320,31 @@ func TestCompaction(t *testing.T) {
 	}
 }
 
+// TODO: test more complicated cases:
+// with unfinished compaction
+// with removed keys
+func TestRestore(t *testing.T) {
+	s0 := newStore("test")
+	defer os.Remove("test")
+
+	s0.Put([]byte("foo"), []byte("bar"))
+	s0.Put([]byte("foo1"), []byte("bar1"))
+	s0.Put([]byte("foo2"), []byte("bar2"))
+	s0.Put([]byte("foo"), []byte("bar11"))
+	s0.Put([]byte("foo1"), []byte("bar12"))
+	s0.Put([]byte("foo2"), []byte("bar13"))
+	s0.Put([]byte("foo1"), []byte("bar14"))
+
+	s0.Close()
+
+	s1 := newStore("test")
+	s1.Restore()
+
+	if !s0.Equal(s1) {
+		t.Errorf("not equal!")
+	}
+}
+
 func BenchmarkStorePut(b *testing.B) {
 	s := newStore("test")
 	defer os.Remove("test")

--- a/storage/reversion.go
+++ b/storage/reversion.go
@@ -7,6 +7,10 @@ type reversion struct {
 	sub  int64
 }
 
+func newRevBytes() []byte {
+	return make([]byte, 8+1+8)
+}
+
 func revToBytes(rev reversion, bytes []byte) {
 	binary.BigEndian.PutUint64(bytes, uint64(rev.main))
 	bytes[8] = '_'


### PR DESCRIPTION
Snapshot takes an io.Writer and writes the entire backend data to
the given writer. Snapshot writes a consistent view and does not
block other storage operations.

Restore restores the in-memory states (index and book keeping) of
the storage from the backend data.