### PR TITLE
storage: add tests, benchmarks to watchable_store.go

### DIFF
--- a/storage/watchable_store_bench_test.go
+++ b/storage/watchable_store_bench_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkKVWatcherMemoryUsageWithUnsynced(b *testing.B) {
+	s := newWatchableStore(tmpPath)
+	defer cleanup(s, tmpPath)
+
+	wa, cancel := s.Watcher([]byte("foo"), true, -1, 0)
+	defer cancel()
+
+	for i := 0; i < 3; i++ {
+		s.Put([]byte("foo"), []byte("bar"))
+	}
+	select {
+	case <-wa.Event():
+	}
+	s.Put([]byte("foo1"), []byte("bar1"))
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s.Watcher([]byte(fmt.Sprint("foo", i)), false, -1, 0)
+	}
+}

--- a/storage/watchable_store_test.go
+++ b/storage/watchable_store_test.go
@@ -1,0 +1,139 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/storage/storagepb"
+)
+
+func TesttWatchableStoreRev(t *testing.T) {
+	s := newWatchableStore(tmpPath)
+	defer os.Remove(tmpPath)
+
+	for i := 0; i < 3; i++ {
+		s.Put([]byte("foo"), []byte("bar"))
+		if r := s.Rev(); r != int64(i+1) {
+			t.Errorf("#%d: rev = %d, want %d", i, r, i+1)
+		}
+	}
+}
+
+func TestWatchableKVWatchWithUnsynced(t *testing.T) {
+	s := newWatchableStore(tmpPath)
+	defer cleanup(s, tmpPath)
+
+	wa, cancel := s.Watcher([]byte("foo"), true, -1, 0)
+	defer cancel()
+
+	s.Put([]byte("foo"), []byte("bar"))
+	select {
+	case ev := <-wa.Event():
+		wev := storagepb.Event{
+			Type: storagepb.PUT,
+			Kv: &storagepb.KeyValue{
+				Key:            []byte("foo"),
+				Value:          []byte("bar"),
+				CreateRevision: 1,
+				ModRevision:    1,
+				Version:        1,
+			},
+		}
+		if !reflect.DeepEqual(ev, wev) {
+			t.Errorf("watched event = %+v, want %+v", ev, wev)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("failed to watch the event")
+	}
+
+	s.Put([]byte("foo1"), []byte("bar1"))
+	select {
+	case ev := <-wa.Event():
+		wev := storagepb.Event{
+			Type: storagepb.PUT,
+			Kv: &storagepb.KeyValue{
+				Key:            []byte("foo1"),
+				Value:          []byte("bar1"),
+				CreateRevision: 2,
+				ModRevision:    2,
+				Version:        1,
+			},
+		}
+		if !reflect.DeepEqual(ev, wev) {
+			t.Errorf("watched event = %+v, want %+v", ev, wev)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("failed to watch the event")
+	}
+
+	wa, cancel = s.Watcher([]byte("foo1"), false, -1, 4)
+	defer cancel()
+
+	select {
+	case ev := <-wa.Event():
+		wev := storagepb.Event{
+			Type: storagepb.PUT,
+			Kv: &storagepb.KeyValue{
+				Key:            []byte("foo1"),
+				Value:          []byte("bar1"),
+				CreateRevision: 2,
+				ModRevision:    2,
+				Version:        1,
+			},
+		}
+		if !reflect.DeepEqual(ev, wev) {
+			t.Errorf("watched event = %+v, want %+v", ev, wev)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("failed to watch the event")
+	}
+
+	s.Put([]byte("foo1"), []byte("bar11"))
+	select {
+	case ev := <-wa.Event():
+		wev := storagepb.Event{
+			Type: storagepb.PUT,
+			Kv: &storagepb.KeyValue{
+				Key:            []byte("foo1"),
+				Value:          []byte("bar11"),
+				CreateRevision: 2,
+				ModRevision:    3,
+				Version:        2,
+			},
+		}
+		if !reflect.DeepEqual(ev, wev) {
+			t.Errorf("watched event = %+v, want %+v", ev, wev)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("failed to watch the event")
+	}
+
+	select {
+	case ev := <-wa.Event():
+		if !reflect.DeepEqual(ev, storagepb.Event{}) {
+			t.Errorf("watched event = %+v, want %+v", ev, storagepb.Event{})
+		}
+		if g := wa.Err(); g != ExceedEnd {
+			t.Errorf("err = %+v, want %+v", g, ExceedEnd)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("failed to watch the event")
+	}
+
+}


### PR DESCRIPTION
This is a new pull request following up with:
- https://github.com/coreos/etcd/pull/3575
- https://github.com/coreos/etcd/pull/3577

The goal of this PR is to have prerequisites for `TODO: use map to reduce cancel cost`. 
And please note that `TestWatchableKVWatchWithUnsynced` is just copied from [`kv_test.go`](https://github.com/coreos/etcd/blob/master/storage/kv_test.go#L730-L831).
The only difference is to pass `startRev` not equal to 0, to make it append `watcher` to
its  `unsynced` slice. I would like compare the performance between `map` and `slice`.  This
PR does not change anything on its implementation. 

Also in `BenchmarkKVWatcherMemoryUsageWithUnsynced`, I explicitly set the `startRev` non-zero,
to make use of `unsynced` slice for `watcher`s.

I got up to `15334` entries in the `unsynced` with this benchmark. My machine is `Intel(R)
Core(TM) i7-4750HQ CPU @ 2.00GHz`.

Here's the benchmark result:

```
$ go test -bench=. -benchmem -cpu 1,2,4,8

BenchmarkKVWatcherMemoryUsageWithUnsynced	  500000	      3498 ns/op	     759 B/op	      14 allocs/op
BenchmarkKVWatcherMemoryUsageWithUnsynced-2	  500000	      2535 ns/op	     749 B/op	      14 allocs/op
BenchmarkKVWatcherMemoryUsageWithUnsynced-4	  500000	      2100 ns/op	     657 B/op	      14 allocs/op
BenchmarkKVWatcherMemoryUsageWithUnsynced-8	  500000	      2062 ns/op	     657 B/op	      14 allocs/op

```