### PR TITLE
rafthttp: pretty print message drop info

### DIFF
--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -161,8 +161,11 @@ func startPeer(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID, r
 					if isMsgSnap(m) {
 						p.r.ReportSnapshot(m.To, raft.SnapshotFailure)
 					}
-					// TODO: log start and end of message dropping
-					plog.Warningf("dropping %s to %s since %s's sending buffer is full", m.Type, p.id, name)
+					if status.isActive() {
+						plog.Warningf("dropped %s to %s since %s's sending buffer is full", m.Type, p.id, name)
+					} else {
+						plog.Debugf("dropped %s to %s since %s's sending buffer is full", m.Type, p.id, name)
+					}
 				}
 			case mm := <-p.recvc:
 				if err := r.Process(context.TODO(), mm); err != nil {

--- a/rafthttp/peer_status.go
+++ b/rafthttp/peer_status.go
@@ -65,3 +65,9 @@ func (s *peerStatus) deactivate(failure failureType, reason string) {
 	s.failureMap[failure] = reason
 	plog.Errorf(logline)
 }
+
+func (s *peerStatus) isActive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active
+}

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -359,9 +359,11 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 			select {
 			case recvc <- m:
 			default:
-				// TODO: log start and end of message dropping
-				plog.Warningf("dropping %s from %x because receiving buffer is full",
-					m.Type, m.From)
+				if cr.status.isActive() {
+					plog.Warningf("dropped %s from %s since receiving buffer is full", m.Type, m.From)
+				} else {
+					plog.Debugf("dropped %s from %s since receiving buffer is full", m.Type, m.From)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
add a member with unresponsive peer url in normal log level: no additional info about drop

add a member with unresponsive peer url in debug log level:
```
2015/06/11 22:26:31 rafthttp: dropped MsgApp to db031fe71d043d60 since pipeline's sending buffer is full
2015/06/11 22:26:31 rafthttp: dropped MsgHeartbeat to db031fe71d043d60 since pipeline's sending buffer is full
```

for #2845 