### PR TITLE
etcdmain: improve log when join discovery fails

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -160,6 +160,12 @@ func Main() {
 				}
 				os.Exit(1)
 			}
+			if etcdserver.IsDiscoveryError(err) {
+				plog.Errorf("%v", err)
+				plog.Infof("discovery token %s was used, but failed to bootstrap the cluster.", cfg.durl)
+				plog.Infof("please generate a new discovery token and try to bootstrap again.")
+				os.Exit(1)
+			}
 			plog.Fatalf("%v", err)
 		}
 	}

--- a/etcdserver/errors.go
+++ b/etcdserver/errors.go
@@ -16,6 +16,7 @@ package etcdserver
 
 import (
 	"errors"
+	"fmt"
 
 	etcdErr "github.com/coreos/etcd/error"
 )
@@ -37,4 +38,18 @@ var (
 func isKeyNotFound(err error) bool {
 	e, ok := err.(*etcdErr.Error)
 	return ok && e.ErrorCode == etcdErr.EcodeKeyNotFound
+}
+
+type discoveryError struct {
+	op  string
+	err error
+}
+
+func (e discoveryError) Error() string {
+	return fmt.Sprintf("failed to %s discovery cluster (%v)", e.op, e.err)
+}
+
+func IsDiscoveryError(err error) bool {
+	_, ok := err.(*discoveryError)
+	return ok
 }

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -247,7 +247,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 			var err error
 			str, err = discovery.JoinCluster(cfg.DiscoveryURL, cfg.DiscoveryProxy, m.ID, cfg.InitialPeerURLsMap.String())
 			if err != nil {
-				return nil, err
+				return nil, &discoveryError{op: "join", err: err}
 			}
 			urlsmap, err := types.NewURLsMap(str)
 			if err != nil {


### PR DESCRIPTION
[Updated]

Before this PR, the log is

```
2015/09/1 13:18:31 etcdmain: client: etcd cluster is unavailable or
misconfigured
```

It is quite hard for people to understand what happens.

Now we print out the exact reason for the failure, and explains the way
to handle it.

```
2015-09-28 23:22:49.080239 E | etcdmain: failed to join discovery cluster (client: etcd cluster is unavailable or misconfigured)
2015-09-28 23:22:49.080245 I | etcdmain: discovery token http://localhost:5001/v2 was used, but failed to bootstrap the cluster.
2015-09-28 23:22:49.080250 I | etcdmain: please generate a new discovery token and try to bootstrap again.
```

fixes #3423 