### PR TITLE
client: return cluster error if the etcd cluster is not avaliable

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -30,6 +30,7 @@ import (
 var (
 	ErrNoEndpoints           = errors.New("client: no endpoints available")
 	ErrTooManyRedirects      = errors.New("client: too many redirects")
+	ErrClousterNotAvailable  = errors.New("client: etcd cluster is not available or misconfigured")
 	errTooManyRedirectChecks = errors.New("client: too many redirect checks")
 )
 
@@ -222,24 +223,28 @@ func (c *httpClusterClient) Do(ctx context.Context, act httpAction) (*http.Respo
 
 	var resp *http.Response
 	var body []byte
+	var cerr ClusterError
 	var err error
 
 	for _, ep := range eps {
 		hc := c.clientFactory(ep)
 		resp, body, err = hc.Do(ctx, action)
 		if err != nil {
+			cerr.Errors = append(cerr.Errors, err)
 			if err == context.DeadlineExceeded || err == context.Canceled {
-				return nil, nil, err
+				return nil, nil, cerr
 			}
 			continue
 		}
 		if resp.StatusCode/100 == 5 {
+			// TODO: make sure this is a no leader response
+			cerr.Errors = append(cerr.Errors, fmt.Errorf("client: etcd member %s has no leader", ep.String()))
 			continue
 		}
-		break
+		return resp, body, nil
 	}
 
-	return resp, body, err
+	return nil, nil, cerr
 }
 
 func (c *httpClusterClient) Endpoints() []string {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -342,7 +342,7 @@ func TestHTTPClusterClientDo(t *testing.T) {
 					},
 				),
 			},
-			wantErr: context.DeadlineExceeded,
+			wantErr: ClusterError{Errors: []error{context.DeadlineExceeded}},
 		},
 
 		// context.Canceled short-circuits Do
@@ -356,7 +356,7 @@ func TestHTTPClusterClientDo(t *testing.T) {
 					},
 				),
 			},
-			wantErr: context.Canceled,
+			wantErr: ClusterError{Errors: []error{context.Canceled}},
 		},
 
 		// return err if there are no endpoints
@@ -379,7 +379,7 @@ func TestHTTPClusterClientDo(t *testing.T) {
 					},
 				),
 			},
-			wantErr: fakeErr,
+			wantErr: ClusterError{Errors: []error{fakeErr, fakeErr}},
 		},
 
 		// 500-level errors cause Do to fallthrough to next endpoint

--- a/client/cluster_error.go
+++ b/client/cluster_error.go
@@ -1,0 +1,23 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+type ClusterError struct {
+	Errors []error
+}
+
+func (ce ClusterError) Error() string {
+	return ErrClousterNotAvailable.Error()
+}


### PR DESCRIPTION
Add a new ClusterError type. It contains all encountered errors and
return ClusterNotAvailable as the error string.

Fix #2887