### PR TITLE
scripts: add release.sh

### DIFF
--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -8,7 +8,7 @@ IMAGEDIR=${IMAGEDIR:-bin/image-aci}
 
 VERSION=$1
 
-if [ ! -x "$ACTOOL" ] ; then
+if ! command -v $ACTOOL >/dev/null; then
     echo "actool ($ACTOOL) is not executable"
     exit 1
 fi

--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+BINARYDIR=${BINARYDIR:-bin}
+BUILDDIR=${BUILDDIR:-bin}
+
 # A non-installed actool can be used, for example:
 # ACTOOL=../../appc/spec/bin/actool
 ACTOOL=${ACTOOL:-actool}
 
-IMAGEDIR=${IMAGEDIR:-bin/image-aci}
+IMAGEDIR=${IMAGEDIR:-$BUILDDIR/image-aci}
 
 VERSION=$1
 
@@ -13,8 +16,8 @@ if ! command -v $ACTOOL >/dev/null; then
     exit 1
 fi
 
-if [ ! -x bin/etcd ] ; then
-    echo "bin/etcd not found. Is it compiled?"
+if [ ! -x $BINARYDIR/etcd ] ; then
+    echo "$BINARYDIR/etcd not found. Is it compiled?"
     exit 1
 fi
 
@@ -34,7 +37,7 @@ if [ -n "$(ls -A $IMAGEDIR/rootfs)" ]; then
     exit 1
 fi
 
-cp bin/etcd bin/etcdctl $IMAGEDIR/rootfs/
+cp $BINARYDIR/etcd $BINARYDIR/etcdctl $IMAGEDIR/rootfs/
 cp README.md            $IMAGEDIR/rootfs/
 cp etcdctl/README.md    $IMAGEDIR/rootfs/README-etcdctl.md
 cp -r Documentation     $IMAGEDIR/rootfs/
@@ -98,4 +101,4 @@ cat <<DF > $IMAGEDIR/rootfs/etc/hosts
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 DF
 
-$ACTOOL build -overwrite=true $IMAGEDIR bin/etcd-${1}-linux-amd64.aci
+$ACTOOL build -overwrite=true $IMAGEDIR $BUILDDIR/etcd-${1}-linux-amd64.aci

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -e
 
 VER=$1
 PROJ="etcd"

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-tar cv --files-from /dev/null | docker import - scratch
 
 cat <<DF > Dockerfile
 FROM scratch

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-cat <<DF > Dockerfile
+BINARYDIR=${BINARYDIR:-.}
+BUILDDIR=${BUILDDIR:-.}
+
+IMAGEDIR=${BUILDDIR}/image-docker
+
+mkdir -p ${IMAGEDIR}
+cp ${BINARYDIR}/etcd ${BINARYDIR}/etcdctl ${IMAGEDIR}
+
+cat <<DF > ${IMAGEDIR}/Dockerfile
 FROM scratch
 ADD etcd /
 ADD etcdctl /
@@ -8,4 +16,4 @@ EXPOSE 4001 7001 2379 2380
 ENTRYPOINT ["/etcd"]
 DF
 
-docker build -t quay.io/coreos/etcd:${1} .
+docker build -t quay.io/coreos/etcd:${1} ${IMAGEDIR}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Build all release binaries and images to directory ./release.
+# Run from repository root.
+#
+set -e
+
+VERSION=$1
+if [ -z "${VERSION}" ]; then
+	echo "Usage: ${0} VERSION" >> /dev/stderr
+	exit 255
+fi
+
+# A non-installed actool can be used, for example:
+# ACTOOL=../../appc/spec/bin/actool
+ACTOOL=${ACTOOL:-actool}
+if ! command -v $ACTOOL >/dev/null; then
+    echo "cannot find actool ($ACTOOL)"
+    exit 1
+fi
+
+if ! command -v docker >/dev/null; then
+    echo "cannot find docker"
+    exit 1
+fi
+
+ETCD_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+pushd ${ETCD_ROOT} >/dev/null
+	echo Building etcd binary...
+	./scripts/build-binary ${VERSION}
+	echo Building aci image...
+	BINARYDIR=release/etcd-${VERSION}-linux-amd64 BUILDDIR=release ./scripts/build-aci ${VERSION}
+	echo Building docker image...
+	BINARYDIR=release/etcd-${VERSION}-linux-amd64 BUILDDIR=release ./scripts/build-docker ${VERSION}
+popd >/dev/null


### PR DESCRIPTION
The release script could build all release binaries and images for the given version. It formalizes the build process and saves the time to switch between directory to run build-xxx scripts.

for https://github.com/coreos/etcd/issues/3294

/cc @jonboulle @philips @xiang90 