### PR TITLE
integration: extend request timeout

### DIFF
--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -45,7 +45,7 @@ import (
 const (
 	tickDuration   = 10 * time.Millisecond
 	clusterName    = "etcd"
-	requestTimeout = 2 * time.Second
+	requestTimeout = 20 * time.Second
 )
 
 var (


### PR DESCRIPTION
Extend request timeout to give etcd cluster enough time to return
response.