### PR TITLE
client: return context canceled error correctly

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -349,11 +349,9 @@ func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Respon
 
 	select {
 	case <-ctx.Done():
-		err = resp.Body.Close()
+		resp.Body.Close()
 		<-done
-		if err == nil {
-			err = ctx.Err()
-		}
+		return nil, nil, ctx.Err()
 	case <-done:
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -257,8 +257,8 @@ func TestSimpleHTTPClientDoCancelContextResponseBodyClosedWithBlockingBody(t *te
 	}()
 
 	_, _, err := c.Do(ctx, &fakeAction{})
-	if err == nil {
-		t.Fatalf("expected non-nil error, got nil")
+	if err != context.Canceled {
+		t.Fatalf("expected %+v, got %+v", context.Canceled, err)
 	}
 
 	if !body.closed {


### PR DESCRIPTION
If the body is closed to stop watching, it will ignore the error from
reading body and return context error.

Before this PR, the cancel when watching always returns error `read tcp
127.0.0.1:57824: use of closed network connection`. After this PR, it
will return expected context canceled error.

fixes #3209 