### PR TITLE
Remove deprected nyet test with go tool vet

### DIFF
--- a/test
+++ b/test
@@ -20,7 +20,7 @@ TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdse
 # TODO: add it to race testing when the issue is resolved
 # https://github.com/golang/go/issues/9946
 NO_RACE_TESTABLE="rafthttp"
-FORMATTABLE="$TESTABLE_AND_FORMATTABLE $NO_RACE_TESTABLE *.go etcdctl/ integration"
+FORMATTABLE="$TESTABLE_AND_FORMATTABLE $NO_RACE_TESTABLE etcdctl/ integration"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then
@@ -74,13 +74,11 @@ if [ -n "${vetRes}" ]; then
 	exit 255
 fi
 
-if command -v go-nyet >/dev/null 2>&1; then
-  echo "Checking go-nyet..."
-  nyetRes=$(go-nyet -exitWith 0 $FMT)
-  if [ -n "${nyetRes}" ]; then
-          echo -e "go-nyet checking failed:\n${nyetRes}"
-          exit 255
-  fi
+echo "Checking go tool vet..."
+gtvetRes=$(go tool vet $FMT)
+if [ -n "${gtvetRes}" ]; then
+	echo -e "go tool vet checking failed:\n${vetRes}"
+	exit 255
 fi
 
 echo "Success"


### PR DESCRIPTION
Update test script to use 'go tool vet'. 

@xiang90 - per conversation on slack. 