### PR TITLE
raft: kill TODO about behavior when snapshot fails

### DIFF
--- a/raft/storage.go
+++ b/raft/storage.go
@@ -57,6 +57,9 @@ type Storage interface {
 	// first log entry is not available).
 	FirstIndex() (uint64, error)
 	// Snapshot returns the most recent snapshot.
+	// If snapshot is temporarily unavailable, it should return ErrTemporarilyUnavailable,
+	// so raft state machine could know that Storage needs some time to prepare
+	// snapshot and call Snapshot later.
 	Snapshot() (pb.Snapshot, error)
 }
 


### PR DESCRIPTION
etcd is going to support incremental snapshot, and we design to let it
send at most one snapshot out at first stage. So when one snapshot is in
flight, snapshot request will return error.

When failing to get snapshot when sending MsgSnap, raft prints out
related log and abort sending message.

/cc @xiang90 @bdarnell 

for #3549 