### PR TITLE
etcdserver: better log message for url mismatch

### DIFF
--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -94,7 +94,7 @@ func (c *ServerConfig) verifyLocalMember(strict bool) error {
 	urls.Sort()
 	if strict {
 		if !reflect.DeepEqual(apurls, urls.StringSlice()) {
-			return fmt.Errorf("%s has different advertised URLs in the cluster and advertised peer URLs list", c.Name)
+			return fmt.Errorf("advertise URLs of %q do not match in --initial-advertise-peer-urls %s and --initial-cluster %s", c.Name, apurls, urls.StringSlice())
 		}
 	}
 	return nil


### PR DESCRIPTION
Fix #2303 

before
```
default has different advertised URLs in the cluster and advertised peer URLs list
```

after
```
 advertise URLs of "default" do not match in --initial-cluster [http://bad:9090] and --initial-advertise-peer-urls [http://localhost:2380 http://localhost:7001]
```