### PR TITLE
Warn about proxy loops with incorrect advertise-client-urls

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -82,6 +82,7 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 ##### -advertise-client-urls
 + List of this member's client URLs to advertise to the rest of the cluster.
 + default: "http://localhost:2379,http://localhost:4001"
++ Be careful if you are advertising URLs such as http://localhost:2379 from a cluster member and are using the proxy feature of etcd. This will cause loops, because the proxy will be forwarding requests to itself until its resources (memory, file descriptors) are eventually depleted.
 
 ##### -discovery
 + Discovery URL used to bootstrap the cluster.

--- a/Documentation/proxy.md
+++ b/Documentation/proxy.md
@@ -6,7 +6,7 @@ etcd currently supports two proxy modes: `readwrite` and `readonly`. The default
 
 The proxy will shuffle the list of cluster members periodically to avoid sending all connections to a single member.
 
-The member list used by proxy consists of all client URLs advertised within the cluster, as specified in each members' `-advertise-client-urls` flag. If this flag is set incorrectly, requests sent to the proxy are forwarded to wrong addresses and then fail. The fix for this problem is to restart etcd member with correct `-advertise-client-urls` flag. After client URLs list in proxy is recalculated, which happens every 30 seconds, requests will be forwarded correctly.
+The member list used by proxy consists of all client URLs advertised within the cluster, as specified in each members' `-advertise-client-urls` flag. If this flag is set incorrectly, requests sent to the proxy are forwarded to wrong addresses and then fail. Including URLs in the `-advertise-client-urls` flag that point to the proxy itself, e.g. http://localhost:2379, is even more problematic as it will cause loops, because the proxy keeps trying to forward requests to itself until its resources (memory, file descriptors) are eventually depleted. The fix for this problem is to restart etcd member with correct `-advertise-client-urls` flag. After client URLs list in proxy is recalculated, which happens every 30 seconds, requests will be forwarded correctly.
 
 ### Using an etcd proxy
 To start etcd in proxy mode, you need to provide three flags: `proxy`, `listen-client-urls`, and `initial-cluster` (or `discovery`). 


### PR DESCRIPTION
As stated in issues like #2728 #2772 the documentation should contain warnings about potential proxy loops if the `advertise-client-urls` flag is set incorrectly.