### PR TITLE
etcdmain: support gRPC addr flag

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -116,7 +116,8 @@ type config struct {
 
 	printVersion bool
 
-	v3demo bool
+	v3demo   bool
+	gRPCAddr string
 
 	ignored []string
 }
@@ -214,6 +215,7 @@ func NewConfig() *config {
 
 	// demo flag
 	fs.BoolVar(&cfg.v3demo, "experimental-v3demo", false, "Enable experimental v3 demo API")
+	fs.StringVar(&cfg.gRPCAddr, "experimental-gRPC-addr", "127.0.0.1:2378", "gRPC address for experimental v3 demo API")
 
 	// backwards-compatibility with v0.4.6
 	fs.Var(&flags.IPAddressPort{}, "addr", "DEPRECATED: Use -advertise-client-urls instead.")

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -239,11 +239,11 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 
 	var v3l net.Listener
 	if cfg.v3demo {
-		v3l, err = net.Listen("tcp", "127.0.0.1:12379")
+		v3l, err = net.Listen("tcp", cfg.gRPCAddr)
 		if err != nil {
 			plog.Fatal(err)
 		}
-		plog.Infof("listening for client rpc on 127.0.0.1:12379")
+		plog.Infof("listening for client rpc on %s", cfg.gRPCAddr)
 	}
 
 	srvcfg := &etcdserver.ServerConfig{


### PR DESCRIPTION
Support gRPC addr flag, then we can have multiple etcd members on localhost listening on different gRPC addr.