### PR TITLE
pkg/fileutil: wait longer before checking purge results

### DIFF
--- a/pkg/fileutil/purge_test.go
+++ b/pkg/fileutil/purge_test.go
@@ -86,7 +86,7 @@ func TestPurgeFileHoldingLock(t *testing.T) {
 
 	stop := make(chan struct{})
 	errch := PurgeFile(dir, "test", 3, time.Millisecond, stop)
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	fnames, err := ReadDir(dir)
 	if err != nil {
@@ -112,7 +112,7 @@ func TestPurgeFileHoldingLock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	fnames, err = ReadDir(dir)
 	if err != nil {


### PR DESCRIPTION
multiple cpu running may be slower than single cpu running, so it may
take longer time to remove files.
Increase from 5ms to 20ms to give it enough time.

fixes #2969 