### PR TITLE
use /usr/bin/env to find bash

### DIFF
--- a/cover
+++ b/cover
@@ -1,8 +1,9 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Generate coverage HTML for a package
 # e.g. PKG=./unit ./cover
 #
+set -e
 
 if [ -z "$PKG" ]; then
 	echo "cover only works with a single package, sorry"

--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A non-installed actool can be used, for example:
 # ACTOOL=../../appc/spec/bin/actool

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 tar cv --files-from /dev/null | docker import - scratch
 
 cat <<DF > Dockerfile

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -1,8 +1,9 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Generate all etcd protobuf bindings.
 # Run from repository root.
 #
+set -e
 
 PREFIX="github.com/coreos/etcd/Godeps/_workspace/src"
 DIRS="./wal/walpb ./etcdserver/etcdserverpb ./snap/snappb ./raft/raftpb ./storage/storagepb"
@@ -27,7 +28,7 @@ popd
 export PATH="${GOBIN}:${PATH}"
 
 # copy all proto dependencies inside etcd to gopath
-for dir in ${DIRS}; do 
+for dir in ${DIRS}; do
 	mkdir -p ${GOPATH}/src/github.com/coreos/etcd/${dir}
 	pushd ${dir}
 		cp *.proto ${GOPATH}/src/github.com/coreos/etcd/${dir}

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Run all etcd tests
 # ./test
@@ -8,6 +8,7 @@
 #
 # PKG=./wal ./test
 # PKG=snap ./test
+set -e
 
 # Invoke ./cover for HTML output
 COVER=${COVER:-"-cover"}


### PR DESCRIPTION
Not everyone has `/bin/bash`. `/usr/bin/env bash` should be an acceptable replacement. Unfortunately you cannot, as far as I know, pass arguments (`-e`) when using `env` to find an interpreter.