### PR TITLE
etcdserver, store: fix grammars in comments (a->an existing)

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -116,7 +116,7 @@ type Server interface {
 	// ErrIDNotFound if member ID is not in the cluster.
 	RemoveMember(ctx context.Context, id uint64) error
 
-	// UpdateMember attempts to update a existing member in the cluster. It will
+	// UpdateMember attempts to update an existing member in the cluster. It will
 	// return ErrIDNotFound if the member ID does not exist.
 	UpdateMember(ctx context.Context, updateMemb Member) error
 

--- a/store/node.go
+++ b/store/node.go
@@ -183,7 +183,7 @@ func (n *node) GetChild(name string) (*node, *etcdErr.Error) {
 
 // Add function adds a node to the receiver node.
 // If the receiver is not a directory, a "Not A Directory" error will be returned.
-// If there is a existing node with the same name under the directory, a "Already Exist"
+// If there is an existing node with the same name under the directory, a "Already Exist"
 // error will be returned
 func (n *node) Add(child *node) *etcdErr.Error {
 	if !n.IsDir() {

--- a/store/store.go
+++ b/store/store.go
@@ -528,7 +528,7 @@ func (s *store) internalCreate(nodePath string, dir bool, value string, unique, 
 
 	n, _ := d.GetChild(nodeName)
 
-	// force will try to replace a existing file
+	// force will try to replace an existing file
 	if n != nil {
 		if replace {
 			if n.IsDir() {


### PR DESCRIPTION
I found some grammatical errors in comments.

Same pull request was submitted https://github.com/coreos/etcd/pull/3513.
I am resubmitting following the correct guidlines.