### PR TITLE
rafthttp: message_sent_latency metrics: channel -> sendingType

### DIFF
--- a/Documentation/metrics.md
+++ b/Documentation/metrics.md
@@ -49,17 +49,17 @@ Abnormally high snapshot duration (`snapshot_save_total_durations_microseconds`)
 
 ### rafthttp
 
-| Name                              | Description                                | Type    | Labels                     |
-|-----------------------------------|--------------------------------------------|---------|----------------------------|
-| message_sent_latency_microseconds | The latency distributions of messages sent | Summary | channel, msgType, remoteID |
-| message_sent_failed_total         | The total number of failed messages sent   | Summary | channel, msgType, remoteID |
+| Name                              | Description                                | Type    | Labels                         |
+|-----------------------------------|--------------------------------------------|---------|--------------------------------|
+| message_sent_latency_microseconds | The latency distributions of messages sent | Summary | sendingType, msgType, remoteID |
+| message_sent_failed_total         | The total number of failed messages sent   | Summary | sendingType, msgType, remoteID |
 
 
 Abnormally high message duration (`message_sent_latency_microseconds`) indicates network issues and might cause the cluster to be unstable.
 
 An increase in message failures (`message_sent_failed_total`) indicates more severe network issues and might cause the cluster to be unstable.
 
-Label `channel` is the channel to send message. `message`, `msgapp` and `msgappv2` channels use HTTP streaming, while `pipeline` does HTTP request for each message.
+Label `sendingType` is the connection type to send messages. `message`, `msgapp` and `msgappv2` use HTTP streaming, while `pipeline` does HTTP request for each message.
 
 Label `msgType` is the type of raft message. `MsgApp` is log replication message; `MsgSnap` is snapshot install message; `MsgProp` is proposal forward message; the others are used to maintain raft internal status. If you have a large snapshot, you would expect a long msgSnap sending latency. For other types of messages, you would expect low latency, which is comparable to your ping latency if you have enough network bandwidth.
 

--- a/rafthttp/metrics.go
+++ b/rafthttp/metrics.go
@@ -30,7 +30,7 @@ var (
 			Name:      "message_sent_latency_microseconds",
 			Help:      "message sent latency distributions.",
 		},
-		[]string{"channel", "remoteID", "msgType"},
+		[]string{"sendingType", "remoteID", "msgType"},
 	)
 
 	msgSentFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -39,7 +39,7 @@ var (
 		Name:      "message_sent_failed_total",
 		Help:      "The total number of failed messages sent.",
 	},
-		[]string{"channel", "remoteID", "msgType"},
+		[]string{"sendingType", "remoteID", "msgType"},
 	)
 )
 
@@ -48,18 +48,18 @@ func init() {
 	prometheus.MustRegister(msgSentFailed)
 }
 
-func reportSentDuration(channel string, m raftpb.Message, duration time.Duration) {
+func reportSentDuration(sendingType string, m raftpb.Message, duration time.Duration) {
 	typ := m.Type.String()
 	if isLinkHeartbeatMessage(m) {
 		typ = "MsgLinkHeartbeat"
 	}
-	msgSentDuration.WithLabelValues(channel, types.ID(m.To).String(), typ).Observe(float64(duration.Nanoseconds() / int64(time.Microsecond)))
+	msgSentDuration.WithLabelValues(sendingType, types.ID(m.To).String(), typ).Observe(float64(duration.Nanoseconds() / int64(time.Microsecond)))
 }
 
-func reportSentFailure(channel string, m raftpb.Message) {
+func reportSentFailure(sendingType string, m raftpb.Message) {
 	typ := m.Type.String()
 	if isLinkHeartbeatMessage(m) {
 		typ = "MsgLinkHeartbeat"
 	}
-	msgSentFailed.WithLabelValues(channel, types.ID(m.To).String(), typ).Inc()
+	msgSentFailed.WithLabelValues(sendingType, types.ID(m.To).String(), typ).Inc()
 }


### PR DESCRIPTION
Better naming.

for https://github.com/coreos/etcd/pull/3051#discussion_r33370502