### PR TITLE
etcdserver: specify request timeout error due to connection down

### DIFF
--- a/etcdserver/errors.go
+++ b/etcdserver/errors.go
@@ -21,15 +21,16 @@ import (
 )
 
 var (
-	ErrUnknownMethod          = errors.New("etcdserver: unknown method")
-	ErrStopped                = errors.New("etcdserver: server stopped")
-	ErrIDRemoved              = errors.New("etcdserver: ID removed")
-	ErrIDExists               = errors.New("etcdserver: ID exists")
-	ErrIDNotFound             = errors.New("etcdserver: ID not found")
-	ErrPeerURLexists          = errors.New("etcdserver: peerURL exists")
-	ErrCanceled               = errors.New("etcdserver: request cancelled")
-	ErrTimeout                = errors.New("etcdserver: request timed out")
-	ErrTimeoutDueToLeaderFail = errors.New("etcdserver: request timed out, possibly due to previous leader failure")
+	ErrUnknownMethod              = errors.New("etcdserver: unknown method")
+	ErrStopped                    = errors.New("etcdserver: server stopped")
+	ErrIDRemoved                  = errors.New("etcdserver: ID removed")
+	ErrIDExists                   = errors.New("etcdserver: ID exists")
+	ErrIDNotFound                 = errors.New("etcdserver: ID not found")
+	ErrPeerURLexists              = errors.New("etcdserver: peerURL exists")
+	ErrCanceled                   = errors.New("etcdserver: request cancelled")
+	ErrTimeout                    = errors.New("etcdserver: request timed out")
+	ErrTimeoutDueToLeaderFail     = errors.New("etcdserver: request timed out, possibly due to previous leader failure")
+	ErrTimeoutDueToConnectionLost = errors.New("etcdserver: request timed out, possibly due to connection lost")
 )
 
 func isKeyNotFound(err error) bool {

--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -593,9 +593,10 @@ func writeKeyError(w http.ResponseWriter, err error) {
 	case *etcdErr.Error:
 		e.WriteTo(w)
 	default:
-		if err == etcdserver.ErrTimeoutDueToLeaderFail {
+		switch err {
+		case etcdserver.ErrTimeoutDueToLeaderFail, etcdserver.ErrTimeoutDueToConnectionLost:
 			plog.Error(err)
-		} else {
+		default:
 			plog.Errorf("got unexpected response error (%v)", err)
 		}
 		ee := etcdErr.NewError(etcdErr.EcodeRaftInternal, err.Error(), 0)

--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -54,9 +54,10 @@ func writeError(w http.ResponseWriter, err error) {
 		herr := httptypes.NewHTTPError(e.HTTPStatus(), e.Error())
 		herr.WriteTo(w)
 	default:
-		if err == etcdserver.ErrTimeoutDueToLeaderFail {
+		switch err {
+		case etcdserver.ErrTimeoutDueToLeaderFail, etcdserver.ErrTimeoutDueToConnectionLost:
 			plog.Error(err)
-		} else {
+		default:
 			plog.Errorf("got unexpected response error (%v)", err)
 		}
 		herr := httptypes.NewHTTPError(http.StatusInternalServerError, "Internal Server Error")

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1417,6 +1417,7 @@ func (s *nopTransporter) AddPeer(id types.ID, us []string)    {}
 func (s *nopTransporter) RemovePeer(id types.ID)              {}
 func (s *nopTransporter) RemoveAllPeers()                     {}
 func (s *nopTransporter) UpdatePeer(id types.ID, us []string) {}
+func (s *nopTransporter) ActiveSince(id types.ID) time.Time   { return time.Time{} }
 func (s *nopTransporter) Stop()                               {}
 func (s *nopTransporter) Pause()                              {}
 func (s *nopTransporter) Resume()                             {}

--- a/rafthttp/http_test.go
+++ b/rafthttp/http_test.go
@@ -366,4 +366,5 @@ func (pr *fakePeer) Send(m raftpb.Message)                 { pr.msgs = append(pr
 func (pr *fakePeer) Update(urls types.URLs)                { pr.urls = urls }
 func (pr *fakePeer) setTerm(term uint64)                   { pr.term = term }
 func (pr *fakePeer) attachOutgoingConn(conn *outgoingConn) { pr.connc <- conn }
+func (pr *fakePeer) activeSince() time.Time                { return time.Time{} }
 func (pr *fakePeer) Stop()                                 {}

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -66,6 +66,9 @@ type Peer interface {
 	// connection hands over to the peer. The peer will close the connection
 	// when it is no longer used.
 	attachOutgoingConn(conn *outgoingConn)
+	// activeSince returns the time that the connection with the
+	// peer becomes active.
+	activeSince() time.Time
 	// Stop performs any necessary finalization and terminates the peer
 	// elegantly.
 	Stop()
@@ -86,6 +89,8 @@ type peer struct {
 	// id of the remote raft peer node
 	id types.ID
 	r  Raft
+
+	status *peerStatus
 
 	msgAppWriter *streamWriter
 	writer       *streamWriter
@@ -112,6 +117,7 @@ func startPeer(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID, r
 	p := &peer{
 		id:           to,
 		r:            r,
+		status:       status,
 		msgAppWriter: startStreamWriter(to, status, fs, r),
 		writer:       startStreamWriter(to, status, fs, r),
 		pipeline:     newPipeline(tr, picker, local, to, cid, status, fs, r, errorc),
@@ -222,6 +228,8 @@ func (p *peer) attachOutgoingConn(conn *outgoingConn) {
 		conn.Close()
 	}
 }
+
+func (p *peer) activeSince() time.Time { return p.status.activeSince }
 
 // Pause pauses the peer. The peer will simply drops all incoming
 // messages without retruning an error.


### PR DESCRIPTION
It specifies request timeout error possibly caused by connection down,
and print out better log for user to understand.

It handles two cases:
1. the leader cannot connect to majority of cluster.
2. the connection between follower and leader is down for a while,
and it losts proposals.

log format:
```
20:04:19 etcd3 | 2015-08-25 20:04:19.368126 E | etcdhttp: etcdserver:
request timed out, possibly due to network down
20:04:19 etcd3 | 2015-08-25 20:04:19.368227 E | etcdhttp: etcdserver:
request timed out, possibly due to network down
```

fixes #3279 