### PR TITLE
pkg/transport: print ClientCertAuth in TLSInfo.String()

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -78,7 +78,7 @@ type TLSInfo struct {
 }
 
 func (info TLSInfo) String() string {
-	return fmt.Sprintf("cert = %s, key = %s, ca = %s, trusted-ca = %s", info.CertFile, info.KeyFile, info.CAFile, info.TrustedCAFile)
+	return fmt.Sprintf("cert = %s, key = %s, ca = %s, trusted-ca = %s, client-cert-auth = %v", info.CertFile, info.KeyFile, info.CAFile, info.TrustedCAFile, info.ClientCertAuth)
 }
 
 func (info TLSInfo) Empty() bool {


### PR DESCRIPTION
It is good to print it in debug output:

```
21:56:12 etcd1 | 2015-08-25 21:56:12.162406 I | etcdmain: peerTLS: cert
= certs/etcd1.pem, key = certs/etcd1-key.pem, ca = , trusted-ca =
certs/ca.pem, client-cert-auth = true
```

follow #3096 