### PR TITLE
etcdctl: use a context with -total-timeout in simple commands

### DIFF
--- a/etcdctl/command/get_command.go
+++ b/etcdctl/command/get_command.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -47,7 +46,9 @@ func getCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	key := c.Args()[0]
 	sorted := c.Bool("sort")
 
-	resp, err := ki.Get(context.TODO(), key, &client.GetOptions{Sort: sorted})
+	ctx, cancel := contextWithTotalTimeout(c)
+	resp, err := ki.Get(ctx, key, &client.GetOptions{Sort: sorted})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/etcdctl/command/ls_command.go
+++ b/etcdctl/command/ls_command.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -47,7 +46,9 @@ func lsCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	sort := c.Bool("sort")
 	recursive := c.Bool("recursive")
 
-	resp, err := ki.Get(context.TODO(), key, &client.GetOptions{Sort: sort, Recursive: recursive})
+	ctx, cancel := contextWithTotalTimeout(c)
+	resp, err := ki.Get(ctx, key, &client.GetOptions{Sort: sort, Recursive: recursive})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/etcdctl/command/mk_command.go
+++ b/etcdctl/command/mk_command.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -51,7 +50,9 @@ func mkCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	ttl := c.Int("ttl")
 
-	resp, err := ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevIgnore})
+	ctx, cancel := contextWithTotalTimeout(c)
+	resp, err := ki.Set(ctx, key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevIgnore})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/etcdctl/command/mkdir_command.go
+++ b/etcdctl/command/mkdir_command.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -46,7 +45,9 @@ func mkdirCommandFunc(c *cli.Context, ki client.KeysAPI, prevExist client.PrevEx
 	key := c.Args()[0]
 	ttl := c.Int("ttl")
 
-	_, err := ki.Set(context.TODO(), key, "", &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: prevExist})
+	ctx, cancel := contextWithTotalTimeout(c)
+	_, err := ki.Set(ctx, key, "", &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: prevExist})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/etcdctl/command/rm_command.go
+++ b/etcdctl/command/rm_command.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -50,7 +49,9 @@ func rmCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	prevValue := c.String("with-value")
 	prevIndex := c.Int("with-index")
 
-	resp, err := ki.Delete(context.TODO(), key, &client.DeleteOptions{PrevIndex: uint64(prevIndex), PrevValue: prevValue, Dir: dir, Recursive: recursive})
+	ctx, cancel := contextWithTotalTimeout(c)
+	resp, err := ki.Delete(ctx, key, &client.DeleteOptions{PrevIndex: uint64(prevIndex), PrevValue: prevValue, Dir: dir, Recursive: recursive})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/etcdctl/command/rmdir_command.go
+++ b/etcdctl/command/rmdir_command.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -40,7 +39,9 @@ func rmdirCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	}
 	key := c.Args()[0]
 
-	resp, err := ki.Delete(context.TODO(), key, &client.DeleteOptions{Dir: true})
+	ctx, cancel := contextWithTotalTimeout(c)
+	resp, err := ki.Delete(ctx, key, &client.DeleteOptions{Dir: true})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/etcdctl/command/set_command.go
+++ b/etcdctl/command/set_command.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -55,7 +54,9 @@ func setCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	prevValue := c.String("swap-with-value")
 	prevIndex := c.Int("swap-with-index")
 
-	resp, err := ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevIndex: uint64(prevIndex), PrevValue: prevValue})
+	ctx, cancel := contextWithTotalTimeout(c)
+	resp, err := ki.Set(ctx, key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevIndex: uint64(prevIndex), PrevValue: prevValue})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/etcdctl/command/update_command.go
+++ b/etcdctl/command/update_command.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -51,7 +50,9 @@ func updateCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	ttl := c.Int("ttl")
 
-	resp, err := ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevExist})
+	ctx, cancel := contextWithTotalTimeout(c)
+	resp, err := ki.Set(ctx, key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevExist})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/etcdctl/command/update_dir_command.go
+++ b/etcdctl/command/update_dir_command.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/client"
 )
 
@@ -51,7 +50,9 @@ func updatedirCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	ttl := c.Int("ttl")
 
-	_, err = ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: client.PrevExist})
+	ctx, cancel := contextWithTotalTimeout(c)
+	_, err = ki.Set(ctx, key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: client.PrevExist})
+	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
 	}


### PR DESCRIPTION
Like the commit 8ebc9331111, this commit lets simple etcdctl commands
use a context with timeout value passed via -total-timeout.

This commit doesn't change complex commands like watch,
cluster-health, and import because it is not obvious that using the
context in the commands is good or not.