### PR TITLE
Documentation: proxy.md typo, line-breaks

### DIFF
--- a/Documentation/proxy.md
+++ b/Documentation/proxy.md
@@ -1,6 +1,6 @@
 ## Proxy
 
-etcd can now run as a transparent proxy. Running etcd as a proxy allows for easily discovery of etcd within your infrastructure, since it can run on each machine as a local service. In this mode, etcd acts as a reverse proxy and forwards client requests to an active etcd cluster. The etcd proxy does not participate in the consensus replication of the etcd cluster, thus it neither increases the resilience nor decreases the write performance of the etcd cluster.
+etcd can now run as a transparent proxy. Running etcd as a proxy allows for easy discovery of etcd within your infrastructure, since it can run on each machine as a local service. In this mode, etcd acts as a reverse proxy and forwards client requests to an active etcd cluster. The etcd proxy does not participate in the consensus replication of the etcd cluster, thus it neither increases the resilience nor decreases the write performance of the etcd cluster.
 
 etcd currently supports two proxy modes: `readwrite` and `readonly`. The default mode is `readwrite`, which forwards both read and write requests to the etcd cluster. A `readonly` etcd proxy only forwards read requests to the etcd cluster, and returns `HTTP 501` to all write requests. 
 
@@ -19,7 +19,9 @@ The proxy will be listening on `listen-client-urls` and forward requests to the 
 To start a proxy that will connect to a statically defined etcd cluster, specify the `initial-cluster` flag:
 
 ```
-etcd -proxy on -listen-client-urls http://127.0.0.1:8080 -initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380
+etcd -proxy on \
+-listen-client-urls http://127.0.0.1:8080 \
+-initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380
 ```
 
 #### Start an etcd proxy with the discovery service
@@ -28,7 +30,9 @@ If you bootstrap an etcd cluster using the [discovery service][discovery-service
 To start a proxy using the discovery service, specify the `discovery` flag. The proxy will wait until the etcd cluster defined at the `discovery` url finishes bootstrapping, and then start to forward the requests. 
 
 ```
-etcd -proxy on -listen-client-urls http://127.0.0.1:8080 -discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
+etcd -proxy on \
+-listen-client-urls http://127.0.0.1:8080 \
+-discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 ```
 
 #### Fallback to proxy mode with discovery service
@@ -98,7 +102,11 @@ Finally, start the reconfigured member and make sure it joins the cluster correc
 $ export ETCD_NAME="infra1"
 $ export ETCD_INITIAL_CLUSTER="infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380"
 $ export ETCD_INITIAL_CLUSTER_STATE=existing
-$ etcd -listen-client-urls http://10.0.1.11:2379 -advertise-client-urls http://10.0.1.11:2379  -listen-peer-urls http://10.0.1.11:2380 -initial-advertise-peer-urls http://10.0.1.11:2380 -data-dir %data_dir%
+$ etcd -listen-client-urls http://10.0.1.11:2379 \
+-advertise-client-urls http://10.0.1.11:2379 \
+-listen-peer-urls http://10.0.1.11:2380 \
+-initial-advertise-peer-urls http://10.0.1.11:2380 \
+-data-dir %data_dir%
 ```
 
 If you are running etcd under systemd, you should modify the service file with correct configuration and restart the service:


### PR DESCRIPTION
1. I found a little typo (easily -> easy)
2. If you go to https://coreos.com/etcd/docs/2.0.9/proxy.html,
   the proxy flag command is out of width of the web-page. Can
   we have line-breaks between flags to make the command easier
   to read?

Thanks for the great documentation!