### PR TITLE
rafthttp: support sending v3 snapshot

### DIFF
--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -132,6 +132,12 @@ func (c *ServerConfig) ReqTimeout() time.Duration {
 	return 5*time.Second + 2*time.Duration(c.ElectionTicks)*time.Duration(c.TickMs)*time.Millisecond
 }
 
+// MaxRTT returns maximal round-trip time between etcd members.
+func (c *ServerConfig) MaxRTT() time.Duration {
+	// one RTT is always smaller than one fifth of election timeout
+	return time.Duration(c.ElectionTicks) * time.Duration(c.TickMs) * time.Millisecond / 5
+}
+
 func (c *ServerConfig) PrintWithInitial() { c.print(true) }
 
 func (c *ServerConfig) Print() { c.print(false) }

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -17,6 +17,7 @@ package etcdserver
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 	"reflect"
@@ -1455,14 +1456,16 @@ func (n *readyNode) Ready() <-chan raft.Ready { return n.readyc }
 
 type nopTransporter struct{}
 
-func (s *nopTransporter) Handler() http.Handler               { return nil }
-func (s *nopTransporter) Send(m []raftpb.Message)             {}
-func (s *nopTransporter) AddRemote(id types.ID, us []string)  {}
-func (s *nopTransporter) AddPeer(id types.ID, us []string)    {}
-func (s *nopTransporter) RemovePeer(id types.ID)              {}
-func (s *nopTransporter) RemoveAllPeers()                     {}
-func (s *nopTransporter) UpdatePeer(id types.ID, us []string) {}
-func (s *nopTransporter) ActiveSince(id types.ID) time.Time   { return time.Time{} }
-func (s *nopTransporter) Stop()                               {}
-func (s *nopTransporter) Pause()                              {}
-func (s *nopTransporter) Resume()                             {}
+func (s *nopTransporter) Handler() http.Handler                     { return nil }
+func (s *nopTransporter) Send(m []raftpb.Message)                   {}
+func (s *nopTransporter) SetLocalPeerURLs(us []string)              {}
+func (s *nopTransporter) AddRemote(id types.ID, us []string)        {}
+func (s *nopTransporter) AddPeer(id types.ID, us []string)          {}
+func (s *nopTransporter) RemovePeer(id types.ID)                    {}
+func (s *nopTransporter) RemoveAllPeers()                           {}
+func (s *nopTransporter) UpdatePeer(id types.ID, us []string)       {}
+func (s *nopTransporter) ActiveSince(id types.ID) time.Time         { return time.Time{} }
+func (s *nopTransporter) SnapshotReady(index uint64, w io.WriterTo) {}
+func (s *nopTransporter) Stop()                                     {}
+func (s *nopTransporter) Pause()                                    {}
+func (s *nopTransporter) Resume()                                   {}

--- a/pkg/ioutil/writer.go
+++ b/pkg/ioutil/writer.go
@@ -1,0 +1,22 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ioutil
+
+// ErrWriter always returns error when calling Write method.
+type ErrWriter struct {
+	Err error
+}
+
+func (w *ErrWriter) Write(p []byte) (n int, err error) { return 0, w.Err }

--- a/rafthttp/functional_test.go
+++ b/rafthttp/functional_test.go
@@ -30,14 +30,14 @@ import (
 
 func TestSendMessage(t *testing.T) {
 	// member 1
-	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, newServerStats(), stats.NewLeaderStats("1"))
+	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, nil, newServerStats(), stats.NewLeaderStats("1"), time.Second, false)
 	srv := httptest.NewServer(tr.Handler())
 	defer srv.Close()
 
 	// member 2
 	recvc := make(chan raftpb.Message, 1)
 	p := &fakeRaft{recvc: recvc}
-	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), p, nil, newServerStats(), stats.NewLeaderStats("2"))
+	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), p, nil, nil, newServerStats(), stats.NewLeaderStats("2"), time.Second, false)
 	srv2 := httptest.NewServer(tr2.Handler())
 	defer srv2.Close()
 
