### PR TITLE
docs: convert relative to absolute links

### DIFF
--- a/Documentation/admin_guide.md
+++ b/Documentation/admin_guide.md
@@ -15,7 +15,7 @@ Using an out-of-date data directory can lead to inconsistency as the member had 
 For maximum safety, if an etcd member suffers any sort of data corruption or loss, it must be removed from the cluster.
 Once removed the member can be re-added with an empty data directory.
 
-[members-api]: other_apis.md#members-api
+[members-api]: https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md#members-api
 
 #### Contents
 
@@ -57,7 +57,7 @@ As you can see, adding another member to bring the size of cluster up to an odd 
 
 #### Changing Cluster Size
 
-After your cluster is up and running, adding or removing members is done via [runtime reconfiguration](runtime-configuration.md), which allows the cluster to be modified without downtime. The `etcdctl` tool has a `member list`, `member add` and `member remove` commands to complete this process.
+After your cluster is up and running, adding or removing members is done via [runtime reconfiguration](https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md), which allows the cluster to be modified without downtime. The `etcdctl` tool has a `member list`, `member add` and `member remove` commands to complete this process.
 
 ### Member Migration
 
@@ -133,7 +133,7 @@ etcd -name node1 \
 -advertise-client-urls http://10.0.1.13:2379,http://127.0.0.1:2379
 ```
 
-[change peer url]: other_apis.md#change-the-peer-urls-of-a-member
+[change peer url]: https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md#change-the-peer-urls-of-a-member
 
 ### Disaster Recovery
 
@@ -181,9 +181,9 @@ Once you have verified that etcd has started successfully, shut it down and move
 
 #### Restoring the cluster
 
-Now that the node is running successfully, you should [change its advertised peer URLs](other_apis.md#change-the-peer-urls-of-a-member), as the `--force-new-cluster` has set the peer URL to the default (listening on localhost).
+Now that the node is running successfully, you should [change its advertised peer URLs](https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md#change-the-peer-urls-of-a-member), as the `--force-new-cluster` has set the peer URL to the default (listening on localhost).
 
-You can then add more nodes to the cluster and restore resiliency. See the [runtime configuration](runtime-configuration.md) guide for more details.
+You can then add more nodes to the cluster and restore resiliency. See the [runtime configuration](https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md) guide for more details.
 
 ### Client Request Timeout
 

--- a/Documentation/clustering.md
+++ b/Documentation/clustering.md
@@ -4,7 +4,7 @@
 
 Starting an etcd cluster statically requires that each member knows another in the cluster. In a number of cases, you might not know the IPs of your cluster members ahead of time. In these cases, you can bootstrap an etcd cluster with the help of a discovery service.
 
-Once an etcd cluster is up and running, adding or removing members is done via [runtime reconfiguration](runtime-configuration.md).
+Once an etcd cluster is up and running, adding or removing members is done via [runtime reconfiguration](https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md).
 
 This guide will cover the following mechanisms for bootstrapping an etcd cluster:
 
@@ -68,7 +68,7 @@ $ etcd -name infra2 -initial-advertise-peer-urls http://10.0.1.12:2380 \
   -initial-cluster-state new
 ```
 
-The command line parameters starting with `-initial-cluster` will be ignored on subsequent runs of etcd. You are free to remove the environment variables or command line flags after the initial bootstrap process. If you need to make changes to the configuration later (for example, adding or removing members to/from the cluster), see the [runtime configuration](runtime-configuration.md) guide.
+The command line parameters starting with `-initial-cluster` will be ignored on subsequent runs of etcd. You are free to remove the environment variables or command line flags after the initial bootstrap process. If you need to make changes to the configuration later (for example, adding or removing members to/from the cluster), see the [runtime configuration](https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md) guide.
 
 ### Error Cases
 
@@ -128,7 +128,7 @@ A discovery URL identifies a unique etcd cluster. Instead of reusing a discovery
 
 Moreover, discovery URLs should ONLY be used for the initial bootstrapping of a cluster. To change cluster membership after the cluster is already running, see the [runtime reconfiguration][runtime] guide.
 
-[runtime]: runtime-configuration.md
+[runtime]: https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md
 
 #### Custom etcd Discovery Service
 
@@ -183,8 +183,8 @@ This will create the cluster with an initial expected size of 3 members. If you 
 
 If you bootstrap an etcd cluster using discovery service with more than the expected number of etcd members, the extra etcd processes will [fall back][fall-back] to being [proxies][proxy] by default.
 
