### PR TITLE
detect duplicate names when using discovery bootstrap

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -109,10 +109,14 @@ func Main() {
 		switch err {
 		case discovery.ErrDuplicateID:
 			plog.Errorf("member %q has previously registered with discovery service token (%s).", cfg.name, cfg.durl)
-			plog.Errorf("But etcd could not find vaild cluster configuration in the given data dir (%s).", cfg.dir)
+			plog.Errorf("But etcd could not find valid cluster configuration in the given data dir (%s).", cfg.dir)
 			plog.Infof("Please check the given data dir path if the previous bootstrap succeeded")
 			plog.Infof("or use a new discovery token if the previous bootstrap failed.")
 			os.Exit(1)
+		case discovery.ErrDuplicateName:
+			plog.Errorf("member with duplicated name has registered with discovery service token(%s).", cfg.durl)
+			plog.Errorf("please check (cURL) the discovery token for more information.")
+			plog.Errorf("please do not reuse the discovery token and generate a new one to bootstrap the cluster.")
 		default:
 			plog.Fatalf("%v", err)
 		}

--- a/pkg/types/urlsmap.go
+++ b/pkg/types/urlsmap.go
@@ -25,7 +25,7 @@ type URLsMap map[string]URLs
 
 // NewURLsMap returns a URLsMap instantiated from the given string,
 // which consists of discovery-formatted names-to-URLs, like:
-// mach0=http://1.1.1.1,mach0=http://2.2.2.2,mach1=http://3.3.3.3,mach2=http://4.4.4.4
+// mach0=http://1.1.1.1:2380,mach0=http://2.2.2.2::2380,mach1=http://3.3.3.3:2380,mach2=http://4.4.4.4:2380
 func NewURLsMap(s string) (URLsMap, error) {
 	cl := URLsMap{}
 	v, err := url.ParseQuery(strings.Replace(s, ",", "&", -1))
@@ -68,4 +68,8 @@ func (c URLsMap) URLs() []string {
 	}
 	sort.Strings(urls)
 	return urls
+}
+
+func (c URLsMap) Len() int {
+	return len(c)
 }


### PR DESCRIPTION
After the fix, the duplicate name case prints out:
```
18:13:24 etcdmain: member with duplicated name has registered with discovery service token(https://discovery.etcd.io/9ade3c2e1c8b0f48ceca974adab1d9af).
18:13:24 etcdmain: please check (cURL) the discovery token for more information.
etcdmain: please do not reuse the discovery token and generate a new one to bootstrap the cluster.
```
and exits.

curl https://discovery.etcd.io/9ade3c2e1c8b0f48ceca974adab1d9af
```
{"action":"get","node":{"key":"/_etcd/registry/9ade3c2e1c8b0f48ceca974adab1d9af","dir":true,"nodes":[{"key":"/_etcd/registry/9ade3c2e1c8b0f48ceca974adab1d9af/95c7ef0fcbe9f0b8","value":"infra3=http://127.0.0.1:7003","modifiedIndex":658514690,"createdIndex":658514690},{"key":"/_etcd/registry/9ade3c2e1c8b0f48ceca974adab1d9af/4d59f8148bb377e2","value":"infra1=http://127.0.0.1:7002","modifiedIndex":658514691,"createdIndex":658514691},{"key":"/_etcd/registry/9ade3c2e1c8b0f48ceca974adab1d9af/2546639afa13373f","value":"infra1=http://127.0.0.1:7001","modifiedIndex":658514692,"createdIndex":658514692}],"modifiedIndex":658514676,"createdIndex":658514676}}
```

There are two `infra1` in the list.

Fix #2899