### PR TITLE
*: key handler should write auth error as etcd error

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -29,13 +29,14 @@ import (
 )
 
 const (
-	ErrorCodeKeyNotFound = 100
-	ErrorCodeTestFailed  = 101
-	ErrorCodeNotFile     = 102
-	ErrorCodeNotDir      = 104
-	ErrorCodeNodeExist   = 105
-	ErrorCodeRootROnly   = 107
-	ErrorCodeDirNotEmpty = 108
+	ErrorCodeKeyNotFound  = 100
+	ErrorCodeTestFailed   = 101
+	ErrorCodeNotFile      = 102
+	ErrorCodeNotDir       = 104
+	ErrorCodeNodeExist    = 105
+	ErrorCodeRootROnly    = 107
+	ErrorCodeDirNotEmpty  = 108
+	ErrorCodeUnauthorized = 110
 
 	ErrorCodePrevValueRequired = 201
 	ErrorCodeTTLNaN            = 202

--- a/error/error.go
+++ b/error/error.go
@@ -35,6 +35,7 @@ var errors = map[int]string{
 	EcodeRootROnly:        "Root is read only",
 	EcodeDirNotEmpty:      "Directory not empty",
 	ecodeExistingPeerAddr: "Peer address has existed",
+	EcodeUnauthorized:     "The request requires user authentication",
 
 	// Post form related errors
 	ecodeValueRequired:        "Value is Required in POST form",
@@ -68,6 +69,7 @@ var errorStatus = map[int]int{
 	EcodeKeyNotFound:  http.StatusNotFound,
 	EcodeNotFile:      http.StatusForbidden,
 	EcodeDirNotEmpty:  http.StatusForbidden,
+	EcodeUnauthorized: http.StatusUnauthorized,
 	EcodeTestFailed:   http.StatusPreconditionFailed,
 	EcodeNodeExist:    http.StatusPreconditionFailed,
 	EcodeRaftInternal: http.StatusInternalServerError,
@@ -85,6 +87,7 @@ const (
 	EcodeRootROnly        = 107
 	EcodeDirNotEmpty      = 108
 	ecodeExistingPeerAddr = 109
+	EcodeUnauthorized     = 110
 
 	ecodeValueRequired        = 200
 	EcodePrevValueRequired    = 201

--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -136,7 +136,7 @@ func (h *keysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// The path must be valid at this point (we've parsed the request successfully).
 	if !hasKeyPrefixAccess(h.sec, r, r.URL.Path[len(keysPrefix):], rr.Recursive) {
-		writeNoAuth(w)
+		writeKeyNoAuth(w)
 		return
 	}
 
@@ -576,6 +576,11 @@ func writeKeyEvent(w http.ResponseWriter, ev *store.Event, rt etcdserver.RaftTim
 
 	ev = trimEventPrefix(ev, etcdserver.StoreKeysPrefix)
 	return json.NewEncoder(w).Encode(ev)
+}
+
+func writeKeyNoAuth(w http.ResponseWriter) {
+	e := etcdErr.NewError(etcdErr.EcodeUnauthorized, "Insufficient credentials", 0)
+	e.WriteTo(w)
 }
 
 func handleKeyWatch(ctx context.Context, w http.ResponseWriter, wa store.Watcher, stream bool, rt etcdserver.RaftTimer) {


### PR DESCRIPTION
We should return etcd error json for all request under /v2/keys/

Fix part of https://github.com/coreos/etcd/issues/3235

/cc @raoofmd