### PR TITLE
fix build bug & added bolt/bolt_arm64.go for arm64

### DIFF
--- a/Godeps/_workspace/src/github.com/boltdb/bolt/bolt_arm64.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/bolt_arm64.go
@@ -1,0 +1,7 @@
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/etcd"

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/etcd"
@@ -15,7 +15,8 @@ GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
 
 val=$(go version)
 ver=$(echo $val | awk -F ' ' '{print $3}' | awk -F '.' '{print $2}')
-if [ $ver -gt 4 ]; then
+ver=${ver:0:1}
+if [[ $ver -gt 4 ]]; then
 	LINK_OPERATOR="="
 else
 	LINK_OPERATOR=" "


### PR DESCRIPTION
fix when go version is 1.5rc1 or other 1.5beta1/2 error
added bolt/bolt_arm64.go for build binary error:
undefined: maxMapSize

Signed-off-by: jefby <jef199006@gmail.com>