### PR TITLE
etcdmain: print usage in stderr when flag.Parse fail

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -146,7 +146,7 @@ func NewConfig() *config {
 	cfg.FlagSet = flag.NewFlagSet("etcd", flag.ContinueOnError)
 	fs := cfg.FlagSet
 	fs.Usage = func() {
-		fmt.Println(usageline)
+		fmt.Fprintln(os.Stderr, usageline)
 	}
 
 	// member


### PR DESCRIPTION
This fits the requirement of stderr.

I still let `etcd --version` and `etcd --help` print out to stdout
because when users ask explicitly for version/help docs, they expect to see
the doc in stdout.

Ref:
http://www.jstorimer.com/blogs/workingwithcode/7766119-when-to-use-stderr-instead-of-stdout