### PR TITLE
storage: correctly restore create and ver

### DIFF
--- a/storage/key_index.go
+++ b/storage/key_index.go
@@ -78,6 +78,16 @@ func (ki *keyIndex) put(main int64, sub int64) {
 	ki.modified = rev
 }
 
+func (ki *keyIndex) restore(created, modified reversion, ver int64) {
+	if len(ki.generations) != 0 {
+		log.Panicf("store.keyindex: cannot restore non-empty keyIndex")
+	}
+
+	ki.modified = modified
+	g := generation{created: created, ver: ver, revs: []reversion{modified}}
+	ki.generations = append(ki.generations, g)
+}
+
 // tombstone puts a reversion, pointing to a tombstone, to the keyIndex.
 // It also creates a new empty generation in the keyIndex.
 func (ki *keyIndex) tombstone(main int64, sub int64) {

--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -205,7 +205,7 @@ func (s *store) Restore() error {
 		// restore index
 		switch e.Type {
 		case storagepb.PUT:
-			s.kvindex.Put(e.Kv.Key, rev)
+			s.kvindex.Restore(e.Kv.Key, reversion{e.Kv.CreateIndex, 0}, rev, e.Kv.Version)
 		case storagepb.DELETE:
 			s.kvindex.Tombstone(e.Kv.Key, rev)
 		default:


### PR DESCRIPTION
Add a restore func to correctly restore create reversion and
version of keys for the index.