### PR TITLE
etcdctl/command: print more details about ErrNoEndpoint

### DIFF
--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -181,36 +181,7 @@ func mustNewMembersAPI(c *cli.Context) client.MembersAPI {
 }
 
 func mustNewClient(c *cli.Context) client.Client {
-	eps, err := getEndpoints(c)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	tr, err := getTransport(c)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cfg := client.Config{
-		Transport:               tr,
-		Endpoints:               eps,
-		HeaderTimeoutPerRequest: c.GlobalDuration("timeout"),
-	}
-
-	uFlag := c.GlobalString("username")
-	if uFlag != "" {
-		username, password, err := getUsernamePasswordFromFlag(uFlag)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
-		}
-		cfg.Username = username
-		cfg.Password = password
-	}
-
-	hc, err := client.New(cfg)
+	hc, err := newClient(c)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
@@ -223,7 +194,7 @@ func mustNewClient(c *cli.Context) client.Client {
 		if err != nil {
 			if err == client.ErrNoEndpoints {
 				fmt.Fprintf(os.Stderr, "etcd cluster has no published client endpoints.\n")
-				fmt.Fprintf(os.Stderr, "Try '--no-sync' if you want to access non-published client endpoints(%s).\n", strings.Join(eps, ","))
+				fmt.Fprintf(os.Stderr, "Try '--no-sync' if you want to access non-published client endpoints(%s).\n", strings.Join(hc.Endpoints(), ","))
 			}
 			handleError(ExitServerError, err)
 			os.Exit(1)
@@ -236,4 +207,49 @@ func mustNewClient(c *cli.Context) client.Client {
 	}
 
 	return hc
+}
+
+func mustNewClientNoSync(c *cli.Context) client.Client {
+	hc, err := newClient(c)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	if c.GlobalBool("debug") {
+		fmt.Fprintf(os.Stderr, "Cluster-Endpoints: %s\n", strings.Join(hc.Endpoints(), ", "))
+		client.EnablecURLDebug()
+	}
+
+	return hc
+}
+
+func newClient(c *cli.Context) (client.Client, error) {
+	eps, err := getEndpoints(c)
+	if err != nil {
+		return nil, err
+	}
+
+	tr, err := getTransport(c)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := client.Config{
+		Transport:               tr,
+		Endpoints:               eps,
+		HeaderTimeoutPerRequest: c.GlobalDuration("timeout"),
+	}
+
+	uFlag := c.GlobalString("username")
+	if uFlag != "" {
+		username, password, err := getUsernamePasswordFromFlag(uFlag)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Username = username
+		cfg.Password = password
+	}
+
+	return client.New(cfg)
 }

--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -221,6 +221,10 @@ func mustNewClient(c *cli.Context) client.Client {
 		err := hc.Sync(ctx)
 		cancel()
 		if err != nil {
+			if err == client.ErrNoEndpoints {
+				fmt.Fprintf(os.Stderr, "etcd cluster has no published client endpoints.\n")
+				fmt.Fprintf(os.Stderr, "Try '--no-sync' if you want to access non-published client endpoints(%s).\n", strings.Join(eps, ","))
+			}
 			handleError(ExitServerError, err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
This commit prints more details if getting ErrNoEndpoint when sync with
cluster. For cluster-health, it skips sync and anaylzes member one by one.

Before:
```
Error:  client: no endpoints available
```

After when normal operations:
```
etcd cluster has no published client endpoints.
Try '--no-sync' if you want to access non-published client endpoints(http://127.0.0.1:22379).
Error:  client: no endpoints available
```

After when cluster-health:
```
member 8211f1d0f64f3269 is unreachable: it has zero client endpoints available. Please ensure the member has published its advertise client urls.
member 91bc3c398fb3c146 is unreachable: it has zero client endpoints available. Please ensure the member has published its advertise client urls.
member fd422379fda50e48 is unreachable: it has zero client endpoints available. Please ensure the member has published its advertise client urls.
cluster is unhealthy
```

from #3402 