### PR TITLE
add groupID in raft log to distinguish different multinode group

### DIFF
--- a/raft/multinode.go
+++ b/raft/multinode.go
@@ -180,6 +180,7 @@ func (mn *multiNode) run() {
 		select {
 		case gc := <-mn.groupc:
 			gc.config.ID = mn.id
+			gc.config.groupID = gc.id
 			r := newRaft(gc.config)
 			group = &groupState{
 				id:   gc.id,

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -56,6 +56,9 @@ type Config struct {
 	// ID is the identity of the local raft. ID cannot be 0.
 	ID uint64
 
+	// groupID is the group identity in multinode. groupID can be 0
+	// in single group etcd cluster.
+	groupID uint64
 	// peers contains the IDs of all nodes (including self) in
 	// the raft cluster. It should only be set when starting a new
 	// raft cluster.
@@ -127,6 +130,9 @@ type raft struct {
 
 	id uint64
 
+	// groupID in multinode
+	groupID uint64
+
 	// the log
 	raftLog *raftLog
 
@@ -175,6 +181,7 @@ func newRaft(c *Config) *raft {
 	}
 	r := &raft{
 		id:      c.ID,
+		groupID: c.groupID,
 		lead:    None,
 		raftLog: raftlog,
 		// 4MB for now and hard code it
@@ -203,8 +210,8 @@ func newRaft(c *Config) *raft {
 		nodesStrs = append(nodesStrs, fmt.Sprintf("%x", n))
 	}
 
-	raftLogger.Infof("newRaft %x [peers: [%s], term: %d, commit: %d, applied: %d, lastindex: %d, lastterm: %d]",
-		r.id, strings.Join(nodesStrs, ","), r.Term, r.raftLog.committed, r.raftLog.applied, r.raftLog.lastIndex(), r.raftLog.lastTerm())
+	raftLogger.Infof("newRaft %x group %d [peers: [%s], term: %d, commit: %d, applied: %d, lastindex: %d, lastterm: %d]",
+		r.id, r.groupID, strings.Join(nodesStrs, ","), r.Term, r.raftLog.committed, r.raftLog.applied, r.raftLog.lastIndex(), r.raftLog.lastTerm())
 	return r
 }
 
@@ -258,10 +265,10 @@ func (r *raft) sendAppend(to uint64) {
 		}
 		m.Snapshot = snapshot
 		sindex, sterm := snapshot.Metadata.Index, snapshot.Metadata.Term
-		raftLogger.Infof("%x [firstindex: %d, commit: %d] sent snapshot[index: %d, term: %d] to %x [%s]",
-			r.id, r.raftLog.firstIndex(), r.Commit, sindex, sterm, to, pr)
+		raftLogger.Infof("%x group %d [firstindex: %d, commit: %d] sent snapshot[index: %d, term: %d] to %x [%s]",
+			r.id, r.groupID, r.raftLog.firstIndex(), r.Commit, sindex, sterm, to, pr)
 		pr.becomeSnapshot(sindex)
-		raftLogger.Infof("%x paused sending replication messages to %x [%s]", r.id, to, pr)
+		raftLogger.Infof("%x group %d paused sending replication messages to %x [%s]", r.id, r.groupID, to, pr)
 	} else {
 		m.Type = pb.MsgApp
 		m.Index = pr.Next - 1
@@ -278,7 +285,7 @@ func (r *raft) sendAppend(to uint64) {
 			case ProgressStateProbe:
 				pr.pause()
 			default:
-				raftLogger.Panicf("%x is sending append in unhandled state %s", r.id, pr.State)
+				raftLogger.Panicf("%x group %d is sending append in unhandled state %s", r.id, r.groupID, pr.State)
 			}
 		}
 	}
@@ -391,7 +398,7 @@ func (r *raft) becomeFollower(term uint64, lead uint64) {
 	r.tick = r.tickElection
 	r.lead = lead
 	r.state = StateFollower
-	raftLogger.Infof("%x became follower at term %d", r.id, r.Term)
+	raftLogger.Infof("%x group %d became follower at term %d", r.id, r.groupID, r.Term)
 }
 
 func (r *raft) becomeCandidate() {
@@ -404,7 +411,7 @@ func (r *raft) becomeCandidate() {
 	r.tick = r.tickElection
 	r.Vote = r.id
 	r.state = StateCandidate
-	raftLogger.Infof("%x became candidate at term %d", r.id, r.Term)
+	raftLogger.Infof("%x group %d became candidate at term %d", r.id, r.groupID, r.Term)
 }
 
 func (r *raft) becomeLeader() {
@@ -419,7 +426,7 @@ func (r *raft) becomeLeader() {
 	r.state = StateLeader
 	ents, err := r.raftLog.entries(r.raftLog.committed+1, noLimit)
 	if err != nil {
-		raftLogger.Panicf("unexpected error getting uncommitted entries (%v)", err)
+		raftLogger.Panicf("unexpected error groupID %d getting uncommitted entries (%v)", r.groupID, err)
 	}
 
 	for _, e := range ents {
@@ -432,7 +439,7 @@ func (r *raft) becomeLeader() {
 		r.pendingConf = true
 	}
 	r.appendEntry(pb.Entry{Data: nil})
-	raftLogger.Infof("%x became leader at term %d", r.id, r.Term)
+	raftLogger.Infof("%x group %d became leader at term %d", r.id, r.groupID, r.Term)
 }
 
 func (r *raft) campaign() {
@@ -445,17 +452,17 @@ func (r *raft) campaign() {
 		if i == r.id {
 			continue
 		}
-		raftLogger.Infof("%x [logterm: %d, index: %d] sent vote request to %x at term %d",
-			r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), i, r.Term)
+		raftLogger.Infof("%x group %d [logterm: %d, index: %d] sent vote request to %x at term %d",
+			r.id, r.groupID, r.raftLog.lastTerm(), r.raftLog.lastIndex(), i, r.Term)
 		r.send(pb.Message{To: i, Type: pb.MsgVote, Index: r.raftLog.lastIndex(), LogTerm: r.raftLog.lastTerm()})
 	}
 }
 
 func (r *raft) poll(id uint64, v bool) (granted int) {
 	if v {
-		raftLogger.Infof("%x received vote from %x at term %d", r.id, id, r.Term)
+		raftLogger.Infof("%x group %d received vote from %x at term %d", r.id, r.groupID, id, r.Term)
 	} else {
-		raftLogger.Infof("%x received vote rejection from %x at term %d", r.id, id, r.Term)
+		raftLogger.Infof("%x group %d received vote rejection from %x at term %d", r.id, r.groupID, id, r.Term)
 	}
 	if _, ok := r.votes[id]; !ok {
 		r.votes[id] = v
@@ -470,7 +477,7 @@ func (r *raft) poll(id uint64, v bool) (granted int) {
 
 func (r *raft) Step(m pb.Message) error {
 	if m.Type == pb.MsgHup {
-		raftLogger.Infof("%x is starting a new election at term %d", r.id, r.Term)
+		raftLogger.Infof("%x group %d is starting a new election at term %d", r.id, r.groupID, r.Term)
 		r.campaign()
 		r.Commit = r.raftLog.committed
 		return nil
@@ -484,13 +491,13 @@ func (r *raft) Step(m pb.Message) error {
 		if m.Type == pb.MsgVote {
 			lead = None
 		}
-		raftLogger.Infof("%x [term: %d] received a %s message with higher term from %x [term: %d]",
-			r.id, r.Term, m.Type, m.From, m.Term)
+		raftLogger.Infof("%x group %d [term: %d] received a %s message with higher term from %x [term: %d]",
+			r.id, r.groupID, r.Term, m.Type, m.From, m.Term)
 		r.becomeFollower(m.Term, lead)
 	case m.Term < r.Term:
 		// ignore
-		raftLogger.Infof("%x [term: %d] ignored a %s message with lower term from %x [term: %d]",
-			r.id, r.Term, m.Type, m.From, m.Term)
+		raftLogger.Infof("%x group %d [term: %d] ignored a %s message with lower term from %x [term: %d]",
+			r.id, r.groupID, r.Term, m.Type, m.From, m.Term)
 		return nil
 	}
 	r.step(r, m)
@@ -508,7 +515,7 @@ func stepLeader(r *raft, m pb.Message) {
 		r.bcastHeartbeat()
 	case pb.MsgProp:
 		if len(m.Entries) == 0 {
-			raftLogger.Panicf("%x stepped empty MsgProp", r.id)
+			raftLogger.Panicf("%x group %d stepped empty MsgProp", r.id, r.groupID)
 		}
 		for i, e := range m.Entries {
 			if e.Type == pb.EntryConfChange {
@@ -522,10 +529,10 @@ func stepLeader(r *raft, m pb.Message) {
 		r.bcastAppend()
 	case pb.MsgAppResp:
 		if m.Reject {
-			raftLogger.Debugf("%x received msgApp rejection(lastindex: %d) from %x for index %d",
-				r.id, m.RejectHint, m.From, m.Index)
+			raftLogger.Debugf("%x group %d received msgApp rejection(lastindex: %d) from %x for index %d",
+				r.id, r.groupID, m.RejectHint, m.From, m.Index)
 			if pr.maybeDecrTo(m.Index, m.RejectHint) {
-				raftLogger.Debugf("%x decreased progress of %x to [%s]", r.id, m.From, pr)
+				raftLogger.Debugf("%x groupID %d decreased progress of %x to [%s]", r.id, r.groupID, m.From, pr)
 				if pr.State == ProgressStateReplicate {
 					pr.becomeProbe()
 				}
@@ -538,7 +545,7 @@ func stepLeader(r *raft, m pb.Message) {
 				case pr.State == ProgressStateProbe:
 					pr.becomeReplicate()
 				case pr.State == ProgressStateSnapshot && pr.maybeSnapshotAbort():
-					raftLogger.Infof("%x snapshot aborted, resumed sending replication messages to %x [%s]", r.id, m.From, pr)
+					raftLogger.Infof("%x group %d snapshot aborted, resumed sending replication messages to %x [%s]", r.id, r.groupID, m.From, pr)
 					pr.becomeProbe()
 				case pr.State == ProgressStateReplicate:
 					pr.ins.freeTo(m.Index)
@@ -562,8 +569,8 @@ func stepLeader(r *raft, m pb.Message) {
 			r.sendAppend(m.From)
 		}
 	case pb.MsgVote:
-		raftLogger.Infof("%x [logterm: %d, index: %d, vote: %x] rejected vote from %x [logterm: %d, index: %d] at term %d",
-			r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
+		raftLogger.Infof("%x group %d [logterm: %d, index: %d, vote: %x] rejected vote from %x [logterm: %d, index: %d] at term %d",
+			r.id, r.groupID, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
 		r.send(pb.Message{To: m.From, Type: pb.MsgVoteResp, Reject: true})
 	case pb.MsgSnapStatus:
 		if pr.State != ProgressStateSnapshot {
@@ -571,11 +578,11 @@ func stepLeader(r *raft, m pb.Message) {
 		}
 		if !m.Reject {
 			pr.becomeProbe()
-			raftLogger.Infof("%x snapshot succeeded, resumed sending replication messages to %x [%s]", r.id, m.From, pr)
+			raftLogger.Infof("%x group %d snapshot succeeded, resumed sending replication messages to %x [%s]", r.id, r.groupID, m.From, pr)
 		} else {
 			pr.snapshotFailure()
 			pr.becomeProbe()
-			raftLogger.Infof("%x snapshot failed, resumed sending replication messages to %x [%s]", r.id, m.From, pr)
+			raftLogger.Infof("%x group %d snapshot failed, resumed sending replication messages to %x [%s]", r.id, r.groupID, m.From, pr)
 		}
 		// If snapshot finish, wait for the msgAppResp from the remote node before sending
 		// out the next msgApp.
@@ -587,14 +594,14 @@ func stepLeader(r *raft, m pb.Message) {
 		if pr.State == ProgressStateReplicate {
 			pr.becomeProbe()
 		}
-		raftLogger.Debugf("%x failed to send message to %x because it is unreachable [%s]", r.id, m.From, pr)
+		raftLogger.Debugf("%x group %d failed to send message to %x because it is unreachable [%s]", r.id, r.groupID, m.From, pr)
 	}
 }
 
 func stepCandidate(r *raft, m pb.Message) {
 	switch m.Type {
 	case pb.MsgProp:
-		raftLogger.Infof("%x no leader at term %d; dropping proposal", r.id, r.Term)
+		raftLogger.Infof("%x group %d no leader at term %d; dropping proposal", r.id, r.groupID, r.Term)
 		return
 	case pb.MsgApp:
 		r.becomeFollower(r.Term, m.From)
@@ -606,12 +613,12 @@ func stepCandidate(r *raft, m pb.Message) {
 		r.becomeFollower(m.Term, m.From)
 		r.handleSnapshot(m)
 	case pb.MsgVote:
-		raftLogger.Infof("%x [logterm: %d, index: %d, vote: %x] rejected vote from %x [logterm: %d, index: %d] at term %x",
-			r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
+		raftLogger.Infof("%x group %d [logterm: %d, index: %d, vote: %x] rejected vote from %x [logterm: %d, index: %d] at term %x",
+			r.id, r.groupID, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
 		r.send(pb.Message{To: m.From, Type: pb.MsgVoteResp, Reject: true})
 	case pb.MsgVoteResp:
 		gr := r.poll(m.From, !m.Reject)
-		raftLogger.Infof("%x [q:%d] has received %d votes and %d vote rejections", r.id, r.q(), gr, len(r.votes)-gr)
+		raftLogger.Infof("%x group %d [q:%d] has received %d votes and %d vote rejections", r.id, r.groupID, r.q(), gr, len(r.votes)-gr)
 		switch r.q() {
 		case gr:
 			r.becomeLeader()
@@ -626,7 +633,7 @@ func stepFollower(r *raft, m pb.Message) {
 	switch m.Type {
 	case pb.MsgProp:
 		if r.lead == None {
-			raftLogger.Infof("%x no leader at term %d; dropping proposal", r.id, r.Term)
+			raftLogger.Infof("%x group %d no leader at term %d; dropping proposal", r.id, r.groupID, r.Term)
 			return
 		}
 		m.To = r.lead
@@ -645,13 +652,13 @@ func stepFollower(r *raft, m pb.Message) {
 	case pb.MsgVote:
 		if (r.Vote == None || r.Vote == m.From) && r.raftLog.isUpToDate(m.Index, m.LogTerm) {
 			r.elapsed = 0
-			raftLogger.Infof("%x [logterm: %d, index: %d, vote: %x] voted for %x [logterm: %d, index: %d] at term %d",
-				r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
+			raftLogger.Infof("%x group %d [logterm: %d, index: %d, vote: %x] voted for %x [logterm: %d, index: %d] at term %d",
+				r.id, r.groupID, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
 			r.Vote = m.From
 			r.send(pb.Message{To: m.From, Type: pb.MsgVoteResp})
 		} else {
-			raftLogger.Infof("%x [logterm: %d, index: %d, vote: %x] rejected vote from %x [logterm: %d, index: %d] at term %d",
-				r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
+			raftLogger.Infof("%x group %d [logterm: %d, index: %d, vote: %x] rejected vote from %x [logterm: %d, index: %d] at term %d",
+				r.id, r.groupID, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
 			r.send(pb.Message{To: m.From, Type: pb.MsgVoteResp, Reject: true})
 		}
 	}
@@ -666,8 +673,8 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 	if mlastIndex, ok := r.raftLog.maybeAppend(m.Index, m.LogTerm, m.Commit, m.Entries...); ok {
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: mlastIndex})
 	} else {
-		raftLogger.Debugf("%x [logterm: %d, index: %d] rejected msgApp [logterm: %d, index: %d] from %x",
-			r.id, zeroTermOnErrCompacted(r.raftLog.term(m.Index)), m.Index, m.LogTerm, m.Index, m.From)
+		raftLogger.Debugf("%x group %d [logterm: %d, index: %d] rejected msgApp [logterm: %d, index: %d] from %x",
+			r.id, r.groupID, zeroTermOnErrCompacted(r.raftLog.term(m.Index)), m.Index, m.LogTerm, m.Index, m.From)
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: m.Index, Reject: true, RejectHint: r.raftLog.lastIndex()})
 	}
 }
@@ -680,12 +687,12 @@ func (r *raft) handleHeartbeat(m pb.Message) {
 func (r *raft) handleSnapshot(m pb.Message) {
 	sindex, sterm := m.Snapshot.Metadata.Index, m.Snapshot.Metadata.Term
 	if r.restore(m.Snapshot) {
-		raftLogger.Infof("%x [commit: %d] restored snapshot [index: %d, term: %d]",
-			r.id, r.Commit, sindex, sterm)
+		raftLogger.Infof("%x group %d [commit: %d] restored snapshot [index: %d, term: %d]",
+			r.id, r.groupID, r.Commit, sindex, sterm)
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.lastIndex()})
 	} else {
-		raftLogger.Infof("%x [commit: %d] ignored snapshot [index: %d, term: %d]",
-			r.id, r.Commit, sindex, sterm)
+		raftLogger.Infof("%x group %d [commit: %d] ignored snapshot [index: %d, term: %d]",
+			r.id, r.groupID, r.Commit, sindex, sterm)
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.committed})
 	}
 }
@@ -697,14 +704,14 @@ func (r *raft) restore(s pb.Snapshot) bool {
 		return false
 	}
 	if r.raftLog.matchTerm(s.Metadata.Index, s.Metadata.Term) {
-		raftLogger.Infof("%x [commit: %d, lastindex: %d, lastterm: %d] fast-forwarded commit to snapshot [index: %d, term: %d]",
-			r.id, r.Commit, r.raftLog.lastIndex(), r.raftLog.lastTerm(), s.Metadata.Index, s.Metadata.Term)
+		raftLogger.Infof("%x group %d [commit: %d, lastindex: %d, lastterm: %d] fast-forwarded commit to snapshot [index: %d, term: %d]",
+			r.id, r.groupID, r.Commit, r.raftLog.lastIndex(), r.raftLog.lastTerm(), s.Metadata.Index, s.Metadata.Term)
 		r.raftLog.commitTo(s.Metadata.Index)
 		return false
 	}
 
-	raftLogger.Infof("%x [commit: %d, lastindex: %d, lastterm: %d] starts to restore snapshot [index: %d, term: %d]",
-		r.id, r.Commit, r.raftLog.lastIndex(), r.raftLog.lastTerm(), s.Metadata.Index, s.Metadata.Term)
+	raftLogger.Infof("%x group %d [commit: %d, lastindex: %d, lastterm: %d] starts to restore snapshot [index: %d, term: %d]",
+		r.id, r.groupID, r.Commit, r.raftLog.lastIndex(), r.raftLog.lastTerm(), s.Metadata.Index, s.Metadata.Term)
 
 	r.raftLog.restore(s)
 	r.prs = make(map[uint64]*Progress)
@@ -716,7 +723,7 @@ func (r *raft) restore(s pb.Snapshot) bool {
 			match = 0
 		}
 		r.setProgress(n, match, next)
-		raftLogger.Infof("%x restored progress of %x [%s]", r.id, n, r.prs[n])
+		raftLogger.Infof("%x group %d restored progress of %x [%s]", r.id, r.groupID, n, r.prs[n])
 	}
 	return true
 }
@@ -756,7 +763,7 @@ func (r *raft) delProgress(id uint64) {
 
 func (r *raft) loadState(state pb.HardState) {
 	if state.Commit < r.raftLog.committed || state.Commit > r.raftLog.lastIndex() {
-		raftLogger.Panicf("%x state.commit %d is out of range [%d, %d]", r.id, state.Commit, r.raftLog.committed, r.raftLog.lastIndex())
+		raftLogger.Panicf("%x group %d state.commit %d is out of range [%d, %d]", r.id, r.groupID, state.Commit, r.raftLog.committed, r.raftLog.lastIndex())
 	}
 	r.raftLog.committed = state.Commit
 	r.Term = state.Term


### PR DESCRIPTION
There are multiple groups in multinode implementation, so it's difficult to distinguish raft log if there is no groupID. 