### PR TITLE
etcdserver: fix TestTriggerSnap

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -748,6 +748,8 @@ func TestTriggerSnap(t *testing.T) {
 		srv.Do(context.Background(), pb.Request{Method: "PUT"})
 	}
 	srv.Stop()
+	// wait for snapshot goroutine to finish
+	testutil.WaitSchedule()
 
 	gaction := p.Action()
 	// each operation is recorded as a Save


### PR DESCRIPTION
Before checking, it needs to wait for snapshot goroutine to finish its
work.

fixes https://github.com/coreos/etcd/issues/2990