### PR TITLE
integration: only print critical log

### DIFF
--- a/integration/v2_http_kv_test.go
+++ b/integration/v2_http_kv_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -27,10 +26,12 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 )
 
 func init() {
-	log.SetOutput(ioutil.Discard)
+	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
 }
 
 func TestV2Set(t *testing.T) {


### PR DESCRIPTION
This limits the logs printed out in integration test, so it will not
have log flood and help us read fatal log in travis.

for https://github.com/coreos/etcd/pull/3359#issuecomment-134023954