### PR TITLE
extend hardcoded timeout for globally-deployed etcd cluster

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -174,7 +174,7 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 		return nil, fmt.Errorf("error setting up initial cluster: %v", err)
 	}
 
-	pt, err := transport.NewTimeoutTransport(cfg.peerTLSInfo, rafthttp.DialTimeout, rafthttp.ConnReadTimeout, rafthttp.ConnWriteTimeout)
+	pt, err := transport.NewTimeoutTransport(cfg.peerTLSInfo, peerDialTimeout(cfg.ElectionMs), rafthttp.ConnReadTimeout, rafthttp.ConnWriteTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -502,4 +502,10 @@ func setupLogging(cfg *config) {
 		}
 		repoLog.SetLogLevel(settings)
 	}
+}
+
+func peerDialTimeout(electionMs uint) time.Duration {
+	// 1s for queue wait and system delay
+	// + one RTT, which is smaller than 1/5 election timeout
+	return time.Second + time.Duration(electionMs)*time.Millisecond/5
 }

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -215,7 +215,6 @@ func isCompatibleWithVers(vers map[string]*version.Versions, local types.ID, min
 func getVersion(m *Member, tr *http.Transport) (*version.Versions, error) {
 	cc := &http.Client{
 		Transport: tr,
-		Timeout:   time.Second,
 	}
 	var (
 		err  error

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -842,7 +842,8 @@ func mustNewHTTPClient(t *testing.T, eps []string) client.Client {
 }
 
 func mustNewTransport(t *testing.T, tlsInfo transport.TLSInfo) *http.Transport {
-	tr, err := transport.NewTimeoutTransport(tlsInfo, rafthttp.DialTimeout, rafthttp.ConnReadTimeout, rafthttp.ConnWriteTimeout)
+	// tick in integration test is short, so 1s dial timeout could play well.
+	tr, err := transport.NewTimeoutTransport(tlsInfo, time.Second, rafthttp.ConnReadTimeout, rafthttp.ConnWriteTimeout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	DialTimeout = time.Second
 	// ConnRead/WriteTimeout is the i/o timeout set on each connection rafthttp pkg creates.
 	// A 5 seconds timeout is good enough for recycling bad connections. Or we have to wait for
 	// tcp keepalive failing to detect a bad connection, which is at minutes level.


### PR DESCRIPTION
I have manually set three physical machines and let messages from one peer to another have 2.5s delay. After applying this PR, a 3-member cluster could work well, including bootstrap, catch-up leader, client boom requests.

for #964 