### PR TITLE
Avoid future errors with GitSHA

### DIFF
--- a/build
+++ b/build
@@ -14,5 +14,5 @@ eval $(go env)
 GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
 
 # Static compilation is useful when etcd is run in a container
-CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-s -X ${REPO_PATH}/version.GitSHA ${GIT_SHA}" -o bin/etcd ${REPO_PATH}
+CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-s -X ${REPO_PATH}/version.GitSHA=${GIT_SHA}" -o bin/etcd ${REPO_PATH}
 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-s" -o bin/etcdctl ${REPO_PATH}/etcdctl


### PR DESCRIPTION
As this message states:
```
link: warning: option -X github.com/coreos/etcd/version.GitSHA xxxxx may not work in future releases; use -X github.com/coreos/etcd/version.GitSHA=xxxxx
```