### PR TITLE
etcdserver: get existing snapshot instead of requesting one

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -120,6 +120,7 @@ type raftNode struct {
 // TODO: Ideally raftNode should get rid of the passed in server structure.
 func (r *raftNode) start(s *EtcdServer) {
 	r.s = s
+	r.raftStorage.raftStarted = true
 	r.applyc = make(chan apply)
 	r.stopped = make(chan struct{})
 	r.done = make(chan struct{})


### PR DESCRIPTION
This fixes the problem that proposal cannot be applied.

When start the etcdserver.run loop, it expects to get the latest
existing snapshot, but the code doesn't match the expectation. It should not attempt to request one because the loop
is the entity to create the snapshot.