### PR TITLE
storage: remove unnecessary ForceCommit in kvstore.Close

### DIFF
--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -233,7 +233,6 @@ func (s *store) Restore() error {
 func (s *store) Close() error {
 	close(s.stopc)
 	s.wg.Wait()
-	s.b.ForceCommit()
 	return s.b.Close()
 }
 


### PR DESCRIPTION
s.b.Close will commit pending ops, so there is no need to FroceCommit
it in kvstore.Close()