### PR TITLE
snap: export durations of marsharing cost during snapshot save

### DIFF
--- a/snap/metrics.go
+++ b/snap/metrics.go
@@ -18,15 +18,22 @@ import "github.com/coreos/etcd/Godeps/_workspace/src/github.com/prometheus/clien
 
 var (
 	// TODO: save_fsync latency?
-	// TODO: save_encoding latency?
 	saveDurations = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "etcd",
 		Subsystem: "snapshot",
 		Name:      "save_total_durations_microseconds",
 		Help:      "The total latency distributions of save called by snapshot.",
 	})
+
+	marshallingDurations = prometheus.NewSummary(prometheus.SummaryOpts{
+		Namespace: "etcd",
+		Subsystem: "snapshot",
+		Name:      "save_marshalling_durations_microseconds",
+		Help:      "The marshalling cost distributions of save called by snapshot.",
+	})
 )
 
 func init() {
 	prometheus.MustRegister(saveDurations)
+	prometheus.MustRegister(marshallingDurations)
 }

--- a/snap/snapshotter.go
+++ b/snap/snapshotter.go
@@ -73,7 +73,10 @@ func (s *Snapshotter) save(snapshot *raftpb.Snapshot) error {
 	d, err := snap.Marshal()
 	if err != nil {
 		return err
+	} else {
+		marshallingDurations.Observe(float64(time.Since(start).Nanoseconds() / int64(time.Microsecond)))
 	}
+
 	err = ioutil.WriteFile(path.Join(s.dir, fname), d, 0666)
 	if err == nil {
 		saveDurations.Observe(float64(time.Since(start).Nanoseconds() / int64(time.Microsecond)))


### PR DESCRIPTION
Currently, total duration of snapshot saving is exported for
prometheus. For more detailed analysis, this commit let etcd export
durations of marsharing for prometheus.