### PR TITLE
etcdserver: init raft internal var early

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -109,9 +109,6 @@ type raftNode struct {
 }
 
 func (r *raftNode) run() {
-	r.stopped = make(chan struct{})
-	r.done = make(chan struct{})
-
 	var syncC <-chan time.Time
 
 	defer r.stop()

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -152,6 +152,8 @@ func TestStopRaftWhenWaitingForApplyDone(t *testing.T) {
 		storage:     &storageRecorder{},
 		raftStorage: raft.NewMemoryStorage(),
 		transport:   &nopTransporter{},
+		stopped:     make(chan struct{}),
+		done:        make(chan struct{}),
 	}
 	r.s = &EtcdServer{r: r}
 	go r.run()

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -416,6 +416,8 @@ func (s *EtcdServer) run() {
 	// TODO: get rid of the raft initialization in etcd server
 	s.r.s = s
 	s.r.applyc = make(chan apply)
+	s.r.stopped = make(chan struct{})
+	s.r.done = make(chan struct{})
 	go s.r.run()
 	defer func() {
 		s.r.stopped <- struct{}{}


### PR DESCRIPTION
Its `stopped`/`done` should be created always before being used
in defer in server loop.

It fixes the race detected when running TestSyncTrigger.

for the data race problem of #3060 