### PR TITLE
etcdhttp/auth: BasicAuth method in standard pkg

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -141,7 +141,6 @@ func Main() {
 			plog.Errorf("But etcd could not find valid cluster configuration in the given data dir (%s).", cfg.dir)
 			plog.Infof("Please check the given data dir path if the previous bootstrap succeeded")
 			plog.Infof("or use a new discovery token if the previous bootstrap failed.")
-			os.Exit(1)
 		case discovery.ErrDuplicateName:
 			plog.Errorf("member with duplicated name has registered with discovery service token(%s).", cfg.durl)
 			plog.Errorf("please check (cURL) the discovery token for more information.")
@@ -162,6 +161,7 @@ func Main() {
 			}
 			plog.Fatalf("%v", err)
 		}
+		os.Exit(1)
 	}
 
 	osutil.HandleInterrupts()

--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -381,6 +381,7 @@ func serveVersion(w http.ResponseWriter, r *http.Request, clusterV string) {
 		Cluster: clusterV,
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	b, err := json.Marshal(&vs)
 	if err != nil {
 		plog.Panicf("cannot marshal versions to json (%v)", err)

--- a/etcdserver/etcdhttp/client_auth.go
+++ b/etcdserver/etcdhttp/client_auth.go
@@ -126,9 +126,11 @@ func hasGuestAccess(sec auth.Store, r *http.Request, key string) bool {
 	return false
 }
 
-func writeNoAuth(w http.ResponseWriter) {
+func writeNoAuth(w http.ResponseWriter, r *http.Request) {
 	herr := httptypes.NewHTTPError(http.StatusUnauthorized, "Insufficient credentials")
-	herr.WriteTo(w)
+	if err := herr.WriteTo(w); err != nil {
+		plog.Debugf("error writing HTTPError (%v) to %s", err, r.RemoteAddr)
+	}
 }
 
 func handleAuth(mux *http.ServeMux, sh *authHandler) {
@@ -144,7 +146,7 @@ func (sh *authHandler) baseRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !hasRootAccess(sh.sec, r) {
-		writeNoAuth(w)
+		writeNoAuth(w, r)
 		return
 	}
 
@@ -153,7 +155,7 @@ func (sh *authHandler) baseRoles(w http.ResponseWriter, r *http.Request) {
 
 	roles, err := sh.sec.AllRoles()
 	if err != nil {
-		writeError(w, err)
+		writeError(w, r, err)
 		return
 	}
 	if roles == nil {
@@ -162,7 +164,7 @@ func (sh *authHandler) baseRoles(w http.ResponseWriter, r *http.Request) {
 
 	err = r.ParseForm()
 	if err != nil {
-		writeError(w, err)
+		writeError(w, r, err)
 		return
 	}
 
@@ -173,7 +175,7 @@ func (sh *authHandler) baseRoles(w http.ResponseWriter, r *http.Request) {
 		var role auth.Role
 		role, err = sh.sec.GetRole(roleName)
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 		rolesCollections.Roles = append(rolesCollections.Roles, role)
@@ -182,7 +184,7 @@ func (sh *authHandler) baseRoles(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		plog.Warningf("baseRoles error encoding on %s", r.URL)
-		writeError(w, err)
+		writeError(w, r, err)
 		return
 	}
 }
@@ -197,7 +199,7 @@ func (sh *authHandler) handleRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(pieces) != 3 {
-		writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, "Invalid path"))
+		writeError(w, r, httptypes.NewHTTPError(http.StatusBadRequest, "Invalid path"))
 		return
 	}
 	sh.forRole(w, r, pieces[2])
@@ -208,7 +210,7 @@ func (sh *authHandler) forRole(w http.ResponseWriter, r *http.Request, role stri
 		return
 	}
 	if !hasRootAccess(sh.sec, r) {
-		writeNoAuth(w)
+		writeNoAuth(w, r)
 		return
 	}
 	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
@@ -218,7 +220,7 @@ func (sh *authHandler) forRole(w http.ResponseWriter, r *http.Request, role stri
 	case "GET":
 		data, err := sh.sec.GetRole(role)
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 		err = json.NewEncoder(w).Encode(data)
@@ -231,11 +233,11 @@ func (sh *authHandler) forRole(w http.ResponseWriter, r *http.Request, role stri
 		var in auth.Role
 		err := json.NewDecoder(r.Body).Decode(&in)
 		if err != nil {
-			writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, "Invalid JSON in request body."))
+			writeError(w, r, httptypes.NewHTTPError(http.StatusBadRequest, "Invalid JSON in request body."))
 			return
 		}
 		if in.Role != role {
-			writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, "Role JSON name does not match the name in the URL"))
+			writeError(w, r, httptypes.NewHTTPError(http.StatusBadRequest, "Role JSON name does not match the name in the URL"))
 			return
 		}
 
@@ -245,19 +247,19 @@ func (sh *authHandler) forRole(w http.ResponseWriter, r *http.Request, role stri
 		if in.Grant.IsEmpty() && in.Revoke.IsEmpty() {
 			err = sh.sec.CreateRole(in)
 			if err != nil {
-				writeError(w, err)
+				writeError(w, r, err)
 				return
 			}
 			w.WriteHeader(http.StatusCreated)
 			out = in
 		} else {
 			if !in.Permissions.IsEmpty() {
-				writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, "Role JSON contains both permissions and grant/revoke"))
+				writeError(w, r, httptypes.NewHTTPError(http.StatusBadRequest, "Role JSON contains both permissions and grant/revoke"))
 				return
 			}
 			out, err = sh.sec.UpdateRole(in)
 			if err != nil {
-				writeError(w, err)
+				writeError(w, r, err)
 				return
 			}
 			w.WriteHeader(http.StatusOK)
@@ -272,7 +274,7 @@ func (sh *authHandler) forRole(w http.ResponseWriter, r *http.Request, role stri
 	case "DELETE":
 		err := sh.sec.DeleteRole(role)
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 	}
@@ -288,7 +290,7 @@ func (sh *authHandler) baseUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !hasRootAccess(sh.sec, r) {
-		writeNoAuth(w)
+		writeNoAuth(w, r)
 		return
 	}
 	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
@@ -296,7 +298,7 @@ func (sh *authHandler) baseUsers(w http.ResponseWriter, r *http.Request) {
 
 	users, err := sh.sec.AllUsers()
 	if err != nil {
-		writeError(w, err)
+		writeError(w, r, err)
 		return
 	}
 	if users == nil {
@@ -305,7 +307,7 @@ func (sh *authHandler) baseUsers(w http.ResponseWriter, r *http.Request) {
 
 	err = r.ParseForm()
 	if err != nil {
-		writeError(w, err)
+		writeError(w, r, err)
 		return
 	}
 
@@ -316,7 +318,7 @@ func (sh *authHandler) baseUsers(w http.ResponseWriter, r *http.Request) {
 		var user auth.User
 		user, err = sh.sec.GetUser(userName)
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 
@@ -325,7 +327,7 @@ func (sh *authHandler) baseUsers(w http.ResponseWriter, r *http.Request) {
 			var role auth.Role
 			role, err = sh.sec.GetRole(roleName)
 			if err != nil {
-				writeError(w, err)
+				writeError(w, r, err)
 				return
 			}
 			uwr.Roles = append(uwr.Roles, role)
@@ -337,7 +339,7 @@ func (sh *authHandler) baseUsers(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		plog.Warningf("baseUsers error encoding on %s", r.URL)
-		writeError(w, err)
+		writeError(w, r, err)
 		return
 	}
 }
@@ -352,7 +354,7 @@ func (sh *authHandler) handleUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(pieces) != 3 {
-		writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, "Invalid path"))
+		writeError(w, r, httptypes.NewHTTPError(http.StatusBadRequest, "Invalid path"))
 		return
 	}
 	sh.forUser(w, r, pieces[2])
@@ -363,7 +365,7 @@ func (sh *authHandler) forUser(w http.ResponseWriter, r *http.Request, user stri
 		return
 	}
 	if !hasRootAccess(sh.sec, r) {
-		writeNoAuth(w)
+		writeNoAuth(w, r)
 		return
 	}
 	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
@@ -373,13 +375,13 @@ func (sh *authHandler) forUser(w http.ResponseWriter, r *http.Request, user stri
 	case "GET":
 		u, err := sh.sec.GetUser(user)
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 
 		err = r.ParseForm()
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 
@@ -388,7 +390,7 @@ func (sh *authHandler) forUser(w http.ResponseWriter, r *http.Request, user stri
 			var role auth.Role
 			role, err = sh.sec.GetRole(roleName)
 			if err != nil {
-				writeError(w, err)
+				writeError(w, r, err)
 				return
 			}
 			uwr.Roles = append(uwr.Roles, role)
@@ -404,11 +406,11 @@ func (sh *authHandler) forUser(w http.ResponseWriter, r *http.Request, user stri
 		var u auth.User
 		err := json.NewDecoder(r.Body).Decode(&u)
 		if err != nil {
-			writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, "Invalid JSON in request body."))
+			writeError(w, r, httptypes.NewHTTPError(http.StatusBadRequest, "Invalid JSON in request body."))
 			return
 		}
 		if u.User != user {
-			writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, "User JSON name does not match the name in the URL"))
+			writeError(w, r, httptypes.NewHTTPError(http.StatusBadRequest, "User JSON name does not match the name in the URL"))
 			return
 		}
 
@@ -428,18 +430,18 @@ func (sh *authHandler) forUser(w http.ResponseWriter, r *http.Request, user stri
 			}
 
 			if err != nil {
-				writeError(w, err)
+				writeError(w, r, err)
 				return
 			}
 		} else {
 			// update case
 			if len(u.Roles) != 0 {
-				writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, "User JSON contains both roles and grant/revoke"))
+				writeError(w, r, httptypes.NewHTTPError(http.StatusBadRequest, "User JSON contains both roles and grant/revoke"))
 				return
 			}
 			out, err = sh.sec.UpdateUser(u)
 			if err != nil {
-				writeError(w, err)
+				writeError(w, r, err)
 				return
 			}
 		}
@@ -461,7 +463,7 @@ func (sh *authHandler) forUser(w http.ResponseWriter, r *http.Request, user stri
 	case "DELETE":
 		err := sh.sec.DeleteUser(user)
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 	}
@@ -476,7 +478,7 @@ func (sh *authHandler) enableDisable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !hasWriteRootAccess(sh.sec, r) {
-		writeNoAuth(w)
+		writeNoAuth(w, r)
 		return
 	}
 	w.Header().Set("X-Etcd-Cluster-ID", sh.cluster.ID().String())
@@ -492,13 +494,13 @@ func (sh *authHandler) enableDisable(w http.ResponseWriter, r *http.Request) {
 	case "PUT":
 		err := sh.sec.EnableAuth()
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 	case "DELETE":
 		err := sh.sec.DisableAuth()
 		if err != nil {
-			writeError(w, err)
+			writeError(w, r, err)
 			return
 		}
 	}

--- a/etcdserver/etcdhttp/client_auth.go
+++ b/etcdserver/etcdhttp/client_auth.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/auth"
 	"github.com/coreos/etcd/etcdserver/etcdhttp/httptypes"
-	"github.com/coreos/etcd/pkg/netutil"
 )
 
 type authHandler struct {
@@ -46,7 +45,7 @@ func hasRootAccess(sec auth.Store, r *http.Request) bool {
 	if !sec.AuthEnabled() {
 		return true
 	}
-	username, password, ok := netutil.BasicAuth(r)
+	username, password, ok := r.BasicAuth()
 	if !ok {
 		return false
 	}
@@ -80,7 +79,7 @@ func hasKeyPrefixAccess(sec auth.Store, r *http.Request, key string, recursive b
 		plog.Warningf("auth: no authorization provided, checking guest access")
 		return hasGuestAccess(sec, r, key)
 	}
-	username, password, ok := netutil.BasicAuth(r)
+	username, password, ok := r.BasicAuth()
 	if !ok {
 		plog.Warningf("auth: malformed basic auth encoding")
 		return false

--- a/etcdserver/etcdhttp/client_test.go
+++ b/etcdserver/etcdhttp/client_test.go
@@ -1341,6 +1341,9 @@ func TestServeVersion(t *testing.T) {
 	if g := rw.Body.String(); g != string(w) {
 		t.Fatalf("body = %q, want %q", g, string(w))
 	}
+	if ct := rw.HeaderMap.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("contet-type header = %s, want %s", ct, "application/json")
+	}
 }
 
 func TestServeVersionFails(t *testing.T) {

--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -81,7 +81,8 @@ func (fs *errServer) ClusterVersion() *semver.Version { return nil }
 func TestWriteError(t *testing.T) {
 	// nil error should not panic
 	rec := httptest.NewRecorder()
-	writeError(rec, nil)
+	r := new(http.Request)
+	writeError(rec, r, nil)
 	h := rec.Header()
 	if len(h) > 0 {
 		t.Fatalf("unexpected non-empty headers: %#v", h)
@@ -114,7 +115,7 @@ func TestWriteError(t *testing.T) {
 
 	for i, tt := range tests {
 		rw := httptest.NewRecorder()
-		writeError(rw, tt.err)
+		writeError(rw, r, tt.err)
 		if code := rw.Code; code != tt.wcode {
 			t.Errorf("#%d: code=%d, want %d", i, code, tt.wcode)
 		}

--- a/etcdserver/etcdhttp/httptypes/errors.go
+++ b/etcdserver/etcdhttp/httptypes/errors.go
@@ -35,15 +35,17 @@ func (e HTTPError) Error() string {
 	return e.Message
 }
 
-// TODO(xiangli): handle http write errors
-func (e HTTPError) WriteTo(w http.ResponseWriter) {
+func (e HTTPError) WriteTo(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(e.Code)
 	b, err := json.Marshal(e)
 	if err != nil {
 		plog.Panicf("marshal HTTPError should never fail (%v)", err)
 	}
-	w.Write(b)
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	return nil
 }
 
 func NewHTTPError(code int, m string) *HTTPError {

--- a/etcdserver/etcdhttp/httptypes/errors_test.go
+++ b/etcdserver/etcdhttp/httptypes/errors_test.go
@@ -24,7 +24,9 @@ import (
 func TestHTTPErrorWriteTo(t *testing.T) {
 	err := NewHTTPError(http.StatusBadRequest, "what a bad request you made!")
 	rr := httptest.NewRecorder()
-	err.WriteTo(rr)
+	if e := err.WriteTo(rr); e != nil {
+		t.Fatalf("HTTPError.WriteTo error (%v)", e)
+	}
 
 	wcode := http.StatusBadRequest
 	wheader := http.Header(map[string][]string{

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -15,13 +15,10 @@
 package netutil
 
 import (
-	"encoding/base64"
 	"net"
-	"net/http"
 	"net/url"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	"github.com/coreos/etcd/pkg/types"
@@ -117,37 +114,4 @@ func URLStringsEqual(a []string, b []string) bool {
 	}
 
 	return urlsEqual(urlsA, urlsB)
-}
-
-// BasicAuth returns the username and password provided in the request's
-// Authorization header, if the request uses HTTP Basic Authentication.
-// See RFC 2617, Section 2.
-// Based on the BasicAuth method from the Golang standard lib.
-// TODO: use the standard lib BasicAuth method when we move to Go 1.4.
-func BasicAuth(r *http.Request) (username, password string, ok bool) {
-	auth := r.Header.Get("Authorization")
-	if auth == "" {
-		return
-	}
-	return parseBasicAuth(auth)
-}
-
-// parseBasicAuth parses an HTTP Basic Authentication string.
-// "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" returns ("Aladdin", "open sesame", true).
-// Taken from the Golang standard lib.
-// TODO: use the standard lib BasicAuth method when we move to Go 1.4.
-func parseBasicAuth(auth string) (username, password string, ok bool) {
-	if !strings.HasPrefix(auth, "Basic ") {
-		return
-	}
-	c, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
-	if err != nil {
-		return
-	}
-	cs := string(c)
-	s := strings.IndexByte(cs, ':')
-	if s < 0 {
-		return
-	}
-	return cs[:s], cs[s+1:], true
 }

--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -33,8 +33,7 @@ type watchableStore struct {
 	KV
 
 	// contains all unsynced watchers that needs to sync events that have happened
-	// TODO: use map to reduce cancel cost
-	unsynced []*watcher
+	unsynced map[*watcher]struct{}
 	// contains all synced watchers that are tracking the events that will happen
 	// The key of the map is the key that the watcher is watching on.
 	synced map[string][]*watcher
@@ -49,10 +48,11 @@ type watchableStore struct {
 
 func newWatchableStore(path string) *watchableStore {
 	s := &watchableStore{
-		KV:     newStore(path),
-		synced: make(map[string][]*watcher),
-		endm:   make(map[int64][]*watcher),
-		stopc:  make(chan struct{}),
+		KV:       newStore(path),
+		unsynced: make(map[*watcher]struct{}),
+		synced:   make(map[string][]*watcher),
+		endm:     make(map[int64][]*watcher),
+		stopc:    make(chan struct{}),
 	}
 	s.wg.Add(1)
 	go s.syncWatchersLoop()
@@ -172,7 +172,7 @@ func (s *watchableStore) Watcher(key []byte, prefix bool, startRev, endRev int64
 			s.endm[endRev] = append(s.endm[endRev], wa)
 		}
 	} else {
-		s.unsynced = append(s.unsynced, wa)
+		s.unsynced[wa] = struct{}{}
 	}
 
 	cancel := CancelFunc(func() {
@@ -181,11 +181,9 @@ func (s *watchableStore) Watcher(key []byte, prefix bool, startRev, endRev int64
 		wa.stopWithError(ErrCanceled)
 
 		// remove global references of the watcher
-		for i, w := range s.unsynced {
-			if w == wa {
-				s.unsynced = append(s.unsynced[:i], s.unsynced[i+1:]...)
-				return
-			}
+		if _, ok := s.unsynced[wa]; ok {
+			delete(s.unsynced, wa)
+			return
 		}
 
 		for i, w := range s.synced[k] {
@@ -227,10 +225,8 @@ func (s *watchableStore) syncWatchersLoop() {
 func (s *watchableStore) syncWatchers() {
 	_, curRev, _ := s.KV.Range(nil, nil, 0, 0)
 
-	// filtering without allocating
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	nws := s.unsynced[:0]
-	for _, w := range s.unsynced {
+	nws := make(map[*watcher]struct{})
+	for w := range s.unsynced {
 		var end []byte
 		if w.prefix {
 			end = make([]byte, len(w.key))
@@ -240,7 +236,7 @@ func (s *watchableStore) syncWatchers() {
 		limit := cap(w.ch) - len(w.ch)
 		// the channel is full, try it in the next round
 		if limit == 0 {
-			nws = append(nws, w)
+			nws[w] = struct{}{}
 			continue
 		}
 		evs, nextRev, err := s.KV.(*store).RangeEvents(w.key, end, int64(limit), w.cur, w.end)
@@ -268,7 +264,7 @@ func (s *watchableStore) syncWatchers() {
 		}
 		// put it back to try it in the next round
 		w.cur = nextRev
-		nws = append(nws, w)
+		nws[w] = struct{}{}
 	}
 	s.unsynced = nws
 }
@@ -305,7 +301,7 @@ func (s *watchableStore) notify(rev int64, ev storagepb.Event) {
 					}
 				}
 				w.cur = rev
-				s.unsynced = append(s.unsynced, w)
+				s.unsynced[w] = struct{}{}
 			}
 		}
 		s.synced[string(ev.Kv.Key[:i])] = nws

--- a/storage/watchable_store_bench_test.go
+++ b/storage/watchable_store_bench_test.go
@@ -1,0 +1,87 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkWatchableStoreUnsyncedCancel(b *testing.B) {
+	s := newWatchableStore(tmpPath)
+	defer cleanup(s, tmpPath)
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Put 1042 keys
+		keys := [][]byte{}
+		for j := 0; j < 1042; j++ {
+			k := []byte(fmt.Sprint("foo", i))
+			s.Put(k, []byte("bar"))
+			keys = append(keys, k)
+		}
+		cancels := []func(){}
+		// First populate unsynced watchers
+		for _, k := range keys {
+			_, cancel := s.Watcher(k, true, -1, 0)
+			cancels = append(cancels, cancel)
+		}
+		// then cancel one by one, asynchronously
+		done := make(chan struct{})
+		for _, cancel := range cancels {
+			go func(cancel func()) {
+				cancel()
+				done <- struct{}{}
+			}(cancel)
+		}
+		cn := 0
+		for range done {
+			cn++
+			if cn == len(cancels) {
+				close(done)
+			}
+		}
+	}
+}
+
+func BenchmarkWatchableStoreUnsyncedCancelSequential(b *testing.B) {
+	s := newWatchableStore(tmpPath)
+	defer cleanup(s, tmpPath)
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Put 1042 keys
+		keys := [][]byte{}
+		for j := 0; j < 1042; j++ {
+			k := []byte(fmt.Sprint("foo", i))
+			s.Put(k, []byte("bar"))
+			keys = append(keys, k)
+		}
+		cancels := []func(){}
+		// First populate unsynced watchers
+		for _, k := range keys {
+			_, cancel := s.Watcher(k, true, -1, 0)
+			cancels = append(cancels, cancel)
+		}
+		// then cancel one by one, sequentially
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}
+}


### PR DESCRIPTION
This is for `TODO: use the standard lib BasicAuth method when we move to
Go 1.4.` [1]. `BasicAuth` method got into Go standard package a year ago. [2] 

If `etcd` uses Go 1.4 or later, we should switch to standard package one.

Thanks and have a great weekend.

---
1. https://github.com/coreos/etcd/blob/master/pkg/netutil/netutil.go#L126-L138
2. https://codereview.appspot.com/76540043/