### PR TITLE
storage: extend timeout to wait for put complete

### DIFF
--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -430,7 +430,7 @@ func TestKVTxnBlockNonTnxOperations(t *testing.T) {
 		s.TxnEnd(id)
 		select {
 		case <-done:
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(100 * time.Millisecond):
 			t.Fatalf("#%d: operation failed to be unblocked", i)
 		}
 	}


### PR DESCRIPTION
travis is sometimes slow, and it could fail to complete the put in 10ms.

The original issue panics because the put happened after the test has closed the backend when the test thought put was blocked.

fixes #3419 