### PR TITLE
pkg/testutil: extend wait schedule time to 10ms

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -22,7 +22,7 @@ import (
 
 // TODO: improve this when we are able to know the schedule or status of target go-routine.
 func WaitSchedule() {
-	time.Sleep(3 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 }
 
 func MustNewURLs(t *testing.T, urls []string) []url.URL {


### PR DESCRIPTION
Waiting 3ms is not long enough for schedule to work well. The test suite
may fail once per 200 times in travis due to this. Extend this to 10ms
to ensure schedule could work. Now it could run 1000 times successfully
in travis.

fixes #3060 