### PR TITLE
rafthttp: not waiting for peer stop

### DIFF
--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -391,7 +391,7 @@ func (cr *streamReader) stop() {
 	cr.cancelRequest()
 	cr.close()
 	cr.mu.Unlock()
-	<-cr.done
+	// TODO: wait for cr.done when it can always cancel in-flight connection
 }
 
 func (cr *streamReader) isWorking() bool {


### PR DESCRIPTION
The stop may hang forever because it fails to cancel request
successfully. This is hard to be fixed in go1.4 because CancelRequest
will panic if called twice. Do not wait for peer stop to avoid the
block.

for #3076 