### PR TITLE
rafthttp: always init streamReader before return from newPeer

### DIFF
--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -143,10 +143,10 @@ func startPeer(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID, r
 		}
 	}()
 
+	p.msgAppReader = startStreamReader(tr, picker, streamTypeMsgAppV2, local, to, cid, status, p.recvc, p.propc, errorc)
+	reader := startStreamReader(tr, picker, streamTypeMessage, local, to, cid, status, p.recvc, p.propc, errorc)
 	go func() {
 		var paused bool
-		p.msgAppReader = startStreamReader(tr, picker, streamTypeMsgAppV2, local, to, cid, status, p.recvc, p.propc, errorc)
-		reader := startStreamReader(tr, picker, streamTypeMessage, local, to, cid, status, p.recvc, p.propc, errorc)
 		for {
 			select {
 			case m := <-p.sendc:


### PR DESCRIPTION
Or etcd will panic if someone calls `setTerm()`, which uses streamReader
internally, before streamReader is inited.

fixes #2966 