### PR TITLE
pkg/wait: extend timeout to check closed channel

### DIFF
--- a/pkg/wait/wait_time_test.go
+++ b/pkg/wait/wait_time_test.go
@@ -61,7 +61,7 @@ func TestWaitTestStress(t *testing.T) {
 	for _, ch := range chs {
 		select {
 		case <-ch:
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(time.Second):
 			t.Fatalf("cannot receive from ch as expected")
 		}
 	}


### PR DESCRIPTION
It is possible to trigger the time.After case if the timer went off
between time.After setting the timer for its channel and the time that
select looked at the channel. So it needs to be longer.

refer: https://groups.google.com/forum/#!topic/golang-nuts/1tjcV80ccq8

fixes https://github.com/coreos/etcd/issues/2948