### PR TITLE
test: extend integration timeout to 10m

### DIFF
--- a/test
+++ b/test
@@ -50,7 +50,7 @@ go test -timeout 3m ${COVER} $@ ${NO_RACE_TEST} -cpu 1,2,4
 
 if [ -n "$INTEGRATION" ]; then
 	echo "Running integration tests..."
-	go test -timeout 3m $@ ${REPO_PATH}/integration -v -cpu 1,2,4
+	go test -timeout 10m $@ ${REPO_PATH}/integration -v -cpu 1,2,4
 fi
 
 echo "Checking gofmt..."


### PR DESCRIPTION
We test with `-cpu 1,2,4` now, and it takes longer time. One round of test takes about 100s, and three rounds of test should take around 300s now. Give it 10m for safety.