### PR TITLE
etcdserver/auth: use fast password gen and check when testing

### DIFF
--- a/etcdserver/auth/auth.go
+++ b/etcdserver/auth/auth.go
@@ -68,6 +68,14 @@ var guestRole = Role{
 	},
 }
 
+var (
+	// These variables are functions to generate and check hashed password.
+	// They could be switched to fake one in tests to shorten the testing
+	// period because bcrypt functions are slow.
+	GenerateFromPassword   = bcrypt.GenerateFromPassword
+	CompareHashAndPassword = bcrypt.CompareHashAndPassword
+)
+
 type doer interface {
 	Do(context.Context, etcdserverpb.Request) (etcdserver.Response, error)
 }
@@ -214,7 +222,7 @@ func (s *store) createUserInternal(user User) (User, error) {
 	if user.Password == "" {
 		return user, authErr(http.StatusBadRequest, "Cannot create user %s with an empty password", user.User)
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
+	hash, err := GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return user, err
 	}
@@ -434,7 +442,7 @@ func (u User) merge(n User) (User, error) {
 	}
 	out.User = u.User
 	if n.Password != "" {
-		hash, err := bcrypt.GenerateFromPassword([]byte(n.Password), bcrypt.DefaultCost)
+		hash, err := GenerateFromPassword([]byte(n.Password), bcrypt.DefaultCost)
 		if err != nil {
 			return User{}, err
 		}
@@ -463,7 +471,7 @@ func (u User) merge(n User) (User, error) {
 }
 
 func (u User) CheckPassword(password string) bool {
-	err := bcrypt.CompareHashAndPassword([]byte(u.Password), []byte(password))
+	err := CompareHashAndPassword([]byte(u.Password), []byte(password))
 	return err == nil
 }
 


### PR DESCRIPTION
[Updated]

It helps to fasten the testing speed. The period changes from 92s to
47s.

I could make it even faster by replacing INTEGRATION to LONG, and only doing race testing in LONG mode.