### PR TITLE
pkg/transport: warn when listening on HTTP if TLS is set

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -145,6 +145,9 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 	}
 	plns := make([]net.Listener, 0)
 	for _, u := range cfg.lpurls {
+		if u.Scheme == "http" && !cfg.peerTLSInfo.Empty() {
+			plog.Warningf("The scheme of peer url %s is http while peer key/cert files are presented. Ignored peer key/cert files.", u.String())
+		}
 		var l net.Listener
 		l, err = transport.NewTimeoutListener(u.Host, u.Scheme, cfg.peerTLSInfo, rafthttp.ConnReadTimeout, rafthttp.ConnWriteTimeout)
 		if err != nil {
@@ -167,6 +170,9 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 	}
 	clns := make([]net.Listener, 0)
 	for _, u := range cfg.lcurls {
+		if u.Scheme == "http" && !cfg.clientTLSInfo.Empty() {
+			plog.Warningf("The scheme of client url %s is http while client key/cert files are presented. Ignored client key/cert files.", u.String())
+		}
 		var l net.Listener
 		l, err = transport.NewKeepAliveListener(u.Host, u.Scheme, cfg.clientTLSInfo)
 		if err != nil {


### PR DESCRIPTION
[Updated]

If the user sets TLS info, this implies that he wants to listen on TLS.
If etcd finds that urls to listen is still HTTP schema, it prints out
warning to notify user about possible wrong setting.

/cc @crawford @kelseyhightower @barakmich 

Before this PR:
```
$ ./bin/etcd --listen-client-urls http://127.0.0.1:4001 -advertise-client-urls http://127.0.0.1:4001 -ca-file ca.crt -key-file server1.key.insecure -cert-file server1.crt
2015/07/14 17:54:38 etcdmain: setting maximum number of CPUs to 1, total number of available CPUs is 8
2015/07/14 17:54:38 etcdmain: no data-dir provided, using default data-dir ./default.etcd
2015/07/14 17:54:38 etcdmain: the server is already initialized as member before, starting as etcd member...
2015/07/14 17:54:38 etcdmain: listening for peers on http://localhost:2380
2015/07/14 17:54:38 etcdmain: listening for peers on http://localhost:7001
2015/07/14 17:54:38 etcdmain: clientTLS: cert = server1.crt, key = server1.key.insecure, ca = ca.crt
2015/07/14 17:54:38 etcdmain: listening for client requests on http://127.0.0.1:4001
2015/07/14 17:54:38 etcdserver: name = default
2015/07/14 17:54:38 etcdserver: data dir = default.etcd
2015/07/14 17:54:38 etcdserver: member dir = default.etcd/member
2015/07/14 17:54:38 etcdserver: heartbeat = 100ms
2015/07/14 17:54:38 etcdserver: election = 1000ms
2015/07/14 17:54:38 etcdserver: snapshot count = 10000
2015/07/14 17:54:38 etcdserver: advertise client URLs = http://127.0.0.1:4001
2015/07/14 17:54:38 etcdserver: restarting member ce2a822cea30bfca in cluster 7e27652122e8b2ae at commit index 3486
2015/07/14 17:54:38 raft: ce2a822cea30bfca became follower at term 4
2015/07/14 17:54:38 raft: newRaft ce2a822cea30bfca [peers: [], term: 4, commit: 3486, applied: 0, lastindex: 3486, lastterm: 4]
2015/07/14 17:54:38 etcdserver: starting server... [version: 2.1.0-rc.0+git, cluster version: to_be_decided]
2015/07/14 17:54:38 etcdserver: cannot monitor file descriptor usage (cannot get FDUsage on darwin)
2015/07/14 17:54:38 etcdserver: added local member ce2a822cea30bfca [http://localhost:2380 http://localhost:7001] to cluster 7e27652122e8b2ae
2015/07/14 17:54:38 etcdserver: set the initial cluster version to 2.1.0
2015/07/14 17:54:39 raft: ce2a822cea30bfca is starting a new election at term 4
2015/07/14 17:54:39 raft: ce2a822cea30bfca became candidate at term 5
2015/07/14 17:54:39 raft: ce2a822cea30bfca received vote from ce2a822cea30bfca at term 5
2015/07/14 17:54:39 raft: ce2a822cea30bfca became leader at term 5
2015/07/14 17:54:39 raft: raft.node: ce2a822cea30bfca elected leader ce2a822cea30bfca at term 5
2015/07/14 17:54:39 etcdserver: published {Name:default ClientURLs:[http://127.0.0.1:4001]} to cluster 7e27652122e8b2ae
^C2015/07/14 17:54:55 osutil: received interrupt signal, shutting down...
```

After this PR:
```
...
2015/07/15 21:33:15 etcdmain: listening for peers on http://localhost:2380
2015/07/15 21:33:15 etcdmain: listening for peers on http://localhost:7001
2015/07/15 21:33:15 etcdmain: clientTLS: cert = server1.crt, key = server1.key.insecure, ca = ca.crt
2015/07/15 21:33:15 etcdmain: The scheme of client url http://127.0.0.1:4001 is http while client key/cert files are presented. Ignored client key/cert files.
2015/07/15 21:33:15 etcdmain: listening for client requests on http://127.0.0.1:4001
...
```

fixes #2234 