### PR TITLE
proxy: handle canceled proxy request gracefully

### DIFF
--- a/proxy/reverse.go
+++ b/proxy/reverse.go
@@ -98,10 +98,11 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 		go func() {
 			select {
 			case <-closeNotifier.CloseNotify():
+				atomic.StoreInt32(&requestClosed, 1)
+				log.Printf("proxy: client %v closed request prematurely", clientreq.RemoteAddr)
+
 				tp, ok := p.transport.(*http.Transport)
 				if ok {
-					atomic.StoreInt32(&requestClosed, 1)
-					log.Printf("proxy: request from %v canceled", clientreq.RemoteAddr)
 					tp.CancelRequest(proxyreq)
 				}
 			case <-completeCh:


### PR DESCRIPTION
when a client of the proxy server cancels a request the proxy should not set the endpoint state to unavailable.

**the problem**
if a client closes the connection to the proxy and the proxy request is canceled than the current and all remaining endpoints will be set to unavailable.

**steps to reproduce**
goreman start

execute following script
```
#!/bin/bash
export ETCDCTL_PEERS=http://localhost:8080

for i in $(seq 1 10); do 
    etcdctl --no-sync set /test $i &
    PID=$!
    sleep 0.00$i
    kill -SIGKILL $PID
done
```

output of script
```
etcd :: (master*) » ./kill-proxy                                                                                                                                                   ~/Go/src/github.com/webner/etcd  
Error:  502:  (unhandled http status [Service Unavailable] with body [{"message":"proxy: zero endpoints currently available"}]) [0]
./kill-proxy: line 4: 25843 Killed                  etcdctl --no-sync set /test $i
Error:  502:  (unhandled http status [Service Unavailable] with body [{"message":"proxy: zero endpoints currently available"}]) [0]
./kill-proxy: line 8: kill: (25852) - No such process
Error:  502:  (unhandled http status [Service Unavailable] with body [{"message":"proxy: zero endpoints currently available"}]) [0]
./kill-proxy: line 8: kill: (25857) - No such process
Error:  502:  (unhandled http status [Service Unavailable] with body [{"message":"proxy: zero endpoints currently available"}]) [0]
./kill-proxy: line 8: kill: (25862) - No such process
Error:  502:  (unhandled http status [Service Unavailable] with body [{"message":"proxy: zero endpoints currently available"}]) [0]
./kill-proxy: line 8: kill: (25867) - No such process
```
and output of proxy log
```
20:57:39 proxy | 2015/06/16 20:57:39 proxy: zero endpoints currently available
20:57:39 proxy | 2015/06/16 20:57:39 proxy: zero endpoints currently available
20:57:39 proxy | 2015/06/16 20:57:39 proxy: zero endpoints currently available
20:57:39 proxy | 2015/06/16 20:57:39 proxy: zero endpoints currently available
20:57:39 proxy | 2015/06/16 20:57:39 proxy: zero endpoints currently available
20:57:39 proxy | 2015/06/16 20:57:39 proxy: zero endpoints currently available
```

**expected result**
```
21:06:01 proxy | 2015/06/16 21:06:01 proxy: request from 127.0.0.1:45189 canceled
21:06:01 proxy | 2015/06/16 21:06:01 proxy: request from 127.0.0.1:45190 canceled
21:06:01 proxy | 2015/06/16 21:06:01 proxy: request from 127.0.0.1:45192 canceled
21:06:01 proxy | 2015/06/16 21:06:01 proxy: request from 127.0.0.1:45194 canceled
21:06:01 proxy | 2015/06/16 21:06:01 proxy: request from 127.0.0.1:45196 canceled
21:06:01 proxy | 2015/06/16 21:06:01 proxy: request from 127.0.0.1:45198 canceled
21:06:01 proxy | 2015/06/16 21:06:01 proxy: request from 127.0.0.1:45200 canceled
21:06:01 proxy | 2015/06/16 21:06:01 proxy: request from 127.0.0.1:45202 canceled
```
