### PR TITLE
etcdmain: better logging when user forget to set initial flags

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -40,7 +40,8 @@ const (
 	clusterStateFlagNew      = "new"
 	clusterStateFlagExisting = "existing"
 
-	defaultName = "default"
+	defaultName                     = "default"
+	defaultInitialAdvertisePeerURLs = "http://localhost:2380,http://localhost:7001"
 
 	// maxElectionMs specifies the maximum value of election timeout.
 	// More details are listed in ../Documentation/tuning.md#time-parameters.
@@ -162,7 +163,7 @@ func NewConfig() *config {
 	fs.UintVar(&cfg.ElectionMs, "election-timeout", 1000, "Time (in milliseconds) for an election to timeout.")
 
 	// clustering
-	fs.Var(flags.NewURLsValue("http://localhost:2380,http://localhost:7001"), "initial-advertise-peer-urls", "List of this member's peer URLs to advertise to the rest of the cluster")
+	fs.Var(flags.NewURLsValue(defaultInitialAdvertisePeerURLs), "initial-advertise-peer-urls", "List of this member's peer URLs to advertise to the rest of the cluster")
 	fs.Var(flags.NewURLsValue("http://localhost:2379,http://localhost:4001"), "advertise-client-urls", "List of this member's client URLs to advertise to the rest of the cluster")
 	fs.StringVar(&cfg.durl, "discovery", "", "Discovery service used to bootstrap the initial cluster")
 	fs.Var(cfg.fallback, "discovery-fallback", fmt.Sprintf("Valid values include %s", strings.Join(cfg.fallback.Values, ", ")))

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"reflect"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/go-systemd/daemon"
@@ -146,6 +147,19 @@ func Main() {
 			plog.Errorf("please check (cURL) the discovery token for more information.")
 			plog.Errorf("please do not reuse the discovery token and generate a new one to bootstrap the cluster.")
 		default:
+			if strings.Contains(err.Error(), "include") && strings.Contains(err.Error(), "--initial-cluster") {
+				plog.Infof("%v", err)
+				if cfg.initialCluster == initialClusterFromName(cfg.name) {
+					plog.Infof("forgot to set --initial-cluster flag?")
+				}
+				if types.URLs(cfg.apurls).String() == defaultInitialAdvertisePeerURLs {
+					plog.Infof("forgot to set --initial-advertise-peer-urls flag?")
+				}
+				if cfg.initialCluster == initialClusterFromName(cfg.name) && len(cfg.durl) == 0 {
+					plog.Infof("if you want to use discovery service, please set --discovery flag.")
+				}
+				os.Exit(1)
+			}
 			plog.Fatalf("%v", err)
 		}
 	}

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -102,7 +102,7 @@ func (c *ServerConfig) verifyLocalMember(strict bool) error {
 	urls.Sort()
 	if strict {
 		if !netutil.URLStringsEqual(apurls, urls.StringSlice()) {
-			return fmt.Errorf("advertise URLs of %q do not match in --initial-advertise-peer-urls %s and --initial-cluster %s", c.Name, apurls, urls.StringSlice())
+			return fmt.Errorf("--initial-cluster must include %s=%s given --initial-advertise-peer-urls=%s", c.Name, apurls, apurls)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/3552

Now it will log as if you forgot to set both `--initial-cluster` and `--discovery` and the configuration does not match.

```
2015-09-18 15:19:16.721741 I | etcdmain: advertise URLs of "default" do not match in --initial-advertise-peer-urls [http://example.com:1234] and --initial-cluster [http://localhost:2380 http://localhost:7001]
2015-09-18 15:19:16.721746 I | etcdmain: forgot to set --initial-cluster flag?
2015-09-18 15:19:16.721754 I | etcdmain: if you want to use discovery service, please set --discovery flag.
```