### PR TITLE
rafthttp: fix TestStopBlockedPipeline

### DIFF
--- a/rafthttp/pipeline.go
+++ b/rafthttp/pipeline.go
@@ -153,6 +153,7 @@ func (p *pipeline) post(data []byte) (err error) {
 		select {
 		case <-done:
 		case <-p.stopc:
+			waitSchedule()
 			stopped = true
 			if cancel, ok := p.tr.(canceler); ok {
 				cancel.CancelRequest(req)
@@ -199,3 +200,6 @@ func (p *pipeline) post(data []byte) (err error) {
 		return fmt.Errorf("unexpected http status %s while posting to %q", http.StatusText(resp.StatusCode), req.URL.String())
 	}
 }
+
+// waitSchedule waits other goroutines to be scheduled for a while
+func waitSchedule() { time.Sleep(time.Millisecond) }


### PR DESCRIPTION
- rafthttp: wait 1ms before enabling cancel …
CancelRequest only effects on in-flight request, so we need to wait
for Do(request) called before enabling cancel.

- rafthttp: fix TestStopBlockedPipeline …
Refactor the fake cancel implementation.

The old one may cancel other in-flight message in random, which leaves
the original target message blocked forever.

fixes #2946 