### PR TITLE
client: return cluster error if the etcd cluster is not avaliable

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -349,7 +349,7 @@ func TestHTTPClusterClientDo(t *testing.T) {
 				),
 				rand: rand.New(rand.NewSource(0)),
 			},
-			wantErr: context.DeadlineExceeded,
+			wantErr: &ClusterError{Errors: []error{context.DeadlineExceeded}},
 		},
 
 		// context.Canceled short-circuits Do
@@ -364,7 +364,7 @@ func TestHTTPClusterClientDo(t *testing.T) {
 				),
 				rand: rand.New(rand.NewSource(0)),
 			},
-			wantErr: context.Canceled,
+			wantErr: &ClusterError{Errors: []error{context.Canceled}},
 		},
 
 		// return err if there are no endpoints
@@ -389,7 +389,7 @@ func TestHTTPClusterClientDo(t *testing.T) {
 				),
 				rand: rand.New(rand.NewSource(0)),
 			},
-			wantErr: fakeErr,
+			wantErr: &ClusterError{Errors: []error{fakeErr, fakeErr}},
 		},
 
 		// 500-level errors cause Do to fallthrough to next endpoint

--- a/client/cluster_error.go
+++ b/client/cluster_error.go
@@ -14,10 +14,20 @@
 
 package client
 
+import "fmt"
+
 type ClusterError struct {
 	Errors []error
 }
 
 func (ce *ClusterError) Error() string {
 	return ErrClusterUnavailable.Error()
+}
+
+func (ce *ClusterError) Detail() string {
+	s := ""
+	for i, e := range ce.Errors {
+		s += fmt.Sprintf("error #%d: %s\n", i, e)
+	}
+	return s
 }

--- a/client/cluster_error.go
+++ b/client/cluster_error.go
@@ -1,0 +1,23 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+type ClusterError struct {
+	Errors []error
+}
+
+func (ce *ClusterError) Error() string {
+	return ErrClusterUnavailable.Error()
+}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -221,7 +221,8 @@ func (d *discovery) checkCluster() ([]*client.Node, int, uint64, error) {
 		if err == client.ErrInvalidJSON {
 			return nil, 0, 0, ErrBadDiscoveryEndpoint
 		}
-		if _, ok := err.(*client.ClusterError); ok {
+		if ce, ok := err.(*client.ClusterError); ok {
+			plog.Error(ce.Detail())
 			return d.checkClusterRetry()
 		}
 		return nil, 0, 0, err
@@ -235,7 +236,8 @@ func (d *discovery) checkCluster() ([]*client.Node, int, uint64, error) {
 	resp, err = d.c.Get(ctx, d.cluster, nil)
 	cancel()
 	if err != nil {
-		if _, ok := err.(*client.ClusterError); ok {
+		if ce, ok := err.(*client.ClusterError); ok {
+			plog.Error(ce.Detail())
 			return d.checkClusterRetry()
 		}
 		return nil, 0, 0, err
@@ -266,7 +268,7 @@ func (d *discovery) checkCluster() ([]*client.Node, int, uint64, error) {
 func (d *discovery) logAndBackoffForRetry(step string) {
 	d.retries++
 	retryTime := time.Second * (0x1 << d.retries)
-	plog.Infof("%s: connection to %s timed out, retrying in %s", step, d.url, retryTime)
+	plog.Infof("%s: error connecting to %s, retrying in %s", step, d.url, retryTime)
 	d.clock.Sleep(retryTime)
 }
 
@@ -311,7 +313,8 @@ func (d *discovery) waitNodes(nodes []*client.Node, size int, index uint64) ([]*
 		plog.Noticef("found %d peer(s), waiting for %d more", len(all), size-len(all))
 		resp, err := w.Next(context.Background())
 		if err != nil {
-			if _, ok := err.(*client.ClusterError); ok {
+			if ce, ok := err.(*client.ClusterError); ok {
+				plog.Error(ce.Detail())
 				return d.waitNodesRetry()
 			}
 			return nil, err

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -221,7 +221,7 @@ func (d *discovery) checkCluster() ([]*client.Node, int, uint64, error) {
 		if err == client.ErrInvalidJSON {
 			return nil, 0, 0, ErrBadDiscoveryEndpoint
 		}
-		if err == context.DeadlineExceeded {
+		if _, ok := err.(*client.ClusterError); ok {
 			return d.checkClusterRetry()
 		}
 		return nil, 0, 0, err
@@ -235,7 +235,7 @@ func (d *discovery) checkCluster() ([]*client.Node, int, uint64, error) {
 	resp, err = d.c.Get(ctx, d.cluster, nil)
 	cancel()
 	if err != nil {
-		if err == context.DeadlineExceeded {
+		if _, ok := err.(*client.ClusterError); ok {
 			return d.checkClusterRetry()
 		}
 		return nil, 0, 0, err
@@ -311,7 +311,7 @@ func (d *discovery) waitNodes(nodes []*client.Node, size int, index uint64) ([]*
 		plog.Noticef("found %d peer(s), waiting for %d more", len(all), size-len(all))
 		resp, err := w.Next(context.Background())
 		if err != nil {
-			if err == context.DeadlineExceeded {
+			if _, ok := err.(*client.ClusterError); ok {
 				return d.waitNodesRetry()
 			}
 			return nil, err

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -524,7 +524,7 @@ type clientWithRetry struct {
 func (c *clientWithRetry) Create(ctx context.Context, key string, value string) (*client.Response, error) {
 	if c.failCount < c.failTimes {
 		c.failCount++
-		return nil, context.DeadlineExceeded
+		return nil, &client.ClusterError{Errors: []error{context.DeadlineExceeded}}
 	}
 	return c.clientWithResp.Create(ctx, key, value)
 }
@@ -532,7 +532,7 @@ func (c *clientWithRetry) Create(ctx context.Context, key string, value string) 
 func (c *clientWithRetry) Get(ctx context.Context, key string, opts *client.GetOptions) (*client.Response, error) {
 	if c.failCount < c.failTimes {
 		c.failCount++
-		return nil, context.DeadlineExceeded
+		return nil, &client.ClusterError{Errors: []error{context.DeadlineExceeded}}
 	}
 	return c.clientWithResp.Get(ctx, key, opts)
 }
@@ -547,7 +547,7 @@ type watcherWithRetry struct {
 func (w *watcherWithRetry) Next(context.Context) (*client.Response, error) {
 	if w.failCount < w.failTimes {
 		w.failCount++
-		return nil, context.DeadlineExceeded
+		return nil, &client.ClusterError{Errors: []error{context.DeadlineExceeded}}
 	}
 	if len(w.rs) == 0 {
 		return &client.Response{}, nil


### PR DESCRIPTION
Add a new ClusterError type. It contains all encountered errors and
return ClusterNotAvailable as the error string.