### PR TITLE
etcdmian: fix initialization confilct

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -92,19 +92,28 @@ func Main() {
 	which := identifyDataDirOrDie(cfg.dir)
 	if which != dirEmpty {
 		plog.Noticef("the server is already initialized as %v before, starting as etcd %v...", which, which)
-	}
-
-	shouldProxy := cfg.isProxy() || which == dirProxy
-	if !shouldProxy {
-		stopped, err = startEtcd(cfg)
-		if err == discovery.ErrFullCluster && cfg.shouldFallbackToProxy() {
-			plog.Noticef("discovery cluster full, falling back to %s", fallbackFlagProxy)
-			shouldProxy = true
+		switch which {
+		case dirMember:
+			stopped, err = startEtcd(cfg)
+		case dirProxy:
+			err = startProxy(cfg)
+		default:
+			plog.Panicf("unhandled dir type %v", which)
+		}
+	} else {
+		shouldProxy := cfg.isProxy()
+		if !shouldProxy {
+			stopped, err = startEtcd(cfg)
+			if err == discovery.ErrFullCluster && cfg.shouldFallbackToProxy() {
+				plog.Noticef("discovery cluster full, falling back to %s", fallbackFlagProxy)
+				shouldProxy = true
+			}
+		}
+		if shouldProxy {
+			err = startProxy(cfg)
 		}
 	}
-	if shouldProxy {
-		err = startProxy(cfg)
-	}
+
 	if err != nil {
 		switch err {
 		case discovery.ErrDuplicateID:


### PR DESCRIPTION
Fix #3142

Ignore flags if etcd is already initialized.

@yichengq @gouyang

I believe this is a better way to fix the issue.

Here is the behavior after this fix

```
./etcd
...
2015/07/19 09:58:16 raft: raft.node: ce2a822cea30bfca elected leader ce2a822cea30bfca at term 2
2015/07/19 09:58:16 etcdserver: published {Name:default ClientURLs:[http://localhost:2379 http://localhost:4001]} to cluster 7e27652122e8b2ae
2015/07/19 09:58:16 etcdserver: setting up the initial cluster version to 2.1.0
2015/07/19 09:58:16 etcdserver: set the initial cluster version to 2.1.0
```

Proxy flag will be ignored.

```
./etcd --proxy=on
...
2015/07/19 09:59:24 etcdmain: the server is already initialized as member before, starting as etcd member...
...
2015/07/19 09:59:25 raft: raft.node: ce2a822cea30bfca elected leader ce2a822cea30bfca at term 3
2015/07/19 09:59:25 etcdserver: published {Name:default ClientURLs:[http://localhost:2379 http://localhost:4001]} to cluster 7e27652122e8b2ae
```
