### PR TITLE
storage: fix hash by iterating kv

### DIFF
--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"errors"
-	"hash/crc32"
 	"io"
 	"log"
 	"math"
@@ -289,12 +288,8 @@ func (s *store) Compact(rev int64) error {
 }
 
 func (s *store) Hash() (uint32, error) {
-	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
-	_, err := s.Snapshot(h)
-	if err != nil {
-		return 0, err
-	}
-	return h.Sum32(), nil
+	s.b.ForceCommit()
+	return s.b.Hash()
 }
 
 func (s *store) Snapshot(w io.Writer) (int64, error) {

--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -722,6 +722,7 @@ type fakeBackend struct {
 }
 
 func (b *fakeBackend) BatchTx() backend.BatchTx                  { return b.tx }
+func (b *fakeBackend) Hash() (uint32, error)                     { return 0, nil }
 func (b *fakeBackend) Snapshot(w io.Writer) (n int64, err error) { return 0, errors.New("unsupported") }
 func (b *fakeBackend) ForceCommit()                              {}
 func (b *fakeBackend) Close() error                              { return nil }


### PR DESCRIPTION
child buckets are stored in a `map` in-memory during a transaction and iterated over when flushed. there’s no ordering guarantee of maps in Go. so the snapshot data might be different even if the kv are identical. 