### PR TITLE
etcdserver: describe how to validate PeerURLs

### DIFF
--- a/etcdserver/member.go
+++ b/etcdserver/member.go
@@ -35,7 +35,7 @@ var (
 
 // RaftAttributes represents the raft related attributes of an etcd member.
 type RaftAttributes struct {
-	// TODO(philips): ensure these are URLs
+	// PeerURLs must be valid URLs.
 	PeerURLs []string `json:"peerURLs"`
 }
 


### PR DESCRIPTION
Here's the list of code that uses `peerURLs` as an argument
or handles it as a string slice:

- https://github.com/coreos/etcd/blob/master/etcdserver/member_test.go#L109
- https://github.com/coreos/etcd/blob/master/client/members.go#L165
- https://github.com/coreos/etcd/blob/master/etcdserver/etcdhttp/httptypes/member.go#L48
- https://github.com/coreos/etcd/blob/master/etcdserver/etcdhttp/client.go#L760

But they are all validated with `types.NewURLs` functions as [here](https://github.com/coreos/etcd/blob/master/etcdserver/etcdhttp/httptypes/member.go#L48-L51). And https://github.com/coreos/etcd/blob/master/etcdserver/member.go#L56 already
uses `types.URLs` type for creating a new member.