### PR TITLE
pkg/fileutil: wait longer for relock

### DIFF
--- a/pkg/fileutil/lock_test.go
+++ b/pkg/fileutil/lock_test.go
@@ -90,7 +90,7 @@ func TestLockAndUnlock(t *testing.T) {
 	// the previously blocked routine should be unblocked
 	select {
 	case <-locked:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(20 * time.Millisecond):
 		t.Error("unexpected blocking")
 	}
 }


### PR DESCRIPTION
multiple cpu running makes it slower, so it waits longer for relock.

fixes #2974 