### PR TITLE
*: regenerate proto to use local import path

### DIFF
--- a/etcdserver/etcdserverpb/etcdserver.pb.go
+++ b/etcdserver/etcdserverpb/etcdserver.pb.go
@@ -19,7 +19,7 @@ package etcdserverpb
 import proto "github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/coreos/etcd/Godeps/_workspace/src/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"

--- a/etcdserver/etcdserverpb/etcdserver.proto
+++ b/etcdserver/etcdserverpb/etcdserver.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 package etcdserverpb;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "gogoproto/gogo.proto";
 
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.sizer_all) = true;

--- a/etcdserver/etcdserverpb/raft_internal.pb.go
+++ b/etcdserver/etcdserverpb/raft_internal.pb.go
@@ -6,7 +6,7 @@ package etcdserverpb
 
 import proto "github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/coreos/etcd/Godeps/_workspace/src/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"

--- a/etcdserver/etcdserverpb/raft_internal.proto
+++ b/etcdserver/etcdserverpb/raft_internal.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package etcdserverpb;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "gogoproto/gogo.proto";
 import "etcdserver.proto";
 import "rpc.proto";
 

--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package etcdserverpb;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
-import "github.com/coreos/etcd/storage/storagepb/kv.proto";
+import "gogoproto/gogo.proto";
+import "etcd/storage/storagepb/kv.proto";
 
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.unmarshaler_all) = true;
@@ -50,7 +50,7 @@ message RangeRequest {
   bytes range_end = 2;
   // limit the number of keys returned.
   int64 limit = 3;
-  // the response will be consistent with previous request with same token if the token is 
+  // the response will be consistent with previous request with same token if the token is
   // given and is valid.
   bytes consistent_token = 4;
 }
@@ -127,9 +127,9 @@ message Compare {
   }
 }
 
-// If the comparisons succeed, then the success requests will be processed in order, 
+// If the comparisons succeed, then the success requests will be processed in order,
 // and the response will contain their respective responses in order.
-// If the comparisons fail, then the failure requests will be processed in order, 
+// If the comparisons fail, then the failure requests will be processed in order,
 // and the response will contain their respective responses in order.
 
 // From google paxosdb paper:
@@ -159,9 +159,9 @@ message TxnResponse {
   repeated ResponseUnion responses = 3;
 }
 
-// Compaction compacts the kv store upto the given index (including). 
-// It removes the old versions of a key. It keeps the newest version of 
-// the key even if its latest modification index is smaller than the given 
+// Compaction compacts the kv store upto the given index (including).
+// It removes the old versions of a key. It keeps the newest version of
+// the key even if its latest modification index is smaller than the given
 // index.
 message CompactionRequest {
   int64 index = 1;

--- a/raft/raftpb/raft.pb.go
+++ b/raft/raftpb/raft.pb.go
@@ -22,7 +22,7 @@ package raftpb
 import proto "github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/coreos/etcd/Godeps/_workspace/src/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"

--- a/raft/raftpb/raft.proto
+++ b/raft/raftpb/raft.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 package raftpb;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "gogoproto/gogo.proto";
 
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.sizer_all) = true;

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -22,7 +22,7 @@ export GOBIN=${PWD}/bin
 go get github.com/gogo/protobuf/{proto,protoc-gen-gogo,gogoproto}
 pushd ${GOPATH}/src/github.com/gogo/protobuf/
 	git reset --hard ${SHA}
-	make
+	make install
 popd
 
 export PATH="${GOBIN}:${PATH}"
@@ -35,10 +35,17 @@ for dir in ${DIRS}; do
 	popd
 done
 
+COREOS_ROOT="${GOPATH}/src/github.com/coreos"
+GOGOPROTO_ROOT="${GOPATH}/src/github.com/gogo/protobuf"
+GOGOPROTO_PATH="${GOGOPROTO_ROOT}:${GOGOPROTO_ROOT}/protobuf"
+
+ESCAPED_PREFIX=$(echo $PREFIX | sed -e 's/[\/&]/\\&/g')
+
 for dir in ${DIRS}; do
 	pushd ${dir}
-		protoc --gogofast_out=plugins=grpc:. -I=.:${GOPATH}/src/github.com/gogo/protobuf/protobuf:${GOPATH}/src *.proto
-		sed -i".bak" -e "s|github.com/gogo/protobuf/proto|${PREFIX}/github.com/gogo/protobuf/proto|" *.go
+		protoc --gogofast_out=plugins=grpc,import_prefix=github.com/coreos/:. -I=.:"${GOGOPROTO_PATH}":"${COREOS_ROOT}" *.proto
+		sed -i.bak -E "s/github\.com\/coreos\/(gogoproto|github\.com|golang\.org|google\.golang\.org)/${ESCAPED_PREFIX}\/\1/g" *.pb.go
+		sed -i.bak -E 's/github\.com\/coreos\/(errors|fmt|io)/\1/g' *.pb.go
 		rm -f *.bak
 	popd
 done

--- a/snap/snappb/snap.pb.go
+++ b/snap/snappb/snap.pb.go
@@ -16,7 +16,7 @@ package snappb
 import proto "github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/coreos/etcd/Godeps/_workspace/src/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"

--- a/snap/snappb/snap.proto
+++ b/snap/snappb/snap.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 package snappb;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "gogoproto/gogo.proto";
 
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.sizer_all) = true;

--- a/storage/storagepb/kv.pb.go
+++ b/storage/storagepb/kv.pb.go
@@ -16,7 +16,7 @@ package storagepb
 
 import proto "github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/coreos/etcd/Godeps/_workspace/src/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"
@@ -48,10 +48,10 @@ func (x Event_EventType) String() string {
 }
 
 type KeyValue struct {
-	Key []byte `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Key         []byte `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	CreateIndex int64  `protobuf:"varint,2,opt,name=create_index,proto3" json:"create_index,omitempty"`
 	// mod_index is the last modified index of the key.
-	CreateIndex int64 `protobuf:"varint,2,opt,name=create_index,proto3" json:"create_index,omitempty"`
-	ModIndex    int64 `protobuf:"varint,3,opt,name=mod_index,proto3" json:"mod_index,omitempty"`
+	ModIndex int64 `protobuf:"varint,3,opt,name=mod_index,proto3" json:"mod_index,omitempty"`
 	// version is the version of the key. A deletion resets
 	// the version to zero and any modification of the key
 	// increases its version.

--- a/storage/storagepb/kv.proto
+++ b/storage/storagepb/kv.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package storagepb;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "gogoproto/gogo.proto";
 
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.sizer_all) = true;

--- a/wal/walpb/record.pb.go
+++ b/wal/walpb/record.pb.go
@@ -17,7 +17,7 @@ package walpb
 import proto "github.com/coreos/etcd/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 import math "math"
 
-// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+// discarding unused import gogoproto "github.com/coreos/etcd/Godeps/_workspace/src/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"

--- a/wal/walpb/record.proto
+++ b/wal/walpb/record.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 package walpb;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "gogoproto/gogo.proto";
 
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.sizer_all) = true;


### PR DESCRIPTION
Using Go-style import paths in protos is not idiomatic. Normally, this
detail would be internal to etcd, but the path from which gogoproto
is imported affects downstream consumers (e.g. cockroachdb).

In cockroach, we want to avoid including `$GOPATH/src` in our protoc
include path for various reasons. This patch puts etcd on the same
convention, which allows this for cockroach.

More information: https://github.com/cockroachdb/cockroach/pull/2339#discussion_r38663417

This commit also regenerates all the protos, which seem to have
drifted a tiny bit.

cc @xiang90 @yichengq @bdarnell 