### PR TITLE
etcdctl: fix exec-watch panic when handling command arguments

### DIFF
--- a/etcdctl/command/exec_watch_command.go
+++ b/etcdctl/command/exec_watch_command.go
@@ -51,21 +51,15 @@ func execWatchCommandFunc(c *cli.Context, ki client.KeysAPI) {
 		handleError(ExitBadArgs, errors.New("key and command to exec required"))
 	}
 
-	key := args[argslen-1]
-	cmdArgs := args[:argslen-1]
+	key := args[0]
+	cmdArgs := args[1:]
 
 	index := 0
 	if c.Int("after-index") != 0 {
 		index = c.Int("after-index") + 1
-		key = args[0]
-		cmdArgs = args[2:]
 	}
 
 	recursive := c.Bool("recursive")
-	if recursive != false {
-		key = args[0]
-		cmdArgs = args[2:]
-	}
 
 	sigch := make(chan os.Signal, 1)
 	signal.Notify(sigch, os.Interrupt)


### PR DESCRIPTION
if you run etcdctl exec-watch --recursive / env, the code changes the
slice of the command to be executed, resulting in a panic:

panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/coreos/etcd/etcdctl/command.execWatchCommandFunc(0xc208064420, 0xc20807a3f0, 0x5, 0x0, 0x0)
        /home/mischief/code/go/src/github.com/coreos/etcd/etcdctl/command/exec_watch_command.go:88
...