### PR TITLE
etcdctl: fix watch -after-index parsing

### DIFF
--- a/etcdctl/command/watch_command.go
+++ b/etcdctl/command/watch_command.go
@@ -49,10 +49,7 @@ func watchCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	key := c.Args()[0]
 	recursive := c.Bool("recursive")
 	forever := c.Bool("forever")
-	index := 0
-	if c.Int("after-index") != 0 {
-		index = c.Int("after-index") + 1
-	}
+	index := c.Int("after-index")
 
 	stop := false
 	w := ki.Watcher(key, &client.WatcherOptions{AfterIndex: uint64(index), Recursive: recursive})


### PR DESCRIPTION
It uses -after-index incorrectly now:

```
$ ./bin/etcdctl --debug watch -after-index 31 foo
Cluster-Endpoints: http://localhost:2379, http://localhost:4001
cURL Command: curl -X GET
http://localhost:2379/v2/keys/foo?recursive=false&wait=true&waitIndex=33
```

After this PR:

```
$ ./bin/etcdctl --debug watch -after-index 31 foo
Cluster-Endpoints: http://localhost:2379, http://localhost:4001
cURL Command: curl -X GET
http://localhost:2379/v2/keys/foo?recursive=false&wait=true&waitIndex=32
```