### PR TITLE
etcdmain: print out version information on startup

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -45,6 +45,7 @@ import (
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/proxy"
 	"github.com/coreos/etcd/rafthttp"
+	"github.com/coreos/etcd/version"
 )
 
 type dirType string
@@ -88,6 +89,11 @@ func Main() {
 	setupLogging(cfg)
 
 	var stopped <-chan struct{}
+
+	plog.Infof("etcd Version: %s\n", version.Version)
+	plog.Infof("Git SHA: %s\n", version.GitSHA)
+	plog.Infof("Go Version: %s\n", runtime.Version())
+	plog.Infof("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 
 	GoMaxProcs := 1
 	if envMaxProcs, err := strconv.Atoi(os.Getenv("GOMAXPROCS")); err == nil {


### PR DESCRIPTION
Fix #3332 

example output

```
./etcd
2015-08-20 14:49:29.875955 I | etcdmain: etcd Version: 2.2.0-alpha.1+git
2015-08-20 14:49:29.876090 I | etcdmain: Git SHA: 7cf9770
2015-08-20 14:49:29.876095 I | etcdmain: Go Version: go1.5
2015-08-20 14:49:29.876099 I | etcdmain: Go OS/Arch: darwin/amd64
```

/cc @brianredbeard 