### PR TITLE
storage/backend: extend wait timeout for commit to finish

### DIFF
--- a/storage/backend/backend_test.go
+++ b/storage/backend/backend_test.go
@@ -105,6 +105,8 @@ func TestBackendBatchIntervalCommit(t *testing.T) {
 	// give time for batch interval commit to happen
 	time.Sleep(time.Nanosecond)
 	testutil.WaitSchedule()
+	// give time for commit to finish, including possible disk IO
+	time.Sleep(50 * time.Millisecond)
 
 	// check whether put happens via db view
 	b.db.View(func(tx *bolt.Tx) error {


### PR DESCRIPTION
It needs to take more time on travis. Fix:

```
--- FAIL: TestBackendBatchIntervalCommit (0.01s)
		backend_test.go:113: bucket test does not exit
```