### PR TITLE
etcdctl: fix exec watch command

### DIFF
--- a/etcdctl/command/exec_watch_command.go
+++ b/etcdctl/command/exec_watch_command.go
@@ -51,21 +51,35 @@ func execWatchCommandFunc(c *cli.Context, ki client.KeysAPI) {
 		handleError(ExitBadArgs, errors.New("key and command to exec required"))
 	}
 
-	key := args[argslen-1]
-	cmdArgs := args[:argslen-1]
+	var (
+		key     string
+		cmdArgs []string
+	)
+
+	foundSep := false
+	for i := range args {
+		if args[i] == "--" && i != 0 {
+			foundSep = true
+			break
+		}
+	}
+
+	if foundSep {
+		key = args[0]
+		cmdArgs = args[2:]
+	} else {
+		// If no flag is parsed, the order of key and cmdArgs will be switched and
+		// args will not contain `--`.
+		key = args[argslen-1]
+		cmdArgs = args[:argslen-1]
+	}
 
 	index := 0
 	if c.Int("after-index") != 0 {
 		index = c.Int("after-index") + 1
-		key = args[0]
-		cmdArgs = args[2:]
 	}
 
 	recursive := c.Bool("recursive")
-	if recursive != false {
-		key = args[0]
-		cmdArgs = args[2:]
-	}
 
 	sigch := make(chan os.Signal, 1)
 	signal.Notify(sigch, os.Interrupt)


### PR DESCRIPTION
The previous flag parsing has a small issue. It uses
`recursive == true` and `after-index == 0` to determine
if user specifies the sub flags. This is incorrect since
user can specify `after-index = 0`. Then the flag parsing
would be confused.

This commit explicitly find the `--` in the remaining args
and determine the key and cmdArgs accordingly.