### PR TITLE
etcdserver: clean up start and stop logic of raft

### DIFF
--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -148,15 +148,11 @@ func TestStopRaftWhenWaitingForApplyDone(t *testing.T) {
 	n := newReadyNode()
 	r := raftNode{
 		Node:        n,
-		applyc:      make(chan apply),
 		storage:     &storageRecorder{},
 		raftStorage: raft.NewMemoryStorage(),
 		transport:   &nopTransporter{},
-		stopped:     make(chan struct{}),
-		done:        make(chan struct{}),
 	}
-	r.s = &EtcdServer{r: r}
-	go r.run()
+	r.start(&EtcdServer{r: r})
 	n.readyc <- raft.Ready{}
 	select {
 	case <-r.applyc:

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -413,15 +413,9 @@ func (s *EtcdServer) run() {
 	confState := snap.Metadata.ConfState
 	snapi := snap.Metadata.Index
 	appliedi := snapi
-	// TODO: get rid of the raft initialization in etcd server
-	s.r.s = s
-	s.r.applyc = make(chan apply)
-	s.r.stopped = make(chan struct{})
-	s.r.done = make(chan struct{})
-	go s.r.run()
+	s.r.start(s)
 	defer func() {
-		s.r.stopped <- struct{}{}
-		<-s.r.done
+		s.r.stop()
 		close(s.done)
 	}()
 


### PR DESCRIPTION
kill TODO and make it more readable.

follows #3077 