### PR TITLE
Documentation/security: add FAQ about peer TLS and etcd 2.0.x

### DIFF
--- a/Documentation/security.md
+++ b/Documentation/security.md
@@ -147,6 +147,13 @@ The etcd members will form a cluster and all communication between members in th
 
 ## Frequently Asked Questions
 
+### My cluster is not working with peer tls configuration?
+
+The internal protocol of etcd v2.0.x uses a lot of short-lived HTTP connections.
+So, when enabling TLS you may need to increase the heartbeat interval and election timeouts to reduce internal cluster connection churn.
+A reasonable place to start are these values: ` --heartbeat-interval 500 --election-timeout 2500`.
+This issues is resolved in the etcd v2.1.x series of releases which uses fewer connections.
+
 ### I'm seeing a SSLv3 alert handshake failure when using SSL client authentication?
 
 The `crypto/tls` package of `golang` checks the key usage of the certificate public key before using it.


### PR DESCRIPTION
etcd 2.0.x TLS can appear not to work on smaller machines with less
horse-power or lots of other work going on. Document the timeout
workaround.