### PR TITLE
docs: glibc NSS module for resolving names in etcd

### DIFF
--- a/Documentation/libraries-and-tools.md
+++ b/Documentation/libraries-and-tools.md
@@ -117,3 +117,4 @@ A detailed recap of client functionalities can be found in the [clients compatib
 - [xordataexchange/crypt](https://github.com/xordataexchange/crypt) - Securely store values in etcd using GPG encryption
 - [spf13/viper](https://github.com/spf13/viper) - Go configuration library, reads values from ENV, pflags, files, and etcd with optional encryption
 - [lytics/metafora](https://github.com/lytics/metafora) - Go distributed task library
+- [ryandoyle/nss-etcd](https://github.com/ryandoyle/nss-etcd) - A GNU libc NSS module for resolving names from etcd.


### PR DESCRIPTION
Hi

I've written a module for GNU libc that allows one to resolve names using the normal `gethostbyname(3)` call from information in etcd. This allows programs that may have have traditionally had their configuration for services in DNS to be provided by etcd.