### PR TITLE
Fix etcd/client API example

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -38,6 +38,8 @@ func main() {
 	resp, err := kapi.Set(context.Background(), "foo", "bar", nil)
 	if err != nil {
 		log.Fatal(err)
+	} else {
+		log.Print(resp)
 	}
 }
 ```


### PR DESCRIPTION
Response variable is not being used which results in compile error. This commit fixes the etcd/client API example.