### PR TITLE
etcdserver: forbid to unset v3 demo once used

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -16,6 +16,7 @@ package etcdserver
 
 import (
 	"encoding/json"
+	"errors"
 	"expvar"
 	"fmt"
 	"math/rand"
@@ -180,6 +181,11 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 	var id types.ID
 	var cl *cluster
 
+	demoFile := path.Join(cfg.MemberDir(), "v3demo")
+	if !cfg.V3demo && fileutil.Exist(demoFile) {
+		return nil, errors.New("experimental-v3demo cannot be disabled once it is enabled")
+	}
+
 	// Run the migrations.
 	dataVer, err := version.DetectDataDir(cfg.DataDir)
 	if err != nil {
@@ -324,10 +330,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 	}
 
 	if cfg.V3demo {
-		srv.kv = dstorage.New(path.Join(cfg.DataDir, "member", "v3demo"))
-	} else {
-		// we do not care about the error of the removal
-		os.RemoveAll(path.Join(cfg.DataDir, "member", "v3demo"))
+		srv.kv = dstorage.New(demoFile)
 	}
 
 	// TODO: move transport initialization near the definition of remote

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -55,3 +55,8 @@ func ReadDir(dirpath string) ([]string, error) {
 	sort.Strings(names)
 	return names, nil
 }
+
+func Exist(name string) bool {
+	_, err := os.Stat(name)
+	return err == nil
+}

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -65,3 +65,20 @@ func TestReadDir(t *testing.T) {
 		t.Fatalf("ReadDir: got %v, want %v", fs, wfs)
 	}
 }
+
+func TestExist(t *testing.T) {
+	f, err := ioutil.TempFile(os.TempDir(), "fileutil")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if g := Exist(f.Name()); g != true {
+		t.Errorf("exist = %v, want true", g)
+	}
+
+	os.Remove(f.Name())
+	if g := Exist(f.Name()); g != false {
+		t.Errorf("exist = %v, want false", g)
+	}
+}


### PR DESCRIPTION
After enabling v3 demo, it may change the underlying data organization
for v3 store. So we forbid to unset --experimental-v3demo once it has
been used.