### PR TITLE
pkg/mflag: add modified flag package

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -137,7 +137,6 @@ func NewConfig() *config {
 	fs := cfg.FlagSet
 	fs.Usage = func() {
 		fmt.Println(usageline)
-		fmt.Println(flagsline)
 	}
 
 	// member
@@ -225,6 +224,7 @@ func (cfg *config) Parse(arguments []string) error {
 	switch perr {
 	case nil:
 	case flag.ErrHelp:
+		fmt.Println(flagsline)
 		os.Exit(0)
 	default:
 		os.Exit(2)


### PR DESCRIPTION
Currently etcd is using the standard flag package, which cannot
customize it. Add a modifed version to improve the flexibility.

Fixes #3141.

Signed-off-by: Guohua Ouyang <gouyang@redhat.com>