### PR TITLE
etcdserver: support RetryMsgProp

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -434,6 +434,9 @@ func (s *EtcdServer) ReportSnapshot(id uint64, status raft.SnapshotStatus) {
 	s.r.ReportSnapshot(id, status)
 }
 
+// RetryMsgProp attempts to propose the data in given message again.
+func (s *EtcdServer) RetryMsgProp(m raftpb.Message) { s.r.retryMsgProp(m) }
+
 func (s *EtcdServer) run() {
 	snap, err := s.r.raftStorage.Snapshot()
 	if err != nil {

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -779,6 +779,7 @@ func TestRecvSnapshot(t *testing.T) {
 	cl := newCluster("abc")
 	cl.SetStore(store.New())
 	s := &EtcdServer{
+		cfg: &ServerConfig{},
 		r: raftNode{
 			Node:        n,
 			transport:   &nopTransporter{},
@@ -814,6 +815,7 @@ func TestApplySnapshotAndCommittedEntries(t *testing.T) {
 	cl.SetStore(store.New())
 	storage := raft.NewMemoryStorage()
 	s := &EtcdServer{
+		cfg: &ServerConfig{},
 		r: raftNode{
 			Node:        n,
 			storage:     &storageRecorder{},
@@ -937,6 +939,7 @@ func TestUpdateMember(t *testing.T) {
 	cl.SetStore(st)
 	cl.AddMember(&Member{ID: 1234})
 	s := &EtcdServer{
+		cfg: &ServerConfig{},
 		r: raftNode{
 			Node:        n,
 			raftStorage: raft.NewMemoryStorage(),
@@ -1311,7 +1314,7 @@ func (n *nodeRecorder) Propose(ctx context.Context, data []byte) error {
 	return nil
 }
 func (n *nodeRecorder) ProposeConfChange(ctx context.Context, conf raftpb.ConfChange) error {
-	n.Record(testutil.Action{Name: "ProposeConfChange"})
+	n.Record(testutil.Action{Name: "ProposeConfChange", Params: []interface{}{conf}})
 	return nil
 }
 func (n *nodeRecorder) Step(ctx context.Context, msg raftpb.Message) error {

--- a/rafthttp/functional_test.go
+++ b/rafthttp/functional_test.go
@@ -152,3 +152,5 @@ func (p *fakeRaft) IsIDRemoved(id uint64) bool { return id == p.removedID }
 func (p *fakeRaft) ReportUnreachable(id uint64) {}
 
 func (p *fakeRaft) ReportSnapshot(id uint64, status raft.SnapshotStatus) {}
+
+func (p *fakeRaft) RetryMsgProp(m raftpb.Message) {}

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/etcdserver/stats"
 	"github.com/coreos/etcd/pkg/types"
-	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
@@ -162,10 +161,7 @@ func startPeer(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID, r
 				select {
 				case writec <- m:
 				default:
-					p.r.ReportUnreachable(m.To)
-					if isMsgSnap(m) {
-						p.r.ReportSnapshot(m.To, raft.SnapshotFailure)
-					}
+					dropMessage(m, r)
 					if status.isActive() {
 						plog.Warningf("dropped %s to %s since %s's sending buffer is full", m.Type, p.id, name)
 					} else {

--- a/rafthttp/pipeline.go
+++ b/rafthttp/pipeline.go
@@ -104,10 +104,7 @@ func (p *pipeline) handle() {
 			if m.Type == raftpb.MsgApp && p.fs != nil {
 				p.fs.Fail()
 			}
-			p.r.ReportUnreachable(m.To)
-			if isMsgSnap(m) {
-				p.r.ReportSnapshot(m.To, raft.SnapshotFailure)
-			}
+			dropMessage(m, p.r)
 		} else {
 			p.status.activate()
 			if m.Type == raftpb.MsgApp && p.fs != nil {

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -164,7 +164,7 @@ func (cw *streamWriter) run() {
 					cw.close()
 					heartbeatc, msgc = nil, nil
 					// TODO: report to raft at peer level
-					cw.r.ReportUnreachable(m.To)
+					dropMessage(m, cw.r)
 				}
 				continue
 			}
@@ -226,10 +226,7 @@ func (cw *streamWriter) close() {
 		return
 	}
 	cw.closer.Close()
-	if len(cw.msgc) > 0 {
-		cw.r.ReportUnreachable(uint64(cw.id))
-	}
-	cw.msgc = make(chan raftpb.Message, streamBufSize)
+	dropMessageChan(cw.msgc, cw.r)
 	cw.working = false
 }
 

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -35,6 +35,7 @@ type Raft interface {
 	IsIDRemoved(id uint64) bool
 	ReportUnreachable(id uint64)
 	ReportSnapshot(id uint64, status raft.SnapshotStatus)
+	RetryMsgProp(m raftpb.Message)
 }
 
 type Transporter interface {

--- a/rafthttp/transport_bench_test.go
+++ b/rafthttp/transport_bench_test.go
@@ -94,6 +94,8 @@ func (r *countRaft) ReportUnreachable(id uint64) {}
 
 func (r *countRaft) ReportSnapshot(id uint64, status raft.SnapshotStatus) {}
 
+func (r *countRaft) RetryMsgProp(m raftpb.Message) {}
+
 func (r *countRaft) count() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
When MsgProp is dropped at rafthttp, raft loop is notified and add it
to the retry queue. When raft loop thinks it is a good time to retry it,
it proposes the data to raft state machine. If it cannot find a good time,
it drops proposals.

I have tested it manually. It works really well, and reduces the number of dropped messages from 12 to 4 in my test. The left 4 dropped because it is hard to tell when stream is broken.

fixes #3380 