### PR TITLE
storage/watchable_store.go: use map for unsynced

### DIFF
--- a/storage/watchable_store_bench_test.go
+++ b/storage/watchable_store_bench_test.go
@@ -1,0 +1,81 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"math/rand"
+	"os"
+	"testing"
+)
+
+// Benchmarks on cancel function performance for unsynced watchers
+// in a WatchableStore. It creates k*N watchers to populate unsynced
+// with a reasonably large number of watchers. And measures the time it
+// takes to cancel N watchers out of k*N watchers. The performance is
+// expected to differ depending on the unsynced member implementation.
+// TODO: k is an arbitrary constant. We need to figure out what factor
+// we should put to simulate the real-world use cases.
+func BenchmarkWatchableStoreUnsyncedCancel(b *testing.B) {
+	const k int = 2
+	benchSampleSize := b.N
+	watcherSize := k * benchSampleSize
+	// manually create watchableStore instead of newWatchableStore
+	// because newWatchableStore periodically calls syncWatchersLoop
+	// method to sync watchers in unsynced map. We want to keep watchers
+	// in unsynced for this benchmark.
+	s := &watchableStore{
+		store:    newStore(tmpPath),
+		unsynced: make(map[*watcher]struct{}),
+
+		// For previous implementation, use:
+		// unsynced: make([]*watcher, 0),
+
+		// to make the test not crash from assigning to nil map.
+		// 'synced' doesn't get populated in this test.
+		synced: make(map[string][]*watcher),
+	}
+
+	defer func() {
+		s.store.Close()
+		os.Remove(tmpPath)
+	}()
+
+	// Put a key so that we can spawn watchers on that key
+	// (testKey in this test). This increases the rev to 1,
+	// and later we can we set the watcher's startRev to 1,
+	// and force watchers to be in unsynced.
+	testKey := []byte("foo")
+	testValue := []byte("bar")
+	s.Put(testKey, testValue)
+
+	cancels := make([]CancelFunc, watcherSize)
+	for i := 0; i < watcherSize; i++ {
+		// non-0 value to keep watchers in unsynced
+		_, cancel := s.Watcher(testKey, true, 1)
+		cancels[i] = cancel
+	}
+
+	// random-cancel N watchers to make it not biased towards
+	// data structures with an order, such as slice.
+	ix := rand.Perm(watcherSize)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	// cancel N watchers
+	for _, idx := range ix[:benchSampleSize] {
+		cancels[idx]()
+	}
+}


### PR DESCRIPTION
This is a new pull request following up with:
- https://github.com/coreos/etcd/pull/3575
- https://github.com/coreos/etcd/pull/3582

And the goal of this PR is, as @yichengq suggests, `use map to reduce cancel cost,
and benchmark its difference`. As you see in my [example benchmark](https://github.com/gyuho/learn/blob/master/doc/go_function_method_pointer_nil_map_slice/slice_vs_map/benchmark_results.txt) [1], theoretically Go map should be faster in
deletion. And current watchable store does deletion in its unsynced slice with
cancel function. So I expected map version to be faster, if not slower:

```
go test -bench='BenchmarkWatchableStoreUnsynced' -benchmem -cpu 1,2,4,8 > slice.txt;

go test -bench='BenchmarkWatchableStoreUnsynced' -benchmem -cpu 1,2,4,8 > map.txt;

go get -v -u golang.org/x/tools/cmd/benchcmp;
benchcmp slice.txt map.txt > benchmark_results.txt;
```

<br>
Results (old is original code with slice, **negative** means `map` version is **faster** than `slice` version):

```
benchmark                              old ns/op     new ns/op     delta
BenchmarkWatchableStoreUnsynced        15358884      8238657       -46.36%
BenchmarkWatchableStoreUnsynced-2      2672428       2701123       +1.07%
BenchmarkWatchableStoreUnsynced-4      2253534       2445470       +8.52%
BenchmarkWatchableStoreUnsynced-8      2139670       2103291       -1.70%

benchmark                              old allocs     new allocs     delta
BenchmarkWatchableStoreUnsynced        10912          10330          -5.33%
BenchmarkWatchableStoreUnsynced-2      9717           9843           +1.30%
BenchmarkWatchableStoreUnsynced-4      10273          10241          -0.31%
BenchmarkWatchableStoreUnsynced-8      9889           7906           -20.05%

benchmark                              old bytes     new bytes     delta
BenchmarkWatchableStoreUnsynced        404238        386040        -4.50%
BenchmarkWatchableStoreUnsynced-2      356543        366115        +2.68%
BenchmarkWatchableStoreUnsynced-4      373095        382577        +2.54%
BenchmarkWatchableStoreUnsynced-8      359913        299902        -16.67%

```

So, my question is:

1. Do you think my benchmark is valid to compare `slice` and `map` in
   watchable store?
2. If not, what would be the best way to test real-life cases for `unsynced`?

Thanks! And please let me know if you have any feedback.

---

1. https://github.com/gyuho/learn/blob/master/doc/go_function_method_pointer_nil_map_slice/slice_vs_map/benchmark_results.txt