### PR TITLE
client: consume json error and return ErrInvaildJSON

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -37,14 +37,15 @@ import (
 var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "discovery")
 
-	ErrInvalidURL     = errors.New("discovery: invalid URL")
-	ErrBadSizeKey     = errors.New("discovery: size key is bad")
-	ErrSizeNotFound   = errors.New("discovery: size key not found")
-	ErrTokenNotFound  = errors.New("discovery: token not found")
-	ErrDuplicateID    = errors.New("discovery: found duplicate id")
-	ErrDuplicateName  = errors.New("discovery: found duplicate name")
-	ErrFullCluster    = errors.New("discovery: cluster is full")
-	ErrTooManyRetries = errors.New("discovery: too many retries")
+	ErrInvalidURL           = errors.New("discovery: invalid URL")
+	ErrBadSizeKey           = errors.New("discovery: size key is bad")
+	ErrSizeNotFound         = errors.New("discovery: size key not found")
+	ErrTokenNotFound        = errors.New("discovery: token not found")
+	ErrDuplicateID          = errors.New("discovery: found duplicate id")
+	ErrDuplicateName        = errors.New("discovery: found duplicate name")
+	ErrFullCluster          = errors.New("discovery: cluster is full")
+	ErrTooManyRetries       = errors.New("discovery: too many retries")
+	ErrBadDiscoveryEndpoint = errors.New("discovery: bad discovery endpoint")
 )
 
 var (
@@ -216,6 +217,9 @@ func (d *discovery) checkCluster() ([]*client.Node, int, uint64, error) {
 	if err != nil {
 		if eerr, ok := err.(*client.Error); ok && eerr.Code == client.ErrorCodeKeyNotFound {
 			return nil, 0, 0, ErrSizeNotFound
+		}
+		if err == client.ErrInvalidJSON {
+			return nil, 0, 0, ErrBadDiscoveryEndpoint
 		}
 		if err == context.DeadlineExceeded {
 			return d.checkClusterRetry()


### PR DESCRIPTION
The default JSON error is not very readable. We let client
consume the error and return a more understandable error in
the context of etcd.

Fix #3120 

```
ETCD_DISCOVERY=https://discovery.etcd.io ETCD_PROXY=on ./etcd
2015/07/15 07:45:54 etcdmain: setting maximum number of CPUs to 1, total number of available CPUs is 4
2015/07/15 07:45:54 etcdmain: no data-dir provided, using default data-dir ./default.etcd
2015/07/15 07:45:57 etcdmain: discovery: bad discovery endpoint
```