### PR TITLE
etcdctl: use user specified timeout value for entire command execution

### DIFF
--- a/etcdctl/command/auth_commands.go
+++ b/etcdctl/command/auth_commands.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -67,7 +66,7 @@ func authEnableDisable(c *cli.Context, enable bool) {
 		os.Exit(1)
 	}
 	s := mustNewAuthAPI(c)
-	ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
+	ctx, cancel := contextWithTotalTimeout(c)
 	var err error
 	if enable {
 		err = s.Enable(ctx)

--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -263,3 +263,7 @@ func newClient(c *cli.Context) (client.Client, error) {
 
 	return client.New(cfg)
 }
+
+func contextWithTotalTimeout(c *cli.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), c.GlobalDuration("total-timeout"))
+}

--- a/etcdctl/main.go
+++ b/etcdctl/main.go
@@ -40,6 +40,7 @@ func main() {
 		cli.StringFlag{Name: "ca-file", Value: "", Usage: "verify certificates of HTTPS-enabled servers using this CA bundle"},
 		cli.StringFlag{Name: "username, u", Value: "", Usage: "provide username[:password] and prompt if password is not supplied."},
 		cli.DurationFlag{Name: "timeout", Value: time.Second, Usage: "connection timeout per request"},
+		cli.DurationFlag{Name: "total-timeout", Value: 5 * time.Second, Usage: "timeout for the command execution (except watch)"},
 	}
 	app.Commands = []cli.Command{
 		command.NewBackupCommand(),


### PR DESCRIPTION
etcdctl should be capable to use a user specified timeout value for
total command execution, not only per request timeout. This commit
adds a new option --total-timeout to the command. The value passed via
this option is used as a timeout value of entire command execution.

Fixes coreos#3517

This is the new version of the PR https://github.com/coreos/etcd/pull/3518 . This new one is so different from the old one, so I made a new PR.