### PR TITLE
etcdmain: check error before assigning peer transport

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -314,10 +314,10 @@ func startProxy(cfg *config) error {
 	}
 
 	pt, err := transport.NewTimeoutTransport(cfg.peerTLSInfo, time.Duration(cfg.proxyDialTimeoutMs)*time.Millisecond, time.Duration(cfg.proxyReadTimeoutMs)*time.Millisecond, time.Duration(cfg.proxyWriteTimeoutMs)*time.Millisecond)
-	pt.MaxIdleConnsPerHost = proxy.DefaultMaxIdleConnsPerHost
 	if err != nil {
 		return err
 	}
+	pt.MaxIdleConnsPerHost = proxy.DefaultMaxIdleConnsPerHost
 
 	tr, err := transport.NewTimeoutTransport(cfg.peerTLSInfo, time.Duration(cfg.proxyDialTimeoutMs)*time.Millisecond, time.Duration(cfg.proxyReadTimeoutMs)*time.Millisecond, time.Duration(cfg.proxyWriteTimeoutMs)*time.Millisecond)
 	if err != nil {


### PR DESCRIPTION
Or it may panic when new transport fails, e.g., TLS info is invalid.

example when providing nonexistant TLS info:
```
22:06:00 proxy | panic: runtime error: invalid memory address or nil pointer dereference
22:06:00 proxy | [signal 0xb code=0x1 addr=
22:06:00 proxy | 0x80 pc=0x660bf]
22:06:00 proxy | goroutine 1 [running]:
22:06:00 proxy | github.com/coreos/etcd/etcdmain.startProxy(0x820b1a900, 0x0, 0x0)
22:06:00 proxy | 	/Users/unihorn/gopath/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/etcdmain/etcd.go:317 +0x22f
```