### PR TITLE
better dns discovery error and doc

### DIFF
--- a/Documentation/clustering.md
+++ b/Documentation/clustering.md
@@ -300,6 +300,8 @@ infra2.example.com.	300	IN	A	10.0.1.12
 
 etcd cluster members can listen on domain names or IP address, the bootstrap process will resolve DNS A records.
 
+The resolved address in `-initial-advertise-peer-urls` *must match* one of the resolved addresses in the SRV targets. The etcd member reads the resolved address to find out if it belongs to the cluster defined in the SRV records.
+
 ```
 $ etcd -name infra0 \
 -discovery-srv example.com \
@@ -375,6 +377,10 @@ DNS SRV records can also be used to configure the list of peers for an etcd serv
 ```
 $ etcd --proxy on -discovery-srv example.com
 ```
+
+#### Error Cases
+
+You might see the an error like `cannot find local etcd $name from SRV records.`. That means the etcd member fails to find itself from the cluster defined in SRV records. The resolved address in `-initial-advertise-peer-urls` *must match* one of the resolved addresses in the SRV targets.
 
 # 0.4 to 2.0+ Migration Guide
 

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -403,6 +403,9 @@ func getPeerURLsMapAndToken(cfg *config) (urlsmap types.URLsMap, token string, e
 			return nil, "", err
 		}
 		urlsmap, err = types.NewURLsMap(clusterStr)
+		if _, ok := urlsmap[cfg.name]; !ok {
+			return nil, "", fmt.Errorf("cannot find local etcd member %q in SRV records", cfg.name)
+		}
 	default:
 		// We're statically configured, and cluster has appropriately been set.
 		urlsmap, err = types.NewURLsMap(cfg.initialCluster)


### PR DESCRIPTION
1. move dns discovery cluster checking to etcdmain and give it a better error message

2. add doc around it

Fix https://github.com/coreos/etcd/issues/2426

/cc @robszumski @kelseyhightower 