### PR TITLE
raft/rafttest/node.go: make send async in start

### DIFF
--- a/raft/rafttest/node.go
+++ b/raft/rafttest/node.go
@@ -73,9 +73,22 @@ func (n *node) start() {
 				}
 				n.storage.Append(rd.Entries)
 				time.Sleep(time.Millisecond)
-				// TODO: make send async, more like real world...
-				for _, m := range rd.Messages {
-					n.iface.send(m)
+				// make send async, more like real world...
+				if len(rd.Messages) > 0 {
+					done := make(chan struct{})
+					for _, m := range rd.Messages {
+						go func(m raftpb.Message) {
+							n.iface.send(m)
+							done <- struct{}{}
+						}(m)
+					}
+					doneCnt := 0
+					for range done {
+						doneCnt++
+						if doneCnt == len(rd.Messages) {
+							close(done)
+						}
+					}
 				}
 				n.Advance()
 			case m := <-n.iface.recv():


### PR DESCRIPTION
This is for `TODO: make send async, more like real world...`.
And what does it mean by `like real world`? In real world, does
node wait until it sends out all messages, and then `Advance`
to return the next available `Ready`? This change would send out the
messages in parallel, not in a sequential order: this is asynchronous
not waiting all sends to return. But it still has synchronization step
to wait for all concurrent `n.iface.send(m)` to be done, *right before*
`n.Advance()`.

It seems to pass the test even without waiting for sends
(just run `n.iface.send(m)` in the background with `goroutine`)
and just `n.Advance` right after launching goroutines, as below:

```
for _, m := range rd.Messages {
    go func(m raftpb.Message) {
        n.iface.send(m)
    }(m)
}
n.Advance()
```

Thanks,