### PR TITLE
etcdctl: print out key and action when watching recursively

### DIFF
--- a/etcdctl/command/watch_command.go
+++ b/etcdctl/command/watch_command.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 
@@ -72,6 +73,10 @@ func watchCommandFunc(c *cli.Context, ki client.KeysAPI) {
 		if resp.Node.Dir {
 			continue
 		}
+		if recursive {
+			fmt.Printf("[%s] %s\n", resp.Action, resp.Node.Key)
+		}
+
 		printResponseKey(resp, c.GlobalString("output"))
 
 		if !forever {


### PR DESCRIPTION
Fix #2922 

```
./etcdctl watch --recursive --forever foo
[set] /foo/bar
bar
[set] /foo/bar
bar
[set] /foo/bar
barbar
[delete] /foo/bar
PrevNode.Value: barbar
```
