### PR TITLE
Dockerfile: use a consistent default user id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM golang:onbuild
+USER 2379
 EXPOSE 4001 7001 2379 2380

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -3,6 +3,7 @@ tar cv --files-from /dev/null | docker import - scratch
 
 cat <<DF > Dockerfile
 FROM scratch
+USER 2379
 ADD etcd /
 ADD etcdctl /
 EXPOSE 4001 7001 2379 2380


### PR DESCRIPTION
Docker defaults to root. We really would rather etcd not run as root.
For lack of a better choice lets use 2379, the etcd port number, as the
default.

We should probably start documenting this elsewhere.

WARNING: when we merge this we will need to warn folks that upgrading
from version X to Y will require they chown their data directories.
I suggest we hold off on merging this until 2.3.
