### PR TITLE
doc: add a description of -strict-reconfig-check

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -130,6 +130,11 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 + default: none
 + env variable: ETCD_DISCOVERY_PROXY
 
+##### -strict-reconfig-check
++ Reject reconfiguration requests that would cause quorum loss.
++ default: false
++ env variable: ETCD_STRICT_RECONFIG_CHECK
+
 ### Proxy Flags
 
 `-proxy` prefix flags configures etcd to run in [proxy mode][proxy].

--- a/Documentation/runtime-configuration.md
+++ b/Documentation/runtime-configuration.md
@@ -161,3 +161,11 @@ $ etcd
 etcd: this member has been permanently removed from the cluster. Exiting.
 exit 1
 ```
+
+#### Strict Reconfiguration Check Mode (`-strict-reconfig-check`)
+
+As described in the above, the best practice of adding new members is to configure a single member at a time and verify it starts correctly before adding more new members. This step by step approach is very important because if newly added members is not configured correctly (for example the peer URLs are incorrect), the cluster can lose quorum. The quorum loss happens since the newly added member are counted in the quorum even if that member is not reachable from other existing members. Also quorum loss might happen if there is a connectivity issue or there are operational issues.
+
+For avoiding this problem, etcd provides an option `-strict-reconfig-check`. If this option is passed to etcd, etcd rejects reconfiguration requests if the number of started members will be less than a quorum of the reconfigured cluster.
+
+It is recommended to enable this option. However, it is disabled by default because of keeping compatibility.

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -68,7 +68,8 @@ clustering flags:
 		HTTP proxy to use for traffic to discovery service.
 	--discovery-srv ''
 		dns srv domain used to bootstrap the cluster.
-
+	--strict-reconfig-check
+		reject reconfiguration requests that would cause quorum loss.
 
 proxy flags:
 


### PR DESCRIPTION
This PR adds a description of the newly added option `-strict-reconfig-check` to the document.