### PR TITLE
etcdserver: go back to marshal request in 2.1 way

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -529,9 +529,7 @@ func (s *EtcdServer) Do(ctx context.Context, r pb.Request) (Response, error) {
 	}
 	switch r.Method {
 	case "POST", "PUT", "DELETE", "QGET":
-		var raftReq pb.InternalRaftRequest
-		raftReq.V2 = &r
-		data, err := raftReq.Marshal()
+		data, err := r.Marshal()
 		if err != nil {
 			return Response{}, err
 		}

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -989,11 +989,10 @@ func TestPublish(t *testing.T) {
 		t.Fatalf("action = %s, want Propose", action[0].Name)
 	}
 	data := action[0].Params[0].([]byte)
-	var rr pb.InternalRaftRequest
-	if err := rr.Unmarshal(data); err != nil {
+	var r pb.Request
+	if err := r.Unmarshal(data); err != nil {
 		t.Fatalf("unmarshal request error: %v", err)
 	}
-	r := rr.V2
 	if r.Method != "PUT" {
 		t.Errorf("method = %s, want PUT", r.Method)
 	}
@@ -1073,11 +1072,10 @@ func TestUpdateVersion(t *testing.T) {
 		t.Fatalf("action = %s, want Propose", action[0].Name)
 	}
 	data := action[0].Params[0].([]byte)
-	var rr pb.InternalRaftRequest
-	if err := rr.Unmarshal(data); err != nil {
+	var r pb.Request
+	if err := r.Unmarshal(data); err != nil {
 		t.Fatalf("unmarshal request error: %v", err)
 	}
-	r := rr.V2
 	if r.Method != "PUT" {
 		t.Errorf("method = %s, want PUT", r.Method)
 	}


### PR DESCRIPTION
It fixes the problem that 2.1 cannot roll upgrade to 2.2 smoothly
because 2.1 cannot understand the bytes marshalled at 2.2.

I have manually tested it, and it could upgrade smoothly now.