### PR TITLE
rafthttp: fix TestStream uses outdated stream

### DIFF
--- a/rafthttp/stream_test.go
+++ b/rafthttp/stream_test.go
@@ -274,11 +274,8 @@ func TestStream(t *testing.T) {
 		h.sw = sw
 
 		picker := mustNewURLPicker(t, []string{srv.URL})
-		sr := startStreamReader(&http.Transport{}, picker, tt.t, types.ID(1), types.ID(2), types.ID(1), newPeerStatus(types.ID(1)), recvc, propc, nil, 1)
+		sr := startStreamReader(&http.Transport{}, picker, tt.t, types.ID(1), types.ID(2), types.ID(1), newPeerStatus(types.ID(1)), recvc, propc, nil, tt.term)
 		defer sr.stop()
-		if tt.t == streamTypeMsgApp {
-			sr.updateMsgAppTerm(tt.term)
-		}
 		// wait for stream to work
 		var writec chan<- raftpb.Message
 		for {


### PR DESCRIPTION
rafthttp: expose streamWriter.msgAppTerm() …
So upper level could know msgAppTerm of streamWriter, which is
determined by the connection from the remote.

rafthttp: fix TestStream uses outdated stream …
The original code doesn't work because reader side may update the
stream, while writer side writes message to the old stream and fails.

fixes #2961 