### PR TITLE
discovery: remove ResponseHeaderTimeout when discovery

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -127,8 +127,8 @@ func newDiscovery(durl, dproxyurl string, id types.ID) (*discovery, error) {
 				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}).Dial,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 5 * time.Second,
+			TLSHandshakeTimeout: 10 * time.Second,
+			// TODO: add ResponseHeaderTimeout back when watch on discovery service writes header early
 		},
 		Endpoints: []string{u.String()},
 	}


### PR DESCRIPTION
The discovery service doesn't return HTTP header early when watch
starts. This may trigger ResponseHeaderTimeout and cause the watch
request failed.

The fix on discovery service may take some time. Remove the
ResponseHeaderTimeout first so it behaves as before.

for #3126 