### PR TITLE
etcdctl: suggest endpoint over peers flag

### DIFF
--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -59,10 +59,16 @@ func argOrStdin(args []string, stdin io.Reader, i int) (string, error) {
 }
 
 func getPeersFlagValue(c *cli.Context) []string {
-	peerstr := c.GlobalString("peers")
+	peerstr := c.GlobalString("endpoint")
 
-	// Use an environment variable if nothing was supplied on the
-	// command line
+	if peerstr == "" {
+		peerstr = os.Getenv("ETCDCTL_ENDPOINT")
+	}
+
+	if peerstr == "" {
+		peerstr = c.GlobalString("peers")
+	}
+
 	if peerstr == "" {
 		peerstr = os.Getenv("ETCDCTL_PEERS")
 	}

--- a/etcdctl/main.go
+++ b/etcdctl/main.go
@@ -34,6 +34,7 @@ func main() {
 		cli.StringFlag{Name: "output, o", Value: "simple", Usage: "output response in the given format (`simple`, `extended` or `json`)"},
 		cli.StringFlag{Name: "discovery-srv, D", Usage: "domain name to query for SRV records describing cluster endpoints"},
 		cli.StringFlag{Name: "peers, C", Value: "", Usage: "a comma-delimited list of machine addresses in the cluster (default: \"http://127.0.0.1:4001,http://127.0.0.1:2379\")"},
+		cli.StringFlag{Name: "endpoint", Value: "", Usage: "a comma-delimited list of machine addresses in the cluster (default: \"http://127.0.0.1:4001,http://127.0.0.1:2379\")"},
 		cli.StringFlag{Name: "cert-file", Value: "", Usage: "identify HTTPS client using this SSL certificate file"},
 		cli.StringFlag{Name: "key-file", Value: "", Usage: "identify HTTPS client using this SSL key file"},
 		cli.StringFlag{Name: "ca-file", Value: "", Usage: "verify certificates of HTTPS-enabled servers using this CA bundle"},


### PR DESCRIPTION
Fix #https://github.com/coreos/etcd/issues/3341

We still support `peers` flag, but print out a warning.
```
./etcdctl --peers http://127.0.0.1:9999 set foo bar
flag peers may not work in future releases; use endpoint
```

But I am not sure if someone would rely on the output of etcdctl... They should not though since we never try to maintain the same format for each release.

/cc @philips @robszumski @yichengq Any opinion on this?

**Decision is to keep the pervious behavior**