### PR TITLE
proxy: check loop with proxyID, endpoint in header

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -17,8 +17,11 @@ package proxy
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/coreos/etcd/pkg/idutil"
 )
 
 const (
@@ -42,9 +45,12 @@ type GetProxyURLs func() []string
 // which will proxy requests to an etcd cluster.
 // The handler will periodically update its view of the cluster.
 func NewHandler(t *http.Transport, urlsFunc GetProxyURLs, failureWait time.Duration, refreshInterval time.Duration) http.Handler {
+	idgen := idutil.NewGenerator(0, time.Now())
+	proxyID := strconv.FormatUint(idgen.Next(), 10)
 	p := &reverseProxy{
 		director:  newDirector(urlsFunc, failureWait, refreshInterval),
 		transport: t,
+		proxyID:   proxyID,
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
This detects proxy loop by passing around proxyID and endpoints in HTTP header.
Once it detects the loop, it updates proxy's endpoints.

Fixes #3317.

(*updated PR description according the most recent commit)