### PR TITLE
snap: Record the snapshot save duration on success rather than only on error

### DIFF
--- a/snap/snapshotter.go
+++ b/snap/snapshotter.go
@@ -75,7 +75,7 @@ func (s *Snapshotter) save(snapshot *raftpb.Snapshot) error {
 		return err
 	}
 	err = ioutil.WriteFile(path.Join(s.dir, fname), d, 0666)
-	if err != nil {
+	if err == nil {
 		saveDurations.Observe(float64(time.Since(start).Nanoseconds() / int64(time.Microsecond)))
 	}
 	return err


### PR DESCRIPTION
It looks like a bug that the latency is only recorded on error rather than only on success.

If you'd rather record it in both success and failure cases, I'm happy to modify the change.