### PR TITLE
etcdhttp/auth: BasicAuth method in standard pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you're considering etcd for production use, please see: [production-ready.md]
 The easiest way to get etcd is to install one of the pre-built binaries from the tagged releases: instructions are available on [GitHub][github-release].
 
 For those wanting to try the very latest version, you can build the latest version of etcd from the `master` branch.
+You will first need [*Go*](https://golang.org/) installed on your machine (version 1.4+ is required).
 All development occurs on `master`, including new features and bug fixes.
 Bug fixes are first targeted at `master` and subsequently ported to release branches, as described in the [branch management][branch-management] guide.
 

--- a/etcdserver/etcdhttp/client_auth.go
+++ b/etcdserver/etcdhttp/client_auth.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/auth"
 	"github.com/coreos/etcd/etcdserver/etcdhttp/httptypes"
-	"github.com/coreos/etcd/pkg/netutil"
 )
 
 type authHandler struct {
@@ -46,7 +45,7 @@ func hasRootAccess(sec auth.Store, r *http.Request) bool {
 	if !sec.AuthEnabled() {
 		return true
 	}
-	username, password, ok := netutil.BasicAuth(r)
+	username, password, ok := r.BasicAuth()
 	if !ok {
 		return false
 	}
@@ -80,7 +79,7 @@ func hasKeyPrefixAccess(sec auth.Store, r *http.Request, key string, recursive b
 		plog.Warningf("auth: no authorization provided, checking guest access")
 		return hasGuestAccess(sec, r, key)
 	}
-	username, password, ok := netutil.BasicAuth(r)
+	username, password, ok := r.BasicAuth()
 	if !ok {
 		plog.Warningf("auth: malformed basic auth encoding")
 		return false

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -15,13 +15,10 @@
 package netutil
 
 import (
-	"encoding/base64"
 	"net"
-	"net/http"
 	"net/url"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	"github.com/coreos/etcd/pkg/types"
@@ -117,37 +114,4 @@ func URLStringsEqual(a []string, b []string) bool {
 	}
 
 	return urlsEqual(urlsA, urlsB)
-}
-
-// BasicAuth returns the username and password provided in the request's
-// Authorization header, if the request uses HTTP Basic Authentication.
-// See RFC 2617, Section 2.
-// Based on the BasicAuth method from the Golang standard lib.
-// TODO: use the standard lib BasicAuth method when we move to Go 1.4.
-func BasicAuth(r *http.Request) (username, password string, ok bool) {
-	auth := r.Header.Get("Authorization")
-	if auth == "" {
-		return
-	}
-	return parseBasicAuth(auth)
-}
-
-// parseBasicAuth parses an HTTP Basic Authentication string.
-// "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" returns ("Aladdin", "open sesame", true).
-// Taken from the Golang standard lib.
-// TODO: use the standard lib BasicAuth method when we move to Go 1.4.
-func parseBasicAuth(auth string) (username, password string, ok bool) {
-	if !strings.HasPrefix(auth, "Basic ") {
-		return
-	}
-	c, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
-	if err != nil {
-		return
-	}
-	cs := string(c)
-	s := strings.IndexByte(cs, ':')
-	if s < 0 {
-		return
-	}
-	return cs[:s], cs[s+1:], true
 }


### PR DESCRIPTION
I created a new PR from https://github.com/coreos/etcd/pull/3598.
This is for `TODO: use the standard lib BasicAuth method when we move to
Go 1.4.` [1]. `BasicAuth` method got into Go standard package a year ago. [2]

---
1. https://github.com/coreos/etcd/blob/master/pkg/netutil/netutil.go#L126-L138
2. https://codereview.appspot.com/76540043/