### PR TITLE
support 'etcdctl mkdir -p'

### DIFF
--- a/etcdctl/command/mkdir_command.go
+++ b/etcdctl/command/mkdir_command.go
@@ -28,6 +28,7 @@ func NewMakeDirCommand() cli.Command {
 		Usage: "make a new directory",
 		Flags: []cli.Flag{
 			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live"},
+			cli.BoolFlag{Name: "p", Usage: "only make the directory if it does not exist"},
 		},
 		Action: func(c *cli.Context) {
 			handleDir(c, makeDirCommandFunc)
@@ -42,6 +43,13 @@ func makeDirCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, er
 	}
 	key := c.Args()[0]
 	ttl := c.Int("ttl")
+	p := c.Bool("p")
+
+	// p allows "mkdir" to succeed even when the directory already exists.
+	_, err := client.Get(key, false, false)
+	if err == nil && p {
+		return nil, nil
+	}
 
 	return client.CreateDir(key, uint64(ttl))
 }


### PR DESCRIPTION
The 'mkdir' subcommand is not idempotent, and it is awkward to do
'etcdctl ls /foo || etcdctl mkdir /foo'.

Add a 'p' flag to the mkdir command so that, when this flag is passed,
it exits with success without trying to create a dir that already
exists.

This allows its easy use in fixture style shell scripts that create a
whole etcdctl structure and run everytime a build is performed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/coreos/etcd/3066)
<!-- Reviewable:end -->
