### PR TITLE
etcdctl: add per request timeout

### DIFF
--- a/etcdctl/command/get_command.go
+++ b/etcdctl/command/get_command.go
@@ -47,7 +47,6 @@ func getCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	key := c.Args()[0]
 	sorted := c.Bool("sort")
 
-	// TODO: handle transport timeout
 	resp, err := ki.Get(context.TODO(), key, &client.GetOptions{Sort: sorted})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/ls_command.go
+++ b/etcdctl/command/ls_command.go
@@ -47,7 +47,6 @@ func lsCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	sort := c.Bool("sort")
 	recursive := c.Bool("recursive")
 
-	// TODO: handle transport timeout
 	resp, err := ki.Get(context.TODO(), key, &client.GetOptions{Sort: sort, Recursive: recursive})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/mk_command.go
+++ b/etcdctl/command/mk_command.go
@@ -51,7 +51,6 @@ func mkCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	ttl := c.Int("ttl")
 
-	// TODO: handle transport timeout
 	resp, err := ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevIgnore})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/mkdir_command.go
+++ b/etcdctl/command/mkdir_command.go
@@ -46,7 +46,6 @@ func mkdirCommandFunc(c *cli.Context, ki client.KeysAPI, prevExist client.PrevEx
 	key := c.Args()[0]
 	ttl := c.Int("ttl")
 
-	// TODO: handle transport timeout
 	_, err := ki.Set(context.TODO(), key, "", &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: prevExist})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/rm_command.go
+++ b/etcdctl/command/rm_command.go
@@ -50,7 +50,6 @@ func rmCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	prevValue := c.String("with-value")
 	prevIndex := c.Int("with-index")
 
-	// TODO: handle transport timeout
 	resp, err := ki.Delete(context.TODO(), key, &client.DeleteOptions{PrevIndex: uint64(prevIndex), PrevValue: prevValue, Dir: dir, Recursive: recursive})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/rmdir_command.go
+++ b/etcdctl/command/rmdir_command.go
@@ -40,7 +40,6 @@ func rmdirCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	}
 	key := c.Args()[0]
 
-	// TODO: handle transport timeout
 	resp, err := ki.Delete(context.TODO(), key, &client.DeleteOptions{Dir: true})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/set_command.go
+++ b/etcdctl/command/set_command.go
@@ -55,7 +55,6 @@ func setCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	prevValue := c.String("swap-with-value")
 	prevIndex := c.Int("swap-with-index")
 
-	// TODO: handle transport timeout
 	resp, err := ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevIndex: uint64(prevIndex), PrevValue: prevValue})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/update_command.go
+++ b/etcdctl/command/update_command.go
@@ -51,7 +51,6 @@ func updateCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	ttl := c.Int("ttl")
 
-	// TODO: handle transport timeout
 	resp, err := ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevExist})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/update_dir_command.go
+++ b/etcdctl/command/update_dir_command.go
@@ -51,7 +51,6 @@ func updatedirCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	ttl := c.Int("ttl")
 
-	// TODO: handle transport timeout
 	_, err = ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: client.PrevExist})
 	if err != nil {
 		handleError(ExitServerError, err)

--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -188,8 +188,9 @@ func mustNewClient(c *cli.Context) client.Client {
 	}
 
 	cfg := client.Config{
-		Transport: tr,
-		Endpoints: eps,
+		Transport:               tr,
+		Endpoints:               eps,
+		HeaderTimeoutPerRequest: c.GlobalDuration("timeout"),
 	}
 
 	uFlag := c.GlobalString("username")

--- a/etcdctl/main.go
+++ b/etcdctl/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
 	"github.com/coreos/etcd/etcdctl/command"
@@ -37,6 +38,7 @@ func main() {
 		cli.StringFlag{Name: "key-file", Value: "", Usage: "identify HTTPS client using this SSL key file"},
 		cli.StringFlag{Name: "ca-file", Value: "", Usage: "verify certificates of HTTPS-enabled servers using this CA bundle"},
 		cli.StringFlag{Name: "username, u", Value: "", Usage: "provide username[:password] and prompt if password is not supplied."},
+		cli.DurationFlag{Name: "timeout", Value: time.Second, Usage: "connection timeout per request"},
 	}
 	app.Commands = []cli.Command{
 		command.NewBackupCommand(),


### PR DESCRIPTION
manually tested

10.0.0.1:8212 is unreachable.

```
time ./etcdctl -peers http://10.0.0.1:8212 get foo
client: etcd cluster is unavailable or misconfigured

real	0m1.024s
user	0m0.005s
sys	0m0.006s


time ./etcdctl --timeout 2s --peers http://10.0.0.1:8212 get foo
client: etcd cluster is unavailable or misconfigured

real	0m2.018s
user	0m0.006s
sys	0m0.007s


etcdctl xiangli$ time ./etcdctl --timeout 5s --peers http://10.0.0.1:8212 get foo
client: etcd cluster is unavailable or misconfigured

real	0m5.017s
user	0m0.006s
sys	0m0.008s

```