@@ -75,14 +75,14 @@ func TestSendMessage(t *testing.T) {
 // remote in a limited time when all underlying connections are broken.
 func TestSendMessageWhenStreamIsBroken(t *testing.T) {
 	// member 1
-	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, newServerStats(), stats.NewLeaderStats("1"))
+	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, nil, newServerStats(), stats.NewLeaderStats("1"), time.Second, false)
 	srv := httptest.NewServer(tr.Handler())
 	defer srv.Close()
 
 	// member 2
 	recvc := make(chan raftpb.Message, 1)
 	p := &fakeRaft{recvc: recvc}
-	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), p, nil, newServerStats(), stats.NewLeaderStats("2"))
+	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), p, nil, nil, newServerStats(), stats.NewLeaderStats("2"), time.Second, false)
 	srv2 := httptest.NewServer(tr2.Handler())
 	defer srv2.Close()
 

--- a/rafthttp/http_test.go
+++ b/rafthttp/http_test.go
@@ -149,7 +149,7 @@ func TestServeRaftPrefix(t *testing.T) {
 		req.Header.Set("X-Etcd-Cluster-ID", tt.clusterID)
 		req.Header.Set("X-Server-Version", version.Version)
 		rw := httptest.NewRecorder()
-		h := NewHandler(tt.p, types.ID(0))
+		h := NewHandler(tt.p, nil, types.ID(0), false)
 		h.ServeHTTP(rw, req)
 		if rw.Code != tt.wcode {
 			t.Errorf("#%d: got code=%d, want %d", i, rw.Code, tt.wcode)

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -111,7 +111,7 @@ type peer struct {
 	done  chan struct{}
 }
 
-func startPeer(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID, r Raft, fs *stats.FollowerStats, errorc chan error, term uint64) *peer {
+func startPeer(tr http.RoundTripper, urls types.URLs, local *member, to, cid types.ID, r Raft, fs *stats.FollowerStats, errorc chan error, term uint64, v3demo bool) *peer {
 	picker := newURLPicker(urls)
 	status := newPeerStatus(to)
 	p := &peer{
@@ -120,7 +120,7 @@ func startPeer(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID, r
 		status:       status,
 		msgAppWriter: startStreamWriter(to, status, fs, r),
 		writer:       startStreamWriter(to, status, fs, r),
-		pipeline:     newPipeline(tr, picker, local, to, cid, status, fs, r, errorc),
+		pipeline:     newPipeline(tr, picker, local, to, cid, status, fs, r, errorc, v3demo),
 		sendc:        make(chan raftpb.Message),
 		recvc:        make(chan raftpb.Message, recvBufSize),
 		propc:        make(chan raftpb.Message, maxPendingProposals),
@@ -148,8 +148,8 @@ func startPeer(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID, r
 		}
 	}()
 
-	p.msgAppReader = startStreamReader(tr, picker, streamTypeMsgAppV2, local, to, cid, status, p.recvc, p.propc, errorc, term)
-	reader := startStreamReader(tr, picker, streamTypeMessage, local, to, cid, status, p.recvc, p.propc, errorc, term)
+	p.msgAppReader = startStreamReader(tr, picker, streamTypeMsgAppV2, local.id, to, cid, status, p.recvc, p.propc, errorc, term)
+	reader := startStreamReader(tr, picker, streamTypeMessage, local.id, to, cid, status, p.recvc, p.propc, errorc, term)
 	go func() {
 		var paused bool
 		for {

--- a/rafthttp/pipeline_test.go
+++ b/rafthttp/pipeline_test.go
@@ -36,7 +36,7 @@ func TestPipelineSend(t *testing.T) {
 	tr := &roundTripperRecorder{}
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
 	fs := &stats.FollowerStats{}
-	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil)
+	p := newPipeline(tr, picker, newMember(types.ID(2)), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil, false)
 
 	p.msgc <- raftpb.Message{Type: raftpb.MsgApp}
 	testutil.WaitSchedule()
@@ -56,7 +56,7 @@ func TestPipelineExceedMaximumServing(t *testing.T) {
 	tr := newRoundTripperBlocker()
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
 	fs := &stats.FollowerStats{}
-	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil)
+	p := newPipeline(tr, picker, newMember(types.ID(2)), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil, false)
 
 	// keep the sender busy and make the buffer full
 	// nothing can go out as we block the sender
@@ -96,7 +96,7 @@ func TestPipelineExceedMaximumServing(t *testing.T) {
 func TestPipelineSendFailed(t *testing.T) {
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
 	fs := &stats.FollowerStats{}
-	p := newPipeline(newRespRoundTripper(0, errors.New("blah")), picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil)
+	p := newPipeline(newRespRoundTripper(0, errors.New("blah")), picker, newMember(types.ID(2)), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), fs, &fakeRaft{}, nil, false)
 
 	p.msgc <- raftpb.Message{Type: raftpb.MsgApp}
 	testutil.WaitSchedule()
@@ -112,7 +112,7 @@ func TestPipelineSendFailed(t *testing.T) {
 func TestPipelinePost(t *testing.T) {
 	tr := &roundTripperRecorder{}
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
-	p := newPipeline(tr, picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, nil)
+	p := newPipeline(tr, picker, newMember(types.ID(2)), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, nil, false)
 	if err := p.post([]byte("some data")); err != nil {
 		t.Fatalf("unexpect post error: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestPipelinePostBad(t *testing.T) {
 	}
 	for i, tt := range tests {
 		picker := mustNewURLPicker(t, []string{tt.u})
-		p := newPipeline(newRespRoundTripper(tt.code, tt.err), picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, make(chan error))
+		p := newPipeline(newRespRoundTripper(tt.code, tt.err), picker, newMember(types.ID(2)), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, make(chan error), false)
 		err := p.post([]byte("some data"))
 		p.stop()
 
@@ -180,7 +180,7 @@ func TestPipelinePostErrorc(t *testing.T) {
 	for i, tt := range tests {
 		picker := mustNewURLPicker(t, []string{tt.u})
 		errorc := make(chan error, 1)
-		p := newPipeline(newRespRoundTripper(tt.code, tt.err), picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, errorc)
+		p := newPipeline(newRespRoundTripper(tt.code, tt.err), picker, newMember(types.ID(2)), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, errorc, false)
 		p.post([]byte("some data"))
 		p.stop()
 		select {
@@ -193,7 +193,7 @@ func TestPipelinePostErrorc(t *testing.T) {
 
 func TestStopBlockedPipeline(t *testing.T) {
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
-	p := newPipeline(newRoundTripperBlocker(), picker, types.ID(2), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, nil)
+	p := newPipeline(newRoundTripperBlocker(), picker, newMember(types.ID(2)), types.ID(1), types.ID(1), newPeerStatus(types.ID(1)), nil, &fakeRaft{}, nil, false)
 	// send many messages that most of them will be blocked in buffer
 	for i := 0; i < connPerPipeline*10; i++ {
 		p.msgc <- raftpb.Message{}

--- a/rafthttp/remote.go
+++ b/rafthttp/remote.go
@@ -27,13 +27,13 @@ type remote struct {
 	pipeline *pipeline
 }
 
-func startRemote(tr http.RoundTripper, urls types.URLs, local, to, cid types.ID, r Raft, errorc chan error) *remote {
+func startRemote(tr http.RoundTripper, urls types.URLs, local *member, to, cid types.ID, r Raft, errorc chan error, v3demo bool) *remote {
 	picker := newURLPicker(urls)
 	status := newPeerStatus(to)
 	return &remote{
 		id:       to,
 		status:   status,
-		pipeline: newPipeline(tr, picker, local, to, cid, status, nil, r, errorc),
+		pipeline: newPipeline(tr, picker, local, to, cid, status, nil, r, errorc, v3demo),
 	}
 }
 

--- a/rafthttp/snapshot.go
+++ b/rafthttp/snapshot.go
@@ -1,0 +1,215 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rafthttp
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/pkg/ioutil"
+	"github.com/coreos/etcd/pkg/types"
+	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+func newSnapshotKeeper(r Raft) *snapshotKeeper {
+	return &snapshotKeeper{r: r}
+}
+
+func newSnapshotProcessor(tr http.RoundTripper, r Raft, snapSaver SnapshotSaver) *snapshotProcessor {
+	return &snapshotProcessor{
+		tr:        tr,
+		r:         r,
+		snapSaver: snapSaver,
+	}
+}
+
+// snapshotKeeper keeps a snapshot for transporter. transporter
+// needs to attach the member ID that the snapshot is sent to
+// as soon as it knows.
+// The kept snapshot can either be released by snapHandler, or
+// be released automatically when it timeout. If snapshot is released
+// automatically, snapshotKeeper also closes the snapshot and
+// reports snapshot failure to raft.
+// snapshotKeeper keeps at most one snapshot at a time.
+type snapshotKeeper struct {
+	r Raft
+
+	// protect fields below
+	mu sync.Mutex
+	// index is the index of snapshot data for snapshot match
+	// index is set to 0 if there is no kept snapshot
+	index uint64
+	// w is the WriterTo that can write the snapshot data
+	w io.WriterTo
+	// remote is the member ID that the kept snapshot will be sent to
+	// remote is set to raft.None if the kept snapshot has not attached remote
+	remote types.ID
+	// when the closeTimer expires, it will call the function attached
+	// via AfterFunc to close the snapshot
+	// closeTimer is set to nil if the kept snapshot has no auto release
+	closeTimer *time.Timer
+}
+
+// keep keeps the given snapshot at the given index.
+// keep keeps at most one snapshot at a time, or it panics.
+func (s *snapshotKeeper) keep(index uint64, w io.WriterTo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.index != 0 {
+		plog.Panicf("unexpected keep snapshot when some snapshot is kept")
+	}
+	s.index = index
+	s.w = w
+	s.remote = types.ID(raft.None)
+	s.closeTimer = nil
+}
+
+// keptIndex returns the index of the kept snapshot.
+// If there is no kept snapshot, it returns 0.
+func (s *snapshotKeeper) keptIndex() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.index
+}
+
+// attachRemote attaches the given remote member ID to the kept snapshot.
+func (s *snapshotKeeper) attachRemote(remote types.ID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.remote = remote
+}
+
+// autoRelease releases the kept snapshot automatically after
+// the given timeout passes.
+// If the snapshot is released automatically, snapshotKeeper also closes
+// the snapshot, and reports snapshot failure to raft.
+// It MUST be called after remote has been attached.
+func (s *snapshotKeeper) autoRelease(timeout time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeTimer = time.AfterFunc(timeout, func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		if s.index == 0 {
+			return
+		}
+		plog.Infof("snapshot [index: %d, to: %s] failed to be sent out due to timeout", s.index, s.remote)
+		s.index = 0
+		s.w.WriteTo(&ioutil.ErrWriter{Err: errors.New("close snapshot due to timeout")})
+		s.r.ReportSnapshot(uint64(s.remote), raft.SnapshotFailure)
+	})
+}
+
+// release releases the kept snapshot with the given index, and stops
+// potential auto release.
+// If there is no available snapshot, release will return an error.
+func (s *snapshotKeeper) release(index uint64) (w io.WriterTo, remote types.ID, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.index == 0 {
+		return nil, 0, fmt.Errorf("no kept snapshot")
+	}
+	if s.index != index {
+		return nil, 0, fmt.Errorf("no matched snapshot with index %d", index)
+	}
+	if s.remote == types.ID(raft.None) {
+		return nil, 0, fmt.Errorf("no remote member ID attached to the kept snapshot")
+	}
+	s.index = 0
+	if s.closeTimer != nil {
+		s.closeTimer.Stop()
+	}
+	return s.w, s.remote, nil
+}
+
+// snapshotProcessor is used to process msgSnap.
+// When the handler receives a msgSnap, it should pass it to snapshotProcessor.
+// snapshotProcessor helps to get and save the snapshot data, then
+// ask raft state machine to further process the message.
+type snapshotProcessor struct {
+	tr        http.RoundTripper
+	r         Raft
+	snapSaver SnapshotSaver
+}
+
+// process processes the given msgSnap.
+// First, it requests the corresponding snapshot data from the given peerURLs.
+// Then it saves the snapshot data into SnapshotStore. And finally, it sends the
+// msgSnap to raft for further processing.
+func (s *snapshotProcessor) process(m raftpb.Message, peerURLs types.URLs) {
+	if m.Type != raftpb.MsgSnap {
+		plog.Panicf("unexpected message type %v", m.Type)
+	}
+
+	// select one random peer URL to request snapshot
+	//
+	// Use one random URL is good enough because
+	// 1. all peer URLs are supposed to function well
+	// 2. snapshot sender keeps snapshot data for limited time
+	// 3. snapshot sender will retry the process if this fails
+	u := peerURLs[rand.Intn(len(peerURLs))]
+	index := m.Snapshot.Metadata.Index
+	snapr, err := s.getSnapFrom(u, index)
+	if err != nil {
+		plog.Warningf("failed to request snapshot [index: %d] (%v)", index, err)
+		return
+	}
+	defer snapr.Close()
+
+	if err := s.snapSaver.SaveFrom(snapr, index); err != nil {
+		plog.Warningf("failed to read snapshot [index: %d] (%v)", index, err)
+		return
+	}
+	if err := s.r.Process(context.TODO(), m); err != nil {
+		plog.Warningf("failed to process raft message (%v)", err)
+	}
+}
+
+// getSnapFrom requests the snapshot data at the given index from the given url.
+// It returns a ReadCloser for the snapshot data when succeeds. Otherwise, an
+// error will be returned.
+// It is the caller's responsibility to close returned ReadCloser.
+func (s *snapshotProcessor) getSnapFrom(u url.URL, index uint64) (io.ReadCloser, error) {
+	u.Path = RaftSnapPrefix
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		plog.Panicf("unexpected new request error: %v", err)
+	}
+	req.Header.Set("X-Raft-Snapshot-Index", strconv.FormatUint(index, 10))
+	resp, err := s.tr.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return resp.Body, nil
+	default:
+		resp.Body.Close()
+		return nil, fmt.Errorf("unexpected http status %s", http.StatusText(resp.StatusCode))
+	}
+}

--- a/rafthttp/transport_bench_test.go
+++ b/rafthttp/transport_bench_test.go
@@ -30,13 +30,13 @@ import (
 
 func BenchmarkSendingMsgApp(b *testing.B) {
 	// member 1
-	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, newServerStats(), stats.NewLeaderStats("1"))
+	tr := NewTransporter(&http.Transport{}, types.ID(1), types.ID(1), &fakeRaft{}, nil, nil, newServerStats(), stats.NewLeaderStats("1"), time.Second, false)
 	srv := httptest.NewServer(tr.Handler())
 	defer srv.Close()
 
 	// member 2
 	r := &countRaft{}
-	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), r, nil, newServerStats(), stats.NewLeaderStats("2"))
+	tr2 := NewTransporter(&http.Transport{}, types.ID(2), types.ID(1), r, nil, nil, newServerStats(), stats.NewLeaderStats("2"), time.Second, false)
 	srv2 := httptest.NewServer(tr2.Handler())
 	defer srv2.Close()
 

--- a/rafthttp/transport_test.go
+++ b/rafthttp/transport_test.go
@@ -71,6 +71,7 @@ func TestTransportAdd(t *testing.T) {
 	term := uint64(10)
 	tr := &transport{
 		roundTripper: &roundTripperRecorder{},
+		local:        newMember(types.ID(2)),
 		leaderStats:  ls,
 		term:         term,
 		peers:        make(map[types.ID]Peer),
@@ -104,6 +105,7 @@ func TestTransportAdd(t *testing.T) {
 func TestTransportRemove(t *testing.T) {
 	tr := &transport{
 		roundTripper: &roundTripperRecorder{},
+		local:        newMember(types.ID(2)),
 		leaderStats:  stats.NewLeaderStats(""),
 		peers:        make(map[types.ID]Peer),
 		prober:       probing.NewProber(nil),
@@ -135,6 +137,7 @@ func TestTransportErrorc(t *testing.T) {
 	errorc := make(chan error, 1)
 	tr := &transport{
 		roundTripper: newRespRoundTripper(http.StatusForbidden, nil),
+		local:        newMember(types.ID(2)),
 		leaderStats:  stats.NewLeaderStats(""),
 		peers:        make(map[types.ID]Peer),
 		prober:       probing.NewProber(nil),


### PR DESCRIPTION
After sending raft snapshot message as before, sender will wait for receiver to request the full snapshot and send it to the receiver.
Only after sender sends out the full snapshot, it thinks that snapshot is sent successfully.
Only after receiver receives the full snapshot, it acknowledges the snapshot is received and process the raft snapshot message.

Compared to using stream, this method handles the case that how remote struct receives snapshot well, let external have the control about how to read/write snapshot, and doesn't require to maintain a long-term connection for rare snapshot message.

I have tested it manually and it works well.

for #3549 