### PR TITLE
etcdctl fsck: a command for offline diagnosing etcd data

### DIFF
--- a/etcdctl/command/fsck_command.go
+++ b/etcdctl/command/fsck_command.go
@@ -1,0 +1,58 @@
+
+package command
+
+import (
+	"fmt"
+	"log"
+	"path"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/coreos/etcd/snap"
+	"github.com/coreos/etcd/wal"
+	"github.com/coreos/etcd/wal/walpb"
+)
+
+func NewFsckCommand() cli.Command {
+	return cli.Command{
+		Name:  "fsck",
+		Usage: "diagnose an etcd directory in offline condition",
+		Flags: []cli.Flag{
+			cli.StringFlag{Name: "data-dir", Value: "", Usage: "Path to the etcd data dir"},
+			cli.BoolFlag{Name: "verbose", Usage: "be verbose"},
+		},
+		Action: handleFsck,
+	}
+}
+
+func handleFsck(c *cli.Context) {
+	verbose := c.Bool("verbose")
+
+	snapPath := path.Join(c.String("data-dir"), "member", "snap")
+	walPath := path.Join(c.String("data-dir"), "member", "wal")
+
+	ss := snap.New(snapPath)
+	snapshot, err := ss.Load()
+	if err != nil && err != snap.ErrNoSnapshot {
+		log.Fatal(err)
+	}
+
+	var walsnap walpb.Snapshot
+	if snapshot != nil {
+		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
+	}
+
+	w, err := wal.OpenForRead(walPath, walsnap)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer w.Close()
+
+	_, _, _, err = w.ReadAll()
+	if err != nil {
+		fmt.Errorf("failed to read wal (index: %d, term: %d): %s", err)
+	} else {
+		if verbose {
+			fmt.Printf("WAL is healthy (index: %d, term: %d)\n", walsnap.Index, walsnap.Term)
+		}
+	}
+}

--- a/etcdctl/main.go
+++ b/etcdctl/main.go
@@ -61,6 +61,7 @@ func main() {
 		command.NewUserCommands(),
 		command.NewRoleCommands(),
 		command.NewAuthCommands(),
+		command.NewFsckCommand(),
 	}
 
 	app.Run(os.Args)


### PR DESCRIPTION
Current etcd seems to lack a tool for offline diagnosing tool for
validating stored data and metadata. So this patch adds a new command
"fsck" to etcdctl. It would be a start point for checking data
corruption, data integrity, difference between replicas, etc.

Example usage:
$ etcdctl fsck --data-dir infra1.etcd --verbose
WAL is healthy (index: 2296, term: 4)

Of course, current implementation of the command is very slack and not so useful. I want to have a consensus about below points:

 - Is current etcd really lacking offline diagnosis tool?
 - Is the idea of offline diagnosis tool acceptable for etcd community?
 - Is etcdctl suitable place for the fsck command? (is etcdctlv3 more suitable?)
