### PR TITLE
pkg/transport: fix a data race in TestWriteReadTimeoutListener

### DIFF
--- a/pkg/transport/timeout_listener_test.go
+++ b/pkg/transport/timeout_listener_test.go
@@ -68,18 +68,23 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 
 	// fill the socket buffer
 	data := make([]byte, 5*1024*1024)
-	timer := time.AfterFunc(wln.wtimeoutd*5, func() {
-		t.Fatal("wait timeout")
-	})
-	defer timer.Stop()
+	done := make(chan struct{})
+	go func() {
+		_, err = conn.Write(data)
+		done <- struct{}{}
+	}()
 
-	_, err = conn.Write(data)
+	select {
+	case <-done:
+	case <-time.After(wln.wtimeoutd * 5):
+		t.Fatal("wait timeout")
+	}
+
 	if operr, ok := err.(*net.OpError); !ok || operr.Op != "write" || !operr.Timeout() {
 		t.Errorf("err = %v, want write i/o timeout error", err)
 	}
 	stop <- struct{}{}
 
-	timer.Reset(wln.rdtimeoutd * 5)
 	go blocker()
 
 	conn, err = wln.Accept()
@@ -87,7 +92,18 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 		t.Fatalf("unexpected accept error: %v", err)
 	}
 	buf := make([]byte, 10)
-	_, err = conn.Read(buf)
+
+	go func() {
+		_, err = conn.Read(buf)
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(wln.rdtimeoutd * 5):
+		t.Fatal("wait timeout")
+	}
+
 	if operr, ok := err.(*net.OpError); !ok || operr.Op != "read" || !operr.Timeout() {
 		t.Errorf("err = %v, want write i/o timeout error", err)
 	}


### PR DESCRIPTION
We cannot access test.T async which causes the data race.

Change to use select to coordinate the access of test.T. 