-[fall-back]: proxy.md#fallback-to-proxy-mode-with-discovery-service
-[proxy]: proxy.md
+[fall-back]: https://github.com/coreos/etcd/blob/master/Documentation/proxy.md#fallback-to-proxy-mode-with-discovery-service
+[proxy]: https://github.com/coreos/etcd/blob/master/Documentation/proxy.md
 
 ```
 ETCD_DISCOVERY=https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de

--- a/Documentation/docker_guide.md
+++ b/Documentation/docker_guide.md
@@ -1,6 +1,6 @@
 # Running etcd under Docker
 
-The following guide will show you how to run etcd under Docker using the [static bootstrap process](clustering.md#static).
+The following guide will show you how to run etcd under Docker using the [static bootstrap process](https://github.com/coreos/etcd/blob/master/Documentation/clustering.md#static).
 
 ## Running etcd in standalone mode
 

--- a/Documentation/proxy.md
+++ b/Documentation/proxy.md
@@ -33,4 +33,4 @@ etcd -proxy on -listen-client-urls 127.0.0.1:8080  -discovery https://discovery.
 #### Fallback to proxy mode with discovery service
 If you bootstrap a etcd cluster using [discovery service][discovery-service] with more than the expected number of etcd members, the extra etcd processes will fall back to being `readwrite` proxies by default. They will forward the requests to the cluster as described above. For example, if you create a discovery url with `size=5`, and start ten etcd processes using that same discovery url, the result will be a cluster with five etcd members and five proxies. Note that this behaviour can be disabled with the `proxy-fallback` flag.
 
-[discovery-service]: clustering.md#discovery
+[discovery-service]: https://github.com/coreos/etcd/blob/master/Documentation/clustering.md#discovery

--- a/Documentation/runtime-configuration.md
+++ b/Documentation/runtime-configuration.md
@@ -16,7 +16,7 @@ If you need to move multiple members of your cluster due to planned maintenance 
 
 It is safe to remove the leader, however there is a brief period of downtime while the election process takes place. If your cluster holds more than 50MB, it is recommended to [migrate the member's data directory][member migration].
 
-[member migration]: admin_guide.md#member-migration
+[member migration]: https://github.com/coreos/etcd/blob/master/Documentation/admin_guide.md#member-migration
 
 ### Change the Cluster Size
 
@@ -24,7 +24,7 @@ Increasing the cluster size can enhance [failure tolerance][fault tolerance tabl
 
 Decreasing the cluster size can improve the write performance of a cluster, with a trade-off of decreased resilience. Writes into the cluster are replicated to a majority of members of the cluster before considered committed. Decreasing the cluster size lowers the majority, and each write is committed more quickly.
 
-[fault tolerance table]: admin_guide.md#fault-tolerance-table
+[fault tolerance table]: https://github.com/coreos/etcd/blob/master/Documentation/admin_guide.md#fault-tolerance-table
 
 ### Replace A Failed Machine
 
@@ -41,7 +41,7 @@ If the majority of your cluster is lost, then you need to take manual action in 
 The basic steps in the recovery process include [creating a new cluster using the old data][disaster recovery], forcing a single member to act as the leader, and finally using runtime configuration to [add new members][add member] to this new cluster one at a time.
 
 [add member]: #add-a-new-member
-[disaster recovery]: admin_guide.md#disaster-recovery
+[disaster recovery]: https://github.com/coreos/etcd/blob/master/Documentation/admin_guide.md#disaster-recovery
 
 ## Cluster Reconfiguration Operations
 
@@ -57,7 +57,7 @@ To increase from 3 to 5 members you will make two add operations
 To decrease from 5 to 3 you will make two remove operations
 
 All of these examples will use the `etcdctl` command line tool that ships with etcd.
-If you want to use the member API directly you can find the documentation [here](other_apis.md).
+If you want to use the member API directly you can find the documentation [here](https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md).
 
 ### Remove a Member
 
@@ -90,10 +90,10 @@ It is safe to remove the leader, however the cluster will be inactive while a ne
 
 Adding a member is a two step process:
 
- * Add the new member to the cluster via the [members API](other_apis.md#post-v2members) or the `etcdctl member add` command.
+ * Add the new member to the cluster via the [members API](https://github.com/coreos/etcd/blob/master/Documentation/other_apis.md#post-v2members) or the `etcdctl member add` command.
  * Start the new member with the new cluster configuration, including a list of the updated members (existing members + the new member).
 
-Using `etcdctl` let's add the new member to the cluster by specifying its [name](configuration.md#-name) and [advertised peer URLs](configuration.md#-initial-advertise-peer-urls):
+Using `etcdctl` let's add the new member to the cluster by specifying its [name](https://github.com/coreos/etcd/blob/master/Documentation/configuration.md#-name) and [advertised peer URLs](https://github.com/coreos/etcd/blob/master/Documentation/configuration.md#-initial-advertise-peer-urls):
 
 ```
 $ etcdctl member add infra3 http://10.0.1.13:2380


### PR DESCRIPTION
We have just a few relative links (the rest are absolute). This prevents links from breaking on coreos.com and won't affect anyone browsing Github.