### PR TITLE
storage: update KV.Snapshot function

### DIFF
--- a/storage/backend/backend_test.go
+++ b/storage/backend/backend_test.go
@@ -72,8 +72,9 @@ func TestBackendSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = b.Snapshot(f)
-	if err != nil {
+	snap := b.Snapshot()
+	defer snap.Close()
+	if _, err := snap.WriteTo(f); err != nil {
 		t.Fatal(err)
 	}
 	f.Close()

--- a/storage/kv.go
+++ b/storage/kv.go
@@ -15,14 +15,15 @@
 package storage
 
 import (
-	"io"
-
+	"github.com/coreos/etcd/storage/backend"
 	"github.com/coreos/etcd/storage/storagepb"
 )
 
 // CancelFunc tells an operation to abandon its work. A CancelFunc does not
 // wait for the work to stop.
 type CancelFunc func()
+
+type Snapshot backend.Snapshot
 
 type KV interface {
 	// Rev returns the current revision of the KV.
@@ -65,8 +66,8 @@ type KV interface {
 	// This method is designed for consistency checking purpose.
 	Hash() (uint32, error)
 
-	// Write a snapshot to the given io writer
-	Snapshot(w io.Writer) (int64, error)
+	// Snapshot snapshots the full KV store.
+	Snapshot() Snapshot
 
 	Restore() error
 	Close() error

--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -706,7 +706,9 @@ func TestKVSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.Snapshot(f)
+	snap := s.Snapshot()
+	defer snap.Close()
+	_, err = snap.WriteTo(f)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"errors"
-	"io"
 	"log"
 	"math"
 	"math/rand"
@@ -292,9 +291,9 @@ func (s *store) Hash() (uint32, error) {
 	return s.b.Hash()
 }
 
-func (s *store) Snapshot(w io.Writer) (int64, error) {
+func (s *store) Snapshot() Snapshot {
 	s.b.ForceCommit()
-	return s.b.Snapshot(w)
+	return s.b.Snapshot()
 }
 
 func (s *store) Restore() error {

--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -17,8 +17,6 @@ package storage
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"errors"
-	"io"
 	"math"
 	"os"
 	"reflect"
@@ -721,11 +719,11 @@ type fakeBackend struct {
 	tx *fakeBatchTx
 }
 
-func (b *fakeBackend) BatchTx() backend.BatchTx                  { return b.tx }
-func (b *fakeBackend) Hash() (uint32, error)                     { return 0, nil }
-func (b *fakeBackend) Snapshot(w io.Writer) (n int64, err error) { return 0, errors.New("unsupported") }
-func (b *fakeBackend) ForceCommit()                              {}
-func (b *fakeBackend) Close() error                              { return nil }
+func (b *fakeBackend) BatchTx() backend.BatchTx   { return b.tx }
+func (b *fakeBackend) Hash() (uint32, error)      { return 0, nil }
+func (b *fakeBackend) Snapshot() backend.Snapshot { return nil }
+func (b *fakeBackend) ForceCommit()               {}
+func (b *fakeBackend) Close() error               { return nil }
 
 type indexGetResp struct {
 	rev     revision


### PR DESCRIPTION
[Updated]

When using Snapshot function, it is expected:
1. know the size of snapshot before writing data
2. split snapshot-ready phase and write-data phase. so we could cut
snapshot first and write data later.

Update its interface to fit the requirement of etcdserver.

for #3549 