### PR TITLE
storage: use map for watchableStorage.unsynced

### DIFF
--- a/storage/watchable_store_test.go
+++ b/storage/watchable_store_test.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestingWatchableStore(t *testing.T) {
+	s := newWatchableStore(tmpPath)
+	defer cleanup(s, tmpPath)
+
+	for i := 0; i < 3; i++ {
+		s.Put([]byte("foo"), []byte("bar"))
+		if r := s.Rev(); r != int64(i+1) {
+			t.Errorf("#%d: rev = %d, want %d", i, r, i+1)
+		}
+		s.Watcher([]byte(fmt.Sprint("foo", i)), false, 0, 0)
+	}
+}


### PR DESCRIPTION
From `TODO: use map to reduce cancel cost`:
This changes unsynced from `[]*watcher` to `map[*watcher]struct{}`,
and fixes a line that seemed to be missing `defer` statement.

Here's the benchmark results:

```
With []*watcher:

BenchmarkStorePut	   20000	     63670 ns/op	    2120 B/op	      26 allocs/op
BenchmarkStorePut-2	   30000	     34961 ns/op	    1885 B/op	      22 allocs/op
BenchmarkStorePut-4	   30000	     38461 ns/op	    1862 B/op	      22 allocs/op
BenchmarkStorePut-8	   30000	     35052 ns/op	    1896 B/op	      22 allocs/op
BenchmarkStorePut-16	   30000	     34053 ns/op	    1916 B/op	      22 allocs/op
BenchmarkKVWatcherMemoryUsage	  200000	     22775 ns/op	     614 B/op	      13 allocs/op
BenchmarkKVWatcherMemoryUsage-2	  500000	      2791 ns/op	     676 B/op	      13 allocs/op
BenchmarkKVWatcherMemoryUsage-4	  500000	      2269 ns/op	     676 B/op	      13 allocs/op
BenchmarkKVWatcherMemoryUsage-8	  500000	      2209 ns/op	     676 B/op	      13 allocs/op
BenchmarkKVWatcherMemoryUsage-16	  500000	      2108 ns/op	     676 B/op	      13 allocs/op

With map[*watcher]struct{}:

BenchmarkStorePut	   30000	     54057 ns/op	    1777 B/op	      21 allocs/op
BenchmarkStorePut-2	   30000	     38730 ns/op	    1718 B/op	      20 allocs/op
BenchmarkStorePut-4	   30000	     41090 ns/op	    1892 B/op	      22 allocs/op
BenchmarkStorePut-8	   20000	     52318 ns/op	    1972 B/op	      23 allocs/op
BenchmarkStorePut-16	   50000	     32132 ns/op	    1545 B/op	      16 allocs/op
BenchmarkKVWatcherMemoryUsage	  100000	     12495 ns/op	     599 B/op	      13 allocs/op
BenchmarkKVWatcherMemoryUsage-2	  500000	      3046 ns/op	     677 B/op	      13 allocs/op
BenchmarkKVWatcherMemoryUsage-4	  500000	      2214 ns/op	     676 B/op	      13 allocs/op
BenchmarkKVWatcherMemoryUsage-8	  500000	      2159 ns/op	     676 B/op	      13 allocs/op
BenchmarkKVWatcherMemoryUsage-16	  500000	      2121 ns/op	     676 B/op	      13 allocs/op

```

Performance gain is unnoticeable.

Thanks,