### PR TITLE
etcdhttp: fix access check for multiple roles in auth

### DIFF
--- a/etcdserver/etcdhttp/client_auth.go
+++ b/etcdserver/etcdhttp/client_auth.go
@@ -97,9 +97,12 @@ func hasKeyPrefixAccess(sec auth.Store, r *http.Request, key string, recursive b
 			continue
 		}
 		if recursive {
-			return role.HasRecursiveAccess(key, writeAccess)
+			if role.HasRecursiveAccess(key, writeAccess) {
+				return true
+			}
+		} else if role.HasKeyAccess(key, writeAccess) {
+			return true
 		}
-		return role.HasKeyAccess(key, writeAccess)
 	}
 	plog.Warningf("auth: invalid access for user %s on key %s.", username, key)
 	return false


### PR DESCRIPTION
Check access for multiple roles should go through all roles.

fixes #3212 