### PR TITLE
client: return context.DeadlineExceeded instead of ClusterError

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -275,14 +275,9 @@ func (c *httpClusterClient) Do(ctx context.Context, act httpAction) (*http.Respo
 		resp, body, err = hc.Do(ctx, action)
 		if err != nil {
 			cerr.Errors = append(cerr.Errors, err)
-			// mask previous errors with canceled error if the user explicitly canceled the request
-			if err == context.Canceled {
-				return nil, nil, context.Canceled
-			}
-
-			// TODO: deal with deadline error when we improve the deadline handling.
-			if err == context.DeadlineExceeded {
-				return nil, nil, cerr
+			// mask previous errors with context error, which is controlled by user
+			if err == context.Canceled || err == context.DeadlineExceeded {
+				return nil, nil, err
 			}
 			continue
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -459,9 +459,8 @@ func TestHTTPClusterClientDoDeadlineExceedContext(t *testing.T) {
 
 	select {
 	case err := <-errc:
-		werr := &ClusterError{Errors: []error{context.DeadlineExceeded}}
-		if !reflect.DeepEqual(err, werr) {
-			t.Errorf("err = %+v, want %+v", err, werr)
+		if err != context.DeadlineExceeded {
+			t.Errorf("err = %+v, want %+v", err, context.DeadlineExceeded)
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("unexpected timeout when waitting for request to deadline exceed")


### PR DESCRIPTION
This is done to match user expectation to see context.DeadlineExceeded
when it reaches deadline.

for #3208 

/cc @mwitkow-io