### PR TITLE
docs: add experimental notice on auth doc

### DIFF
--- a/Documentation/authentication.md
+++ b/Documentation/authentication.md
@@ -1,5 +1,7 @@
 # Authentication Guide
 
+**NOTE: The authentication feature is considered experimental. We may change workflow without warning in future releases.**
+
 ## Overview
 
 Authentication -- having users and roles in etcd -- was added in etcd 2.1. This guide will help you set up basic authentication in etcd.


### PR DESCRIPTION
Reasons for the notice:
1. No users have reported about their feedback about auth feature so
far.
2. We haven't used it internally.
3. This is the first release that includes auth feature, so it is good
to be more cautious.

/cc @barakmich 