### PR TITLE
*: only print out major.minor version for cluster version

### DIFF
--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/coreos/etcd/store"
+	"github.com/coreos/etcd/version"
 )
 
 const (
@@ -358,9 +359,9 @@ func (c *cluster) SetVersion(ver *semver.Version) {
 	c.Lock()
 	defer c.Unlock()
 	if c.version != nil {
-		plog.Noticef("updated the cluster version from %v to %v", c.version.String(), ver.String())
+		plog.Noticef("updated the cluster version from %v to %v", version.Cluster(c.version.String()), version.Cluster(ver.String()))
 	} else {
-		plog.Noticef("set the initial cluster version to %v", ver.String())
+		plog.Noticef("set the initial cluster version to %v", version.Cluster(ver.String()))
 	}
 	c.version = ver
 }

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -361,7 +361,7 @@ func (s *EtcdServer) start() {
 	s.done = make(chan struct{})
 	s.stop = make(chan struct{})
 	if s.ClusterVersion() != nil {
-		plog.Infof("starting server... [version: %v, cluster version: %v]", version.Version, s.ClusterVersion())
+		plog.Infof("starting server... [version: %v, cluster version: %v]", version.Version, version.Cluster(s.ClusterVersion().String()))
 	} else {
 		plog.Infof("starting server... [version: %v, cluster version: to_be_decided]", version.Version)
 	}
@@ -991,9 +991,9 @@ func (s *EtcdServer) monitorVersions() {
 
 func (s *EtcdServer) updateClusterVersion(ver string) {
 	if s.cluster.Version() == nil {
-		plog.Infof("setting up the initial cluster version to %v", ver)
+		plog.Infof("setting up the initial cluster version to %s", version.Cluster(ver))
 	} else {
-		plog.Infof("updating the cluster version from %v to %v", s.cluster.Version(), ver)
+		plog.Infof("updating the cluster version from %s to %s", version.Cluster(s.cluster.Version().String()), version.Cluster(ver))
 	}
 	req := pb.Request{
 		Method: "PUT",

--- a/version/version.go
+++ b/version/version.go
@@ -15,8 +15,10 @@
 package version
 
 import (
+	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/pkg/types"
@@ -75,4 +77,13 @@ func DetectDataDir(dirpath string) (DataDirVersion, error) {
 		return DataDir2_0Proxy, nil
 	}
 	return DataDirUnknown, nil
+}
+
+// Cluster only keeps the major.minor.
+func Cluster(v string) string {
+	vs := strings.Split(v, ".")
+	if len(vs) <= 2 {
+		return v
+	}
+	return fmt.Sprintf("%s.%s", vs[0], vs[1])
 }


### PR DESCRIPTION
Fix #3284 

The patch version has no meaning for cluster version. And it might confuse people who is running a 2.2.3 version of etcd but has a cluster version printed as 2.2.0.

Now 
```
etcdserver: set the initial cluster version to 2.2
```

Before
```
etcdserver: set the initial cluster version to 2.2.0
```

/cc @polvi 