### PR TITLE
*: support send real-time v3 snapshot

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -103,7 +103,7 @@ type raftNode struct {
 
 	// utility
 	ticker      <-chan time.Time
-	raftStorage *raft.MemoryStorage
+	raftStorage *raftStorage
 	storage     Storage
 	// transport specifies the transport to send and receive msgs to members.
 	// Sending messages MUST NOT block. It is okay to drop messages, since
@@ -178,6 +178,10 @@ func (r *raftNode) start(s *EtcdServer) {
 
 				r.s.send(rd.Messages)
 
+				// TODO: it may have deadlock here. unsent messages may include
+				// MsgSnap which holds boltdb read-only txn, while apply loop
+				// wants to get write txn to apply entry. boltdb will block in
+				// this case.
 				select {
 				case <-apply.done:
 				case <-r.stopped:
@@ -238,7 +242,7 @@ func advanceTicksForElection(n raft.Node, electionTicks int) {
 	}
 }
 
-func startNode(cfg *ServerConfig, cl *cluster, ids []types.ID) (id types.ID, n raft.Node, s *raft.MemoryStorage, w *wal.WAL) {
+func startNode(cfg *ServerConfig, cl *cluster, ids []types.ID) (id types.ID, n raft.Node, s *raftStorage, w *wal.WAL) {
 	var err error
 	member := cl.MemberByName(cfg.Name)
 	metadata := pbutil.MustMarshal(
@@ -263,7 +267,7 @@ func startNode(cfg *ServerConfig, cl *cluster, ids []types.ID) (id types.ID, n r
 	}
 	id = member.ID
 	plog.Infof("starting member %s in cluster %s", id, cl.ID())
-	s = raft.NewMemoryStorage()
+	s = newRaftStorage()
 	c := &raft.Config{
 		ID:              uint64(id),
 		ElectionTick:    cfg.ElectionTicks,
@@ -278,7 +282,7 @@ func startNode(cfg *ServerConfig, cl *cluster, ids []types.ID) (id types.ID, n r
 	return
 }
 
-func restartNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *cluster, raft.Node, *raft.MemoryStorage, *wal.WAL) {
+func restartNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *cluster, raft.Node, *raftStorage, *wal.WAL) {
 	var walsnap walpb.Snapshot
 	if snapshot != nil {
 		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
@@ -288,7 +292,7 @@ func restartNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *clust
 	plog.Infof("restarting member %s in cluster %s at commit index %d", id, cid, st.Commit)
 	cl := newCluster("")
 	cl.SetID(cid)
-	s := raft.NewMemoryStorage()
+	s := newRaftStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)
 	}
@@ -308,7 +312,7 @@ func restartNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *clust
 	return id, cl, n, s, w
 }
 
-func restartAsStandaloneNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *cluster, raft.Node, *raft.MemoryStorage, *wal.WAL) {
+func restartAsStandaloneNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (types.ID, *cluster, raft.Node, *raftStorage, *wal.WAL) {
 	var walsnap walpb.Snapshot
 	if snapshot != nil {
 		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
@@ -340,7 +344,7 @@ func restartAsStandaloneNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (type
 	plog.Printf("forcing restart of member %s in cluster %s at commit index %d", id, cid, st.Commit)
 	cl := newCluster("")
 	cl.SetID(cid)
-	s := raft.NewMemoryStorage()
+	s := newRaftStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)
 	}

--- a/etcdserver/raft_storage.go
+++ b/etcdserver/raft_storage.go
@@ -1,0 +1,43 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+import (
+	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+type raftStorage struct {
+	*raft.MemoryStorage
+	// hub is the place to request snapshot with latest index.
+	// If hub is nil, it uses the snapshot saved in MemoryStorage.
+	hub *snapshotHub
+}
+
+func newRaftStorage() *raftStorage {
+	return &raftStorage{
+		MemoryStorage: raft.NewMemoryStorage(),
+	}
+}
+
+// Snapshot returns latest raft snapshot. If hub is nil, this method
+// returns snapshot saved in MemoryStorage. If hub exists, this method
+// returns snapshot with latest index.
+func (rs *raftStorage) Snapshot() (raftpb.Snapshot, error) {
+	if rs.hub == nil {
+		return rs.MemoryStorage.Snapshot()
+	}
+	return rs.hub.CreateSnapshot(), nil
+}

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -153,7 +153,7 @@ func TestStopRaftWhenWaitingForApplyDone(t *testing.T) {
 	r := raftNode{
 		Node:        n,
 		storage:     &storageRecorder{},
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: newRaftStorage(),
 		transport:   &nopTransporter{},
 	}
 	r.start(&EtcdServer{r: r})

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -340,6 +340,9 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 			return nil, err
 		}
 		srv.kv = dstorage.New(path.Join(cfg.StorageDir(), databaseFilename))
+		if err := srv.kv.Restore(); err != nil {
+			plog.Fatalf("v3 storage restore error: %v", err)
+		}
 	}
 
 	// TODO: move transport initialization near the definition of remote

--- a/etcdserver/snapshot_hub.go
+++ b/etcdserver/snapshot_hub.go
@@ -1,0 +1,109 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+type snapshot struct {
+	// storing the raft snapshot. the data in raftsnap is v2 store.
+	raftsnap raftpb.Snapshot
+	// rc is a reader that provides the data of KV snapshot.
+	rc io.ReadCloser
+	// dataSize specifies the size of snapshot data.
+	dataSize int64
+}
+
+type snapshotHub struct {
+	// dir to save snapshot data
+	dir string
+
+	// send empty to reqsnapc to notify the channel receiver to send back latest
+	// snapshot to snapc
+	reqsnapc chan struct{}
+	// a chan to receive the requested snapshot
+	// hub will receive from the chan immediately after it sends empty to reqsnapc
+	snapc chan snapshot
+	// host received snapshots
+	snaps []snapshot
+}
+
+func newSnapshotHub(dir string) *snapshotHub {
+	return &snapshotHub{
+		dir:      dir,
+		reqsnapc: make(chan struct{}),
+		snapc:    make(chan snapshot),
+	}
+}
+
+// CreateSnapshot creates snapshot with latest index. The returned snapshot
+// is the mark of snapshot, and caller could call SnapshotData to get its data.
+// TODO: the function should be unblock and finish in 1ms. It may use ~20ms
+// in the peak for 2 million keys.
+func (sh *snapshotHub) CreateSnapshot() raftpb.Snapshot {
+	sh.reqsnapc <- struct{}{}
+	snap := <-sh.snapc
+	sh.snaps = append(sh.snaps, snap)
+	return snap.raftsnap
+}
+
+// SnapshotData returns snapshot data that matches the given raft snapshot.
+// The given raft snapshot must be from returned snapshot. If not, it panics.
+// SnapshotData should be called once and only once for each Snapshot call, because
+// SnapshotData can only be read once and occupies resources if not used.
+func (sh *snapshotHub) SnapshotData(raftsnap raftpb.Snapshot) (io.ReadCloser, int64) {
+	for i, s := range sh.snaps {
+		if s.raftsnap.Metadata.Index == raftsnap.Metadata.Index {
+			sh.snaps = append(sh.snaps[:i], sh.snaps[i+1:]...)
+			return s.rc, s.dataSize
+		}
+	}
+	plog.Panicf("cannot get snapshot of %+v", raftsnap)
+	return nil, 0
+}
+
+// SaveSnapshotData saves snapshot data into disk. If snapshot data of the same
+// snapshot mark has existed, it returns error and keeps the original snapshot
+// data. The function guarantees that if the call is aborted at any time,
+// it leaves either complete snapshot data or nothing.
+func (sh *snapshotHub) SaveSnapshotData(raftsnap raftpb.Snapshot, r io.Reader) error {
+	f, err := ioutil.TempFile(sh.dir, "tmp")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(f, r)
+	f.Close()
+	if err != nil {
+		return err
+	}
+	fn := sh.SavedSnapshotFilename(raftsnap)
+	if fileutil.Exist(fn) {
+		return fmt.Errorf("snapshot to save has existed")
+	}
+	return os.Rename(f.Name(), fn)
+}
+
+// SavedSnapshotFilename returns the filename of saved snapshot.
+func (sh *snapshotHub) SavedSnapshotFilename(raftsnap raftpb.Snapshot) string {
+	return path.Join(sh.dir, fmt.Sprintf("%016x.db", raftsnap.Metadata.Index))
+}

--- a/rafthttp/functional_test.go
+++ b/rafthttp/functional_test.go
@@ -30,14 +30,14 @@ import (
 
 func TestSendMessage(t *testing.T) {
 	// member 1
-	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, newServerStats(), stats.NewLeaderStats("1"))
+	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, nil, newServerStats(), stats.NewLeaderStats("1"), false)
 	srv := httptest.NewServer(tr.Handler())
 	defer srv.Close()
 
 	// member 2
 	recvc := make(chan raftpb.Message, 1)
 	p := &fakeRaft{recvc: recvc}
-	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), p, nil, newServerStats(), stats.NewLeaderStats("2"))
+	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), p, nil, nil, newServerStats(), stats.NewLeaderStats("2"), false)
 	srv2 := httptest.NewServer(tr2.Handler())
 	defer srv2.Close()
 
@@ -75,14 +75,14 @@ func TestSendMessage(t *testing.T) {
 // remote in a limited time when all underlying connections are broken.
 func TestSendMessageWhenStreamIsBroken(t *testing.T) {
 	// member 1
-	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, newServerStats(), stats.NewLeaderStats("1"))
+	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, nil, newServerStats(), stats.NewLeaderStats("1"), false)
 	srv := httptest.NewServer(tr.Handler())
 	defer srv.Close()
 
 	// member 2
 	recvc := make(chan raftpb.Message, 1)
 	p := &fakeRaft{recvc: recvc}
-	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), p, nil, newServerStats(), stats.NewLeaderStats("2"))
+	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), p, nil, nil, newServerStats(), stats.NewLeaderStats("2"), false)
 	srv2 := httptest.NewServer(tr2.Handler())
 	defer srv2.Close()
 

