### PR TITLE
etcdctl: better logging for sync process

### DIFF
--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -187,7 +187,15 @@ func mustNewClient(c *cli.Context) client.Client {
 		os.Exit(1)
 	}
 
+	debug := c.GlobalBool("debug")
+	if debug {
+		client.EnablecURLDebug()
+	}
+
 	if !c.GlobalBool("no-sync") {
+		if debug {
+			fmt.Fprintf(os.Stderr, "start to sync cluster using endpoints(%s)\n", strings.Join(hc.Endpoints(), ","))
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
 		err := hc.Sync(ctx)
 		cancel()
@@ -199,11 +207,13 @@ func mustNewClient(c *cli.Context) client.Client {
 			handleError(ExitServerError, err)
 			os.Exit(1)
 		}
+		if debug {
+			fmt.Fprintf(os.Stderr, "got endpoints(%s) after sync\n", strings.Join(hc.Endpoints(), ","))
+		}
 	}
 
-	if c.GlobalBool("debug") {
+	if debug {
 		fmt.Fprintf(os.Stderr, "Cluster-Endpoints: %s\n", strings.Join(hc.Endpoints(), ", "))
-		client.EnablecURLDebug()
 	}
 
 	return hc


### PR DESCRIPTION
Original issue reveals the problem that users don't even know that etcdctl is doing sync and fails on sync process. So we add more logs for sync process.

After this PR, failure case:

```
$ ./bin/etcdctl --debug set foo bar
start to sync cluster using endpoints(http://127.0.0.1:2379,http://127.0.0.1:4001)
cURL Command: curl -X GET http://127.0.0.1:2379/v2/members
cURL Command: curl -X GET http://127.0.0.1:4001/v2/members
Error:  client: etcd cluster is unavailable or misconfigured
error #0: dial tcp 127.0.0.1:2379: getsockopt: connection refused
error #1: dial tcp 127.0.0.1:4001: getsockopt: connection refused
```

success case:
```
start to sync cluster using endpoints(http://127.0.0.1:4001,http://127.0.0.1:2379)
cURL Command: curl -X GET http://127.0.0.1:4001/v2/members
got endpoints(http://localhost:2379,http://localhost:4001) after sync
Cluster-Endpoints: http://localhost:2379, http://localhost:4001
cURL Command: curl -X PUT http://localhost:2379/v2/keys/foo -d "value=bar"
bar
```

fixes #3402 