### PR TITLE
*: docs and code %s%maximal%maximum%g

### DIFF
--- a/Documentation/admin_guide.md
+++ b/Documentation/admin_guide.md
@@ -212,7 +212,7 @@ If timeout happens several times continuously, administrators should check statu
 
 ### Best Practices
 
-#### Maximal OS threads
+#### Maximum OS threads
 
 By default, etcd uses the default configuration of the Go 1.4 runtime, which means that at most one operating system thread will be used to execute code simultaneously. (Note that this default behavior [may change in Go 1.5](https://docs.google.com/document/d/1At2Ls5_fhJQ59kDK2DFVhFu3g5mATSXqqV5QrxinasI/edit)).
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	// DefaultMaxIdleConnsPerHost indicates the default maximal idle connections
-	// maintained between proxy and each member. We set it to 128 to
+	// DefaultMaxIdleConnsPerHost indicates the default maximum idle connection
+	// count maintained between proxy and each member. We set it to 128 to
 	// let proxy handle 128 concurrent requests in long term smoothly.
 	// If the number of concurrent requests is bigger than this value,
 	// proxy needs to create one new connection when handling each request in

--- a/rafthttp/pipeline_test.go
+++ b/rafthttp/pipeline_test.go
@@ -52,7 +52,7 @@ func TestPipelineSend(t *testing.T) {
 	}
 }
 
-func TestPipelineExceedMaximalServing(t *testing.T) {
+func TestPipelineExceedMaximumServing(t *testing.T) {
 	tr := newRoundTripperBlocker()
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
 	fs := &stats.FollowerStats{}


### PR DESCRIPTION
maximum is a more common word, use it instead