### PR TITLE
storage: add tests for RangeEvents and its underlying functions

### DIFF
--- a/storage/key_index.go
+++ b/storage/key_index.go
@@ -177,6 +177,7 @@ func (ki *keyIndex) since(rev int64) []revision {
 				// replace the revision with a new one that has higher sub value,
 				// because the original one should not be seen by external
 				revs[len(revs)-1] = r
+				continue
 			}
 			revs = append(revs, r)
 			last = r.main

--- a/storage/key_index.go
+++ b/storage/key_index.go
@@ -157,7 +157,11 @@ func (ki *keyIndex) since(rev int64) []revision {
 	var gi int
 	// find the generations to start checking
 	for gi = len(ki.generations) - 1; gi > 0; gi-- {
-		if since.GreaterThan(ki.generations[gi].created) {
+		g := ki.generations[gi]
+		if g.isEmpty() {
+			continue
+		}
+		if since.GreaterThan(g.created) {
 			break
 		}
 	}

--- a/storage/key_index_test.go
+++ b/storage/key_index_test.go
@@ -84,6 +84,29 @@ func TestKeyIndexGet(t *testing.T) {
 	}
 }
 
+func TestKeyIndexSince(t *testing.T) {
+	ki := newTestKeyIndex()
+	ki.compact(4, make(map[revision]struct{}))
+
+	allRevs := []revision{{4, 0}, {6, 0}, {8, 0}, {10, 0}, {12, 0}, {14, 1}, {16, 0}}
+	tests := []struct {
+		rev int64
+
+		wrevs []revision
+	}{
+		{17, nil},
+		{16, allRevs[6:]},
+		{15, allRevs[6:]},
+	}
+
+	for i, tt := range tests {
+		revs := ki.since(tt.rev)
+		if !reflect.DeepEqual(revs, tt.wrevs) {
+			t.Errorf("#%d: revs = %+v, want %+v", i, revs, tt.wrevs)
+		}
+	}
+}
+
 func TestKeyIndexPut(t *testing.T) {
 	ki := &keyIndex{key: []byte("foo")}
 	ki.put(5, 0)

--- a/storage/key_index_test.go
+++ b/storage/key_index_test.go
@@ -97,6 +97,21 @@ func TestKeyIndexSince(t *testing.T) {
 		{17, nil},
 		{16, allRevs[6:]},
 		{15, allRevs[6:]},
+		{14, allRevs[5:]},
+		{13, allRevs[5:]},
+		{12, allRevs[4:]},
+		{11, allRevs[4:]},
+		{10, allRevs[3:]},
+		{9, allRevs[3:]},
+		{8, allRevs[2:]},
+		{7, allRevs[2:]},
+		{6, allRevs[1:]},
+		{5, allRevs[1:]},
+		{4, allRevs},
+		{3, allRevs},
+		{2, allRevs},
+		{1, allRevs},
+		{0, allRevs},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
To help make watch work correctly.

The first commit improves keyIndex built for better testing, which helps to test keyIndex.since better.