### PR TITLE
etcdmain: change default GOMAXPROCS when compiling in go1.5

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -24,7 +24,6 @@ import (
 	"path"
 	"reflect"
 	"runtime"
-	"strconv"
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/go-systemd/daemon"
@@ -96,12 +95,8 @@ func Main() {
 	plog.Infof("Go Version: %s\n", runtime.Version())
 	plog.Infof("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 
-	GoMaxProcs := 1
-	if envMaxProcs, err := strconv.Atoi(os.Getenv("GOMAXPROCS")); err == nil {
-		GoMaxProcs = envMaxProcs
-	}
+	GoMaxProcs := runtime.GOMAXPROCS(0)
 	plog.Infof("setting maximum number of CPUs to %d, total number of available CPUs is %d", GoMaxProcs, runtime.NumCPU())
-	runtime.GOMAXPROCS(GoMaxProcs)
 
 	// TODO: check whether fields are set instead of whether fields have default value
 	if cfg.name != defaultName && cfg.initialCluster == initialClusterFromName(defaultName) {


### PR DESCRIPTION
Change default GOMAXPROCS to the number of CPUs available when compiling
in go1.5

This matches how go 1.5 works:
https://docs.google.com/document/d/1At2Ls5_fhJQ59kDK2DFVhFu3g5mATSXqqV5QrxinasI/edit

This is a behavior change in etcd 2.2, and should be mentioned in release note.