### PR TITLE
pkg/transport: fix HTTPS downgrade bug for keepalive listener

### DIFF
--- a/pkg/transport/keepalive_listener.go
+++ b/pkg/transport/keepalive_listener.go
@@ -16,6 +16,7 @@ package transport
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"time"
 )
@@ -28,7 +29,10 @@ func NewKeepAliveListener(addr string, scheme string, info TLSInfo) (net.Listene
 		return nil, err
 	}
 
-	if !info.Empty() && scheme == "https" {
+	if scheme == "https" {
+		if info.Empty() {
+			return nil, fmt.Errorf("cannot listen on TLS for %s: KeyFile and CertFile are not presented", scheme+"://"+addr)
+		}
 		cfg, err := info.ServerConfig()
 		if err != nil {
 			return nil, err

--- a/pkg/transport/keepalive_listener_test.go
+++ b/pkg/transport/keepalive_listener_test.go
@@ -62,3 +62,10 @@ func TestNewKeepAliveListener(t *testing.T) {
 	conn.Close()
 	tlsln.Close()
 }
+
+func TestNewKeepAliveListenerTLSEmptyInfo(t *testing.T) {
+	_, err := NewListener("127.0.0.1:0", "https", TLSInfo{})
+	if err == nil {
+		t.Errorf("err = nil, want not presented error")
+	}
+}


### PR DESCRIPTION
If TLS config is empty, etcd downgrades keepalive listener from HTTPS to
HTTP without warning. This results in HTTPS downgrade bug for client urls.
The commit returns error if it cannot listen on TLS.

Example output:
```
$ ./bin/etcd --listen-client-urls https://127.0.0.1:4001 -advertise-client-urls https://127.0.0.1:4001
2015/07/14 12:21:30 etcdmain: setting maximum number of CPUs to 1, total number of available CPUs is 8
2015/07/14 12:21:30 etcdmain: no data-dir provided, using default data-dir ./default.etcd
2015/07/14 12:21:30 etcdmain: the server is already initialized as member before, starting as etcd member...
2015/07/14 12:21:30 etcdmain: listening for peers on http://localhost:2380
2015/07/14 12:21:30 etcdmain: listening for peers on http://localhost:7001
2015/07/14 12:21:30 etcdmain: stopping listening for peers on http://localhost:7001
2015/07/14 12:21:30 etcdmain: stopping listening for peers on http://localhost:2380
2015/07/14 12:21:30 etcdmain: cannot listen on TLS for https://127.0.0.1:4001: KeyFile and CertFile are not presented
```

fixes #3129 