--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -32,9 +32,10 @@ const (
 )
 
 var (
-	RaftPrefix       = "/raft"
-	ProbingPrefix    = path.Join(RaftPrefix, "probing")
-	RaftStreamPrefix = path.Join(RaftPrefix, "stream")
+	RaftPrefix         = "/raft"
+	ProbingPrefix      = path.Join(RaftPrefix, "probing")
+	RaftStreamPrefix   = path.Join(RaftPrefix, "stream")
+	RaftSnapshotPrefix = path.Join(RaftPrefix, "snapshot")
 
 	errIncompatibleVersion = errors.New("incompatible version")
 	errClusterIDMismatch   = errors.New("cluster ID mismatch")
@@ -162,6 +163,8 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		t = streamTypeMsgAppV2
 	case path.Join(RaftStreamPrefix, string(streamTypeMessage)):
 		t = streamTypeMessage
+	case path.Join(RaftStreamPrefix, string(streamTypeMsgSnap)):
+		t = streamTypeMsgSnap
 	default:
 		plog.Debugf("ignored unexpected streaming request path %s", r.URL.Path)
 		http.Error(w, "invalid path", http.StatusNotFound)

--- a/rafthttp/msgsnap.go
+++ b/rafthttp/msgsnap.go
@@ -1,0 +1,101 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rafthttp
+
+import (
+	"encoding/binary"
+	"io"
+	"time"
+
+	"github.com/coreos/etcd/pkg/pbutil"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+const (
+	// 1MB usually could be finished in 100ms, which is the default value of
+	// heartbeat interval. rafthttp rests some time after transferring one
+	// block, so it leaves time for leader to send heartbeat to follower.
+	transferBlockSize = 1024 * 1024
+	// sleepRate specifies the rate between sleep time and send time in encoder.
+	sleepRate = 1
+)
+
+type msgSnapEncoder struct {
+	w       io.Writer
+	snaphub SnapshotHub
+}
+
+// TODO: cancel old term message when higher term happens, which helps efficiency.
+func (enc *msgSnapEncoder) encode(m raftpb.Message) error {
+	if isLinkHeartbeatMessage(m) {
+		return binary.Write(enc.w, binary.BigEndian, uint64(0))
+	}
+
+	if err := binary.Write(enc.w, binary.BigEndian, uint64(m.Size())); err != nil {
+		return err
+	}
+	if _, err := enc.w.Write(pbutil.MustMarshal(&m)); err != nil {
+		return err
+	}
+	rc, size := enc.snaphub.SnapshotData(m.Snapshot)
+	defer rc.Close()
+	if err := binary.Write(enc.w, binary.BigEndian, uint64(size)); err != nil {
+		return err
+	}
+	for {
+		lr := &io.LimitedReader{R: rc, N: transferBlockSize}
+		start := time.Now()
+		_, err := io.Copy(enc.w, lr)
+		if err != nil {
+			return err
+		}
+		if lr.N == transferBlockSize {
+			break
+		}
+		time.Sleep(time.Since(start) * time.Duration(sleepRate))
+	}
+	return nil
+}
+
+type msgSnapDecoder struct {
+	r       io.Reader
+	snaphub SnapshotHub
+}
+
+func (dec *msgSnapDecoder) decode() (raftpb.Message, error) {
+	var m raftpb.Message
+	var l uint64
+	if err := binary.Read(dec.r, binary.BigEndian, &l); err != nil {
+		return m, err
+	}
+	if l == 0 {
+		return linkHeartbeatMessage, nil
+	}
+
+	buf := make([]byte, int(l))
+	if _, err := io.ReadFull(dec.r, buf); err != nil {
+		return m, err
+	}
+	if err := m.Unmarshal(buf); err != nil {
+		return m, err
+	}
+	var size int64
+	if err := binary.Read(dec.r, binary.BigEndian, &size); err != nil {
+		return m, err
+	}
+	lr := &io.LimitedReader{R: dec.r, N: size}
+	err := dec.snaphub.SaveSnapshotData(m.Snapshot, lr)
+	return m, err
+}

--- a/rafthttp/remote.go
+++ b/rafthttp/remote.go
@@ -21,6 +21,8 @@ import (
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
+// TODO: support to receive snapshot from remote. plan is to always use peer
+// instead of remote, and keep these peers until catch up.
 type remote struct {
 	id       types.ID
 	status   *peerStatus

--- a/rafthttp/stream_test.go
+++ b/rafthttp/stream_test.go
@@ -35,7 +35,7 @@ import (
 // to streamWriter. After that, streamWriter can use it to send messages
 // continuously, and closes it when stopped.
 func TestStreamWriterAttachOutgoingConn(t *testing.T) {
-	sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{})
+	sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{}, nil)
 	// the expected initial state of streamWrite is not working
 	if _, ok := sw.writec(); ok != false {
 		t.Errorf("initial working status = %v, want false", ok)
@@ -81,7 +81,7 @@ func TestStreamWriterAttachOutgoingConn(t *testing.T) {
 // TestStreamWriterAttachBadOutgoingConn tests that streamWriter with bad
 // outgoingConn will close the outgoingConn and fall back to non-working status.
 func TestStreamWriterAttachBadOutgoingConn(t *testing.T) {
-	sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{})
+	sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{}, nil)
 	defer sw.stop()
 	wfc := &fakeWriteFlushCloser{err: errors.New("blah")}
 	sw.attach(&outgoingConn{t: streamTypeMessage, Writer: wfc, Flusher: wfc, Closer: wfc})
@@ -283,12 +283,12 @@ func TestStream(t *testing.T) {
 		srv := httptest.NewServer(h)
 		defer srv.Close()
 
-		sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{})
+		sw := startStreamWriter(types.ID(1), newPeerStatus(types.ID(1)), &stats.FollowerStats{}, &fakeRaft{}, nil)
 		defer sw.stop()
 		h.sw = sw
 
 		picker := mustNewURLPicker(t, []string{srv.URL})
-		sr := startStreamReader(&http.Transport{}, picker, tt.t, types.ID(1), types.ID(2), types.ID(1), newPeerStatus(types.ID(1)), recvc, propc, nil, tt.term)
+		sr := startStreamReader(&http.Transport{}, picker, tt.t, types.ID(1), types.ID(2), types.ID(1), newPeerStatus(types.ID(1)), recvc, propc, nil, tt.term, nil)
 		defer sr.stop()
 		// wait for stream to work
 		var writec chan<- raftpb.Message

--- a/rafthttp/transport_bench_test.go
+++ b/rafthttp/transport_bench_test.go
@@ -30,13 +30,13 @@ import (
 
 func BenchmarkSendingMsgApp(b *testing.B) {
 	// member 1
-	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, newServerStats(), stats.NewLeaderStats("1"))
+	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, nil, newServerStats(), stats.NewLeaderStats("1"), false)
 	srv := httptest.NewServer(tr.Handler())
 	defer srv.Close()
 
 	// member 2
 	r := &countRaft{}
-	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), r, nil, newServerStats(), stats.NewLeaderStats("2"))
+	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), r, nil, nil, newServerStats(), stats.NewLeaderStats("2"), false)
 	srv2 := httptest.NewServer(tr2.Handler())
 	defer srv2.Close()
 

--- a/storage/backend/backend_test.go
+++ b/storage/backend/backend_test.go
@@ -15,6 +15,7 @@
 package backend
 
 import (
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -72,8 +73,8 @@ func TestBackendSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.Snapshot(f)
-	if err != nil {
+	rc, _ := b.Snapshot()
+	if _, err := io.Copy(f, rc); err != nil {
 		t.Fatal(err)
 	}
 	f.Close()

--- a/storage/kv.go
+++ b/storage/kv.go
@@ -65,8 +65,11 @@ type KV interface {
 	// This method is designed for consistency checking purpose.
 	Hash() (uint32, error)
 
-	// Write a snapshot to the given io writer
-	Snapshot(w io.Writer) (int64, error)
+	// Snapshot snapshots the KV store, and returns an io.ReadCloser to
+	// help read the full snapshot bytes. Close closes the returned io.ReadCloser
+	// and the snapshot got from the underlying storage.
+	// The returned size specifies the size of snapshot.
+	Snapshot() (rc io.ReadCloser, size int64)
 
 	Restore() error
 	Close() error

--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -15,6 +15,7 @@
 package storage
 
 import (
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -706,7 +707,8 @@ func TestKVSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.Snapshot(f)
+	rc, _ := s.Snapshot()
+	_, err = io.Copy(f, rc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -292,9 +292,9 @@ func (s *store) Hash() (uint32, error) {
 	return s.b.Hash()
 }
 
-func (s *store) Snapshot(w io.Writer) (int64, error) {
+func (s *store) Snapshot() (io.ReadCloser, int64) {
 	s.b.ForceCommit()
-	return s.b.Snapshot(w)
+	return s.b.Snapshot()
 }
 
 func (s *store) Restore() error {

--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -17,7 +17,6 @@ package storage
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"errors"
 	"io"
 	"math"
 	"os"
@@ -721,11 +720,11 @@ type fakeBackend struct {
 	tx *fakeBatchTx
 }
 
-func (b *fakeBackend) BatchTx() backend.BatchTx                  { return b.tx }
-func (b *fakeBackend) Hash() (uint32, error)                     { return 0, nil }
-func (b *fakeBackend) Snapshot(w io.Writer) (n int64, err error) { return 0, errors.New("unsupported") }
-func (b *fakeBackend) ForceCommit()                              {}
-func (b *fakeBackend) Close() error                              { return nil }
+func (b *fakeBackend) BatchTx() backend.BatchTx                 { return b.tx }
+func (b *fakeBackend) Hash() (uint32, error)                    { return 0, nil }
+func (b *fakeBackend) Snapshot() (rc io.ReadCloser, size int64) { return nil, 0 }
+func (b *fakeBackend) ForceCommit()                             {}
+func (b *fakeBackend) Close() error                             { return nil }
 
 type indexGetResp struct {
 	rev     revision


### PR DESCRIPTION
The workflow:
1. raft state machine asks for snapshot to send
2. etcdserver is notified and generates real-time snapshot
3. etcdserver gives raftpb.Snapshot to raft state machine,
and keeps KV snapshot at its side
4. When rafthttp sends MsgSnap, it asks etcdserver for KV snapshot part
and sends it too
5. When remote rafthttp receives MsgSnap, it saves KV snapshot into
temporary file.
6. When restore from MsgSnap, let KV restore from the temporary file.

The first commit updates KV.Snapshot function to fit the use case in etcdserver loop. When using Snapshot function in the loop, it is expected:
1. the underlying snapshot read is async
2. know when KV is force committed, so caller could continue after that
3. be able to cancel the underlying snapshot