### PR TITLE
etcdserver: print out correct restored cluster info

### DIFF
--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -223,6 +223,13 @@ func (c *cluster) Recover() {
 	c.members, c.removed = membersFromStore(c.store)
 	c.version = clusterVersionFromStore(c.store)
 	MustDetectDowngrade(c.version)
+
+	for _, m := range c.members {
+		plog.Infof("added member %s %v to cluster %s from store", m.ID, m.PeerURLs, c.id)
+	}
+	if c.version != nil {
+		plog.Infof("set the cluster version to %v from store", version.Cluster(c.version.String()))
+	}
 }
 
 // ValidateConfigurationChange takes a proposed ConfChange and

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -292,9 +292,6 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 			plog.Infof("recovered store from snapshot at index %d", snapshot.Metadata.Index)
 		}
 		cfg.Print()
-		if snapshot != nil {
-			plog.Infof("loaded cluster information from store: %s", cl)
-		}
 		if !cfg.ForceNewCluster {
 			id, cl, n, s, w = restartNode(cfg, snapshot)
 		} else {


### PR DESCRIPTION
Before this PR, it always prints nil because cluster info has not been
covered when print:

```
2015-10-02 14:00:24.353631 I | etcdserver: loaded cluster information
from store: <nil>
```

After:

```
2015-10-02 14:01:53.320350 I | etcdserver: loaded cluster information
from store: {ClusterID:7e27652122e8b2ae Members:[&{ID:ce2a822cea30bfca
	RaftAttributes:{PeerURLs:[http://localhost:2380
		http://localhost:7001]} Attributes:{Name:default
ClientURLs:[http://localhost:2379 http://localhost:4001]}}]
		   RemovedMemberIDs:[]}
```