### PR TITLE
pkg/transport: include debug output for trusted-ca

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -78,7 +78,7 @@ type TLSInfo struct {
 }
 
 func (info TLSInfo) String() string {
-	return fmt.Sprintf("cert = %s, key = %s, ca = %s", info.CertFile, info.KeyFile, info.CAFile)
+	return fmt.Sprintf("cert = %s, key = %s, ca = %s, trusted-ca = %s", info.CertFile, info.KeyFile, info.CAFile, info.TrustedCAFile)
 }
 
 func (info TLSInfo) Empty() bool {


### PR DESCRIPTION
since --peer-ca-file is deprecated we need to update the debug output

before:

```
$ etcd ... --peer-cert-file infra1.crt -peer-key-file
 infra1.key.insecure -peer-trusted-ca-file ca.crt --client-cert-auth
etcdmain: peerTLS: cert = infra1.crt, key = infra1.key.insecure, ca =
```

after:

```
$ etcd ... --peer-cert-file infra1.crt -peer-key-file
 infra1.key.insecure -peer-trusted-ca-file ca.crt --client-cert-auth
etcdmain: peerTLS: cert = infra1.crt, key = infra1.key.insecure, ca = , trusted-ca = ca.crt
```