### PR TITLE
docs/other_apis: add back quote for HTTP response code

### DIFF
--- a/Documentation/other_apis.md
+++ b/Documentation/other_apis.md
@@ -7,7 +7,7 @@
 
 ## List members
 
-Return an HTTP 200 OK response code and a representation of all members in the etcd cluster.
+Return an `HTTP 200` OK response code and a representation of all members in the etcd cluster.
 
 ### Request
 
@@ -50,9 +50,9 @@ curl http://10.0.0.10:2379/v2/members
 
 ## Add a member
 
-Returns an HTTP 201 response code and the representation of added member with a newly generated a memberID when successful. Returns a string describing the failure condition when unsuccessful. 
+Returns an `HTTP 201` response code and the representation of added member with a newly generated memberID when successful. Returns a string describing the failure condition when unsuccessful. 
 
-If the POST body is malformed an HTTP 400 will be returned. If the member exists in the cluster or existed in the cluster at some point in the past an HTTP 409 will be returned. If any of the given peerURLs exists in the cluster an HTTP 409 will be returned. If the cluster fails to process the request within timeout an HTTP 500 will be returned, though the request may be processed later.
+If the POST body is malformed an `HTTP 400` will be returned. If the member exists in the cluster or existed in the cluster at some point in the past an `HTTP 409` will be returned. If any of the given peerURLs exists in the cluster an `HTTP 409` will be returned. If the cluster fails to process the request within timeout an `HTTP 500` will be returned, though the request may be processed later.
 
 ### Request
 
@@ -81,9 +81,9 @@ curl http://10.0.0.10:2379/v2/members -XPOST \
 ## Delete a member
 
 Remove a member from the cluster. The member ID must be a hex-encoded uint64.
-Returns 204 with empty content when successful. Returns a string describing the failure condition when unsuccessful. 
+Returns `HTTP 204` with empty content when successful. Returns a string describing the failure condition when unsuccessful. 
 
-If the member does not exist in the cluster an HTTP 500(TODO: fix this) will be returned. If the cluster fails to process the request within timeout an HTTP 500 will be returned, though the request may be processed later.
+If the member does not exist in the cluster an `HTTP 500`(TODO: fix this) will be returned. If the cluster fails to process the request within timeout an `HTTP 500` will be returned, though the request may be processed later.
 
 ### Request
 
@@ -99,9 +99,9 @@ curl http://10.0.0.10:2379/v2/members/272e204152 -XDELETE
 
 ## Change the peer urls of a member
 
-Change the peer urls of a given member. The member ID must be a hex-encoded uint64. Returns 204 with empty content when successful. Returns a string describing the failure condition when unsuccessful.
+Change the peer urls of a given member. The member ID must be a hex-encoded uint64. Returns `HTTP 204` with empty content when successful. Returns a string describing the failure condition when unsuccessful.
 
-If the POST body is malformed an HTTP 400 will be returned. If the member does not exist in the cluster an HTTP 404 will be returned. If any of the given peerURLs exists in the cluster an HTTP 409 will be returned. If the cluster fails to process the request within timeout an HTTP 500 will be returned, though the request may be processed later.
+If the POST body is malformed an `HTTP 400` will be returned. If the member does not exist in the cluster an `HTTP 404` will be returned. If any of the given peerURLs exists in the cluster an `HTTP 409` will be returned. If the cluster fails to process the request within timeout an HTTP 500 will be returned, though the request may be processed later.
 
 #### Request
 

--- a/Documentation/other_apis.md
+++ b/Documentation/other_apis.md
@@ -101,7 +101,7 @@ curl http://10.0.0.10:2379/v2/members/272e204152 -XDELETE
 
 Change the peer urls of a given member. The member ID must be a hex-encoded uint64. Returns `HTTP 204` with empty content when successful. Returns a string describing the failure condition when unsuccessful.
 
-If the POST body is malformed an `HTTP 400` will be returned. If the member does not exist in the cluster an `HTTP 404` will be returned. If any of the given peerURLs exists in the cluster an `HTTP 409` will be returned. If the cluster fails to process the request within timeout an HTTP 500 will be returned, though the request may be processed later.
+If the POST body is malformed an `HTTP 400` will be returned. If the member does not exist in the cluster an `HTTP 404` will be returned. If any of the given peerURLs exists in the cluster an `HTTP 409` will be returned. If the cluster fails to process the request within timeout an `HTTP 500` will be returned, though the request may be processed later.
 
 #### Request
 


### PR DESCRIPTION
This PR add back quote for HTTP response code in document