### PR TITLE
etcdctl/cluster_health: fix the wrong log when auth fails

### DIFF
--- a/etcdctl/command/cluster_health.go
+++ b/etcdctl/command/cluster_health.go
@@ -58,7 +58,7 @@ func handleClusterHealth(c *cli.Context) {
 	client.SetTransport(tr)
 	resp, err := client.Get("/", false, false)
 	if err != nil {
-		fmt.Println("cluster is unhealthy")
+		fmt.Printf("cluster may be unhealthy: failed to get key at endpoint %s (%v)\n", ep, err)
 		os.Exit(1)
 	}
 	rt0, ri0 := resp.RaftTerm, resp.RaftIndex


### PR DESCRIPTION
Before this PR, if auth is enabled and it doesn't have permission,
it will return error:
```
$ ./bin/etcdctl cluster-health
cluster is unhealthy
```

After this PR, it displays much clear:
```
$ ./bin/etcdctl cluster-health
cluster may be unhealthy: failed to get key at endpoint
http://localhost:4003 (0: Insufficient credentials () [0])
```

for #3238 