### PR TITLE
etcdserver/auth: fix return value when creating root user

### DIFF
--- a/etcdserver/auth/auth.go
+++ b/etcdserver/auth/auth.go
@@ -160,20 +160,10 @@ func (s *Store) GetUser(name string) (User, error) {
 	if err != nil {
 		return u, err
 	}
-	// Require that root always has a root role.
+	// Attach root role to root user.
 	if u.User == "root" {
-		inRoles := false
-		for _, r := range u.Roles {
-			if r == RootRoleName {
-				inRoles = true
-				break
-			}
-		}
-		if !inRoles {
-			u.Roles = append(u.Roles, RootRoleName)
-		}
+		u = attachRootRole(u)
 	}
-
 	return u, nil
 }
 
@@ -191,6 +181,10 @@ func (s *Store) CreateOrUpdateUser(user User) (out User, created bool, err error
 }
 
 func (s *Store) CreateUser(user User) (User, error) {
+	// Attach root role to root user.
+	if user.User == "root" {
+		user = attachRootRole(user)
+	}
 	u, err := s.createUserInternal(user)
 	if err == nil {
 		plog.Noticef("created user %s", user.User)
@@ -603,4 +597,18 @@ func prefixMatch(pattern string, key string) (match bool, err error) {
 		return false, nil
 	}
 	return strings.HasPrefix(key, pattern[:len(pattern)-1]), nil
+}
+
+func attachRootRole(u User) User {
+	inRoles := false
+	for _, r := range u.Roles {
+		if r == RootRoleName {
+			inRoles = true
+			break
+		}
+	}
+	if !inRoles {
+		u.Roles = append(u.Roles, RootRoleName)
+	}
+	return u
 }


### PR DESCRIPTION
Before:

```
$ curl http://127.0.0.1:4001/v2/auth/users/root -XPUT -d '{"user": "root",
"password": "root"}'
{"user":"root","roles":null}
```

After:

```
{"user":"root","roles":["root"]}
```

/cc @barakmich 