### PR TITLE
client: handle watch timing out elegantly

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -356,6 +356,13 @@ So the first watch after the get should be:
 curl 'http://127.0.0.1:2379/v2/keys/foo?wait=true&waitIndex=2008'
 ```
 
+#### Connection being closed prematurely
+
+The server may close a long polling connection before emitting any events.
+This can happend due to a timeout or the server being shutdown.
+Since the HTTP header is sent immediately upon accepting the connection, the response will be seen as empty: `200 OK` and empty body.
+The clients should be prepared to deal with this scenario and retry the watch.
+
 ### Atomically Creating In-Order Keys
 
 Using `POST` on a directory, you can create keys with key names that are created in-order.


### PR DESCRIPTION
Even though current etcd does not time out
watches, the client could be running against
an old etcd version. This patch ignores successful
(as in 200) responses with emtpy bodies instead
of producing JSON errors.