### PR TITLE
etcdserver: add version enforcement when setting cluster version

### DIFF
--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -222,6 +222,7 @@ func (c *cluster) SetStore(st store.Store) { c.store = st }
 func (c *cluster) Recover() {
 	c.members, c.removed = membersFromStore(c.store)
 	c.version = clusterVersionFromStore(c.store)
+	MustDetectDowngrade(c.version)
 }
 
 // ValidateConfigurationChange takes a proposed ConfChange and
@@ -364,6 +365,7 @@ func (c *cluster) SetVersion(ver *semver.Version) {
 		plog.Noticef("set the initial cluster version to %v", version.Cluster(ver.String()))
 	}
 	c.version = ver
+	MustDetectDowngrade(c.version)
 }
 
 func membersFromStore(st store.Store) (map[types.ID]*Member, map[types.ID]bool) {

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -252,3 +252,12 @@ func getVersion(m *Member, tr *http.Transport) (*version.Versions, error) {
 	}
 	return nil, err
 }
+
+func MustDetectDowngrade(cv *semver.Version) {
+	lv := semver.Must(semver.NewVersion(version.Version))
+	// only keep major.minor version for comparison against cluster version
+	lv = &semver.Version{Major: lv.Major, Minor: lv.Minor}
+	if cv != nil && lv.LessThan(*cv) {
+		plog.Fatalf("cluster cannot be downgraded (current version: %s is lower than determined cluster version: %s).", version.Version, version.Cluster(cv.String()))
+	}
+}


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/2716

When setting the cluster version, we detect if the current etcd binary version is at lease as new as the cluster version. Or we can safely know that this etcd member has been started with a newer version of binary and its cluster version has been upgraded. We do not allow downgrade at the moment.

Manually tested. Worked.