### PR TITLE
Godeps: speakeasy should support Solaris

### DIFF
--- a/Godeps/_workspace/src/github.com/bgentry/speakeasy/speakeasy_unix.go
+++ b/Godeps/_workspace/src/github.com/bgentry/speakeasy/speakeasy_unix.go
@@ -4,7 +4,7 @@
 // Original code is based on code by RogerV in the golang-nuts thread:
 // https://groups.google.com/group/golang-nuts/browse_thread/thread/40cc41e9d9fc9247
 
-// +build darwin freebsd linux netbsd openbsd
+// +build darwin freebsd linux netbsd openbsd solaris
 
 package speakeasy
 


### PR DESCRIPTION
This is required for building etcdctl on Solaris systems