### PR TITLE
storage/watchable_store: defer to Unlock s.mu

### DIFF
--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -177,7 +177,7 @@ func (s *watchableStore) Watcher(key []byte, prefix bool, startRev, endRev int64
 
 	cancel := CancelFunc(func() {
 		s.mu.Lock()
-		s.mu.Unlock()
+		defer s.mu.Unlock()
 		wa.stopWithError(ErrCanceled)
 
 		// remove global references of the watcher


### PR DESCRIPTION
New PR from https://github.com/coreos/etcd/pull/3575. This just adds `defer` to  `s.mu`.
Current code does not seem to `Unlock` in the correct scope.

(Sorry, I accidentally deleted my fork so the changes might not sound
continuous from my previous pull requests.)

Thanks,