### PR TITLE
etcdctl: update -peers to default to use schema

### DIFF
--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -69,7 +69,7 @@ func getPeersFlagValue(c *cli.Context) []string {
 
 	// If we still don't have peers, use a default
 	if peerstr == "" {
-		peerstr = "127.0.0.1:4001,127.0.0.1:2379"
+		peerstr = "http://127.0.0.1:4001,http://127.0.0.1:2379"
 	}
 
 	return strings.Split(peerstr, ",")

--- a/etcdctl/main.go
+++ b/etcdctl/main.go
@@ -32,7 +32,7 @@ func main() {
 		cli.BoolFlag{Name: "no-sync", Usage: "don't synchronize cluster information before sending request"},
 		cli.StringFlag{Name: "output, o", Value: "simple", Usage: "output response in the given format (`simple`, `extended` or `json`)"},
 		cli.StringFlag{Name: "discovery-srv, D", Usage: "domain name to query for SRV records describing cluster endpoints"},
-		cli.StringFlag{Name: "peers, C", Value: "", Usage: "a comma-delimited list of machine addresses in the cluster (default: \"127.0.0.1:4001,127.0.0.1:2379\")"},
+		cli.StringFlag{Name: "peers, C", Value: "", Usage: "a comma-delimited list of machine addresses in the cluster (default: \"http://127.0.0.1:4001,http://127.0.0.1:2379\")"},
 		cli.StringFlag{Name: "cert-file", Value: "", Usage: "identify HTTPS client using this SSL certificate file"},
 		cli.StringFlag{Name: "key-file", Value: "", Usage: "identify HTTPS client using this SSL key file"},
 		cli.StringFlag{Name: "ca-file", Value: "", Usage: "verify certificates of HTTPS-enabled servers using this CA bundle"},


### PR DESCRIPTION
Change its default value from `127.0.0.1:4001,127.0.0.1:2379` to
`http://127.0.0.1:4001,http://127.0.0.1:2379`

Adding HTTP schema makes its format consistent with etcd's xxx-urls
flags.

for https://github.com/coreos/etcd/issues/3135#issuecomment-121620185