### PR TITLE
Retry on rejected empty appends

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -1186,6 +1186,7 @@ func TestLeaderAppResp(t *testing.T) {
 		wcommitted uint64
 	}{
 		{3, true, 0, 3, 0, 0, 0},  // stale resp; no replies
+		{0, true, 0, 3, 1, 2, 0},  // empty append was rejected; retry so the commit index is advanced
 		{2, true, 0, 2, 1, 1, 0},  // denied resp; leader does not commit; decrease next and send probing msg
 		{2, false, 2, 4, 2, 2, 2}, // accept resp; leader commits; broadcast with commit index
 		{0, false, 0, 3, 0, 0, 0}, // ignore heartbeat replies

--- a/raft/rafttest/network_test.go
+++ b/raft/rafttest/network_test.go
@@ -41,18 +41,17 @@ func TestNetworkDelay(t *testing.T) {
 	delay := time.Millisecond
 	delayrate := 0.1
 	nt := newRaftNetwork(1, 2)
-
 	nt.delay(1, 2, delay, delayrate)
-	var total time.Duration
+
+	msg := raftpb.Message{From: 1, To: 2}
+	start := time.Now()
 	for i := 0; i < sent; i++ {
-		s := time.Now()
-		nt.send(raftpb.Message{From: 1, To: 2})
-		total += time.Since(s)
+		nt.send(msg)
 	}
+	total := time.Since(start)
 
 	w := time.Duration(float64(sent)*delayrate/2) * delay
-	// there are pretty overhead in the send call, since it genarete random numbers.
-	if total < w+10*delay {
+	if total < w {
 		t.Errorf("total = %v, want > %v", total, w)
 	}
 }


### PR DESCRIPTION
In the event of an empty append (used to advance the commit index)
being rejected, the follower will appear to be caught up despite the
commit index not having been advanced. In our experience, this can
happen when replies arrive out of order.

This commit adds a clause to handle that edge case by resending the
append.

This was discovered when running the github.com/cockroachdb/cockroach
test suite under go1.5beta1.