### PR TITLE
Update dependency on ugorji/go/codec

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -113,7 +113,7 @@
 		},
 		{
 			"ImportPath": "github.com/ugorji/go/codec",
-			"Rev": "5abd4e96a45c386928ed2ca2a7ef63e2533e18ec"
+			"Rev": "45ce7596ace4534e47b69051a92aef7b64ec7b3f"
 		},
 		{
 			"ImportPath": "github.com/xiang90/probing",

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/binc.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/binc.go
@@ -5,6 +5,7 @@ package codec
 
 import (
 	"math"
+	"reflect"
 	"time"
 )
 
@@ -69,7 +70,15 @@ func (e *bincEncDriver) IsBuiltinType(rt uintptr) bool {
 
 func (e *bincEncDriver) EncodeBuiltin(rt uintptr, v interface{}) {
 	if rt == timeTypId {
-		bs := encodeTime(v.(time.Time))
+		var bs []byte
+		switch x := v.(type) {
+		case time.Time:
+			bs = encodeTime(x)
+		case *time.Time:
+			bs = encodeTime(*x)
+		default:
+			e.e.errorf("binc error encoding builtin: expect time.Time, received %T", v)
+		}
 		e.w.writen1(bincVdTimestamp<<4 | uint8(len(bs)))
 		e.w.writeb(bs)
 	}
@@ -895,6 +904,10 @@ func (h *BincHandle) newEncDriver(e *Encoder) encDriver {
 
 func (h *BincHandle) newDecDriver(d *Decoder) decDriver {
 	return &bincDecDriver{d: d, r: d.r, h: h, br: d.bytes}
+}
+
+func (h *BincHandle) SetBytesExt(rt reflect.Type, tag uint64, ext BytesExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{b: ext})
 }
 
 var _ decDriver = (*bincDecDriver)(nil)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/cbor.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/cbor.go
@@ -3,7 +3,10 @@
 
 package codec
 
-import "math"
+import (
+	"math"
+	"reflect"
+)
 
 const (
 	cborMajorUint byte = iota
@@ -158,7 +161,11 @@ func (e *cborEncDriver) EncodeSymbol(v string) {
 }
 
 func (e *cborEncDriver) EncodeStringBytes(c charEncoding, v []byte) {
-	e.encLen(cborBaseBytes, len(v))
+	if c == c_RAW {
+		e.encLen(cborBaseBytes, len(v))
+	} else {
+		e.encLen(cborBaseString, len(v))
+	}
 	e.w.writeb(v)
 }
 
@@ -560,6 +567,10 @@ func (h *CborHandle) newEncDriver(e *Encoder) encDriver {
 
 func (h *CborHandle) newDecDriver(d *Decoder) decDriver {
 	return &cborDecDriver{d: d, r: d.r, h: h, br: d.bytes}
+}
+
+func (h *CborHandle) SetInterfaceExt(rt reflect.Type, tag uint64, ext InterfaceExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{i: ext})
 }
 
 var _ decDriver = (*cborDecDriver)(nil)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/codec_test.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/codec_test.go
@@ -860,6 +860,60 @@ func testCodecRpcOne(t *testing.T, rr Rpc, h Handle, doRequest bool, exitSleepMs
 	return
 }
 
+func doTestMapEncodeForCanonical(t *testing.T, name string, h Handle) {
+	v1 := map[string]interface{}{
+		"a": 1,
+		"b": "hello",
+		"c": map[string]interface{}{
+			"c/a": 1,
+			"c/b": "world",
+			"c/c": []int{1, 2, 3, 4},
+			"c/d": map[string]interface{}{
+				"c/d/a": "fdisajfoidsajfopdjsaopfjdsapofda",
+				"c/d/b": "fdsafjdposakfodpsakfopdsakfpodsakfpodksaopfkdsopafkdopsa",
+				"c/d/c": "poir02  ir30qif4p03qir0pogjfpoaerfgjp ofke[padfk[ewapf kdp[afep[aw",
+				"c/d/d": "fdsopafkd[sa f-32qor-=4qeof -afo-erfo r-eafo 4e-  o r4-qwo ag",
+				"c/d/e": "kfep[a sfkr0[paf[a foe-[wq  ewpfao-q ro3-q ro-4qof4-qor 3-e orfkropzjbvoisdb",
+				"c/d/f": "",
+			},
+			"c/e": map[int]string{
+				1:     "1",
+				22:    "22",
+				333:   "333",
+				4444:  "4444",
+				55555: "55555",
+			},
+			"c/f": map[string]int{
+				"1":     1,
+				"22":    22,
+				"333":   333,
+				"4444":  4444,
+				"55555": 55555,
+			},
+		},
+	}
+	var v2 map[string]interface{}
+	var b1, b2 []byte
+
+	// encode v1 into b1, decode b1 into v2, encode v2 into b2, compare b1 and b2
+
+	bh := h.getBasicHandle()
+	canonical0 := bh.Canonical
+	bh.Canonical = true
+	defer func() { bh.Canonical = canonical0 }()
+
+	e1 := NewEncoderBytes(&b1, h)
+	e1.MustEncode(v1)
+	d1 := NewDecoderBytes(b1, h)
+	d1.MustDecode(&v2)
+	e2 := NewEncoderBytes(&b2, h)
+	e2.MustEncode(v2)
+	if !bytes.Equal(b1, b2) {
+		logT(t, "Unequal bytes: %v VS %v", b1, b2)
+		t.FailNow()
+	}
+}
+
 // Comprehensive testing that generates data encoded from python handle (cbor, msgpack),
 // and validates that our code can read and write it out accordingly.
 // We keep this unexported here, and put actual test in ext_dep_test.go.
@@ -1046,6 +1100,10 @@ func TestCborCodecsMisc(t *testing.T) {
 
 func TestCborCodecsEmbeddedPointer(t *testing.T) {
 	testCodecEmbeddedPointer(t, testCborH)
+}
+
+func TestCborMapEncodeForCanonical(t *testing.T) {
+	doTestMapEncodeForCanonical(t, "cbor", testCborH)
 }
 
 func TestJsonCodecsTable(t *testing.T) {

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/codecgen/gen.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/codecgen/gen.go
@@ -14,6 +14,7 @@ import (
 	"go/build"
 	"go/parser"
 	"go/token"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,6 +23,8 @@ import (
 	"text/template"
 	"time"
 )
+
+const genCodecPkg = "codec1978" // keep this in sync with codec.genCodecPkg
 
 const genFrunMainTmpl = `//+build ignore
 
@@ -69,7 +72,7 @@ func CodecGenTempWrite{{ .RandString }}() {
 	var t{{ $index }} {{ . }}
 	typs = append(typs, reflect.TypeOf(t{{ $index }}))
 {{ end }}
-	{{ if not .CodecPkgFiles }}{{ .CodecPkgName }}.{{ end }}Gen(&out, "{{ .BuildTag }}", "{{ .PackageName }}", {{ .UseUnsafe }}, typs...)
+	{{ if not .CodecPkgFiles }}{{ .CodecPkgName }}.{{ end }}Gen(&out, "{{ .BuildTag }}", "{{ .PackageName }}", "{{ .RandString }}", {{ .UseUnsafe }}, typs...)
 	bout, err := format.Source(out.Bytes())
 	if err != nil {
 		fout.Write(out.Bytes())
@@ -89,7 +92,7 @@ func CodecGenTempWrite{{ .RandString }}() {
 // Tool then executes: "go run __frun__" which creates fout.
 // fout contains Codec(En|De)codeSelf implementations for every type T.
 //
-func Generate(outfile, buildTag, codecPkgPath string, useUnsafe bool, goRunTag string,
+func Generate(outfile, buildTag, codecPkgPath string, uid int64, useUnsafe bool, goRunTag string,
 	regexName *regexp.Regexp, deleteTempFile bool, infiles ...string) (err error) {
 	// For each file, grab AST, find each type, and write a call to it.
 	if len(infiles) == 0 {
@@ -98,6 +101,13 @@ func Generate(outfile, buildTag, codecPkgPath string, useUnsafe bool, goRunTag s
 	if outfile == "" || codecPkgPath == "" {
 		err = errors.New("outfile and codec package path cannot be blank")
 		return
+	}
+	if uid < 0 {
+		uid = -uid
+	}
+	if uid == 0 {
+		rr := rand.New(rand.NewSource(time.Now().UnixNano()))
+		uid = 101 + rr.Int63n(9777)
 	}
 	// We have to parse dir for package, before opening the temp file for writing (else ImportDir fails).
 	// Also, ImportDir(...) must take an absolute path.
@@ -123,12 +133,12 @@ func Generate(outfile, buildTag, codecPkgPath string, useUnsafe bool, goRunTag s
 		UseUnsafe       bool
 	}
 	tv := tmplT{
-		CodecPkgName:    "codec1978",
+		CodecPkgName:    genCodecPkg,
 		OutFile:         outfile,
 		CodecImportPath: codecPkgPath,
 		BuildTag:        buildTag,
 		UseUnsafe:       useUnsafe,
-		RandString:      strconv.FormatInt(time.Now().UnixNano(), 10),
+		RandString:      strconv.FormatInt(uid, 10),
 	}
 	tv.ImportPath = pkg.ImportPath
 	if tv.ImportPath == tv.CodecImportPath {
@@ -261,9 +271,9 @@ func main() {
 	rt := flag.String("rt", "", "tags for go run")
 	x := flag.Bool("x", false, "keep temp file")
 	u := flag.Bool("u", false, "Use unsafe, e.g. to avoid unnecessary allocation on []byte->string")
-
+	d := flag.Int64("d", 0, "random identifier for use in generated code")
 	flag.Parse()
-	if err := Generate(*o, *t, *c, *u, *rt,
+	if err := Generate(*o, *t, *c, *d, *u, *rt,
 		regexp.MustCompile(*r), !*x, flag.Args()...); err != nil {
 		fmt.Fprintf(os.Stderr, "codecgen error: %v\n", err)
 		os.Exit(1)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/decode.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/decode.go
@@ -25,10 +25,6 @@ var (
 // decReader abstracts the reading source, allowing implementations that can
 // read from an io.Reader or directly off a byte slice with zero-copying.
 type decReader interface {
-	// TODO:
-	//   Add method to get num bytes read.
-	//   This will be used to annotate errors, so user knows at what point the error occurred.
-
 	unreadn1()
 
 	// readx will use the implementation scratch buffer if possible i.e. n < len(scratchbuf), OR
@@ -38,6 +34,9 @@ type decReader interface {
 	readb([]byte)
 	readn1() uint8
 	readn1eof() (v uint8, eof bool)
+	numread() int // number of bytes read
+	track()
+	stopTrack() []byte
 }
 
 type decReaderByteScanner interface {
@@ -79,20 +78,13 @@ type decDriver interface {
 	// decodeExt(verifyTag bool, tag byte) (xtag byte, xbs []byte)
 	ReadMapStart() int
 	ReadArrayStart() int
-	ReadMapEnd()
-	ReadArrayEnd()
-	ReadArrayEntrySeparator()
-	ReadMapEntrySeparator()
-	ReadMapKVSeparator()
+	// ReadEnd registers the end of a map or array.
+	ReadEnd()
 }
 
 type decNoSeparator struct{}
 
-func (_ decNoSeparator) ReadMapEnd()              {}
-func (_ decNoSeparator) ReadArrayEnd()            {}
-func (_ decNoSeparator) ReadArrayEntrySeparator() {}
-func (_ decNoSeparator) ReadMapEntrySeparator()   {}
-func (_ decNoSeparator) ReadMapKVSeparator()      {}
+func (_ decNoSeparator) ReadEnd() {}
 
 type DecodeOptions struct {
 	// MapType specifies type to use during schema-less decoding of a map in the stream.
@@ -114,6 +106,14 @@ type DecodeOptions struct {
 
 	// If SignedInteger, use the int64 during schema-less decoding of unsigned values (not uint64).
 	SignedInteger bool
+
+	// MaxInitLen defines the initial length that we "make" a collection (slice, chan or map) with.
+	// If 0 or negative, we default to a sensible value based on the size of an element in the collection.
+	//
+	// For example, when decoding, a stream may say that it has MAX_UINT elements.
+	// We should not auto-matically provision a slice of that length, to prevent Out-Of-Memory crash.
+	// Instead, we provision up to MaxInitLen, fill that up, and start appending after that.
+	MaxInitLen int
 }
 
 // ------------------------------------
@@ -181,8 +181,15 @@ type ioDecReader struct {
 	br decReaderByteScanner
 	// temp byte array re-used internally for efficiency during read.
 	// shares buffer with Decoder, so we keep size of struct within 8 words.
-	x  *[scratchByteArrayLen]byte
-	bs ioDecByteScanner
+	x   *[scratchByteArrayLen]byte
+	bs  ioDecByteScanner
+	n   int    // num read
+	tr  []byte // tracking bytes read
+	trb bool
+}
+
+func (z *ioDecReader) numread() int {
+	return z.n
 }
 
 func (z *ioDecReader) readx(n int) (bs []byte) {
@@ -197,6 +204,10 @@ func (z *ioDecReader) readx(n int) (bs []byte) {
 	if _, err := io.ReadAtLeast(z.br, bs, n); err != nil {
 		panic(err)
 	}
+	z.n += len(bs)
+	if z.trb {
+		z.tr = append(z.tr, bs...)
+	}
 	return
 }
 
@@ -204,8 +215,13 @@ func (z *ioDecReader) readb(bs []byte) {
 	if len(bs) == 0 {
 		return
 	}
-	if _, err := io.ReadAtLeast(z.br, bs, len(bs)); err != nil {
+	n, err := io.ReadAtLeast(z.br, bs, len(bs))
+	z.n += n
+	if err != nil {
 		panic(err)
+	}
+	if z.trb {
+		z.tr = append(z.tr, bs...)
 	}
 }
 
@@ -214,12 +230,20 @@ func (z *ioDecReader) readn1() (b uint8) {
 	if err != nil {
 		panic(err)
 	}
+	z.n++
+	if z.trb {
+		z.tr = append(z.tr, b)
+	}
 	return b
 }
 
 func (z *ioDecReader) readn1eof() (b uint8, eof bool) {
 	b, err := z.br.ReadByte()
 	if err == nil {
+		z.n++
+		if z.trb {
+			z.tr = append(z.tr, b)
+		}
 	} else if err == io.EOF {
 		eof = true
 	} else {
@@ -229,9 +253,28 @@ func (z *ioDecReader) readn1eof() (b uint8, eof bool) {
 }
 
 func (z *ioDecReader) unreadn1() {
-	if err := z.br.UnreadByte(); err != nil {
+	err := z.br.UnreadByte()
+	if err != nil {
 		panic(err)
 	}
+	z.n--
+	if z.trb {
+		if l := len(z.tr) - 1; l >= 0 {
+			z.tr = z.tr[:l]
+		}
+	}
+}
+
+func (z *ioDecReader) track() {
+	if z.tr != nil {
+		z.tr = z.tr[:0]
+	}
+	z.trb = true
+}
+
+func (z *ioDecReader) stopTrack() (bs []byte) {
+	z.trb = false
+	return z.tr
 }
 
 // ------------------------------------
@@ -243,6 +286,11 @@ type bytesDecReader struct {
 	b []byte // data
 	c int    // cursor
 	a int    // available
+	t int    // track start
+}
+
+func (z *bytesDecReader) numread() int {
+	return z.c
 }
 
 func (z *bytesDecReader) unreadn1() {
@@ -298,9 +346,17 @@ func (z *bytesDecReader) readb(bs []byte) {
 	copy(bs, z.readx(len(bs)))
 }
 
+func (z *bytesDecReader) track() {
+	z.t = z.c
+}
+
+func (z *bytesDecReader) stopTrack() (bs []byte) {
+	return z.b[z.t:z.c]
+}
+
 // ------------------------------------
 
-type decFnInfoX struct {
+type decFnInfo struct {
 	d     *Decoder
 	ti    *typeInfo
 	xfFn  Ext
@@ -308,40 +364,26 @@ type decFnInfoX struct {
 	seq   seqType
 }
 
-// decFnInfo has methods for handling decoding of a specific type
-// based on some characteristics (builtin, extension, reflect Kind, etc)
-type decFnInfo struct {
-	// use decFnInfo as a value receiver.
-	// keep most of it less-used variables accessible via a pointer (*decFnInfoX).
-	// As sweet spot for value-receiver is 3 words, keep everything except
-	// decDriver (which everyone needs) directly accessible.
-	// ensure decFnInfoX is set for everyone who needs it i.e.
-	// rawExt, ext, builtin, (selfer|binary|text)Marshal, kSlice, kStruct, kMap, kInterface, fastpath
-
-	dd decDriver
-	*decFnInfoX
-}
-
 // ----------------------------------------
 
 type decFn struct {
 	i decFnInfo
-	f func(decFnInfo, reflect.Value)
+	f func(*decFnInfo, reflect.Value)
 }
 
-func (f decFnInfo) builtin(rv reflect.Value) {
-	f.dd.DecodeBuiltin(f.ti.rtid, rv.Addr().Interface())
+func (f *decFnInfo) builtin(rv reflect.Value) {
+	f.d.d.DecodeBuiltin(f.ti.rtid, rv.Addr().Interface())
 }
 
-func (f decFnInfo) rawExt(rv reflect.Value) {
-	f.dd.DecodeExt(rv.Addr().Interface(), 0, nil)
+func (f *decFnInfo) rawExt(rv reflect.Value) {
+	f.d.d.DecodeExt(rv.Addr().Interface(), 0, nil)
 }
 
-func (f decFnInfo) ext(rv reflect.Value) {
-	f.dd.DecodeExt(rv.Addr().Interface(), f.xfTag, f.xfFn)
+func (f *decFnInfo) ext(rv reflect.Value) {
+	f.d.d.DecodeExt(rv.Addr().Interface(), f.xfTag, f.xfFn)
 }
 
-func (f decFnInfo) getValueForUnmarshalInterface(rv reflect.Value, indir int8) (v interface{}) {
+func (f *decFnInfo) getValueForUnmarshalInterface(rv reflect.Value, indir int8) (v interface{}) {
 	if indir == -1 {
 		v = rv.Addr().Interface()
 	} else if indir == 0 {
@@ -358,95 +400,105 @@ func (f decFnInfo) getValueForUnmarshalInterface(rv reflect.Value, indir int8) (
 	return
 }
 
-func (f decFnInfo) selferUnmarshal(rv reflect.Value) {
+func (f *decFnInfo) selferUnmarshal(rv reflect.Value) {
 	f.getValueForUnmarshalInterface(rv, f.ti.csIndir).(Selfer).CodecDecodeSelf(f.d)
 }
 
-func (f decFnInfo) binaryUnmarshal(rv reflect.Value) {
+func (f *decFnInfo) binaryUnmarshal(rv reflect.Value) {
 	bm := f.getValueForUnmarshalInterface(rv, f.ti.bunmIndir).(encoding.BinaryUnmarshaler)
-	xbs := f.dd.DecodeBytes(nil, false, true)
+	xbs := f.d.d.DecodeBytes(nil, false, true)
 	if fnerr := bm.UnmarshalBinary(xbs); fnerr != nil {
 		panic(fnerr)
 	}
 }
 
-func (f decFnInfo) textUnmarshal(rv reflect.Value) {
+func (f *decFnInfo) textUnmarshal(rv reflect.Value) {
 	tm := f.getValueForUnmarshalInterface(rv, f.ti.tunmIndir).(encoding.TextUnmarshaler)
-	fnerr := tm.UnmarshalText(f.dd.DecodeBytes(f.d.b[:], true, true))
-	// fnerr := tm.UnmarshalText(f.dd.DecodeStringAsBytes(f.d.b[:]))
-
-	// var fnerr error
-	// if sb, sbok := f.dd.(decDriverStringAsBytes); sbok {
-	// 	fnerr = tm.UnmarshalText(sb.decStringAsBytes(f.d.b[:0]))
-	// } else {
-	// 	fnerr = tm.UnmarshalText([]byte(f.dd.decodeString()))
-	// }
+	fnerr := tm.UnmarshalText(f.d.d.DecodeBytes(f.d.b[:], true, true))
 	if fnerr != nil {
 		panic(fnerr)
 	}
 }
 
-func (f decFnInfo) kErr(rv reflect.Value) {
+func (f *decFnInfo) jsonUnmarshal(rv reflect.Value) {
+	tm := f.getValueForUnmarshalInterface(rv, f.ti.junmIndir).(jsonUnmarshaler)
+	// bs := f.d.d.DecodeBytes(f.d.b[:], true, true)
+	// grab the bytes to be read, as UnmarshalJSON wants the full JSON to unmarshal it itself.
+	f.d.r.track()
+	f.d.swallow()
+	bs := f.d.r.stopTrack()
+	// fmt.Printf(">>>>>> REFLECTION JSON: %s\n", bs)
+	fnerr := tm.UnmarshalJSON(bs)
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+func (f *decFnInfo) kErr(rv reflect.Value) {
 	f.d.errorf("no decoding function defined for kind %v", rv.Kind())
 }
 
-func (f decFnInfo) kString(rv reflect.Value) {
-	rv.SetString(f.dd.DecodeString())
+func (f *decFnInfo) kString(rv reflect.Value) {
+	rv.SetString(f.d.d.DecodeString())
 }
 
-func (f decFnInfo) kBool(rv reflect.Value) {
-	rv.SetBool(f.dd.DecodeBool())
+func (f *decFnInfo) kBool(rv reflect.Value) {
+	rv.SetBool(f.d.d.DecodeBool())
 }
 
-func (f decFnInfo) kInt(rv reflect.Value) {
-	rv.SetInt(f.dd.DecodeInt(intBitsize))
+func (f *decFnInfo) kInt(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(intBitsize))
 }
 
-func (f decFnInfo) kInt64(rv reflect.Value) {
-	rv.SetInt(f.dd.DecodeInt(64))
+func (f *decFnInfo) kInt64(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(64))
 }
 
-func (f decFnInfo) kInt32(rv reflect.Value) {
-	rv.SetInt(f.dd.DecodeInt(32))
+func (f *decFnInfo) kInt32(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(32))
 }
 
-func (f decFnInfo) kInt8(rv reflect.Value) {
-	rv.SetInt(f.dd.DecodeInt(8))
+func (f *decFnInfo) kInt8(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(8))
 }
 
-func (f decFnInfo) kInt16(rv reflect.Value) {
-	rv.SetInt(f.dd.DecodeInt(16))
+func (f *decFnInfo) kInt16(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(16))
 }
 
-func (f decFnInfo) kFloat32(rv reflect.Value) {
-	rv.SetFloat(f.dd.DecodeFloat(true))
+func (f *decFnInfo) kFloat32(rv reflect.Value) {
+	rv.SetFloat(f.d.d.DecodeFloat(true))
 }
 
-func (f decFnInfo) kFloat64(rv reflect.Value) {
-	rv.SetFloat(f.dd.DecodeFloat(false))
+func (f *decFnInfo) kFloat64(rv reflect.Value) {
+	rv.SetFloat(f.d.d.DecodeFloat(false))
 }
 
-func (f decFnInfo) kUint8(rv reflect.Value) {
-	rv.SetUint(f.dd.DecodeUint(8))
+func (f *decFnInfo) kUint8(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(8))
 }
 
-func (f decFnInfo) kUint64(rv reflect.Value) {
-	rv.SetUint(f.dd.DecodeUint(64))
+func (f *decFnInfo) kUint64(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(64))
 }
 
-func (f decFnInfo) kUint(rv reflect.Value) {
-	rv.SetUint(f.dd.DecodeUint(uintBitsize))
+func (f *decFnInfo) kUint(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(uintBitsize))
 }
 
-func (f decFnInfo) kUint32(rv reflect.Value) {
-	rv.SetUint(f.dd.DecodeUint(32))
+func (f *decFnInfo) kUintptr(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(uintBitsize))
 }
 
-func (f decFnInfo) kUint16(rv reflect.Value) {
-	rv.SetUint(f.dd.DecodeUint(16))
+func (f *decFnInfo) kUint32(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(32))
 }
 
-// func (f decFnInfo) kPtr(rv reflect.Value) {
+func (f *decFnInfo) kUint16(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(16))
+}
+
+// func (f *decFnInfo) kPtr(rv reflect.Value) {
 // 	debugf(">>>>>>> ??? decode kPtr called - shouldn't get called")
 // 	if rv.IsNil() {
 // 		rv.Set(reflect.New(rv.Type().Elem()))
@@ -456,11 +508,11 @@ func (f decFnInfo) kUint16(rv reflect.Value) {
 
 // var kIntfCtr uint64
 
-func (f decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
+func (f *decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
 	// nil interface:
 	// use some hieristics to decode it appropriately
 	// based on the detected next value in the stream.
-	v, vt, decodeFurther := f.dd.DecodeNaked()
+	v, vt, decodeFurther := f.d.d.DecodeNaked()
 	if vt == valueTypeNil {
 		return
 	}
@@ -506,7 +558,7 @@ func (f decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
 	}
 	if decodeFurther {
 		if useRvn {
-			f.d.decodeValue(rvn, decFn{})
+			f.d.decodeValue(rvn, nil)
 		} else if v != nil {
 			// this v is a pointer, so we need to dereference it when done
 			f.d.decode(v)
@@ -521,7 +573,7 @@ func (f decFnInfo) kInterfaceNaked() (rvn reflect.Value) {
 	return
 }
 
-func (f decFnInfo) kInterface(rv reflect.Value) {
+func (f *decFnInfo) kInterface(rv reflect.Value) {
 	// debugf("\t===> kInterface")
 
 	// Note:
@@ -543,69 +595,66 @@ func (f decFnInfo) kInterface(rv reflect.Value) {
 		// we just decode into it.
 		// Else we create a settable value, decode into it, and set on the interface.
 		if rve.CanSet() {
-			f.d.decodeValue(rve, decFn{})
+			f.d.decodeValue(rve, nil)
 		} else {
 			rve2 := reflect.New(rve.Type()).Elem()
 			rve2.Set(rve)
-			f.d.decodeValue(rve2, decFn{})
+			f.d.decodeValue(rve2, nil)
 			rv.Set(rve2)
 		}
 	}
 }
 
-func (f decFnInfo) kStruct(rv reflect.Value) {
+func (f *decFnInfo) kStruct(rv reflect.Value) {
 	fti := f.ti
 	d := f.d
-	if f.dd.IsContainerType(valueTypeMap) {
-		containerLen := f.dd.ReadMapStart()
+	dd := d.d
+	if dd.IsContainerType(valueTypeMap) {
+		containerLen := dd.ReadMapStart()
 		if containerLen == 0 {
-			f.dd.ReadMapEnd()
+			dd.ReadEnd()
 			return
 		}
 		tisfi := fti.sfi
 		hasLen := containerLen >= 0
 		if hasLen {
 			for j := 0; j < containerLen; j++ {
-				// rvkencname := f.dd.DecodeString()
-				rvkencname := stringView(f.dd.DecodeBytes(f.d.b[:], true, true))
+				// rvkencname := dd.DecodeString()
+				rvkencname := stringView(dd.DecodeBytes(f.d.b[:], true, true))
 				// rvksi := ti.getForEncName(rvkencname)
 				if k := fti.indexForEncName(rvkencname); k > -1 {
 					si := tisfi[k]
-					if f.dd.TryDecodeAsNil() {
+					if dd.TryDecodeAsNil() {
 						si.setToZeroValue(rv)
 					} else {
-						d.decodeValue(si.field(rv, true), decFn{})
+						d.decodeValue(si.field(rv, true), nil)
 					}
 				} else {
 					d.structFieldNotFound(-1, rvkencname)
 				}
 			}
 		} else {
-			for j := 0; !f.dd.CheckBreak(); j++ {
-				if j > 0 {
-					f.dd.ReadMapEntrySeparator()
-				}
-				// rvkencname := f.dd.DecodeString()
-				rvkencname := stringView(f.dd.DecodeBytes(f.d.b[:], true, true))
-				f.dd.ReadMapKVSeparator()
+			for j := 0; !dd.CheckBreak(); j++ {
+				// rvkencname := dd.DecodeString()
+				rvkencname := stringView(dd.DecodeBytes(f.d.b[:], true, true))
 				// rvksi := ti.getForEncName(rvkencname)
 				if k := fti.indexForEncName(rvkencname); k > -1 {
 					si := tisfi[k]
-					if f.dd.TryDecodeAsNil() {
+					if dd.TryDecodeAsNil() {
 						si.setToZeroValue(rv)
 					} else {
-						d.decodeValue(si.field(rv, true), decFn{})
+						d.decodeValue(si.field(rv, true), nil)
 					}
 				} else {
 					d.structFieldNotFound(-1, rvkencname)
 				}
 			}
-			f.dd.ReadMapEnd()
+			dd.ReadEnd()
 		}
-	} else if f.dd.IsContainerType(valueTypeArray) {
-		containerLen := f.dd.ReadArrayStart()
+	} else if dd.IsContainerType(valueTypeArray) {
+		containerLen := dd.ReadArrayStart()
 		if containerLen == 0 {
-			f.dd.ReadArrayEnd()
+			dd.ReadEnd()
 			return
 		}
 		// Not much gain from doing it two ways for array.
@@ -616,55 +665,47 @@ func (f decFnInfo) kStruct(rv reflect.Value) {
 				if j == containerLen {
 					break
 				}
-			} else if f.dd.CheckBreak() {
+			} else if dd.CheckBreak() {
 				break
 			}
-			if j > 0 {
-				f.dd.ReadArrayEntrySeparator()
-			}
-			if f.dd.TryDecodeAsNil() {
+			if dd.TryDecodeAsNil() {
 				si.setToZeroValue(rv)
 			} else {
-				d.decodeValue(si.field(rv, true), decFn{})
+				d.decodeValue(si.field(rv, true), nil)
 			}
-			// if si.i != -1 {
-			// 	d.decodeValue(rv.Field(int(si.i)), decFn{})
-			// } else {
-			// 	d.decEmbeddedField(rv, si.is)
-			// }
 		}
 		if containerLen > len(fti.sfip) {
 			// read remaining values and throw away
 			for j := len(fti.sfip); j < containerLen; j++ {
-				if j > 0 {
-					f.dd.ReadArrayEntrySeparator()
-				}
 				d.structFieldNotFound(j, "")
 			}
 		}
-		f.dd.ReadArrayEnd()
+		dd.ReadEnd()
 	} else {
 		f.d.error(onlyMapOrArrayCanDecodeIntoStructErr)
 		return
 	}
 }
 
-func (f decFnInfo) kSlice(rv reflect.Value) {
+func (f *decFnInfo) kSlice(rv reflect.Value) {
 	// A slice can be set from a map or array in stream.
 	// This way, the order can be kept (as order is lost with map).
 	ti := f.ti
 	d := f.d
-	if f.dd.IsContainerType(valueTypeBytes) || f.dd.IsContainerType(valueTypeString) {
-		if ti.rtid == uint8SliceTypId || ti.rt.Elem().Kind() == reflect.Uint8 {
+	dd := d.d
+	rtelem0 := ti.rt.Elem()
+
+	if dd.IsContainerType(valueTypeBytes) || dd.IsContainerType(valueTypeString) {
+		if ti.rtid == uint8SliceTypId || rtelem0.Kind() == reflect.Uint8 {
 			if f.seq == seqTypeChan {
-				bs2 := f.dd.DecodeBytes(nil, false, true)
+				bs2 := dd.DecodeBytes(nil, false, true)
 				ch := rv.Interface().(chan<- byte)
 				for _, b := range bs2 {
 					ch <- b
 				}
 			} else {
 				rvbs := rv.Bytes()
-				bs2 := f.dd.DecodeBytes(rvbs, false, false)
+				bs2 := dd.DecodeBytes(rvbs, false, false)
 				if rvbs == nil && bs2 != nil || rvbs != nil && bs2 == nil || len(bs2) != len(rvbs) {
 					if rv.CanSet() {
 						rv.SetBytes(bs2)
@@ -681,72 +722,70 @@ func (f decFnInfo) kSlice(rv reflect.Value) {
 
 	slh, containerLenS := d.decSliceHelperStart()
 
+	var rvlen, numToRead int
+	var truncated bool // says that the len of the sequence is not same as the expected number of elements.
+
+	numToRead = containerLenS // if truncated, reset numToRead
+
 	// an array can never return a nil slice. so no need to check f.array here.
 	if rv.IsNil() {
 		// either chan or slice
-		if f.seq == seqTypeSlice {
-			if containerLenS <= 0 {
-				rv.Set(reflect.MakeSlice(ti.rt, 0, 0))
-			} else {
-				rv.Set(reflect.MakeSlice(ti.rt, containerLenS, containerLenS))
-			}
-		} else if f.seq == seqTypeChan {
-			if containerLenS <= 0 {
-				rv.Set(reflect.MakeChan(ti.rt, 0))
-			} else {
-				rv.Set(reflect.MakeChan(ti.rt, containerLenS))
-			}
+		if rvlen, truncated = decInferLen(containerLenS, f.d.h.MaxInitLen, int(rtelem0.Size())); truncated {
+			numToRead = rvlen
 		}
+		if f.seq == seqTypeSlice {
+			rv.Set(reflect.MakeSlice(ti.rt, rvlen, rvlen))
+		} else if f.seq == seqTypeChan {
+			rv.Set(reflect.MakeChan(ti.rt, rvlen))
+		}
+	} else {
+		rvlen = rv.Len()
 	}
 
-	rvlen := rv.Len()
 	if containerLenS == 0 {
 		if f.seq == seqTypeSlice && rvlen != 0 {
 			rv.SetLen(0)
 		}
-		// slh.End() // f.dd.ReadArrayEnd()
+		// dd.ReadEnd()
 		return
 	}
 
-	rtelem0 := ti.rt.Elem()
 	rtelem := rtelem0
 	for rtelem.Kind() == reflect.Ptr {
 		rtelem = rtelem.Elem()
 	}
 	fn := d.getDecFn(rtelem, true, true)
 
-	rv0 := rv
+	var rv0, rv9 reflect.Value
+	rv0 = rv
 	rvChanged := false
 
 	rvcap := rv.Cap()
 
 	// for j := 0; j < containerLenS; j++ {
 
-	hasLen := containerLenS >= 0
-	if hasLen {
+	if containerLenS >= 0 { // hasLen
 		if f.seq == seqTypeChan {
 			// handle chan specially:
 			for j := 0; j < containerLenS; j++ {
-				rv0 := reflect.New(rtelem0).Elem()
-				d.decodeValue(rv0, fn)
-				rv.Send(rv0)
+				rv9 = reflect.New(rtelem0).Elem()
+				d.decodeValue(rv9, fn)
+				rv.Send(rv9)
 			}
-		} else {
-			numToRead := containerLenS
+		} else { // slice or array
 			if containerLenS > rvcap {
 				if f.seq == seqTypeArray {
-					d.arrayCannotExpand(rv.Len(), containerLenS)
-					numToRead = rvlen
+					d.arrayCannotExpand(rvlen, containerLenS)
 				} else {
-					rv = reflect.MakeSlice(ti.rt, containerLenS, containerLenS)
-					if rvlen > 0 && !isMutableKind(ti.rt.Kind()) {
-						rv1 := rv0
-						rv1.SetLen(rvcap)
-						reflect.Copy(rv, rv1)
+					oldRvlenGtZero := rvlen > 0
+					rvlen, truncated = decInferLen(containerLenS, f.d.h.MaxInitLen, int(rtelem0.Size()))
+					rv = reflect.MakeSlice(ti.rt, rvlen, rvlen)
+					if oldRvlenGtZero && !isImmutableKind(rtelem0.Kind()) {
+						reflect.Copy(rv, rv0) // only copy up to length NOT cap i.e. rv0.Slice(0, rvcap)
 					}
 					rvChanged = true
-					rvlen = containerLenS
 				}
+				numToRead = rvlen
 			} else if containerLenS != rvlen {
 				if f.seq == seqTypeSlice {
 					rv.SetLen(containerLenS)
@@ -754,17 +793,31 @@ func (f decFnInfo) kSlice(rv reflect.Value) {
 				}
 			}
 			j := 0
+			// we read up to the numToRead
 			for ; j < numToRead; j++ {
 				d.decodeValue(rv.Index(j), fn)
 			}
+
+			// if slice, expand and read up to containerLenS (or EOF) iff truncated
+			// if array, swallow all the rest.
+
 			if f.seq == seqTypeArray {
 				for ; j < containerLenS; j++ {
 					d.swallow()
 				}
+			} else if truncated { // slice was truncated, as chan NOT in this block
+				for ; j < containerLenS; j++ {
+					rv = expandSliceValue(rv, 1)
+					rv9 = rv.Index(j)
+					if resetSliceElemToZeroValue {
+						rv9.Set(reflect.Zero(rtelem0))
+					}
+					d.decodeValue(rv9, fn)
+				}
 			}
 		}
 	} else {
-		for j := 0; !f.dd.CheckBreak(); j++ {
+		for j := 0; !dd.CheckBreak(); j++ {
 			var decodeIntoBlank bool
 			// if indefinite, etc, then expand the slice if necessary
 			if j >= rvlen {
@@ -772,22 +825,27 @@ func (f decFnInfo) kSlice(rv reflect.Value) {
 					d.arrayCannotExpand(rvlen, j+1)
 					decodeIntoBlank = true
 				} else if f.seq == seqTypeSlice {
-					rv = reflect.Append(rv, reflect.Zero(rtelem0))
+					// rv = reflect.Append(rv, reflect.Zero(rtelem0)) // uses append logic, plus varargs
+					rv = expandSliceValue(rv, 1)
+					rv9 = rv.Index(j)
+					// rv.Index(rv.Len() - 1).Set(reflect.Zero(rtelem0))
+					if resetSliceElemToZeroValue {
+						rv9.Set(reflect.Zero(rtelem0))
+					}
 					rvlen++
 					rvChanged = true
 				}
-			}
-			if j > 0 {
-				slh.Sep(j)
+			} else if f.seq != seqTypeChan { // slice or array
+				rv9 = rv.Index(j)
 			}
 			if f.seq == seqTypeChan {
-				rv0 := reflect.New(rtelem0).Elem()
-				d.decodeValue(rv0, fn)
-				rv.Send(rv0)
+				rv9 = reflect.New(rtelem0).Elem()
+				d.decodeValue(rv9, fn)
+				rv.Send(rv9)
 			} else if decodeIntoBlank {
 				d.swallow()
-			} else {
-				d.decodeValue(rv.Index(j), fn)
+			} else { // seqTypeSlice
+				d.decodeValue(rv9, fn)
 			}
 		}
 		slh.End()
@@ -798,13 +856,15 @@ func (f decFnInfo) kSlice(rv reflect.Value) {
 	}
 }
 
-func (f decFnInfo) kArray(rv reflect.Value) {
+func (f *decFnInfo) kArray(rv reflect.Value) {
 	// f.d.decodeValue(rv.Slice(0, rv.Len()))
 	f.kSlice(rv.Slice(0, rv.Len()))
 }
 
-func (f decFnInfo) kMap(rv reflect.Value) {
-	containerLen := f.dd.ReadMapStart()
+func (f *decFnInfo) kMap(rv reflect.Value) {
+	d := f.d
+	dd := d.d
+	containerLen := dd.ReadMapStart()
 
 	ti := f.ti
 	if rv.IsNil() {
@@ -812,15 +872,14 @@ func (f decFnInfo) kMap(rv reflect.Value) {
 	}
 
 	if containerLen == 0 {
-		// f.dd.ReadMapEnd()
+		// It is not length-prefix style container. They have no End marker.
+		// dd.ReadMapEnd()
 		return
 	}
 
-	d := f.d
-
 	ktype, vtype := ti.rt.Key(), ti.rt.Elem()
 	ktypeId := reflect.ValueOf(ktype).Pointer()
-	var keyFn, valFn decFn
+	var keyFn, valFn *decFn
 	var xtyp reflect.Type
 	for xtyp = ktype; xtyp.Kind() == reflect.Ptr; xtyp = xtyp.Elem() {
 	}
@@ -850,10 +909,7 @@ func (f decFnInfo) kMap(rv reflect.Value) {
 			rv.SetMapIndex(rvk, rvv)
 		}
 	} else {
-		for j := 0; !f.dd.CheckBreak(); j++ {
-			if j > 0 {
-				f.dd.ReadMapEntrySeparator()
-			}
+		for j := 0; !dd.CheckBreak(); j++ {
 			rvk := reflect.New(ktype).Elem()
 			d.decodeValue(rvk, keyFn)
 
@@ -868,15 +924,14 @@ func (f decFnInfo) kMap(rv reflect.Value) {
 			if !rvv.IsValid() {
 				rvv = reflect.New(vtype).Elem()
 			}
-			f.dd.ReadMapKVSeparator()
 			d.decodeValue(rvv, valFn)
 			rv.SetMapIndex(rvk, rvv)
 		}
-		f.dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 }
 
-type rtidDecFn struct {
+type decRtidFn struct {
 	rtid uintptr
 	fn   decFn
 }
@@ -887,19 +942,22 @@ type Decoder struct {
 	// Try to put things that go together to fit within a cache line (8 words).
 
 	d decDriver
+	// NOTE: Decoder shouldn't call it's read methods,
+	// as the handler MAY need to do some coordination.
 	r decReader
-	//sa [32]rtidDecFn
-	s []rtidDecFn
+	// sa [initCollectionCap]decRtidFn
+	s []decRtidFn
 	h *BasicHandle
 
 	rb    bytesDecReader
 	hh    Handle
 	be    bool // is binary encoding
 	bytes bool // is bytes reader
+	js    bool // is json handle
 
 	ri ioDecReader
-	f  map[uintptr]decFn
-	_  uintptr // for alignment purposes, so next one starts from a cache line
+	f  map[uintptr]*decFn
+	// _  uintptr // for alignment purposes, so next one starts from a cache line
 
 	b [scratchByteArrayLen]byte
 }
@@ -910,7 +968,7 @@ type Decoder struct {
 // (eg bufio.Reader, bytes.Buffer).
 func NewDecoder(r io.Reader, h Handle) (d *Decoder) {
 	d = &Decoder{hh: h, h: h.getBasicHandle(), be: h.isBinary()}
-	//d.s = d.sa[:0]
+	// d.s = d.sa[:0]
 	d.ri.x = &d.b
 	d.ri.bs.r = r
 	var ok bool
@@ -919,6 +977,7 @@ func NewDecoder(r io.Reader, h Handle) (d *Decoder) {
 		d.ri.br = &d.ri.bs
 	}
 	d.r = &d.ri
+	_, d.js = h.(*JsonHandle)
 	d.d = h.newDecDriver(d)
 	return
 }
@@ -927,10 +986,11 @@ func NewDecoder(r io.Reader, h Handle) (d *Decoder) {
 // from a byte slice with zero copying.
 func NewDecoderBytes(in []byte, h Handle) (d *Decoder) {
 	d = &Decoder{hh: h, h: h.getBasicHandle(), be: h.isBinary(), bytes: true}
-	//d.s = d.sa[:0]
+	// d.s = d.sa[:0]
 	d.rb.b = in
 	d.rb.a = len(in)
 	d.r = &d.rb
+	_, d.js = h.(*JsonHandle)
 	d.d = h.newDecDriver(d)
 	// d.d = h.newDecDriver(decReaderT{true, &d.rb, &d.ri})
 	return
@@ -995,7 +1055,7 @@ func (d *Decoder) Decode(v interface{}) (err error) {
 // this is not a smart swallow, as it allocates objects and does unnecessary work.
 func (d *Decoder) swallowViaHammer() {
 	var blank interface{}
-	d.decodeValue(reflect.ValueOf(&blank).Elem(), decFn{})
+	d.decodeValue(reflect.ValueOf(&blank).Elem(), nil)
 }
 
 func (d *Decoder) swallow() {
@@ -1014,14 +1074,10 @@ func (d *Decoder) swallow() {
 			} else if dd.CheckBreak() {
 				break
 			}
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			d.swallow()
-			dd.ReadMapKVSeparator()
 			d.swallow()
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	case dd.IsContainerType(valueTypeArray):
 		containerLenS := dd.ReadArrayStart()
 		clenGtEqualZero := containerLenS >= 0
@@ -1033,12 +1089,9 @@ func (d *Decoder) swallow() {
 			} else if dd.CheckBreak() {
 				break
 			}
-			if j > 0 {
-				dd.ReadArrayEntrySeparator()
-			}
 			d.swallow()
 		}
-		dd.ReadArrayEnd()
+		dd.ReadEnd()
 	case dd.IsContainerType(valueTypeBytes):
 		dd.DecodeBytes(d.b[:], false, true)
 	case dd.IsContainerType(valueTypeString):
@@ -1122,7 +1175,7 @@ func (d *Decoder) decode(iv interface{}) {
 
 	case reflect.Value:
 		d.chkPtrValue(v)
-		d.decodeValueNotNil(v.Elem(), decFn{})
+		d.decodeValueNotNil(v.Elem(), nil)
 
 	case *string:
 
@@ -1157,7 +1210,7 @@ func (d *Decoder) decode(iv interface{}) {
 		*v = d.d.DecodeBytes(*v, false, false)
 
 	case *interface{}:
-		d.decodeValueNotNil(reflect.ValueOf(iv).Elem(), decFn{})
+		d.decodeValueNotNil(reflect.ValueOf(iv).Elem(), nil)
 
 	default:
 		if !fastpathDecodeTypeSwitch(iv, d) {
@@ -1196,29 +1249,29 @@ func (d *Decoder) decodeI(iv interface{}, checkPtr, tryNil, checkFastpath, check
 	rv, proceed := d.preDecodeValue(rv, tryNil)
 	if proceed {
 		fn := d.getDecFn(rv.Type(), checkFastpath, checkCodecSelfer)
-		fn.f(fn.i, rv)
+		fn.f(&fn.i, rv)
 	}
 }
 
-func (d *Decoder) decodeValue(rv reflect.Value, fn decFn) {
+func (d *Decoder) decodeValue(rv reflect.Value, fn *decFn) {
 	if rv, proceed := d.preDecodeValue(rv, true); proceed {
-		if fn.f == nil {
+		if fn == nil {
 			fn = d.getDecFn(rv.Type(), true, true)
 		}
-		fn.f(fn.i, rv)
+		fn.f(&fn.i, rv)
 	}
 }
 
-func (d *Decoder) decodeValueNotNil(rv reflect.Value, fn decFn) {
+func (d *Decoder) decodeValueNotNil(rv reflect.Value, fn *decFn) {
 	if rv, proceed := d.preDecodeValue(rv, false); proceed {
-		if fn.f == nil {
+		if fn == nil {
 			fn = d.getDecFn(rv.Type(), true, true)
 		}
-		fn.f(fn.i, rv)
+		fn.f(&fn.i, rv)
 	}
 }
 
-func (d *Decoder) getDecFn(rt reflect.Type, checkFastpath, checkCodecSelfer bool) (fn decFn) {
+func (d *Decoder) getDecFn(rt reflect.Type, checkFastpath, checkCodecSelfer bool) (fn *decFn) {
 	rtid := reflect.ValueOf(rt).Pointer()
 
 	// retrieve or register a focus'ed function for this type
@@ -1229,9 +1282,10 @@ func (d *Decoder) getDecFn(rt reflect.Type, checkFastpath, checkCodecSelfer bool
 	if useMapForCodecCache {
 		fn, ok = d.f[rtid]
 	} else {
-		for _, v := range d.s {
+		for i := range d.s {
+			v := &(d.s[i])
 			if v.rtid == rtid {
-				fn, ok = v.fn, true
+				fn, ok = &(v.fn), true
 				break
 			}
 		}
@@ -1240,11 +1294,25 @@ func (d *Decoder) getDecFn(rt reflect.Type, checkFastpath, checkCodecSelfer bool
 		return
 	}
 
+	if useMapForCodecCache {
+		if d.f == nil {
+			d.f = make(map[uintptr]*decFn, initCollectionCap)
+		}
+		fn = new(decFn)
+		d.f[rtid] = fn
+	} else {
+		if d.s == nil {
+			d.s = make([]decRtidFn, 0, initCollectionCap)
+		}
+		d.s = append(d.s, decRtidFn{rtid: rtid})
+		fn = &(d.s[len(d.s)-1]).fn
+	}
+
 	// debugf("\tCreating new dec fn for type: %v\n", rt)
 	ti := getTypeInfo(rtid, rt)
-	var fi decFnInfo
-	fi.dd = d.d
-	// fi.decFnInfoX = new(decFnInfoX)
+	fi := &(fn.i)
+	fi.d = d
+	fi.ti = ti
 
 	// An extension can be registered for any type, regardless of the Kind
 	// (e.g. type BitSet int64, type MyStruct { / * unexported fields * / }, type X []int, etc.
@@ -1256,31 +1324,26 @@ func (d *Decoder) getDecFn(rt reflect.Type, checkFastpath, checkCodecSelfer bool
 	// NOTE: if decoding into a nil interface{}, we return a non-nil
 	// value except even if the container registers a length of 0.
 	if checkCodecSelfer && ti.cs {
-		fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-		fn.f = (decFnInfo).selferUnmarshal
+		fn.f = (*decFnInfo).selferUnmarshal
 	} else if rtid == rawExtTypId {
-		fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-		fn.f = (decFnInfo).rawExt
+		fn.f = (*decFnInfo).rawExt
 	} else if d.d.IsBuiltinType(rtid) {
-		fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-		fn.f = (decFnInfo).builtin
+		fn.f = (*decFnInfo).builtin
 	} else if xfFn := d.h.getExt(rtid); xfFn != nil {
-		// fi.decFnInfoX = &decFnInfoX{xfTag: xfFn.tag, xfFn: xfFn.ext}
-		fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
 		fi.xfTag, fi.xfFn = xfFn.tag, xfFn.ext
-		fn.f = (decFnInfo).ext
+		fn.f = (*decFnInfo).ext
 	} else if supportMarshalInterfaces && d.be && ti.bunm {
-		fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-		fn.f = (decFnInfo).binaryUnmarshal
+		fn.f = (*decFnInfo).binaryUnmarshal
+	} else if supportMarshalInterfaces && !d.be && d.js && ti.junm {
+		//If JSON, we should check JSONUnmarshal before textUnmarshal
+		fn.f = (*decFnInfo).jsonUnmarshal
 	} else if supportMarshalInterfaces && !d.be && ti.tunm {
-		fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-		fn.f = (decFnInfo).textUnmarshal
+		fn.f = (*decFnInfo).textUnmarshal
 	} else {
 		rk := rt.Kind()
 		if fastpathEnabled && checkFastpath && (rk == reflect.Map || rk == reflect.Slice) {
 			if rt.PkgPath() == "" {
 				if idx := fastpathAV.index(rtid); idx != -1 {
-					fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
 					fn.f = fastpathAV[idx].decfn
 				}
 			} else {
@@ -1296,8 +1359,7 @@ func (d *Decoder) getDecFn(rt reflect.Type, checkFastpath, checkCodecSelfer bool
 				if idx := fastpathAV.index(rtuid); idx != -1 {
 					xfnf := fastpathAV[idx].decfn
 					xrt := fastpathAV[idx].rt
-					fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-					fn.f = func(xf decFnInfo, xrv reflect.Value) {
+					fn.f = func(xf *decFnInfo, xrv reflect.Value) {
 						// xfnf(xf, xrv.Convert(xrt))
 						xfnf(xf, xrv.Addr().Convert(reflect.PtrTo(xrt)).Elem())
 					}
@@ -1307,72 +1369,58 @@ func (d *Decoder) getDecFn(rt reflect.Type, checkFastpath, checkCodecSelfer bool
 		if fn.f == nil {
 			switch rk {
 			case reflect.String:
-				fn.f = (decFnInfo).kString
+				fn.f = (*decFnInfo).kString
 			case reflect.Bool:
-				fn.f = (decFnInfo).kBool
+				fn.f = (*decFnInfo).kBool
 			case reflect.Int:
-				fn.f = (decFnInfo).kInt
+				fn.f = (*decFnInfo).kInt
 			case reflect.Int64:
-				fn.f = (decFnInfo).kInt64
+				fn.f = (*decFnInfo).kInt64
 			case reflect.Int32:
-				fn.f = (decFnInfo).kInt32
+				fn.f = (*decFnInfo).kInt32
 			case reflect.Int8:
-				fn.f = (decFnInfo).kInt8
+				fn.f = (*decFnInfo).kInt8
 			case reflect.Int16:
-				fn.f = (decFnInfo).kInt16
+				fn.f = (*decFnInfo).kInt16
 			case reflect.Float32:
-				fn.f = (decFnInfo).kFloat32
+				fn.f = (*decFnInfo).kFloat32
 			case reflect.Float64:
-				fn.f = (decFnInfo).kFloat64
+				fn.f = (*decFnInfo).kFloat64
 			case reflect.Uint8:
-				fn.f = (decFnInfo).kUint8
+				fn.f = (*decFnInfo).kUint8
 			case reflect.Uint64:
-				fn.f = (decFnInfo).kUint64
+				fn.f = (*decFnInfo).kUint64
 			case reflect.Uint:
-				fn.f = (decFnInfo).kUint
+				fn.f = (*decFnInfo).kUint
 			case reflect.Uint32:
-				fn.f = (decFnInfo).kUint32
+				fn.f = (*decFnInfo).kUint32
 			case reflect.Uint16:
-				fn.f = (decFnInfo).kUint16
+				fn.f = (*decFnInfo).kUint16
 				// case reflect.Ptr:
-				// 	fn.f = (decFnInfo).kPtr
+				// 	fn.f = (*decFnInfo).kPtr
+			case reflect.Uintptr:
+				fn.f = (*decFnInfo).kUintptr
 			case reflect.Interface:
-				fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-				fn.f = (decFnInfo).kInterface
+				fn.f = (*decFnInfo).kInterface
 			case reflect.Struct:
-				fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-				fn.f = (decFnInfo).kStruct
+				fn.f = (*decFnInfo).kStruct
 			case reflect.Chan:
-				fi.decFnInfoX = &decFnInfoX{d: d, ti: ti, seq: seqTypeChan}
-				fn.f = (decFnInfo).kSlice
+				fi.seq = seqTypeChan
+				fn.f = (*decFnInfo).kSlice
 			case reflect.Slice:
-				fi.decFnInfoX = &decFnInfoX{d: d, ti: ti, seq: seqTypeSlice}
-				fn.f = (decFnInfo).kSlice
+				fi.seq = seqTypeSlice
+				fn.f = (*decFnInfo).kSlice
 			case reflect.Array:
-				// fi.decFnInfoX = &decFnInfoX{array: true}
-				fi.decFnInfoX = &decFnInfoX{d: d, ti: ti, seq: seqTypeArray}
-				fn.f = (decFnInfo).kArray
+				fi.seq = seqTypeArray
+				fn.f = (*decFnInfo).kArray
 			case reflect.Map:
-				fi.decFnInfoX = &decFnInfoX{d: d, ti: ti}
-				fn.f = (decFnInfo).kMap
+				fn.f = (*decFnInfo).kMap
 			default:
-				fn.f = (decFnInfo).kErr
+				fn.f = (*decFnInfo).kErr
 			}
 		}
 	}
-	fn.i = fi
 
-	if useMapForCodecCache {
-		if d.f == nil {
-			d.f = make(map[uintptr]decFn, 32)
-		}
-		d.f[rtid] = fn
-	} else {
-		if d.s == nil {
-			d.s = make([]rtidDecFn, 0, 32)
-		}
-		d.s = append(d.s, rtidDecFn{rtid, fn})
-	}
 	return
 }
 
@@ -1417,7 +1465,10 @@ func (d *Decoder) error(err error) {
 }
 
 func (d *Decoder) errorf(format string, params ...interface{}) {
-	err := fmt.Errorf(format, params...)
+	params2 := make([]interface{}, len(params)+1)
+	params2[0] = d.r.numread()
+	copy(params2[1:], params)
+	err := fmt.Errorf("[pos %d]: "+format, params2...)
 	panic(err)
 }
 
@@ -1444,29 +1495,9 @@ func (d *Decoder) decSliceHelperStart() (x decSliceHelper, clen int) {
 	return
 }
 
-func (x decSliceHelper) Sep(index int) {
-	if x.ct == valueTypeArray {
-		x.dd.ReadArrayEntrySeparator()
-	} else {
-		if index%2 == 0 {
-			x.dd.ReadMapEntrySeparator()
-		} else {
-			x.dd.ReadMapKVSeparator()
-		}
-	}
-}
-
 func (x decSliceHelper) End() {
-	if x.ct == valueTypeArray {
-		x.dd.ReadArrayEnd()
-	} else {
-		x.dd.ReadMapEnd()
-	}
+	x.dd.ReadEnd()
 }
-
-// func decErr(format string, params ...interface{}) {
-// 	doPanic(msgTagDec, format, params...)
-// }
 
 func decByteSlice(r decReader, clen int, bs []byte) (bsOut []byte) {
 	if clen == 0 {
@@ -1498,6 +1529,46 @@ func detachZeroCopyBytes(isBytesReader bool, dest []byte, in []byte) (out []byte
 	return in
 }
 
+// decInferLen will infer a sensible length, given the following:
+//    - clen: length wanted.
+//    - maxlen: max length to be returned.
+//      if <= 0, it is unset, and we infer it based on the unit size
+//    - unit: number of bytes for each element of the collection
+func decInferLen(clen, maxlen, unit int) (rvlen int, truncated bool) {
+	// handle when maxlen is not set i.e. <= 0
+	if clen <= 0 {
+		return
+	}
+	if maxlen <= 0 {
+		// no maxlen defined. Use maximum of 256K memory, with a floor of 4K items.
+		// maxlen = 256 * 1024 / unit
+		// if maxlen < (4 * 1024) {
+		// 	maxlen = 4 * 1024
+		// }
+		if unit < (256 / 4) {
+			maxlen = 256 * 1024 / unit
+		} else {
+			maxlen = 4 * 1024
+		}
+	}
+	if clen > maxlen {
+		rvlen = maxlen
+		truncated = true
+	} else {
+		rvlen = clen
+	}
+	return
+	// if clen <= 0 {
+	// 	rvlen = 0
+	// } else if maxlen > 0 && clen > maxlen {
+	// 	rvlen = maxlen
+	// 	truncated = true
+	// } else {
+	// 	rvlen = clen
+	// }
+	// return
+}
+
 // // implement overall decReader wrapping both, for possible use inline:
 // type decReaderT struct {
 // 	bytes bool
@@ -1516,37 +1587,5 @@ func detachZeroCopyBytes(isBytesReader bool, dest []byte, in []byte) (out []byte
 // 		d.ri.unreadn1()
 // 	}
 // }
-
-// func (d *Decoder) readb(b []byte) {
-// 	if d.bytes {
-// 		d.rb.readb(b)
-// 	} else {
-// 		d.ri.readb(b)
-// 	}
-// }
-
-// func (d *Decoder) readx(n int) []byte {
-// 	if d.bytes {
-// 		return d.rb.readx(n)
-// 	} else {
-// 		return d.ri.readx(n)
-// 	}
-// }
-
-// func (d *Decoder) readn1() uint8 {
-// 	if d.bytes {
-// 		return d.rb.readn1()
-// 	} else {
-// 		return d.ri.readn1()
-// 	}
-// }
-
-// func (d *Decoder) readn1eof() (v uint8, eof bool) {
-// 	if d.bytes {
-// 		return d.rb.readn1eof()
-// 	} else {
-// 		return d.ri.readn1eof()
-// 	}
-// }
-
-// var _ decReader = (*Decoder)(nil) // decReaderT{} //
+// ... for other methods of decReader.
+// Testing showed that performance improvement was negligible.

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/encode.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/encode.go
@@ -6,7 +6,6 @@ package codec
 import (
 	"bytes"
 	"encoding"
-	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -63,12 +62,8 @@ type encDriver interface {
 	EncodeRawExt(re *RawExt, e *Encoder)
 	EncodeExt(v interface{}, xtag uint64, ext Ext, e *Encoder)
 	EncodeArrayStart(length int)
-	EncodeArrayEnd()
-	EncodeArrayEntrySeparator()
 	EncodeMapStart(length int)
-	EncodeMapEnd()
-	EncodeMapEntrySeparator()
-	EncodeMapKVSeparator()
+	EncodeEnd()
 	EncodeString(c charEncoding, v string)
 	EncodeSymbol(v string)
 	EncodeStringBytes(c charEncoding, v []byte)
@@ -77,13 +72,13 @@ type encDriver interface {
 	//encStringRunes(c charEncoding, v []rune)
 }
 
+type encDriverAsis interface {
+	EncodeAsis(v []byte)
+}
+
 type encNoSeparator struct{}
 
-func (_ encNoSeparator) EncodeMapEnd()              {}
-func (_ encNoSeparator) EncodeArrayEnd()            {}
-func (_ encNoSeparator) EncodeArrayEntrySeparator() {}
-func (_ encNoSeparator) EncodeMapEntrySeparator()   {}
-func (_ encNoSeparator) EncodeMapKVSeparator()      {}
+func (_ encNoSeparator) EncodeEnd() {}
 
 type encStructFieldBytesV struct {
 	b []byte
@@ -113,8 +108,9 @@ type EncodeOptions struct {
 	// Canonical representation means that encoding a value will always result in the same
 	// sequence of bytes.
 	//
-	// This mostly will apply to maps. In this case, codec will do more work to encode the
-	// map keys out of band, and then sort them, before writing out the map to the stream.
+	// This only affects maps, as the iteration order for maps is random.
+	// In this case, the map keys will first be encoded into []byte, and then sorted,
+	// before writing the sorted keys and the corresponding map values to the stream.
 	Canonical bool
 
 	// AsSymbols defines what should be encoded as symbols.
@@ -249,10 +245,10 @@ func (z *bytesEncWriter) grow(n int) (oldcursor int) {
 	z.c = oldcursor + n
 	if z.c > len(z.b) {
 		if z.c > cap(z.b) {
-			// Tried using appendslice logic: (if cap < 1024, *2, else *1.25).
-			// However, it was too expensive, causing too many iterations of copy.
-			// Using bytes.Buffer model was much better (2*cap + n)
-			bs := make([]byte, 2*cap(z.b)+n)
+			// appendslice logic (if cap < 1024, *2, else *1.25): more expensive. many copy calls.
+			// bytes.Buffer model (2*cap + n): much better
+			// bs := make([]byte, 2*cap(z.b)+n)
+			bs := make([]byte, growCap(cap(z.b), 1, n))
 			copy(bs, z.b[:oldcursor])
 			z.b = bs
 		} else {
@@ -264,7 +260,7 @@ func (z *bytesEncWriter) grow(n int) (oldcursor int) {
 
 // ---------------------------------------------
 
-type encFnInfoX struct {
+type encFnInfo struct {
 	e     *Encoder
 	ti    *typeInfo
 	xfFn  Ext
@@ -272,25 +268,13 @@ type encFnInfoX struct {
 	seq   seqType
 }
 
-type encFnInfo struct {
-	// use encFnInfo as a value receiver.
-	// keep most of it less-used variables accessible via a pointer (*encFnInfoX).
-	// As sweet spot for value-receiver is 3 words, keep everything except
-	// encDriver (which everyone needs) directly accessible.
-	// ensure encFnInfoX is set for everyone who needs it i.e.
-	// rawExt, ext, builtin, (selfer|binary|text)Marshal, kSlice, kStruct, kMap, kInterface, fastpath
-
-	ee encDriver
-	*encFnInfoX
+func (f *encFnInfo) builtin(rv reflect.Value) {
+	f.e.e.EncodeBuiltin(f.ti.rtid, rv.Interface())
 }
 
-func (f encFnInfo) builtin(rv reflect.Value) {
-	f.ee.EncodeBuiltin(f.ti.rtid, rv.Interface())
-}
-
-func (f encFnInfo) rawExt(rv reflect.Value) {
+func (f *encFnInfo) rawExt(rv reflect.Value) {
 	// rev := rv.Interface().(RawExt)
-	// f.ee.EncodeRawExt(&rev, f.e)
+	// f.e.e.EncodeRawExt(&rev, f.e)
 	var re *RawExt
 	if rv.CanAddr() {
 		re = rv.Addr().Interface().(*RawExt)
@@ -298,26 +282,35 @@ func (f encFnInfo) rawExt(rv reflect.Value) {
 		rev := rv.Interface().(RawExt)
 		re = &rev
 	}
-	f.ee.EncodeRawExt(re, f.e)
+	f.e.e.EncodeRawExt(re, f.e)
 }
 
-func (f encFnInfo) ext(rv reflect.Value) {
-	// if this is a struct and it was addressable, then pass the address directly (not the value)
-	if rv.CanAddr() && rv.Kind() == reflect.Struct {
+func (f *encFnInfo) ext(rv reflect.Value) {
+	// if this is a struct|array and it was addressable, then pass the address directly (not the value)
+	if k := rv.Kind(); (k == reflect.Struct || k == reflect.Array) && rv.CanAddr() {
 		rv = rv.Addr()
 	}
-	f.ee.EncodeExt(rv.Interface(), f.xfTag, f.xfFn, f.e)
+	f.e.e.EncodeExt(rv.Interface(), f.xfTag, f.xfFn, f.e)
 }
 
-func (f encFnInfo) getValueForMarshalInterface(rv reflect.Value, indir int8) (v interface{}, proceed bool) {
+func (f *encFnInfo) getValueForMarshalInterface(rv reflect.Value, indir int8) (v interface{}, proceed bool) {
 	if indir == 0 {
 		v = rv.Interface()
 	} else if indir == -1 {
-		v = rv.Addr().Interface()
+		// If a non-pointer was passed to Encode(), then that value is not addressable.
+		// Take addr if addresable, else copy value to an addressable value.
+		if rv.CanAddr() {
+			v = rv.Addr().Interface()
+		} else {
+			rv2 := reflect.New(rv.Type())
+			rv2.Elem().Set(rv)
+			v = rv2.Interface()
+			// fmt.Printf("rv.Type: %v, rv2.Type: %v, v: %v\n", rv.Type(), rv2.Type(), v)
+		}
 	} else {
 		for j := int8(0); j < indir; j++ {
 			if rv.IsNil() {
-				f.ee.EncodeNil()
+				f.e.e.EncodeNil()
 				return
 			}
 			rv = rv.Elem()
@@ -327,74 +320,67 @@ func (f encFnInfo) getValueForMarshalInterface(rv reflect.Value, indir int8) (v 
 	return v, true
 }
 
-func (f encFnInfo) selferMarshal(rv reflect.Value) {
+func (f *encFnInfo) selferMarshal(rv reflect.Value) {
 	if v, proceed := f.getValueForMarshalInterface(rv, f.ti.csIndir); proceed {
 		v.(Selfer).CodecEncodeSelf(f.e)
 	}
 }
 
-func (f encFnInfo) binaryMarshal(rv reflect.Value) {
+func (f *encFnInfo) binaryMarshal(rv reflect.Value) {
 	if v, proceed := f.getValueForMarshalInterface(rv, f.ti.bmIndir); proceed {
 		bs, fnerr := v.(encoding.BinaryMarshaler).MarshalBinary()
-		if fnerr != nil {
-			panic(fnerr)
-		}
-		if bs == nil {
-			f.ee.EncodeNil()
-		} else {
-			f.ee.EncodeStringBytes(c_RAW, bs)
-		}
+		f.e.marshal(bs, fnerr, false, c_RAW)
 	}
 }
 
-func (f encFnInfo) textMarshal(rv reflect.Value) {
+func (f *encFnInfo) textMarshal(rv reflect.Value) {
 	if v, proceed := f.getValueForMarshalInterface(rv, f.ti.tmIndir); proceed {
 		// debugf(">>>> encoding.TextMarshaler: %T", rv.Interface())
 		bs, fnerr := v.(encoding.TextMarshaler).MarshalText()
-		if fnerr != nil {
-			panic(fnerr)
-		}
-		if bs == nil {
-			f.ee.EncodeNil()
-		} else {
-			f.ee.EncodeStringBytes(c_UTF8, bs)
-		}
+		f.e.marshal(bs, fnerr, false, c_UTF8)
 	}
 }
 
-func (f encFnInfo) kBool(rv reflect.Value) {
-	f.ee.EncodeBool(rv.Bool())
+func (f *encFnInfo) jsonMarshal(rv reflect.Value) {
+	if v, proceed := f.getValueForMarshalInterface(rv, f.ti.jmIndir); proceed {
+		bs, fnerr := v.(jsonMarshaler).MarshalJSON()
+		f.e.marshal(bs, fnerr, true, c_UTF8)
+	}
 }
 
-func (f encFnInfo) kString(rv reflect.Value) {
-	f.ee.EncodeString(c_UTF8, rv.String())
+func (f *encFnInfo) kBool(rv reflect.Value) {
+	f.e.e.EncodeBool(rv.Bool())
 }
 
-func (f encFnInfo) kFloat64(rv reflect.Value) {
-	f.ee.EncodeFloat64(rv.Float())
+func (f *encFnInfo) kString(rv reflect.Value) {
+	f.e.e.EncodeString(c_UTF8, rv.String())
 }
 
-func (f encFnInfo) kFloat32(rv reflect.Value) {
-	f.ee.EncodeFloat32(float32(rv.Float()))
+func (f *encFnInfo) kFloat64(rv reflect.Value) {
+	f.e.e.EncodeFloat64(rv.Float())
 }
 
-func (f encFnInfo) kInt(rv reflect.Value) {
-	f.ee.EncodeInt(rv.Int())
+func (f *encFnInfo) kFloat32(rv reflect.Value) {
+	f.e.e.EncodeFloat32(float32(rv.Float()))
 }
 
-func (f encFnInfo) kUint(rv reflect.Value) {
-	f.ee.EncodeUint(rv.Uint())
+func (f *encFnInfo) kInt(rv reflect.Value) {
+	f.e.e.EncodeInt(rv.Int())
 }
 
-func (f encFnInfo) kInvalid(rv reflect.Value) {
-	f.ee.EncodeNil()
+func (f *encFnInfo) kUint(rv reflect.Value) {
+	f.e.e.EncodeUint(rv.Uint())
 }
 
-func (f encFnInfo) kErr(rv reflect.Value) {
+func (f *encFnInfo) kInvalid(rv reflect.Value) {
+	f.e.e.EncodeNil()
+}
+
+func (f *encFnInfo) kErr(rv reflect.Value) {
 	f.e.errorf("unsupported kind %s, for %#v", rv.Kind(), rv)
 }
 
-func (f encFnInfo) kSlice(rv reflect.Value) {
+func (f *encFnInfo) kSlice(rv reflect.Value) {
 	ti := f.ti
 	// array may be non-addressable, so we have to manage with care
 	//   (don't call rv.Bytes, rv.Slice, etc).
@@ -402,13 +388,13 @@ func (f encFnInfo) kSlice(rv reflect.Value) {
 	//   Encode(S{}) will bomb on "panic: slice of unaddressable array".
 	if f.seq != seqTypeArray {
 		if rv.IsNil() {
-			f.ee.EncodeNil()
+			f.e.e.EncodeNil()
 			return
 		}
 		// If in this method, then there was no extension function defined.
 		// So it's okay to treat as []byte.
 		if ti.rtid == uint8SliceTypId {
-			f.ee.EncodeStringBytes(c_RAW, rv.Bytes())
+			f.e.e.EncodeStringBytes(c_RAW, rv.Bytes())
 			return
 		}
 	}
@@ -417,9 +403,9 @@ func (f encFnInfo) kSlice(rv reflect.Value) {
 	if rtelem.Kind() == reflect.Uint8 {
 		switch f.seq {
 		case seqTypeArray:
-			// if l == 0 { f.ee.encodeStringBytes(c_RAW, nil) } else
+			// if l == 0 { f.e.e.encodeStringBytes(c_RAW, nil) } else
 			if rv.CanAddr() {
-				f.ee.EncodeStringBytes(c_RAW, rv.Slice(0, l).Bytes())
+				f.e.e.EncodeStringBytes(c_RAW, rv.Slice(0, l).Bytes())
 			} else {
 				var bs []byte
 				if l <= cap(f.e.b) {
@@ -432,10 +418,10 @@ func (f encFnInfo) kSlice(rv reflect.Value) {
 				// for i := 0; i < l; i++ {
 				// 	bs[i] = byte(rv.Index(i).Uint())
 				// }
-				f.ee.EncodeStringBytes(c_RAW, bs)
+				f.e.e.EncodeStringBytes(c_RAW, bs)
 			}
 		case seqTypeSlice:
-			f.ee.EncodeStringBytes(c_RAW, rv.Bytes())
+			f.e.e.EncodeStringBytes(c_RAW, rv.Bytes())
 		case seqTypeChan:
 			bs := f.e.b[:0]
 			// do not use range, so that the number of elements encoded
@@ -447,7 +433,7 @@ func (f encFnInfo) kSlice(rv reflect.Value) {
 			for i := 0; i < l; i++ {
 				bs = append(bs, <-ch)
 			}
-			f.ee.EncodeStringBytes(c_RAW, bs)
+			f.e.e.EncodeStringBytes(c_RAW, bs)
 		}
 		return
 	}
@@ -457,13 +443,12 @@ func (f encFnInfo) kSlice(rv reflect.Value) {
 			f.e.errorf("mapBySlice requires even slice length, but got %v", l)
 			return
 		}
-		f.ee.EncodeMapStart(l / 2)
+		f.e.e.EncodeMapStart(l / 2)
 	} else {
-		f.ee.EncodeArrayStart(l)
+		f.e.e.EncodeArrayStart(l)
 	}
 
 	e := f.e
-	sep := !e.be
 	if l > 0 {
 		for rtelem.Kind() == reflect.Ptr {
 			rtelem = rtelem.Elem()
@@ -471,88 +456,38 @@ func (f encFnInfo) kSlice(rv reflect.Value) {
 		// if kind is reflect.Interface, do not pre-determine the
 		// encoding type, because preEncodeValue may break it down to
 		// a concrete type and kInterface will bomb.
-		var fn encFn
+		var fn *encFn
 		if rtelem.Kind() != reflect.Interface {
 			rtelemid := reflect.ValueOf(rtelem).Pointer()
 			fn = e.getEncFn(rtelemid, rtelem, true, true)
 		}
 		// TODO: Consider perf implication of encoding odd index values as symbols if type is string
-		if sep {
-			for j := 0; j < l; j++ {
-				if j > 0 {
-					if ti.mbs {
-						if j%2 == 0 {
-							f.ee.EncodeMapEntrySeparator()
-						} else {
-							f.ee.EncodeMapKVSeparator()
-						}
-					} else {
-						f.ee.EncodeArrayEntrySeparator()
-					}
+		for j := 0; j < l; j++ {
+			if f.seq == seqTypeChan {
+				if rv2, ok2 := rv.Recv(); ok2 {
+					e.encodeValue(rv2, fn)
 				}
-				if f.seq == seqTypeChan {
-					if rv2, ok2 := rv.Recv(); ok2 {
-						e.encodeValue(rv2, fn)
-					}
-				} else {
-					e.encodeValue(rv.Index(j), fn)
-				}
-			}
-		} else {
-			for j := 0; j < l; j++ {
-				if f.seq == seqTypeChan {
-					if rv2, ok2 := rv.Recv(); ok2 {
-						e.encodeValue(rv2, fn)
-					}
-				} else {
-					e.encodeValue(rv.Index(j), fn)
-				}
+			} else {
+				e.encodeValue(rv.Index(j), fn)
 			}
 		}
+
 	}
 
-	if sep {
-		if ti.mbs {
-			f.ee.EncodeMapEnd()
-		} else {
-			f.ee.EncodeArrayEnd()
-		}
-	}
+	f.e.e.EncodeEnd()
 }
 
-func (f encFnInfo) kStruct(rv reflect.Value) {
+func (f *encFnInfo) kStruct(rv reflect.Value) {
 	fti := f.ti
 	e := f.e
 	tisfi := fti.sfip
 	toMap := !(fti.toArray || e.h.StructToArray)
 	newlen := len(fti.sfi)
+
 	// Use sync.Pool to reduce allocating slices unnecessarily.
 	// The cost of the occasional locking is less than the cost of locking.
+	pool, poolv, fkvs := encStructPoolGet(newlen)
 
-	var fkvs []encStructFieldKV
-	var pool *sync.Pool
-	var poolv interface{}
-	idxpool := newlen / 8
-	if encStructPoolLen != 4 {
-		panic(errors.New("encStructPoolLen must be equal to 4")) // defensive, in case it is changed
-	}
-	if idxpool < encStructPoolLen {
-		pool = &encStructPool[idxpool]
-		poolv = pool.Get()
-		switch vv := poolv.(type) {
-		case *[8]encStructFieldKV:
-			fkvs = vv[:newlen]
-		case *[16]encStructFieldKV:
-			fkvs = vv[:newlen]
-		case *[32]encStructFieldKV:
-			fkvs = vv[:newlen]
-		case *[64]encStructFieldKV:
-			fkvs = vv[:newlen]
-		}
-	}
-	if fkvs == nil {
-		fkvs = make([]encStructFieldKV, newlen)
-	}
 	// if toMap, use the sorted array. If toArray, use unsorted array (to match sequence in struct)
 	if toMap {
 		tisfi = fti.sfi
@@ -587,60 +522,30 @@ func (f encFnInfo) kStruct(rv reflect.Value) {
 	}
 
 	// debugf(">>>> kStruct: newlen: %v", newlen)
-	sep := !e.be
-	ee := f.ee //don't dereference everytime
-	if sep {
-		if toMap {
-			ee.EncodeMapStart(newlen)
-			// asSymbols := e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
-			asSymbols := e.h.AsSymbols == AsSymbolDefault || e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
-			for j := 0; j < newlen; j++ {
-				kv = fkvs[j]
-				if j > 0 {
-					ee.EncodeMapEntrySeparator()
-				}
-				if asSymbols {
-					ee.EncodeSymbol(kv.k)
-				} else {
-					ee.EncodeString(c_UTF8, kv.k)
-				}
-				ee.EncodeMapKVSeparator()
-				e.encodeValue(kv.v, encFn{})
+	// sep := !e.be
+	ee := f.e.e //don't dereference everytime
+
+	if toMap {
+		ee.EncodeMapStart(newlen)
+		// asSymbols := e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
+		asSymbols := e.h.AsSymbols == AsSymbolDefault || e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
+		for j := 0; j < newlen; j++ {
+			kv = fkvs[j]
+			if asSymbols {
+				ee.EncodeSymbol(kv.k)
+			} else {
+				ee.EncodeString(c_UTF8, kv.k)
 			}
-			ee.EncodeMapEnd()
-		} else {
-			ee.EncodeArrayStart(newlen)
-			for j := 0; j < newlen; j++ {
-				kv = fkvs[j]
-				if j > 0 {
-					ee.EncodeArrayEntrySeparator()
-				}
-				e.encodeValue(kv.v, encFn{})
-			}
-			ee.EncodeArrayEnd()
+			e.encodeValue(kv.v, nil)
 		}
 	} else {
-		if toMap {
-			ee.EncodeMapStart(newlen)
-			// asSymbols := e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
-			asSymbols := e.h.AsSymbols == AsSymbolDefault || e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
-			for j := 0; j < newlen; j++ {
-				kv = fkvs[j]
-				if asSymbols {
-					ee.EncodeSymbol(kv.k)
-				} else {
-					ee.EncodeString(c_UTF8, kv.k)
-				}
-				e.encodeValue(kv.v, encFn{})
-			}
-		} else {
-			ee.EncodeArrayStart(newlen)
-			for j := 0; j < newlen; j++ {
-				kv = fkvs[j]
-				e.encodeValue(kv.v, encFn{})
-			}
+		ee.EncodeArrayStart(newlen)
+		for j := 0; j < newlen; j++ {
+			kv = fkvs[j]
+			e.encodeValue(kv.v, nil)
 		}
 	}
+	ee.EncodeEnd()
 
 	// do not use defer. Instead, use explicit pool return at end of function.
 	// defer has a cost we are trying to avoid.
@@ -650,37 +555,35 @@ func (f encFnInfo) kStruct(rv reflect.Value) {
 	}
 }
 
-// func (f encFnInfo) kPtr(rv reflect.Value) {
+// func (f *encFnInfo) kPtr(rv reflect.Value) {
 // 	debugf(">>>>>>> ??? encode kPtr called - shouldn't get called")
 // 	if rv.IsNil() {
-// 		f.ee.encodeNil()
+// 		f.e.e.encodeNil()
 // 		return
 // 	}
 // 	f.e.encodeValue(rv.Elem())
 // }
 
-func (f encFnInfo) kInterface(rv reflect.Value) {
+func (f *encFnInfo) kInterface(rv reflect.Value) {
 	if rv.IsNil() {
-		f.ee.EncodeNil()
+		f.e.e.EncodeNil()
 		return
 	}
-	f.e.encodeValue(rv.Elem(), encFn{})
+	f.e.encodeValue(rv.Elem(), nil)
 }
 
-func (f encFnInfo) kMap(rv reflect.Value) {
+func (f *encFnInfo) kMap(rv reflect.Value) {
+	ee := f.e.e
 	if rv.IsNil() {
-		f.ee.EncodeNil()
+		ee.EncodeNil()
 		return
 	}
 
 	l := rv.Len()
-	f.ee.EncodeMapStart(l)
+	ee.EncodeMapStart(l)
 	e := f.e
-	sep := !e.be
 	if l == 0 {
-		if sep {
-			f.ee.EncodeMapEnd()
-		}
+		ee.EncodeEnd()
 		return
 	}
 	var asSymbols bool
@@ -691,7 +594,7 @@ func (f encFnInfo) kMap(rv reflect.Value) {
 	// However, if kind is reflect.Interface, do not pre-determine the
 	// encoding type, because preEncodeValue may break it down to
 	// a concrete type and kInterface will bomb.
-	var keyFn, valFn encFn
+	var keyFn, valFn *encFn
 	ti := f.ti
 	rtkey := ti.rt.Key()
 	rtval := ti.rt.Elem()
@@ -718,11 +621,10 @@ func (f encFnInfo) kMap(rv reflect.Value) {
 	}
 	mks := rv.MapKeys()
 	// for j, lmks := 0, len(mks); j < lmks; j++ {
-	ee := f.ee //don't dereference everytime
 	if e.h.Canonical {
 		// first encode each key to a []byte first, then sort them, then record
 		// println(">>>>>>>> CANONICAL <<<<<<<<")
-		var mksv []byte // temporary byte slice for the encoding
+		var mksv []byte = make([]byte, 0, len(mks)*16) // temporary byte slice for the encoding
 		e2 := NewEncoderBytes(&mksv, e.hh)
 		mksbv := make([]encStructFieldBytesV, len(mks))
 		for i, k := range mks {
@@ -730,35 +632,13 @@ func (f encFnInfo) kMap(rv reflect.Value) {
 			e2.MustEncode(k)
 			mksbv[i].v = k
 			mksbv[i].b = mksv[l:]
+			// fmt.Printf(">>>>> %s\n", mksv[l:])
 		}
 		sort.Sort(encStructFieldBytesVslice(mksbv))
 		for j := range mksbv {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.w.writeb(mksbv[j].b)
-			ee.EncodeMapKVSeparator()
+			e.asis(mksbv[j].b)
 			e.encodeValue(rv.MapIndex(mksbv[j].v), valFn)
 		}
-		ee.EncodeMapEnd()
-	} else if sep {
-		for j := range mks {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if keyTypeIsString {
-				if asSymbols {
-					ee.EncodeSymbol(mks[j].String())
-				} else {
-					ee.EncodeString(c_UTF8, mks[j].String())
-				}
-			} else {
-				e.encodeValue(mks[j], keyFn)
-			}
-			ee.EncodeMapKVSeparator()
-			e.encodeValue(rv.MapIndex(mks[j]), valFn)
-		}
-		ee.EncodeMapEnd()
 	} else {
 		for j := range mks {
 			if keyTypeIsString {
@@ -773,6 +653,7 @@ func (f encFnInfo) kMap(rv reflect.Value) {
 			e.encodeValue(rv.MapIndex(mks[j]), valFn)
 		}
 	}
+	ee.EncodeEnd()
 }
 
 // --------------------------------------------------
@@ -783,12 +664,12 @@ func (f encFnInfo) kMap(rv reflect.Value) {
 // instead of executing the checks every time.
 type encFn struct {
 	i encFnInfo
-	f func(encFnInfo, reflect.Value)
+	f func(*encFnInfo, reflect.Value)
 }
 
 // --------------------------------------------------
 
-type rtidEncFn struct {
+type encRtidFn struct {
 	rtid uintptr
 	fn   encFn
 }
@@ -796,17 +677,21 @@ type rtidEncFn struct {
 // An Encoder writes an object to an output stream in the codec format.
 type Encoder struct {
 	// hopefully, reduce derefencing cost by laying the encWriter inside the Encoder
-	e  encDriver
+	e encDriver
+	// NOTE: Encoder shouldn't call it's write methods,
+	// as the handler MAY need to do some coordination.
 	w  encWriter
-	s  []rtidEncFn
+	s  []encRtidFn
 	be bool // is binary encoding
+	js bool // is json handle
 
 	wi ioEncWriter
 	wb bytesEncWriter
 	h  *BasicHandle
 
+	as encDriverAsis
 	hh Handle
-	f  map[uintptr]encFn
+	f  map[uintptr]*encFn
 	b  [scratchByteArrayLen]byte
 }
 
@@ -826,7 +711,9 @@ func NewEncoder(w io.Writer, h Handle) *Encoder {
 	}
 	e.wi.w = ww
 	e.w = &e.wi
+	_, e.js = h.(*JsonHandle)
 	e.e = h.newEncDriver(e)
+	e.as, _ = e.e.(encDriverAsis)
 	return e
 }
 
@@ -843,7 +730,9 @@ func NewEncoderBytes(out *[]byte, h Handle) *Encoder {
 	}
 	e.wb.b, e.wb.out = in, out
 	e.w = &e.wb
+	_, e.js = h.(*JsonHandle)
 	e.e = h.newEncDriver(e)
+	e.as, _ = e.e.(encDriverAsis)
 	return e
 }
 
@@ -873,8 +762,9 @@ func NewEncoderBytes(out *[]byte, h Handle) *Encoder {
 // The empty values (for omitempty option) are false, 0, any nil pointer
 // or interface value, and any array, slice, map, or string of length zero.
 //
-// Anonymous fields are encoded inline if no struct tag is present.
-// Else they are encoded as regular fields.
+// Anonymous fields are encoded inline except:
+//    - the struct tag specifies a replacement name (first value)
+//    - the field is of an interface type
 //
 // Examples:
 //
@@ -885,6 +775,9 @@ func NewEncoderBytes(out *[]byte, h Handle) *Encoder {
 //          Field2 int      `codec:"myName"`       //Use key "myName" in encode stream
 //          Field3 int32    `codec:",omitempty"`   //use key "Field3". Omit if empty.
 //          Field4 bool     `codec:"f4,omitempty"` //use key "f4". Omit if empty.
+//          io.Reader                              //use key "Reader".
+//          MyStruct        `codec:"my1"           //use key "my1".
+//          MyStruct                               //inline it
 //          ...
 //      }
 //
@@ -894,8 +787,9 @@ func NewEncoderBytes(out *[]byte, h Handle) *Encoder {
 //      }
 //
 // The mode of encoding is based on the type of the value. When a value is seen:
+//   - If a Selfer, call its CodecEncodeSelf method
 //   - If an extension is registered for it, call that extension function
-//   - If it implements BinaryMarshaler, call its MarshalBinary() (data []byte, err error)
+//   - If it implements encoding.(Binary|Text|JSON)Marshaler, call its Marshal(Binary|Text|JSON) method
 //   - Else encode it based on its reflect.Kind
 //
 // Note that struct field names and keys in map[string]XXX will be treated as symbols.
@@ -942,7 +836,7 @@ func (e *Encoder) encode(iv interface{}) {
 		v.CodecEncodeSelf(e)
 
 	case reflect.Value:
-		e.encodeValue(v, encFn{})
+		e.encodeValue(v, nil)
 
 	case string:
 		e.e.EncodeString(c_UTF8, v)
@@ -1010,12 +904,15 @@ func (e *Encoder) encode(iv interface{}) {
 
 	default:
 		// canonical mode is not supported for fastpath of maps (but is fine for slices)
+		const checkCodecSelfer1 = true // in case T is passed, where *T is a Selfer, still checkCodecSelfer
 		if e.h.Canonical {
 			if !fastpathEncodeTypeSwitchSlice(iv, e) {
-				e.encodeI(iv, false, false)
+				e.encodeI(iv, false, checkCodecSelfer1)
 			}
-		} else if !fastpathEncodeTypeSwitch(iv, e) {
-			e.encodeI(iv, false, false)
+		} else {
+			if !fastpathEncodeTypeSwitch(iv, e) {
+				e.encodeI(iv, false, checkCodecSelfer1)
+			}
 		}
 	}
 }
@@ -1025,7 +922,7 @@ func (e *Encoder) encodeI(iv interface{}, checkFastpath, checkCodecSelfer bool) 
 		rt := rv.Type()
 		rtid := reflect.ValueOf(rt).Pointer()
 		fn := e.getEncFn(rtid, rt, checkFastpath, checkCodecSelfer)
-		fn.f(fn.i, rv)
+		fn.f(&fn.i, rv)
 	}
 }
 
@@ -1055,27 +952,28 @@ LOOP:
 	return rv, true
 }
 
-func (e *Encoder) encodeValue(rv reflect.Value, fn encFn) {
+func (e *Encoder) encodeValue(rv reflect.Value, fn *encFn) {
 	// if a valid fn is passed, it MUST BE for the dereferenced type of rv
 	if rv, proceed := e.preEncodeValue(rv); proceed {
-		if fn.f == nil {
+		if fn == nil {
 			rt := rv.Type()
 			rtid := reflect.ValueOf(rt).Pointer()
 			fn = e.getEncFn(rtid, rt, true, true)
 		}
-		fn.f(fn.i, rv)
+		fn.f(&fn.i, rv)
 	}
 }
 
-func (e *Encoder) getEncFn(rtid uintptr, rt reflect.Type, checkFastpath, checkCodecSelfer bool) (fn encFn) {
+func (e *Encoder) getEncFn(rtid uintptr, rt reflect.Type, checkFastpath, checkCodecSelfer bool) (fn *encFn) {
 	// rtid := reflect.ValueOf(rt).Pointer()
 	var ok bool
 	if useMapForCodecCache {
 		fn, ok = e.f[rtid]
 	} else {
-		for _, v := range e.s {
+		for i := range e.s {
+			v := &(e.s[i])
 			if v.rtid == rtid {
-				fn, ok = v.fn, true
+				fn, ok = &(v.fn), true
 				break
 			}
 		}
@@ -1083,37 +981,48 @@ func (e *Encoder) getEncFn(rtid uintptr, rt reflect.Type, checkFastpath, checkCo
 	if ok {
 		return
 	}
-	// fi.encFnInfoX = new(encFnInfoX)
+
+	if useMapForCodecCache {
+		if e.f == nil {
+			e.f = make(map[uintptr]*encFn, initCollectionCap)
+		}
+		fn = new(encFn)
+		e.f[rtid] = fn
+	} else {
+		if e.s == nil {
+			e.s = make([]encRtidFn, 0, initCollectionCap)
+		}
+		e.s = append(e.s, encRtidFn{rtid: rtid})
+		fn = &(e.s[len(e.s)-1]).fn
+	}
+
 	ti := getTypeInfo(rtid, rt)
-	var fi encFnInfo
-	fi.ee = e.e
+	fi := &(fn.i)
+	fi.e = e
+	fi.ti = ti
 
 	if checkCodecSelfer && ti.cs {
-		fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-		fn.f = (encFnInfo).selferMarshal
+		fn.f = (*encFnInfo).selferMarshal
 	} else if rtid == rawExtTypId {
-		fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-		fn.f = (encFnInfo).rawExt
+		fn.f = (*encFnInfo).rawExt
 	} else if e.e.IsBuiltinType(rtid) {
-		fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-		fn.f = (encFnInfo).builtin
+		fn.f = (*encFnInfo).builtin
 	} else if xfFn := e.h.getExt(rtid); xfFn != nil {
-		// fi.encFnInfoX = new(encFnInfoX)
-		fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
 		fi.xfTag, fi.xfFn = xfFn.tag, xfFn.ext
-		fn.f = (encFnInfo).ext
+		fn.f = (*encFnInfo).ext
 	} else if supportMarshalInterfaces && e.be && ti.bm {
-		fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-		fn.f = (encFnInfo).binaryMarshal
+		fn.f = (*encFnInfo).binaryMarshal
+	} else if supportMarshalInterfaces && !e.be && e.js && ti.jm {
+		//If JSON, we should check JSONMarshal before textMarshal
+		fn.f = (*encFnInfo).jsonMarshal
 	} else if supportMarshalInterfaces && !e.be && ti.tm {
-		fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-		fn.f = (encFnInfo).textMarshal
+		fn.f = (*encFnInfo).textMarshal
 	} else {
 		rk := rt.Kind()
-		if fastpathEnabled && checkFastpath && (rk == reflect.Map || rk == reflect.Slice) {
+		// if fastpathEnabled && checkFastpath && (rk == reflect.Map || rk == reflect.Slice) {
+		if fastpathEnabled && checkFastpath && (rk == reflect.Slice || (rk == reflect.Map && !e.h.Canonical)) {
 			if rt.PkgPath() == "" {
 				if idx := fastpathAV.index(rtid); idx != -1 {
-					fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
 					fn.f = fastpathAV[idx].encfn
 				}
 			} else {
@@ -1129,8 +1038,7 @@ func (e *Encoder) getEncFn(rtid uintptr, rt reflect.Type, checkFastpath, checkCo
 				if idx := fastpathAV.index(rtuid); idx != -1 {
 					xfnf := fastpathAV[idx].encfn
 					xrt := fastpathAV[idx].rt
-					fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-					fn.f = func(xf encFnInfo, xrv reflect.Value) {
+					fn.f = func(xf *encFnInfo, xrv reflect.Value) {
 						xfnf(xf, xrv.Convert(xrt))
 					}
 				}
@@ -1139,58 +1047,64 @@ func (e *Encoder) getEncFn(rtid uintptr, rt reflect.Type, checkFastpath, checkCo
 		if fn.f == nil {
 			switch rk {
 			case reflect.Bool:
-				fn.f = (encFnInfo).kBool
+				fn.f = (*encFnInfo).kBool
 			case reflect.String:
-				fn.f = (encFnInfo).kString
+				fn.f = (*encFnInfo).kString
 			case reflect.Float64:
-				fn.f = (encFnInfo).kFloat64
+				fn.f = (*encFnInfo).kFloat64
 			case reflect.Float32:
-				fn.f = (encFnInfo).kFloat32
+				fn.f = (*encFnInfo).kFloat32
 			case reflect.Int, reflect.Int8, reflect.Int64, reflect.Int32, reflect.Int16:
-				fn.f = (encFnInfo).kInt
-			case reflect.Uint8, reflect.Uint64, reflect.Uint, reflect.Uint32, reflect.Uint16:
-				fn.f = (encFnInfo).kUint
+				fn.f = (*encFnInfo).kInt
+			case reflect.Uint8, reflect.Uint64, reflect.Uint, reflect.Uint32, reflect.Uint16, reflect.Uintptr:
+				fn.f = (*encFnInfo).kUint
 			case reflect.Invalid:
-				fn.f = (encFnInfo).kInvalid
+				fn.f = (*encFnInfo).kInvalid
 			case reflect.Chan:
-				fi.encFnInfoX = &encFnInfoX{e: e, ti: ti, seq: seqTypeChan}
-				fn.f = (encFnInfo).kSlice
+				fi.seq = seqTypeChan
+				fn.f = (*encFnInfo).kSlice
 			case reflect.Slice:
-				fi.encFnInfoX = &encFnInfoX{e: e, ti: ti, seq: seqTypeSlice}
-				fn.f = (encFnInfo).kSlice
+				fi.seq = seqTypeSlice
+				fn.f = (*encFnInfo).kSlice
 			case reflect.Array:
-				fi.encFnInfoX = &encFnInfoX{e: e, ti: ti, seq: seqTypeArray}
-				fn.f = (encFnInfo).kSlice
+				fi.seq = seqTypeArray
+				fn.f = (*encFnInfo).kSlice
 			case reflect.Struct:
-				fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-				fn.f = (encFnInfo).kStruct
+				fn.f = (*encFnInfo).kStruct
 				// case reflect.Ptr:
-				// 	fn.f = (encFnInfo).kPtr
+				// 	fn.f = (*encFnInfo).kPtr
 			case reflect.Interface:
-				fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-				fn.f = (encFnInfo).kInterface
+				fn.f = (*encFnInfo).kInterface
 			case reflect.Map:
-				fi.encFnInfoX = &encFnInfoX{e: e, ti: ti}
-				fn.f = (encFnInfo).kMap
+				fn.f = (*encFnInfo).kMap
 			default:
-				fn.f = (encFnInfo).kErr
+				fn.f = (*encFnInfo).kErr
 			}
 		}
 	}
-	fn.i = fi
 
-	if useMapForCodecCache {
-		if e.f == nil {
-			e.f = make(map[uintptr]encFn, 32)
-		}
-		e.f[rtid] = fn
-	} else {
-		if e.s == nil {
-			e.s = make([]rtidEncFn, 0, 32)
-		}
-		e.s = append(e.s, rtidEncFn{rtid, fn})
-	}
 	return
+}
+
+func (e *Encoder) marshal(bs []byte, fnerr error, asis bool, c charEncoding) {
+	if fnerr != nil {
+		panic(fnerr)
+	}
+	if bs == nil {
+		e.e.EncodeNil()
+	} else if asis {
+		e.asis(bs)
+	} else {
+		e.e.EncodeStringBytes(c, bs)
+	}
+}
+
+func (e *Encoder) asis(v []byte) {
+	if e.as == nil {
+		e.w.writeb(v)
+	} else {
+		e.as.EncodeAsis(v)
+	}
 }
 
 func (e *Encoder) errorf(format string, params ...interface{}) {
@@ -1205,7 +1119,7 @@ type encStructFieldKV struct {
 	v reflect.Value
 }
 
-const encStructPoolLen = 4
+const encStructPoolLen = 5
 
 // encStructPool is an array of sync.Pool.
 // Each element of the array pools one of encStructPool(8|16|32|64).
@@ -1223,6 +1137,57 @@ func init() {
 	encStructPool[1].New = func() interface{} { return new([16]encStructFieldKV) }
 	encStructPool[2].New = func() interface{} { return new([32]encStructFieldKV) }
 	encStructPool[3].New = func() interface{} { return new([64]encStructFieldKV) }
+	encStructPool[4].New = func() interface{} { return new([128]encStructFieldKV) }
+}
+
+func encStructPoolGet(newlen int) (p *sync.Pool, v interface{}, s []encStructFieldKV) {
+	// if encStructPoolLen != 5 { // constant chec, so removed at build time.
+	// 	panic(errors.New("encStructPoolLen must be equal to 4")) // defensive, in case it is changed
+	// }
+	// idxpool := newlen / 8
+
+	// if pool == nil {
+	// 	fkvs = make([]encStructFieldKV, newlen)
+	// } else {
+	// 	poolv = pool.Get()
+	// 	switch vv := poolv.(type) {
+	// 	case *[8]encStructFieldKV:
+	// 		fkvs = vv[:newlen]
+	// 	case *[16]encStructFieldKV:
+	// 		fkvs = vv[:newlen]
+	// 	case *[32]encStructFieldKV:
+	// 		fkvs = vv[:newlen]
+	// 	case *[64]encStructFieldKV:
+	// 		fkvs = vv[:newlen]
+	// 	case *[128]encStructFieldKV:
+	// 		fkvs = vv[:newlen]
+	// 	}
+	// }
+
+	if newlen <= 8 {
+		p = &encStructPool[0]
+		v = p.Get()
+		s = v.(*[8]encStructFieldKV)[:newlen]
+	} else if newlen <= 16 {
+		p = &encStructPool[1]
+		v = p.Get()
+		s = v.(*[16]encStructFieldKV)[:newlen]
+	} else if newlen <= 32 {
+		p = &encStructPool[2]
+		v = p.Get()
+		s = v.(*[32]encStructFieldKV)[:newlen]
+	} else if newlen <= 64 {
+		p = &encStructPool[3]
+		v = p.Get()
+		s = v.(*[64]encStructFieldKV)[:newlen]
+	} else if newlen <= 128 {
+		p = &encStructPool[4]
+		v = p.Get()
+		s = v.(*[128]encStructFieldKV)[:newlen]
+	} else {
+		s = make([]encStructFieldKV, newlen)
+	}
+	return
 }
 
 // ----------------------------------------

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.generated.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.generated.go
@@ -48,8 +48,8 @@ var fastpathTV fastpathT
 type fastpathE struct {
 	rtid  uintptr
 	rt    reflect.Type
-	encfn func(encFnInfo, reflect.Value)
-	decfn func(decFnInfo, reflect.Value)
+	encfn func(*encFnInfo, reflect.Value)
+	decfn func(*decFnInfo, reflect.Value)
 }
 
 type fastpathA [239]fastpathE
@@ -85,7 +85,7 @@ func init() {
 		return
 	}
 	i := 0
-	fn := func(v interface{}, fe func(encFnInfo, reflect.Value), fd func(decFnInfo, reflect.Value)) (f fastpathE) {
+	fn := func(v interface{}, fe func(*encFnInfo, reflect.Value), fd func(*decFnInfo, reflect.Value)) (f fastpathE) {
 		xrt := reflect.TypeOf(v)
 		xptr := reflect.ValueOf(xrt).Pointer()
 		fastpathAV[i] = fastpathE{xptr, xrt, fe, fd}
@@ -93,246 +93,246 @@ func init() {
 		return
 	}
 
-	fn([]interface{}(nil), (encFnInfo).fastpathEncSliceIntfR, (decFnInfo).fastpathDecSliceIntfR)
-	fn([]string(nil), (encFnInfo).fastpathEncSliceStringR, (decFnInfo).fastpathDecSliceStringR)
-	fn([]float32(nil), (encFnInfo).fastpathEncSliceFloat32R, (decFnInfo).fastpathDecSliceFloat32R)
-	fn([]float64(nil), (encFnInfo).fastpathEncSliceFloat64R, (decFnInfo).fastpathDecSliceFloat64R)
-	fn([]uint(nil), (encFnInfo).fastpathEncSliceUintR, (decFnInfo).fastpathDecSliceUintR)
-	fn([]uint16(nil), (encFnInfo).fastpathEncSliceUint16R, (decFnInfo).fastpathDecSliceUint16R)
-	fn([]uint32(nil), (encFnInfo).fastpathEncSliceUint32R, (decFnInfo).fastpathDecSliceUint32R)
-	fn([]uint64(nil), (encFnInfo).fastpathEncSliceUint64R, (decFnInfo).fastpathDecSliceUint64R)
-	fn([]int(nil), (encFnInfo).fastpathEncSliceIntR, (decFnInfo).fastpathDecSliceIntR)
-	fn([]int8(nil), (encFnInfo).fastpathEncSliceInt8R, (decFnInfo).fastpathDecSliceInt8R)
-	fn([]int16(nil), (encFnInfo).fastpathEncSliceInt16R, (decFnInfo).fastpathDecSliceInt16R)
-	fn([]int32(nil), (encFnInfo).fastpathEncSliceInt32R, (decFnInfo).fastpathDecSliceInt32R)
-	fn([]int64(nil), (encFnInfo).fastpathEncSliceInt64R, (decFnInfo).fastpathDecSliceInt64R)
-	fn([]bool(nil), (encFnInfo).fastpathEncSliceBoolR, (decFnInfo).fastpathDecSliceBoolR)
+	fn([]interface{}(nil), (*encFnInfo).fastpathEncSliceIntfR, (*decFnInfo).fastpathDecSliceIntfR)
+	fn([]string(nil), (*encFnInfo).fastpathEncSliceStringR, (*decFnInfo).fastpathDecSliceStringR)
+	fn([]float32(nil), (*encFnInfo).fastpathEncSliceFloat32R, (*decFnInfo).fastpathDecSliceFloat32R)
+	fn([]float64(nil), (*encFnInfo).fastpathEncSliceFloat64R, (*decFnInfo).fastpathDecSliceFloat64R)
+	fn([]uint(nil), (*encFnInfo).fastpathEncSliceUintR, (*decFnInfo).fastpathDecSliceUintR)
+	fn([]uint16(nil), (*encFnInfo).fastpathEncSliceUint16R, (*decFnInfo).fastpathDecSliceUint16R)
+	fn([]uint32(nil), (*encFnInfo).fastpathEncSliceUint32R, (*decFnInfo).fastpathDecSliceUint32R)
+	fn([]uint64(nil), (*encFnInfo).fastpathEncSliceUint64R, (*decFnInfo).fastpathDecSliceUint64R)
+	fn([]int(nil), (*encFnInfo).fastpathEncSliceIntR, (*decFnInfo).fastpathDecSliceIntR)
+	fn([]int8(nil), (*encFnInfo).fastpathEncSliceInt8R, (*decFnInfo).fastpathDecSliceInt8R)
+	fn([]int16(nil), (*encFnInfo).fastpathEncSliceInt16R, (*decFnInfo).fastpathDecSliceInt16R)
+	fn([]int32(nil), (*encFnInfo).fastpathEncSliceInt32R, (*decFnInfo).fastpathDecSliceInt32R)
+	fn([]int64(nil), (*encFnInfo).fastpathEncSliceInt64R, (*decFnInfo).fastpathDecSliceInt64R)
+	fn([]bool(nil), (*encFnInfo).fastpathEncSliceBoolR, (*decFnInfo).fastpathDecSliceBoolR)
 
-	fn(map[interface{}]interface{}(nil), (encFnInfo).fastpathEncMapIntfIntfR, (decFnInfo).fastpathDecMapIntfIntfR)
-	fn(map[interface{}]string(nil), (encFnInfo).fastpathEncMapIntfStringR, (decFnInfo).fastpathDecMapIntfStringR)
-	fn(map[interface{}]uint(nil), (encFnInfo).fastpathEncMapIntfUintR, (decFnInfo).fastpathDecMapIntfUintR)
-	fn(map[interface{}]uint8(nil), (encFnInfo).fastpathEncMapIntfUint8R, (decFnInfo).fastpathDecMapIntfUint8R)
-	fn(map[interface{}]uint16(nil), (encFnInfo).fastpathEncMapIntfUint16R, (decFnInfo).fastpathDecMapIntfUint16R)
-	fn(map[interface{}]uint32(nil), (encFnInfo).fastpathEncMapIntfUint32R, (decFnInfo).fastpathDecMapIntfUint32R)
-	fn(map[interface{}]uint64(nil), (encFnInfo).fastpathEncMapIntfUint64R, (decFnInfo).fastpathDecMapIntfUint64R)
-	fn(map[interface{}]int(nil), (encFnInfo).fastpathEncMapIntfIntR, (decFnInfo).fastpathDecMapIntfIntR)
-	fn(map[interface{}]int8(nil), (encFnInfo).fastpathEncMapIntfInt8R, (decFnInfo).fastpathDecMapIntfInt8R)
-	fn(map[interface{}]int16(nil), (encFnInfo).fastpathEncMapIntfInt16R, (decFnInfo).fastpathDecMapIntfInt16R)
-	fn(map[interface{}]int32(nil), (encFnInfo).fastpathEncMapIntfInt32R, (decFnInfo).fastpathDecMapIntfInt32R)
-	fn(map[interface{}]int64(nil), (encFnInfo).fastpathEncMapIntfInt64R, (decFnInfo).fastpathDecMapIntfInt64R)
-	fn(map[interface{}]float32(nil), (encFnInfo).fastpathEncMapIntfFloat32R, (decFnInfo).fastpathDecMapIntfFloat32R)
-	fn(map[interface{}]float64(nil), (encFnInfo).fastpathEncMapIntfFloat64R, (decFnInfo).fastpathDecMapIntfFloat64R)
-	fn(map[interface{}]bool(nil), (encFnInfo).fastpathEncMapIntfBoolR, (decFnInfo).fastpathDecMapIntfBoolR)
-	fn(map[string]interface{}(nil), (encFnInfo).fastpathEncMapStringIntfR, (decFnInfo).fastpathDecMapStringIntfR)
-	fn(map[string]string(nil), (encFnInfo).fastpathEncMapStringStringR, (decFnInfo).fastpathDecMapStringStringR)
-	fn(map[string]uint(nil), (encFnInfo).fastpathEncMapStringUintR, (decFnInfo).fastpathDecMapStringUintR)
-	fn(map[string]uint8(nil), (encFnInfo).fastpathEncMapStringUint8R, (decFnInfo).fastpathDecMapStringUint8R)
-	fn(map[string]uint16(nil), (encFnInfo).fastpathEncMapStringUint16R, (decFnInfo).fastpathDecMapStringUint16R)
-	fn(map[string]uint32(nil), (encFnInfo).fastpathEncMapStringUint32R, (decFnInfo).fastpathDecMapStringUint32R)
-	fn(map[string]uint64(nil), (encFnInfo).fastpathEncMapStringUint64R, (decFnInfo).fastpathDecMapStringUint64R)
-	fn(map[string]int(nil), (encFnInfo).fastpathEncMapStringIntR, (decFnInfo).fastpathDecMapStringIntR)
-	fn(map[string]int8(nil), (encFnInfo).fastpathEncMapStringInt8R, (decFnInfo).fastpathDecMapStringInt8R)
-	fn(map[string]int16(nil), (encFnInfo).fastpathEncMapStringInt16R, (decFnInfo).fastpathDecMapStringInt16R)
-	fn(map[string]int32(nil), (encFnInfo).fastpathEncMapStringInt32R, (decFnInfo).fastpathDecMapStringInt32R)
-	fn(map[string]int64(nil), (encFnInfo).fastpathEncMapStringInt64R, (decFnInfo).fastpathDecMapStringInt64R)
-	fn(map[string]float32(nil), (encFnInfo).fastpathEncMapStringFloat32R, (decFnInfo).fastpathDecMapStringFloat32R)
-	fn(map[string]float64(nil), (encFnInfo).fastpathEncMapStringFloat64R, (decFnInfo).fastpathDecMapStringFloat64R)
-	fn(map[string]bool(nil), (encFnInfo).fastpathEncMapStringBoolR, (decFnInfo).fastpathDecMapStringBoolR)
-	fn(map[float32]interface{}(nil), (encFnInfo).fastpathEncMapFloat32IntfR, (decFnInfo).fastpathDecMapFloat32IntfR)
-	fn(map[float32]string(nil), (encFnInfo).fastpathEncMapFloat32StringR, (decFnInfo).fastpathDecMapFloat32StringR)
-	fn(map[float32]uint(nil), (encFnInfo).fastpathEncMapFloat32UintR, (decFnInfo).fastpathDecMapFloat32UintR)
-	fn(map[float32]uint8(nil), (encFnInfo).fastpathEncMapFloat32Uint8R, (decFnInfo).fastpathDecMapFloat32Uint8R)
-	fn(map[float32]uint16(nil), (encFnInfo).fastpathEncMapFloat32Uint16R, (decFnInfo).fastpathDecMapFloat32Uint16R)
-	fn(map[float32]uint32(nil), (encFnInfo).fastpathEncMapFloat32Uint32R, (decFnInfo).fastpathDecMapFloat32Uint32R)
-	fn(map[float32]uint64(nil), (encFnInfo).fastpathEncMapFloat32Uint64R, (decFnInfo).fastpathDecMapFloat32Uint64R)
-	fn(map[float32]int(nil), (encFnInfo).fastpathEncMapFloat32IntR, (decFnInfo).fastpathDecMapFloat32IntR)
-	fn(map[float32]int8(nil), (encFnInfo).fastpathEncMapFloat32Int8R, (decFnInfo).fastpathDecMapFloat32Int8R)
-	fn(map[float32]int16(nil), (encFnInfo).fastpathEncMapFloat32Int16R, (decFnInfo).fastpathDecMapFloat32Int16R)
-	fn(map[float32]int32(nil), (encFnInfo).fastpathEncMapFloat32Int32R, (decFnInfo).fastpathDecMapFloat32Int32R)
-	fn(map[float32]int64(nil), (encFnInfo).fastpathEncMapFloat32Int64R, (decFnInfo).fastpathDecMapFloat32Int64R)
-	fn(map[float32]float32(nil), (encFnInfo).fastpathEncMapFloat32Float32R, (decFnInfo).fastpathDecMapFloat32Float32R)
-	fn(map[float32]float64(nil), (encFnInfo).fastpathEncMapFloat32Float64R, (decFnInfo).fastpathDecMapFloat32Float64R)
-	fn(map[float32]bool(nil), (encFnInfo).fastpathEncMapFloat32BoolR, (decFnInfo).fastpathDecMapFloat32BoolR)
-	fn(map[float64]interface{}(nil), (encFnInfo).fastpathEncMapFloat64IntfR, (decFnInfo).fastpathDecMapFloat64IntfR)
-	fn(map[float64]string(nil), (encFnInfo).fastpathEncMapFloat64StringR, (decFnInfo).fastpathDecMapFloat64StringR)
-	fn(map[float64]uint(nil), (encFnInfo).fastpathEncMapFloat64UintR, (decFnInfo).fastpathDecMapFloat64UintR)
-	fn(map[float64]uint8(nil), (encFnInfo).fastpathEncMapFloat64Uint8R, (decFnInfo).fastpathDecMapFloat64Uint8R)
-	fn(map[float64]uint16(nil), (encFnInfo).fastpathEncMapFloat64Uint16R, (decFnInfo).fastpathDecMapFloat64Uint16R)
-	fn(map[float64]uint32(nil), (encFnInfo).fastpathEncMapFloat64Uint32R, (decFnInfo).fastpathDecMapFloat64Uint32R)
-	fn(map[float64]uint64(nil), (encFnInfo).fastpathEncMapFloat64Uint64R, (decFnInfo).fastpathDecMapFloat64Uint64R)
-	fn(map[float64]int(nil), (encFnInfo).fastpathEncMapFloat64IntR, (decFnInfo).fastpathDecMapFloat64IntR)
-	fn(map[float64]int8(nil), (encFnInfo).fastpathEncMapFloat64Int8R, (decFnInfo).fastpathDecMapFloat64Int8R)
-	fn(map[float64]int16(nil), (encFnInfo).fastpathEncMapFloat64Int16R, (decFnInfo).fastpathDecMapFloat64Int16R)
-	fn(map[float64]int32(nil), (encFnInfo).fastpathEncMapFloat64Int32R, (decFnInfo).fastpathDecMapFloat64Int32R)
-	fn(map[float64]int64(nil), (encFnInfo).fastpathEncMapFloat64Int64R, (decFnInfo).fastpathDecMapFloat64Int64R)
-	fn(map[float64]float32(nil), (encFnInfo).fastpathEncMapFloat64Float32R, (decFnInfo).fastpathDecMapFloat64Float32R)
-	fn(map[float64]float64(nil), (encFnInfo).fastpathEncMapFloat64Float64R, (decFnInfo).fastpathDecMapFloat64Float64R)
-	fn(map[float64]bool(nil), (encFnInfo).fastpathEncMapFloat64BoolR, (decFnInfo).fastpathDecMapFloat64BoolR)
-	fn(map[uint]interface{}(nil), (encFnInfo).fastpathEncMapUintIntfR, (decFnInfo).fastpathDecMapUintIntfR)
-	fn(map[uint]string(nil), (encFnInfo).fastpathEncMapUintStringR, (decFnInfo).fastpathDecMapUintStringR)
-	fn(map[uint]uint(nil), (encFnInfo).fastpathEncMapUintUintR, (decFnInfo).fastpathDecMapUintUintR)
-	fn(map[uint]uint8(nil), (encFnInfo).fastpathEncMapUintUint8R, (decFnInfo).fastpathDecMapUintUint8R)
-	fn(map[uint]uint16(nil), (encFnInfo).fastpathEncMapUintUint16R, (decFnInfo).fastpathDecMapUintUint16R)
-	fn(map[uint]uint32(nil), (encFnInfo).fastpathEncMapUintUint32R, (decFnInfo).fastpathDecMapUintUint32R)
-	fn(map[uint]uint64(nil), (encFnInfo).fastpathEncMapUintUint64R, (decFnInfo).fastpathDecMapUintUint64R)
-	fn(map[uint]int(nil), (encFnInfo).fastpathEncMapUintIntR, (decFnInfo).fastpathDecMapUintIntR)
-	fn(map[uint]int8(nil), (encFnInfo).fastpathEncMapUintInt8R, (decFnInfo).fastpathDecMapUintInt8R)
-	fn(map[uint]int16(nil), (encFnInfo).fastpathEncMapUintInt16R, (decFnInfo).fastpathDecMapUintInt16R)
-	fn(map[uint]int32(nil), (encFnInfo).fastpathEncMapUintInt32R, (decFnInfo).fastpathDecMapUintInt32R)
-	fn(map[uint]int64(nil), (encFnInfo).fastpathEncMapUintInt64R, (decFnInfo).fastpathDecMapUintInt64R)
-	fn(map[uint]float32(nil), (encFnInfo).fastpathEncMapUintFloat32R, (decFnInfo).fastpathDecMapUintFloat32R)
-	fn(map[uint]float64(nil), (encFnInfo).fastpathEncMapUintFloat64R, (decFnInfo).fastpathDecMapUintFloat64R)
-	fn(map[uint]bool(nil), (encFnInfo).fastpathEncMapUintBoolR, (decFnInfo).fastpathDecMapUintBoolR)
-	fn(map[uint8]interface{}(nil), (encFnInfo).fastpathEncMapUint8IntfR, (decFnInfo).fastpathDecMapUint8IntfR)
-	fn(map[uint8]string(nil), (encFnInfo).fastpathEncMapUint8StringR, (decFnInfo).fastpathDecMapUint8StringR)
-	fn(map[uint8]uint(nil), (encFnInfo).fastpathEncMapUint8UintR, (decFnInfo).fastpathDecMapUint8UintR)
-	fn(map[uint8]uint8(nil), (encFnInfo).fastpathEncMapUint8Uint8R, (decFnInfo).fastpathDecMapUint8Uint8R)
-	fn(map[uint8]uint16(nil), (encFnInfo).fastpathEncMapUint8Uint16R, (decFnInfo).fastpathDecMapUint8Uint16R)
-	fn(map[uint8]uint32(nil), (encFnInfo).fastpathEncMapUint8Uint32R, (decFnInfo).fastpathDecMapUint8Uint32R)
-	fn(map[uint8]uint64(nil), (encFnInfo).fastpathEncMapUint8Uint64R, (decFnInfo).fastpathDecMapUint8Uint64R)
-	fn(map[uint8]int(nil), (encFnInfo).fastpathEncMapUint8IntR, (decFnInfo).fastpathDecMapUint8IntR)
-	fn(map[uint8]int8(nil), (encFnInfo).fastpathEncMapUint8Int8R, (decFnInfo).fastpathDecMapUint8Int8R)
-	fn(map[uint8]int16(nil), (encFnInfo).fastpathEncMapUint8Int16R, (decFnInfo).fastpathDecMapUint8Int16R)
-	fn(map[uint8]int32(nil), (encFnInfo).fastpathEncMapUint8Int32R, (decFnInfo).fastpathDecMapUint8Int32R)
-	fn(map[uint8]int64(nil), (encFnInfo).fastpathEncMapUint8Int64R, (decFnInfo).fastpathDecMapUint8Int64R)
-	fn(map[uint8]float32(nil), (encFnInfo).fastpathEncMapUint8Float32R, (decFnInfo).fastpathDecMapUint8Float32R)
-	fn(map[uint8]float64(nil), (encFnInfo).fastpathEncMapUint8Float64R, (decFnInfo).fastpathDecMapUint8Float64R)
-	fn(map[uint8]bool(nil), (encFnInfo).fastpathEncMapUint8BoolR, (decFnInfo).fastpathDecMapUint8BoolR)
-	fn(map[uint16]interface{}(nil), (encFnInfo).fastpathEncMapUint16IntfR, (decFnInfo).fastpathDecMapUint16IntfR)
-	fn(map[uint16]string(nil), (encFnInfo).fastpathEncMapUint16StringR, (decFnInfo).fastpathDecMapUint16StringR)
-	fn(map[uint16]uint(nil), (encFnInfo).fastpathEncMapUint16UintR, (decFnInfo).fastpathDecMapUint16UintR)
-	fn(map[uint16]uint8(nil), (encFnInfo).fastpathEncMapUint16Uint8R, (decFnInfo).fastpathDecMapUint16Uint8R)
-	fn(map[uint16]uint16(nil), (encFnInfo).fastpathEncMapUint16Uint16R, (decFnInfo).fastpathDecMapUint16Uint16R)
-	fn(map[uint16]uint32(nil), (encFnInfo).fastpathEncMapUint16Uint32R, (decFnInfo).fastpathDecMapUint16Uint32R)
-	fn(map[uint16]uint64(nil), (encFnInfo).fastpathEncMapUint16Uint64R, (decFnInfo).fastpathDecMapUint16Uint64R)
-	fn(map[uint16]int(nil), (encFnInfo).fastpathEncMapUint16IntR, (decFnInfo).fastpathDecMapUint16IntR)
-	fn(map[uint16]int8(nil), (encFnInfo).fastpathEncMapUint16Int8R, (decFnInfo).fastpathDecMapUint16Int8R)
-	fn(map[uint16]int16(nil), (encFnInfo).fastpathEncMapUint16Int16R, (decFnInfo).fastpathDecMapUint16Int16R)
-	fn(map[uint16]int32(nil), (encFnInfo).fastpathEncMapUint16Int32R, (decFnInfo).fastpathDecMapUint16Int32R)
-	fn(map[uint16]int64(nil), (encFnInfo).fastpathEncMapUint16Int64R, (decFnInfo).fastpathDecMapUint16Int64R)
-	fn(map[uint16]float32(nil), (encFnInfo).fastpathEncMapUint16Float32R, (decFnInfo).fastpathDecMapUint16Float32R)
-	fn(map[uint16]float64(nil), (encFnInfo).fastpathEncMapUint16Float64R, (decFnInfo).fastpathDecMapUint16Float64R)
-	fn(map[uint16]bool(nil), (encFnInfo).fastpathEncMapUint16BoolR, (decFnInfo).fastpathDecMapUint16BoolR)
-	fn(map[uint32]interface{}(nil), (encFnInfo).fastpathEncMapUint32IntfR, (decFnInfo).fastpathDecMapUint32IntfR)
-	fn(map[uint32]string(nil), (encFnInfo).fastpathEncMapUint32StringR, (decFnInfo).fastpathDecMapUint32StringR)
-	fn(map[uint32]uint(nil), (encFnInfo).fastpathEncMapUint32UintR, (decFnInfo).fastpathDecMapUint32UintR)
-	fn(map[uint32]uint8(nil), (encFnInfo).fastpathEncMapUint32Uint8R, (decFnInfo).fastpathDecMapUint32Uint8R)
-	fn(map[uint32]uint16(nil), (encFnInfo).fastpathEncMapUint32Uint16R, (decFnInfo).fastpathDecMapUint32Uint16R)
-	fn(map[uint32]uint32(nil), (encFnInfo).fastpathEncMapUint32Uint32R, (decFnInfo).fastpathDecMapUint32Uint32R)
-	fn(map[uint32]uint64(nil), (encFnInfo).fastpathEncMapUint32Uint64R, (decFnInfo).fastpathDecMapUint32Uint64R)
-	fn(map[uint32]int(nil), (encFnInfo).fastpathEncMapUint32IntR, (decFnInfo).fastpathDecMapUint32IntR)
-	fn(map[uint32]int8(nil), (encFnInfo).fastpathEncMapUint32Int8R, (decFnInfo).fastpathDecMapUint32Int8R)
-	fn(map[uint32]int16(nil), (encFnInfo).fastpathEncMapUint32Int16R, (decFnInfo).fastpathDecMapUint32Int16R)
-	fn(map[uint32]int32(nil), (encFnInfo).fastpathEncMapUint32Int32R, (decFnInfo).fastpathDecMapUint32Int32R)
-	fn(map[uint32]int64(nil), (encFnInfo).fastpathEncMapUint32Int64R, (decFnInfo).fastpathDecMapUint32Int64R)
-	fn(map[uint32]float32(nil), (encFnInfo).fastpathEncMapUint32Float32R, (decFnInfo).fastpathDecMapUint32Float32R)
-	fn(map[uint32]float64(nil), (encFnInfo).fastpathEncMapUint32Float64R, (decFnInfo).fastpathDecMapUint32Float64R)
-	fn(map[uint32]bool(nil), (encFnInfo).fastpathEncMapUint32BoolR, (decFnInfo).fastpathDecMapUint32BoolR)
-	fn(map[uint64]interface{}(nil), (encFnInfo).fastpathEncMapUint64IntfR, (decFnInfo).fastpathDecMapUint64IntfR)
-	fn(map[uint64]string(nil), (encFnInfo).fastpathEncMapUint64StringR, (decFnInfo).fastpathDecMapUint64StringR)
-	fn(map[uint64]uint(nil), (encFnInfo).fastpathEncMapUint64UintR, (decFnInfo).fastpathDecMapUint64UintR)
-	fn(map[uint64]uint8(nil), (encFnInfo).fastpathEncMapUint64Uint8R, (decFnInfo).fastpathDecMapUint64Uint8R)
-	fn(map[uint64]uint16(nil), (encFnInfo).fastpathEncMapUint64Uint16R, (decFnInfo).fastpathDecMapUint64Uint16R)
-	fn(map[uint64]uint32(nil), (encFnInfo).fastpathEncMapUint64Uint32R, (decFnInfo).fastpathDecMapUint64Uint32R)
-	fn(map[uint64]uint64(nil), (encFnInfo).fastpathEncMapUint64Uint64R, (decFnInfo).fastpathDecMapUint64Uint64R)
-	fn(map[uint64]int(nil), (encFnInfo).fastpathEncMapUint64IntR, (decFnInfo).fastpathDecMapUint64IntR)
-	fn(map[uint64]int8(nil), (encFnInfo).fastpathEncMapUint64Int8R, (decFnInfo).fastpathDecMapUint64Int8R)
-	fn(map[uint64]int16(nil), (encFnInfo).fastpathEncMapUint64Int16R, (decFnInfo).fastpathDecMapUint64Int16R)
-	fn(map[uint64]int32(nil), (encFnInfo).fastpathEncMapUint64Int32R, (decFnInfo).fastpathDecMapUint64Int32R)
-	fn(map[uint64]int64(nil), (encFnInfo).fastpathEncMapUint64Int64R, (decFnInfo).fastpathDecMapUint64Int64R)
-	fn(map[uint64]float32(nil), (encFnInfo).fastpathEncMapUint64Float32R, (decFnInfo).fastpathDecMapUint64Float32R)
-	fn(map[uint64]float64(nil), (encFnInfo).fastpathEncMapUint64Float64R, (decFnInfo).fastpathDecMapUint64Float64R)
-	fn(map[uint64]bool(nil), (encFnInfo).fastpathEncMapUint64BoolR, (decFnInfo).fastpathDecMapUint64BoolR)
-	fn(map[int]interface{}(nil), (encFnInfo).fastpathEncMapIntIntfR, (decFnInfo).fastpathDecMapIntIntfR)
-	fn(map[int]string(nil), (encFnInfo).fastpathEncMapIntStringR, (decFnInfo).fastpathDecMapIntStringR)
-	fn(map[int]uint(nil), (encFnInfo).fastpathEncMapIntUintR, (decFnInfo).fastpathDecMapIntUintR)
-	fn(map[int]uint8(nil), (encFnInfo).fastpathEncMapIntUint8R, (decFnInfo).fastpathDecMapIntUint8R)
-	fn(map[int]uint16(nil), (encFnInfo).fastpathEncMapIntUint16R, (decFnInfo).fastpathDecMapIntUint16R)
-	fn(map[int]uint32(nil), (encFnInfo).fastpathEncMapIntUint32R, (decFnInfo).fastpathDecMapIntUint32R)
-	fn(map[int]uint64(nil), (encFnInfo).fastpathEncMapIntUint64R, (decFnInfo).fastpathDecMapIntUint64R)
-	fn(map[int]int(nil), (encFnInfo).fastpathEncMapIntIntR, (decFnInfo).fastpathDecMapIntIntR)
-	fn(map[int]int8(nil), (encFnInfo).fastpathEncMapIntInt8R, (decFnInfo).fastpathDecMapIntInt8R)
-	fn(map[int]int16(nil), (encFnInfo).fastpathEncMapIntInt16R, (decFnInfo).fastpathDecMapIntInt16R)
-	fn(map[int]int32(nil), (encFnInfo).fastpathEncMapIntInt32R, (decFnInfo).fastpathDecMapIntInt32R)
-	fn(map[int]int64(nil), (encFnInfo).fastpathEncMapIntInt64R, (decFnInfo).fastpathDecMapIntInt64R)
-	fn(map[int]float32(nil), (encFnInfo).fastpathEncMapIntFloat32R, (decFnInfo).fastpathDecMapIntFloat32R)
-	fn(map[int]float64(nil), (encFnInfo).fastpathEncMapIntFloat64R, (decFnInfo).fastpathDecMapIntFloat64R)
-	fn(map[int]bool(nil), (encFnInfo).fastpathEncMapIntBoolR, (decFnInfo).fastpathDecMapIntBoolR)
-	fn(map[int8]interface{}(nil), (encFnInfo).fastpathEncMapInt8IntfR, (decFnInfo).fastpathDecMapInt8IntfR)
-	fn(map[int8]string(nil), (encFnInfo).fastpathEncMapInt8StringR, (decFnInfo).fastpathDecMapInt8StringR)
-	fn(map[int8]uint(nil), (encFnInfo).fastpathEncMapInt8UintR, (decFnInfo).fastpathDecMapInt8UintR)
-	fn(map[int8]uint8(nil), (encFnInfo).fastpathEncMapInt8Uint8R, (decFnInfo).fastpathDecMapInt8Uint8R)
-	fn(map[int8]uint16(nil), (encFnInfo).fastpathEncMapInt8Uint16R, (decFnInfo).fastpathDecMapInt8Uint16R)
-	fn(map[int8]uint32(nil), (encFnInfo).fastpathEncMapInt8Uint32R, (decFnInfo).fastpathDecMapInt8Uint32R)
-	fn(map[int8]uint64(nil), (encFnInfo).fastpathEncMapInt8Uint64R, (decFnInfo).fastpathDecMapInt8Uint64R)
-	fn(map[int8]int(nil), (encFnInfo).fastpathEncMapInt8IntR, (decFnInfo).fastpathDecMapInt8IntR)
-	fn(map[int8]int8(nil), (encFnInfo).fastpathEncMapInt8Int8R, (decFnInfo).fastpathDecMapInt8Int8R)
-	fn(map[int8]int16(nil), (encFnInfo).fastpathEncMapInt8Int16R, (decFnInfo).fastpathDecMapInt8Int16R)
-	fn(map[int8]int32(nil), (encFnInfo).fastpathEncMapInt8Int32R, (decFnInfo).fastpathDecMapInt8Int32R)
-	fn(map[int8]int64(nil), (encFnInfo).fastpathEncMapInt8Int64R, (decFnInfo).fastpathDecMapInt8Int64R)
-	fn(map[int8]float32(nil), (encFnInfo).fastpathEncMapInt8Float32R, (decFnInfo).fastpathDecMapInt8Float32R)
-	fn(map[int8]float64(nil), (encFnInfo).fastpathEncMapInt8Float64R, (decFnInfo).fastpathDecMapInt8Float64R)
-	fn(map[int8]bool(nil), (encFnInfo).fastpathEncMapInt8BoolR, (decFnInfo).fastpathDecMapInt8BoolR)
-	fn(map[int16]interface{}(nil), (encFnInfo).fastpathEncMapInt16IntfR, (decFnInfo).fastpathDecMapInt16IntfR)
-	fn(map[int16]string(nil), (encFnInfo).fastpathEncMapInt16StringR, (decFnInfo).fastpathDecMapInt16StringR)
-	fn(map[int16]uint(nil), (encFnInfo).fastpathEncMapInt16UintR, (decFnInfo).fastpathDecMapInt16UintR)
-	fn(map[int16]uint8(nil), (encFnInfo).fastpathEncMapInt16Uint8R, (decFnInfo).fastpathDecMapInt16Uint8R)
-	fn(map[int16]uint16(nil), (encFnInfo).fastpathEncMapInt16Uint16R, (decFnInfo).fastpathDecMapInt16Uint16R)
-	fn(map[int16]uint32(nil), (encFnInfo).fastpathEncMapInt16Uint32R, (decFnInfo).fastpathDecMapInt16Uint32R)
-	fn(map[int16]uint64(nil), (encFnInfo).fastpathEncMapInt16Uint64R, (decFnInfo).fastpathDecMapInt16Uint64R)
-	fn(map[int16]int(nil), (encFnInfo).fastpathEncMapInt16IntR, (decFnInfo).fastpathDecMapInt16IntR)
-	fn(map[int16]int8(nil), (encFnInfo).fastpathEncMapInt16Int8R, (decFnInfo).fastpathDecMapInt16Int8R)
-	fn(map[int16]int16(nil), (encFnInfo).fastpathEncMapInt16Int16R, (decFnInfo).fastpathDecMapInt16Int16R)
-	fn(map[int16]int32(nil), (encFnInfo).fastpathEncMapInt16Int32R, (decFnInfo).fastpathDecMapInt16Int32R)
-	fn(map[int16]int64(nil), (encFnInfo).fastpathEncMapInt16Int64R, (decFnInfo).fastpathDecMapInt16Int64R)
-	fn(map[int16]float32(nil), (encFnInfo).fastpathEncMapInt16Float32R, (decFnInfo).fastpathDecMapInt16Float32R)
-	fn(map[int16]float64(nil), (encFnInfo).fastpathEncMapInt16Float64R, (decFnInfo).fastpathDecMapInt16Float64R)
-	fn(map[int16]bool(nil), (encFnInfo).fastpathEncMapInt16BoolR, (decFnInfo).fastpathDecMapInt16BoolR)
-	fn(map[int32]interface{}(nil), (encFnInfo).fastpathEncMapInt32IntfR, (decFnInfo).fastpathDecMapInt32IntfR)
-	fn(map[int32]string(nil), (encFnInfo).fastpathEncMapInt32StringR, (decFnInfo).fastpathDecMapInt32StringR)
-	fn(map[int32]uint(nil), (encFnInfo).fastpathEncMapInt32UintR, (decFnInfo).fastpathDecMapInt32UintR)
-	fn(map[int32]uint8(nil), (encFnInfo).fastpathEncMapInt32Uint8R, (decFnInfo).fastpathDecMapInt32Uint8R)
-	fn(map[int32]uint16(nil), (encFnInfo).fastpathEncMapInt32Uint16R, (decFnInfo).fastpathDecMapInt32Uint16R)
-	fn(map[int32]uint32(nil), (encFnInfo).fastpathEncMapInt32Uint32R, (decFnInfo).fastpathDecMapInt32Uint32R)
-	fn(map[int32]uint64(nil), (encFnInfo).fastpathEncMapInt32Uint64R, (decFnInfo).fastpathDecMapInt32Uint64R)
-	fn(map[int32]int(nil), (encFnInfo).fastpathEncMapInt32IntR, (decFnInfo).fastpathDecMapInt32IntR)
-	fn(map[int32]int8(nil), (encFnInfo).fastpathEncMapInt32Int8R, (decFnInfo).fastpathDecMapInt32Int8R)
-	fn(map[int32]int16(nil), (encFnInfo).fastpathEncMapInt32Int16R, (decFnInfo).fastpathDecMapInt32Int16R)
-	fn(map[int32]int32(nil), (encFnInfo).fastpathEncMapInt32Int32R, (decFnInfo).fastpathDecMapInt32Int32R)
-	fn(map[int32]int64(nil), (encFnInfo).fastpathEncMapInt32Int64R, (decFnInfo).fastpathDecMapInt32Int64R)
-	fn(map[int32]float32(nil), (encFnInfo).fastpathEncMapInt32Float32R, (decFnInfo).fastpathDecMapInt32Float32R)
-	fn(map[int32]float64(nil), (encFnInfo).fastpathEncMapInt32Float64R, (decFnInfo).fastpathDecMapInt32Float64R)
-	fn(map[int32]bool(nil), (encFnInfo).fastpathEncMapInt32BoolR, (decFnInfo).fastpathDecMapInt32BoolR)
-	fn(map[int64]interface{}(nil), (encFnInfo).fastpathEncMapInt64IntfR, (decFnInfo).fastpathDecMapInt64IntfR)
-	fn(map[int64]string(nil), (encFnInfo).fastpathEncMapInt64StringR, (decFnInfo).fastpathDecMapInt64StringR)
-	fn(map[int64]uint(nil), (encFnInfo).fastpathEncMapInt64UintR, (decFnInfo).fastpathDecMapInt64UintR)
-	fn(map[int64]uint8(nil), (encFnInfo).fastpathEncMapInt64Uint8R, (decFnInfo).fastpathDecMapInt64Uint8R)
-	fn(map[int64]uint16(nil), (encFnInfo).fastpathEncMapInt64Uint16R, (decFnInfo).fastpathDecMapInt64Uint16R)
-	fn(map[int64]uint32(nil), (encFnInfo).fastpathEncMapInt64Uint32R, (decFnInfo).fastpathDecMapInt64Uint32R)
-	fn(map[int64]uint64(nil), (encFnInfo).fastpathEncMapInt64Uint64R, (decFnInfo).fastpathDecMapInt64Uint64R)
-	fn(map[int64]int(nil), (encFnInfo).fastpathEncMapInt64IntR, (decFnInfo).fastpathDecMapInt64IntR)
-	fn(map[int64]int8(nil), (encFnInfo).fastpathEncMapInt64Int8R, (decFnInfo).fastpathDecMapInt64Int8R)
-	fn(map[int64]int16(nil), (encFnInfo).fastpathEncMapInt64Int16R, (decFnInfo).fastpathDecMapInt64Int16R)
-	fn(map[int64]int32(nil), (encFnInfo).fastpathEncMapInt64Int32R, (decFnInfo).fastpathDecMapInt64Int32R)
-	fn(map[int64]int64(nil), (encFnInfo).fastpathEncMapInt64Int64R, (decFnInfo).fastpathDecMapInt64Int64R)
-	fn(map[int64]float32(nil), (encFnInfo).fastpathEncMapInt64Float32R, (decFnInfo).fastpathDecMapInt64Float32R)
-	fn(map[int64]float64(nil), (encFnInfo).fastpathEncMapInt64Float64R, (decFnInfo).fastpathDecMapInt64Float64R)
-	fn(map[int64]bool(nil), (encFnInfo).fastpathEncMapInt64BoolR, (decFnInfo).fastpathDecMapInt64BoolR)
-	fn(map[bool]interface{}(nil), (encFnInfo).fastpathEncMapBoolIntfR, (decFnInfo).fastpathDecMapBoolIntfR)
-	fn(map[bool]string(nil), (encFnInfo).fastpathEncMapBoolStringR, (decFnInfo).fastpathDecMapBoolStringR)
-	fn(map[bool]uint(nil), (encFnInfo).fastpathEncMapBoolUintR, (decFnInfo).fastpathDecMapBoolUintR)
-	fn(map[bool]uint8(nil), (encFnInfo).fastpathEncMapBoolUint8R, (decFnInfo).fastpathDecMapBoolUint8R)
-	fn(map[bool]uint16(nil), (encFnInfo).fastpathEncMapBoolUint16R, (decFnInfo).fastpathDecMapBoolUint16R)
-	fn(map[bool]uint32(nil), (encFnInfo).fastpathEncMapBoolUint32R, (decFnInfo).fastpathDecMapBoolUint32R)
-	fn(map[bool]uint64(nil), (encFnInfo).fastpathEncMapBoolUint64R, (decFnInfo).fastpathDecMapBoolUint64R)
-	fn(map[bool]int(nil), (encFnInfo).fastpathEncMapBoolIntR, (decFnInfo).fastpathDecMapBoolIntR)
-	fn(map[bool]int8(nil), (encFnInfo).fastpathEncMapBoolInt8R, (decFnInfo).fastpathDecMapBoolInt8R)
-	fn(map[bool]int16(nil), (encFnInfo).fastpathEncMapBoolInt16R, (decFnInfo).fastpathDecMapBoolInt16R)
-	fn(map[bool]int32(nil), (encFnInfo).fastpathEncMapBoolInt32R, (decFnInfo).fastpathDecMapBoolInt32R)
-	fn(map[bool]int64(nil), (encFnInfo).fastpathEncMapBoolInt64R, (decFnInfo).fastpathDecMapBoolInt64R)
-	fn(map[bool]float32(nil), (encFnInfo).fastpathEncMapBoolFloat32R, (decFnInfo).fastpathDecMapBoolFloat32R)
-	fn(map[bool]float64(nil), (encFnInfo).fastpathEncMapBoolFloat64R, (decFnInfo).fastpathDecMapBoolFloat64R)
-	fn(map[bool]bool(nil), (encFnInfo).fastpathEncMapBoolBoolR, (decFnInfo).fastpathDecMapBoolBoolR)
+	fn(map[interface{}]interface{}(nil), (*encFnInfo).fastpathEncMapIntfIntfR, (*decFnInfo).fastpathDecMapIntfIntfR)
+	fn(map[interface{}]string(nil), (*encFnInfo).fastpathEncMapIntfStringR, (*decFnInfo).fastpathDecMapIntfStringR)
+	fn(map[interface{}]uint(nil), (*encFnInfo).fastpathEncMapIntfUintR, (*decFnInfo).fastpathDecMapIntfUintR)
+	fn(map[interface{}]uint8(nil), (*encFnInfo).fastpathEncMapIntfUint8R, (*decFnInfo).fastpathDecMapIntfUint8R)
+	fn(map[interface{}]uint16(nil), (*encFnInfo).fastpathEncMapIntfUint16R, (*decFnInfo).fastpathDecMapIntfUint16R)
+	fn(map[interface{}]uint32(nil), (*encFnInfo).fastpathEncMapIntfUint32R, (*decFnInfo).fastpathDecMapIntfUint32R)
+	fn(map[interface{}]uint64(nil), (*encFnInfo).fastpathEncMapIntfUint64R, (*decFnInfo).fastpathDecMapIntfUint64R)
+	fn(map[interface{}]int(nil), (*encFnInfo).fastpathEncMapIntfIntR, (*decFnInfo).fastpathDecMapIntfIntR)
+	fn(map[interface{}]int8(nil), (*encFnInfo).fastpathEncMapIntfInt8R, (*decFnInfo).fastpathDecMapIntfInt8R)
+	fn(map[interface{}]int16(nil), (*encFnInfo).fastpathEncMapIntfInt16R, (*decFnInfo).fastpathDecMapIntfInt16R)
+	fn(map[interface{}]int32(nil), (*encFnInfo).fastpathEncMapIntfInt32R, (*decFnInfo).fastpathDecMapIntfInt32R)
+	fn(map[interface{}]int64(nil), (*encFnInfo).fastpathEncMapIntfInt64R, (*decFnInfo).fastpathDecMapIntfInt64R)
+	fn(map[interface{}]float32(nil), (*encFnInfo).fastpathEncMapIntfFloat32R, (*decFnInfo).fastpathDecMapIntfFloat32R)
+	fn(map[interface{}]float64(nil), (*encFnInfo).fastpathEncMapIntfFloat64R, (*decFnInfo).fastpathDecMapIntfFloat64R)
+	fn(map[interface{}]bool(nil), (*encFnInfo).fastpathEncMapIntfBoolR, (*decFnInfo).fastpathDecMapIntfBoolR)
+	fn(map[string]interface{}(nil), (*encFnInfo).fastpathEncMapStringIntfR, (*decFnInfo).fastpathDecMapStringIntfR)
+	fn(map[string]string(nil), (*encFnInfo).fastpathEncMapStringStringR, (*decFnInfo).fastpathDecMapStringStringR)
+	fn(map[string]uint(nil), (*encFnInfo).fastpathEncMapStringUintR, (*decFnInfo).fastpathDecMapStringUintR)
+	fn(map[string]uint8(nil), (*encFnInfo).fastpathEncMapStringUint8R, (*decFnInfo).fastpathDecMapStringUint8R)
+	fn(map[string]uint16(nil), (*encFnInfo).fastpathEncMapStringUint16R, (*decFnInfo).fastpathDecMapStringUint16R)
+	fn(map[string]uint32(nil), (*encFnInfo).fastpathEncMapStringUint32R, (*decFnInfo).fastpathDecMapStringUint32R)
+	fn(map[string]uint64(nil), (*encFnInfo).fastpathEncMapStringUint64R, (*decFnInfo).fastpathDecMapStringUint64R)
+	fn(map[string]int(nil), (*encFnInfo).fastpathEncMapStringIntR, (*decFnInfo).fastpathDecMapStringIntR)
+	fn(map[string]int8(nil), (*encFnInfo).fastpathEncMapStringInt8R, (*decFnInfo).fastpathDecMapStringInt8R)
+	fn(map[string]int16(nil), (*encFnInfo).fastpathEncMapStringInt16R, (*decFnInfo).fastpathDecMapStringInt16R)
+	fn(map[string]int32(nil), (*encFnInfo).fastpathEncMapStringInt32R, (*decFnInfo).fastpathDecMapStringInt32R)
+	fn(map[string]int64(nil), (*encFnInfo).fastpathEncMapStringInt64R, (*decFnInfo).fastpathDecMapStringInt64R)
+	fn(map[string]float32(nil), (*encFnInfo).fastpathEncMapStringFloat32R, (*decFnInfo).fastpathDecMapStringFloat32R)
+	fn(map[string]float64(nil), (*encFnInfo).fastpathEncMapStringFloat64R, (*decFnInfo).fastpathDecMapStringFloat64R)
+	fn(map[string]bool(nil), (*encFnInfo).fastpathEncMapStringBoolR, (*decFnInfo).fastpathDecMapStringBoolR)
+	fn(map[float32]interface{}(nil), (*encFnInfo).fastpathEncMapFloat32IntfR, (*decFnInfo).fastpathDecMapFloat32IntfR)
+	fn(map[float32]string(nil), (*encFnInfo).fastpathEncMapFloat32StringR, (*decFnInfo).fastpathDecMapFloat32StringR)
+	fn(map[float32]uint(nil), (*encFnInfo).fastpathEncMapFloat32UintR, (*decFnInfo).fastpathDecMapFloat32UintR)
+	fn(map[float32]uint8(nil), (*encFnInfo).fastpathEncMapFloat32Uint8R, (*decFnInfo).fastpathDecMapFloat32Uint8R)
+	fn(map[float32]uint16(nil), (*encFnInfo).fastpathEncMapFloat32Uint16R, (*decFnInfo).fastpathDecMapFloat32Uint16R)
+	fn(map[float32]uint32(nil), (*encFnInfo).fastpathEncMapFloat32Uint32R, (*decFnInfo).fastpathDecMapFloat32Uint32R)
+	fn(map[float32]uint64(nil), (*encFnInfo).fastpathEncMapFloat32Uint64R, (*decFnInfo).fastpathDecMapFloat32Uint64R)
+	fn(map[float32]int(nil), (*encFnInfo).fastpathEncMapFloat32IntR, (*decFnInfo).fastpathDecMapFloat32IntR)
+	fn(map[float32]int8(nil), (*encFnInfo).fastpathEncMapFloat32Int8R, (*decFnInfo).fastpathDecMapFloat32Int8R)
+	fn(map[float32]int16(nil), (*encFnInfo).fastpathEncMapFloat32Int16R, (*decFnInfo).fastpathDecMapFloat32Int16R)
+	fn(map[float32]int32(nil), (*encFnInfo).fastpathEncMapFloat32Int32R, (*decFnInfo).fastpathDecMapFloat32Int32R)
+	fn(map[float32]int64(nil), (*encFnInfo).fastpathEncMapFloat32Int64R, (*decFnInfo).fastpathDecMapFloat32Int64R)
+	fn(map[float32]float32(nil), (*encFnInfo).fastpathEncMapFloat32Float32R, (*decFnInfo).fastpathDecMapFloat32Float32R)
+	fn(map[float32]float64(nil), (*encFnInfo).fastpathEncMapFloat32Float64R, (*decFnInfo).fastpathDecMapFloat32Float64R)
+	fn(map[float32]bool(nil), (*encFnInfo).fastpathEncMapFloat32BoolR, (*decFnInfo).fastpathDecMapFloat32BoolR)
+	fn(map[float64]interface{}(nil), (*encFnInfo).fastpathEncMapFloat64IntfR, (*decFnInfo).fastpathDecMapFloat64IntfR)
+	fn(map[float64]string(nil), (*encFnInfo).fastpathEncMapFloat64StringR, (*decFnInfo).fastpathDecMapFloat64StringR)
+	fn(map[float64]uint(nil), (*encFnInfo).fastpathEncMapFloat64UintR, (*decFnInfo).fastpathDecMapFloat64UintR)
+	fn(map[float64]uint8(nil), (*encFnInfo).fastpathEncMapFloat64Uint8R, (*decFnInfo).fastpathDecMapFloat64Uint8R)
+	fn(map[float64]uint16(nil), (*encFnInfo).fastpathEncMapFloat64Uint16R, (*decFnInfo).fastpathDecMapFloat64Uint16R)
+	fn(map[float64]uint32(nil), (*encFnInfo).fastpathEncMapFloat64Uint32R, (*decFnInfo).fastpathDecMapFloat64Uint32R)
+	fn(map[float64]uint64(nil), (*encFnInfo).fastpathEncMapFloat64Uint64R, (*decFnInfo).fastpathDecMapFloat64Uint64R)
+	fn(map[float64]int(nil), (*encFnInfo).fastpathEncMapFloat64IntR, (*decFnInfo).fastpathDecMapFloat64IntR)
+	fn(map[float64]int8(nil), (*encFnInfo).fastpathEncMapFloat64Int8R, (*decFnInfo).fastpathDecMapFloat64Int8R)
+	fn(map[float64]int16(nil), (*encFnInfo).fastpathEncMapFloat64Int16R, (*decFnInfo).fastpathDecMapFloat64Int16R)
+	fn(map[float64]int32(nil), (*encFnInfo).fastpathEncMapFloat64Int32R, (*decFnInfo).fastpathDecMapFloat64Int32R)
+	fn(map[float64]int64(nil), (*encFnInfo).fastpathEncMapFloat64Int64R, (*decFnInfo).fastpathDecMapFloat64Int64R)
+	fn(map[float64]float32(nil), (*encFnInfo).fastpathEncMapFloat64Float32R, (*decFnInfo).fastpathDecMapFloat64Float32R)
+	fn(map[float64]float64(nil), (*encFnInfo).fastpathEncMapFloat64Float64R, (*decFnInfo).fastpathDecMapFloat64Float64R)
+	fn(map[float64]bool(nil), (*encFnInfo).fastpathEncMapFloat64BoolR, (*decFnInfo).fastpathDecMapFloat64BoolR)
+	fn(map[uint]interface{}(nil), (*encFnInfo).fastpathEncMapUintIntfR, (*decFnInfo).fastpathDecMapUintIntfR)
+	fn(map[uint]string(nil), (*encFnInfo).fastpathEncMapUintStringR, (*decFnInfo).fastpathDecMapUintStringR)
+	fn(map[uint]uint(nil), (*encFnInfo).fastpathEncMapUintUintR, (*decFnInfo).fastpathDecMapUintUintR)
+	fn(map[uint]uint8(nil), (*encFnInfo).fastpathEncMapUintUint8R, (*decFnInfo).fastpathDecMapUintUint8R)
+	fn(map[uint]uint16(nil), (*encFnInfo).fastpathEncMapUintUint16R, (*decFnInfo).fastpathDecMapUintUint16R)
+	fn(map[uint]uint32(nil), (*encFnInfo).fastpathEncMapUintUint32R, (*decFnInfo).fastpathDecMapUintUint32R)
+	fn(map[uint]uint64(nil), (*encFnInfo).fastpathEncMapUintUint64R, (*decFnInfo).fastpathDecMapUintUint64R)
+	fn(map[uint]int(nil), (*encFnInfo).fastpathEncMapUintIntR, (*decFnInfo).fastpathDecMapUintIntR)
+	fn(map[uint]int8(nil), (*encFnInfo).fastpathEncMapUintInt8R, (*decFnInfo).fastpathDecMapUintInt8R)
+	fn(map[uint]int16(nil), (*encFnInfo).fastpathEncMapUintInt16R, (*decFnInfo).fastpathDecMapUintInt16R)
+	fn(map[uint]int32(nil), (*encFnInfo).fastpathEncMapUintInt32R, (*decFnInfo).fastpathDecMapUintInt32R)
+	fn(map[uint]int64(nil), (*encFnInfo).fastpathEncMapUintInt64R, (*decFnInfo).fastpathDecMapUintInt64R)
+	fn(map[uint]float32(nil), (*encFnInfo).fastpathEncMapUintFloat32R, (*decFnInfo).fastpathDecMapUintFloat32R)
+	fn(map[uint]float64(nil), (*encFnInfo).fastpathEncMapUintFloat64R, (*decFnInfo).fastpathDecMapUintFloat64R)
+	fn(map[uint]bool(nil), (*encFnInfo).fastpathEncMapUintBoolR, (*decFnInfo).fastpathDecMapUintBoolR)
+	fn(map[uint8]interface{}(nil), (*encFnInfo).fastpathEncMapUint8IntfR, (*decFnInfo).fastpathDecMapUint8IntfR)
+	fn(map[uint8]string(nil), (*encFnInfo).fastpathEncMapUint8StringR, (*decFnInfo).fastpathDecMapUint8StringR)
+	fn(map[uint8]uint(nil), (*encFnInfo).fastpathEncMapUint8UintR, (*decFnInfo).fastpathDecMapUint8UintR)
+	fn(map[uint8]uint8(nil), (*encFnInfo).fastpathEncMapUint8Uint8R, (*decFnInfo).fastpathDecMapUint8Uint8R)
+	fn(map[uint8]uint16(nil), (*encFnInfo).fastpathEncMapUint8Uint16R, (*decFnInfo).fastpathDecMapUint8Uint16R)
+	fn(map[uint8]uint32(nil), (*encFnInfo).fastpathEncMapUint8Uint32R, (*decFnInfo).fastpathDecMapUint8Uint32R)
+	fn(map[uint8]uint64(nil), (*encFnInfo).fastpathEncMapUint8Uint64R, (*decFnInfo).fastpathDecMapUint8Uint64R)
+	fn(map[uint8]int(nil), (*encFnInfo).fastpathEncMapUint8IntR, (*decFnInfo).fastpathDecMapUint8IntR)
+	fn(map[uint8]int8(nil), (*encFnInfo).fastpathEncMapUint8Int8R, (*decFnInfo).fastpathDecMapUint8Int8R)
+	fn(map[uint8]int16(nil), (*encFnInfo).fastpathEncMapUint8Int16R, (*decFnInfo).fastpathDecMapUint8Int16R)
+	fn(map[uint8]int32(nil), (*encFnInfo).fastpathEncMapUint8Int32R, (*decFnInfo).fastpathDecMapUint8Int32R)
+	fn(map[uint8]int64(nil), (*encFnInfo).fastpathEncMapUint8Int64R, (*decFnInfo).fastpathDecMapUint8Int64R)
+	fn(map[uint8]float32(nil), (*encFnInfo).fastpathEncMapUint8Float32R, (*decFnInfo).fastpathDecMapUint8Float32R)
+	fn(map[uint8]float64(nil), (*encFnInfo).fastpathEncMapUint8Float64R, (*decFnInfo).fastpathDecMapUint8Float64R)
+	fn(map[uint8]bool(nil), (*encFnInfo).fastpathEncMapUint8BoolR, (*decFnInfo).fastpathDecMapUint8BoolR)
+	fn(map[uint16]interface{}(nil), (*encFnInfo).fastpathEncMapUint16IntfR, (*decFnInfo).fastpathDecMapUint16IntfR)
+	fn(map[uint16]string(nil), (*encFnInfo).fastpathEncMapUint16StringR, (*decFnInfo).fastpathDecMapUint16StringR)
+	fn(map[uint16]uint(nil), (*encFnInfo).fastpathEncMapUint16UintR, (*decFnInfo).fastpathDecMapUint16UintR)
+	fn(map[uint16]uint8(nil), (*encFnInfo).fastpathEncMapUint16Uint8R, (*decFnInfo).fastpathDecMapUint16Uint8R)
+	fn(map[uint16]uint16(nil), (*encFnInfo).fastpathEncMapUint16Uint16R, (*decFnInfo).fastpathDecMapUint16Uint16R)
+	fn(map[uint16]uint32(nil), (*encFnInfo).fastpathEncMapUint16Uint32R, (*decFnInfo).fastpathDecMapUint16Uint32R)
+	fn(map[uint16]uint64(nil), (*encFnInfo).fastpathEncMapUint16Uint64R, (*decFnInfo).fastpathDecMapUint16Uint64R)
+	fn(map[uint16]int(nil), (*encFnInfo).fastpathEncMapUint16IntR, (*decFnInfo).fastpathDecMapUint16IntR)
+	fn(map[uint16]int8(nil), (*encFnInfo).fastpathEncMapUint16Int8R, (*decFnInfo).fastpathDecMapUint16Int8R)
+	fn(map[uint16]int16(nil), (*encFnInfo).fastpathEncMapUint16Int16R, (*decFnInfo).fastpathDecMapUint16Int16R)
+	fn(map[uint16]int32(nil), (*encFnInfo).fastpathEncMapUint16Int32R, (*decFnInfo).fastpathDecMapUint16Int32R)
+	fn(map[uint16]int64(nil), (*encFnInfo).fastpathEncMapUint16Int64R, (*decFnInfo).fastpathDecMapUint16Int64R)
+	fn(map[uint16]float32(nil), (*encFnInfo).fastpathEncMapUint16Float32R, (*decFnInfo).fastpathDecMapUint16Float32R)
+	fn(map[uint16]float64(nil), (*encFnInfo).fastpathEncMapUint16Float64R, (*decFnInfo).fastpathDecMapUint16Float64R)
+	fn(map[uint16]bool(nil), (*encFnInfo).fastpathEncMapUint16BoolR, (*decFnInfo).fastpathDecMapUint16BoolR)
+	fn(map[uint32]interface{}(nil), (*encFnInfo).fastpathEncMapUint32IntfR, (*decFnInfo).fastpathDecMapUint32IntfR)
+	fn(map[uint32]string(nil), (*encFnInfo).fastpathEncMapUint32StringR, (*decFnInfo).fastpathDecMapUint32StringR)
+	fn(map[uint32]uint(nil), (*encFnInfo).fastpathEncMapUint32UintR, (*decFnInfo).fastpathDecMapUint32UintR)
+	fn(map[uint32]uint8(nil), (*encFnInfo).fastpathEncMapUint32Uint8R, (*decFnInfo).fastpathDecMapUint32Uint8R)
+	fn(map[uint32]uint16(nil), (*encFnInfo).fastpathEncMapUint32Uint16R, (*decFnInfo).fastpathDecMapUint32Uint16R)
+	fn(map[uint32]uint32(nil), (*encFnInfo).fastpathEncMapUint32Uint32R, (*decFnInfo).fastpathDecMapUint32Uint32R)
+	fn(map[uint32]uint64(nil), (*encFnInfo).fastpathEncMapUint32Uint64R, (*decFnInfo).fastpathDecMapUint32Uint64R)
+	fn(map[uint32]int(nil), (*encFnInfo).fastpathEncMapUint32IntR, (*decFnInfo).fastpathDecMapUint32IntR)
+	fn(map[uint32]int8(nil), (*encFnInfo).fastpathEncMapUint32Int8R, (*decFnInfo).fastpathDecMapUint32Int8R)
+	fn(map[uint32]int16(nil), (*encFnInfo).fastpathEncMapUint32Int16R, (*decFnInfo).fastpathDecMapUint32Int16R)
+	fn(map[uint32]int32(nil), (*encFnInfo).fastpathEncMapUint32Int32R, (*decFnInfo).fastpathDecMapUint32Int32R)
+	fn(map[uint32]int64(nil), (*encFnInfo).fastpathEncMapUint32Int64R, (*decFnInfo).fastpathDecMapUint32Int64R)
+	fn(map[uint32]float32(nil), (*encFnInfo).fastpathEncMapUint32Float32R, (*decFnInfo).fastpathDecMapUint32Float32R)
+	fn(map[uint32]float64(nil), (*encFnInfo).fastpathEncMapUint32Float64R, (*decFnInfo).fastpathDecMapUint32Float64R)
+	fn(map[uint32]bool(nil), (*encFnInfo).fastpathEncMapUint32BoolR, (*decFnInfo).fastpathDecMapUint32BoolR)
+	fn(map[uint64]interface{}(nil), (*encFnInfo).fastpathEncMapUint64IntfR, (*decFnInfo).fastpathDecMapUint64IntfR)
+	fn(map[uint64]string(nil), (*encFnInfo).fastpathEncMapUint64StringR, (*decFnInfo).fastpathDecMapUint64StringR)
+	fn(map[uint64]uint(nil), (*encFnInfo).fastpathEncMapUint64UintR, (*decFnInfo).fastpathDecMapUint64UintR)
+	fn(map[uint64]uint8(nil), (*encFnInfo).fastpathEncMapUint64Uint8R, (*decFnInfo).fastpathDecMapUint64Uint8R)
+	fn(map[uint64]uint16(nil), (*encFnInfo).fastpathEncMapUint64Uint16R, (*decFnInfo).fastpathDecMapUint64Uint16R)
+	fn(map[uint64]uint32(nil), (*encFnInfo).fastpathEncMapUint64Uint32R, (*decFnInfo).fastpathDecMapUint64Uint32R)
+	fn(map[uint64]uint64(nil), (*encFnInfo).fastpathEncMapUint64Uint64R, (*decFnInfo).fastpathDecMapUint64Uint64R)
+	fn(map[uint64]int(nil), (*encFnInfo).fastpathEncMapUint64IntR, (*decFnInfo).fastpathDecMapUint64IntR)
+	fn(map[uint64]int8(nil), (*encFnInfo).fastpathEncMapUint64Int8R, (*decFnInfo).fastpathDecMapUint64Int8R)
+	fn(map[uint64]int16(nil), (*encFnInfo).fastpathEncMapUint64Int16R, (*decFnInfo).fastpathDecMapUint64Int16R)
+	fn(map[uint64]int32(nil), (*encFnInfo).fastpathEncMapUint64Int32R, (*decFnInfo).fastpathDecMapUint64Int32R)
+	fn(map[uint64]int64(nil), (*encFnInfo).fastpathEncMapUint64Int64R, (*decFnInfo).fastpathDecMapUint64Int64R)
+	fn(map[uint64]float32(nil), (*encFnInfo).fastpathEncMapUint64Float32R, (*decFnInfo).fastpathDecMapUint64Float32R)
+	fn(map[uint64]float64(nil), (*encFnInfo).fastpathEncMapUint64Float64R, (*decFnInfo).fastpathDecMapUint64Float64R)
+	fn(map[uint64]bool(nil), (*encFnInfo).fastpathEncMapUint64BoolR, (*decFnInfo).fastpathDecMapUint64BoolR)
+	fn(map[int]interface{}(nil), (*encFnInfo).fastpathEncMapIntIntfR, (*decFnInfo).fastpathDecMapIntIntfR)
+	fn(map[int]string(nil), (*encFnInfo).fastpathEncMapIntStringR, (*decFnInfo).fastpathDecMapIntStringR)
+	fn(map[int]uint(nil), (*encFnInfo).fastpathEncMapIntUintR, (*decFnInfo).fastpathDecMapIntUintR)
+	fn(map[int]uint8(nil), (*encFnInfo).fastpathEncMapIntUint8R, (*decFnInfo).fastpathDecMapIntUint8R)
+	fn(map[int]uint16(nil), (*encFnInfo).fastpathEncMapIntUint16R, (*decFnInfo).fastpathDecMapIntUint16R)
+	fn(map[int]uint32(nil), (*encFnInfo).fastpathEncMapIntUint32R, (*decFnInfo).fastpathDecMapIntUint32R)
+	fn(map[int]uint64(nil), (*encFnInfo).fastpathEncMapIntUint64R, (*decFnInfo).fastpathDecMapIntUint64R)
+	fn(map[int]int(nil), (*encFnInfo).fastpathEncMapIntIntR, (*decFnInfo).fastpathDecMapIntIntR)
+	fn(map[int]int8(nil), (*encFnInfo).fastpathEncMapIntInt8R, (*decFnInfo).fastpathDecMapIntInt8R)
+	fn(map[int]int16(nil), (*encFnInfo).fastpathEncMapIntInt16R, (*decFnInfo).fastpathDecMapIntInt16R)
+	fn(map[int]int32(nil), (*encFnInfo).fastpathEncMapIntInt32R, (*decFnInfo).fastpathDecMapIntInt32R)
+	fn(map[int]int64(nil), (*encFnInfo).fastpathEncMapIntInt64R, (*decFnInfo).fastpathDecMapIntInt64R)
+	fn(map[int]float32(nil), (*encFnInfo).fastpathEncMapIntFloat32R, (*decFnInfo).fastpathDecMapIntFloat32R)
+	fn(map[int]float64(nil), (*encFnInfo).fastpathEncMapIntFloat64R, (*decFnInfo).fastpathDecMapIntFloat64R)
+	fn(map[int]bool(nil), (*encFnInfo).fastpathEncMapIntBoolR, (*decFnInfo).fastpathDecMapIntBoolR)
+	fn(map[int8]interface{}(nil), (*encFnInfo).fastpathEncMapInt8IntfR, (*decFnInfo).fastpathDecMapInt8IntfR)
+	fn(map[int8]string(nil), (*encFnInfo).fastpathEncMapInt8StringR, (*decFnInfo).fastpathDecMapInt8StringR)
+	fn(map[int8]uint(nil), (*encFnInfo).fastpathEncMapInt8UintR, (*decFnInfo).fastpathDecMapInt8UintR)
+	fn(map[int8]uint8(nil), (*encFnInfo).fastpathEncMapInt8Uint8R, (*decFnInfo).fastpathDecMapInt8Uint8R)
+	fn(map[int8]uint16(nil), (*encFnInfo).fastpathEncMapInt8Uint16R, (*decFnInfo).fastpathDecMapInt8Uint16R)
+	fn(map[int8]uint32(nil), (*encFnInfo).fastpathEncMapInt8Uint32R, (*decFnInfo).fastpathDecMapInt8Uint32R)
+	fn(map[int8]uint64(nil), (*encFnInfo).fastpathEncMapInt8Uint64R, (*decFnInfo).fastpathDecMapInt8Uint64R)
+	fn(map[int8]int(nil), (*encFnInfo).fastpathEncMapInt8IntR, (*decFnInfo).fastpathDecMapInt8IntR)
+	fn(map[int8]int8(nil), (*encFnInfo).fastpathEncMapInt8Int8R, (*decFnInfo).fastpathDecMapInt8Int8R)
+	fn(map[int8]int16(nil), (*encFnInfo).fastpathEncMapInt8Int16R, (*decFnInfo).fastpathDecMapInt8Int16R)
+	fn(map[int8]int32(nil), (*encFnInfo).fastpathEncMapInt8Int32R, (*decFnInfo).fastpathDecMapInt8Int32R)
+	fn(map[int8]int64(nil), (*encFnInfo).fastpathEncMapInt8Int64R, (*decFnInfo).fastpathDecMapInt8Int64R)
+	fn(map[int8]float32(nil), (*encFnInfo).fastpathEncMapInt8Float32R, (*decFnInfo).fastpathDecMapInt8Float32R)
+	fn(map[int8]float64(nil), (*encFnInfo).fastpathEncMapInt8Float64R, (*decFnInfo).fastpathDecMapInt8Float64R)
+	fn(map[int8]bool(nil), (*encFnInfo).fastpathEncMapInt8BoolR, (*decFnInfo).fastpathDecMapInt8BoolR)
+	fn(map[int16]interface{}(nil), (*encFnInfo).fastpathEncMapInt16IntfR, (*decFnInfo).fastpathDecMapInt16IntfR)
+	fn(map[int16]string(nil), (*encFnInfo).fastpathEncMapInt16StringR, (*decFnInfo).fastpathDecMapInt16StringR)
+	fn(map[int16]uint(nil), (*encFnInfo).fastpathEncMapInt16UintR, (*decFnInfo).fastpathDecMapInt16UintR)
+	fn(map[int16]uint8(nil), (*encFnInfo).fastpathEncMapInt16Uint8R, (*decFnInfo).fastpathDecMapInt16Uint8R)
+	fn(map[int16]uint16(nil), (*encFnInfo).fastpathEncMapInt16Uint16R, (*decFnInfo).fastpathDecMapInt16Uint16R)
+	fn(map[int16]uint32(nil), (*encFnInfo).fastpathEncMapInt16Uint32R, (*decFnInfo).fastpathDecMapInt16Uint32R)
+	fn(map[int16]uint64(nil), (*encFnInfo).fastpathEncMapInt16Uint64R, (*decFnInfo).fastpathDecMapInt16Uint64R)
+	fn(map[int16]int(nil), (*encFnInfo).fastpathEncMapInt16IntR, (*decFnInfo).fastpathDecMapInt16IntR)
+	fn(map[int16]int8(nil), (*encFnInfo).fastpathEncMapInt16Int8R, (*decFnInfo).fastpathDecMapInt16Int8R)
+	fn(map[int16]int16(nil), (*encFnInfo).fastpathEncMapInt16Int16R, (*decFnInfo).fastpathDecMapInt16Int16R)
+	fn(map[int16]int32(nil), (*encFnInfo).fastpathEncMapInt16Int32R, (*decFnInfo).fastpathDecMapInt16Int32R)
+	fn(map[int16]int64(nil), (*encFnInfo).fastpathEncMapInt16Int64R, (*decFnInfo).fastpathDecMapInt16Int64R)
+	fn(map[int16]float32(nil), (*encFnInfo).fastpathEncMapInt16Float32R, (*decFnInfo).fastpathDecMapInt16Float32R)
+	fn(map[int16]float64(nil), (*encFnInfo).fastpathEncMapInt16Float64R, (*decFnInfo).fastpathDecMapInt16Float64R)
+	fn(map[int16]bool(nil), (*encFnInfo).fastpathEncMapInt16BoolR, (*decFnInfo).fastpathDecMapInt16BoolR)
+	fn(map[int32]interface{}(nil), (*encFnInfo).fastpathEncMapInt32IntfR, (*decFnInfo).fastpathDecMapInt32IntfR)
+	fn(map[int32]string(nil), (*encFnInfo).fastpathEncMapInt32StringR, (*decFnInfo).fastpathDecMapInt32StringR)
+	fn(map[int32]uint(nil), (*encFnInfo).fastpathEncMapInt32UintR, (*decFnInfo).fastpathDecMapInt32UintR)
+	fn(map[int32]uint8(nil), (*encFnInfo).fastpathEncMapInt32Uint8R, (*decFnInfo).fastpathDecMapInt32Uint8R)
+	fn(map[int32]uint16(nil), (*encFnInfo).fastpathEncMapInt32Uint16R, (*decFnInfo).fastpathDecMapInt32Uint16R)
+	fn(map[int32]uint32(nil), (*encFnInfo).fastpathEncMapInt32Uint32R, (*decFnInfo).fastpathDecMapInt32Uint32R)
+	fn(map[int32]uint64(nil), (*encFnInfo).fastpathEncMapInt32Uint64R, (*decFnInfo).fastpathDecMapInt32Uint64R)
+	fn(map[int32]int(nil), (*encFnInfo).fastpathEncMapInt32IntR, (*decFnInfo).fastpathDecMapInt32IntR)
+	fn(map[int32]int8(nil), (*encFnInfo).fastpathEncMapInt32Int8R, (*decFnInfo).fastpathDecMapInt32Int8R)
+	fn(map[int32]int16(nil), (*encFnInfo).fastpathEncMapInt32Int16R, (*decFnInfo).fastpathDecMapInt32Int16R)
+	fn(map[int32]int32(nil), (*encFnInfo).fastpathEncMapInt32Int32R, (*decFnInfo).fastpathDecMapInt32Int32R)
+	fn(map[int32]int64(nil), (*encFnInfo).fastpathEncMapInt32Int64R, (*decFnInfo).fastpathDecMapInt32Int64R)
+	fn(map[int32]float32(nil), (*encFnInfo).fastpathEncMapInt32Float32R, (*decFnInfo).fastpathDecMapInt32Float32R)
+	fn(map[int32]float64(nil), (*encFnInfo).fastpathEncMapInt32Float64R, (*decFnInfo).fastpathDecMapInt32Float64R)
+	fn(map[int32]bool(nil), (*encFnInfo).fastpathEncMapInt32BoolR, (*decFnInfo).fastpathDecMapInt32BoolR)
+	fn(map[int64]interface{}(nil), (*encFnInfo).fastpathEncMapInt64IntfR, (*decFnInfo).fastpathDecMapInt64IntfR)
+	fn(map[int64]string(nil), (*encFnInfo).fastpathEncMapInt64StringR, (*decFnInfo).fastpathDecMapInt64StringR)
+	fn(map[int64]uint(nil), (*encFnInfo).fastpathEncMapInt64UintR, (*decFnInfo).fastpathDecMapInt64UintR)
+	fn(map[int64]uint8(nil), (*encFnInfo).fastpathEncMapInt64Uint8R, (*decFnInfo).fastpathDecMapInt64Uint8R)
+	fn(map[int64]uint16(nil), (*encFnInfo).fastpathEncMapInt64Uint16R, (*decFnInfo).fastpathDecMapInt64Uint16R)
+	fn(map[int64]uint32(nil), (*encFnInfo).fastpathEncMapInt64Uint32R, (*decFnInfo).fastpathDecMapInt64Uint32R)
+	fn(map[int64]uint64(nil), (*encFnInfo).fastpathEncMapInt64Uint64R, (*decFnInfo).fastpathDecMapInt64Uint64R)
+	fn(map[int64]int(nil), (*encFnInfo).fastpathEncMapInt64IntR, (*decFnInfo).fastpathDecMapInt64IntR)
+	fn(map[int64]int8(nil), (*encFnInfo).fastpathEncMapInt64Int8R, (*decFnInfo).fastpathDecMapInt64Int8R)
+	fn(map[int64]int16(nil), (*encFnInfo).fastpathEncMapInt64Int16R, (*decFnInfo).fastpathDecMapInt64Int16R)
+	fn(map[int64]int32(nil), (*encFnInfo).fastpathEncMapInt64Int32R, (*decFnInfo).fastpathDecMapInt64Int32R)
+	fn(map[int64]int64(nil), (*encFnInfo).fastpathEncMapInt64Int64R, (*decFnInfo).fastpathDecMapInt64Int64R)
+	fn(map[int64]float32(nil), (*encFnInfo).fastpathEncMapInt64Float32R, (*decFnInfo).fastpathDecMapInt64Float32R)
+	fn(map[int64]float64(nil), (*encFnInfo).fastpathEncMapInt64Float64R, (*decFnInfo).fastpathDecMapInt64Float64R)
+	fn(map[int64]bool(nil), (*encFnInfo).fastpathEncMapInt64BoolR, (*decFnInfo).fastpathDecMapInt64BoolR)
+	fn(map[bool]interface{}(nil), (*encFnInfo).fastpathEncMapBoolIntfR, (*decFnInfo).fastpathDecMapBoolIntfR)
+	fn(map[bool]string(nil), (*encFnInfo).fastpathEncMapBoolStringR, (*decFnInfo).fastpathDecMapBoolStringR)
+	fn(map[bool]uint(nil), (*encFnInfo).fastpathEncMapBoolUintR, (*decFnInfo).fastpathDecMapBoolUintR)
+	fn(map[bool]uint8(nil), (*encFnInfo).fastpathEncMapBoolUint8R, (*decFnInfo).fastpathDecMapBoolUint8R)
+	fn(map[bool]uint16(nil), (*encFnInfo).fastpathEncMapBoolUint16R, (*decFnInfo).fastpathDecMapBoolUint16R)
+	fn(map[bool]uint32(nil), (*encFnInfo).fastpathEncMapBoolUint32R, (*decFnInfo).fastpathDecMapBoolUint32R)
+	fn(map[bool]uint64(nil), (*encFnInfo).fastpathEncMapBoolUint64R, (*decFnInfo).fastpathDecMapBoolUint64R)
+	fn(map[bool]int(nil), (*encFnInfo).fastpathEncMapBoolIntR, (*decFnInfo).fastpathDecMapBoolIntR)
+	fn(map[bool]int8(nil), (*encFnInfo).fastpathEncMapBoolInt8R, (*decFnInfo).fastpathDecMapBoolInt8R)
+	fn(map[bool]int16(nil), (*encFnInfo).fastpathEncMapBoolInt16R, (*decFnInfo).fastpathDecMapBoolInt16R)
+	fn(map[bool]int32(nil), (*encFnInfo).fastpathEncMapBoolInt32R, (*decFnInfo).fastpathDecMapBoolInt32R)
+	fn(map[bool]int64(nil), (*encFnInfo).fastpathEncMapBoolInt64R, (*decFnInfo).fastpathDecMapBoolInt64R)
+	fn(map[bool]float32(nil), (*encFnInfo).fastpathEncMapBoolFloat32R, (*decFnInfo).fastpathDecMapBoolFloat32R)
+	fn(map[bool]float64(nil), (*encFnInfo).fastpathEncMapBoolFloat64R, (*decFnInfo).fastpathDecMapBoolFloat64R)
+	fn(map[bool]bool(nil), (*encFnInfo).fastpathEncMapBoolBoolR, (*decFnInfo).fastpathDecMapBoolBoolR)
 
 	sort.Sort(fastpathAslice(fastpathAV[:]))
 }
@@ -2759,7 +2759,7 @@ func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
 
 // -- -- fast path functions
 
-func (f encFnInfo) fastpathEncSliceIntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceIntfR(rv reflect.Value) {
 	fastpathTV.EncSliceIntfV(rv.Interface().([]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceIntfV(v []interface{}, checkNil bool, e *Encoder) {
@@ -2769,22 +2769,13 @@ func (_ fastpathT) EncSliceIntfV(v []interface{}, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			e.encode(v2)
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			e.encode(v2)
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceStringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceStringR(rv reflect.Value) {
 	fastpathTV.EncSliceStringV(rv.Interface().([]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceStringV(v []string, checkNil bool, e *Encoder) {
@@ -2794,22 +2785,13 @@ func (_ fastpathT) EncSliceStringV(v []string, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeString(c_UTF8, v2)
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceFloat32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceFloat32R(rv reflect.Value) {
 	fastpathTV.EncSliceFloat32V(rv.Interface().([]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceFloat32V(v []float32, checkNil bool, e *Encoder) {
@@ -2819,22 +2801,13 @@ func (_ fastpathT) EncSliceFloat32V(v []float32, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeFloat32(v2)
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceFloat64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceFloat64R(rv reflect.Value) {
 	fastpathTV.EncSliceFloat64V(rv.Interface().([]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceFloat64V(v []float64, checkNil bool, e *Encoder) {
@@ -2844,22 +2817,13 @@ func (_ fastpathT) EncSliceFloat64V(v []float64, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeFloat64(v2)
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceUintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceUintR(rv reflect.Value) {
 	fastpathTV.EncSliceUintV(rv.Interface().([]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceUintV(v []uint, checkNil bool, e *Encoder) {
@@ -2869,22 +2833,13 @@ func (_ fastpathT) EncSliceUintV(v []uint, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeUint(uint64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceUint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceUint16R(rv reflect.Value) {
 	fastpathTV.EncSliceUint16V(rv.Interface().([]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceUint16V(v []uint16, checkNil bool, e *Encoder) {
@@ -2894,22 +2849,13 @@ func (_ fastpathT) EncSliceUint16V(v []uint16, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeUint(uint64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceUint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceUint32R(rv reflect.Value) {
 	fastpathTV.EncSliceUint32V(rv.Interface().([]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceUint32V(v []uint32, checkNil bool, e *Encoder) {
@@ -2919,22 +2865,13 @@ func (_ fastpathT) EncSliceUint32V(v []uint32, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeUint(uint64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceUint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceUint64R(rv reflect.Value) {
 	fastpathTV.EncSliceUint64V(rv.Interface().([]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceUint64V(v []uint64, checkNil bool, e *Encoder) {
@@ -2944,22 +2881,13 @@ func (_ fastpathT) EncSliceUint64V(v []uint64, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeUint(uint64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceIntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceIntR(rv reflect.Value) {
 	fastpathTV.EncSliceIntV(rv.Interface().([]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceIntV(v []int, checkNil bool, e *Encoder) {
@@ -2969,22 +2897,13 @@ func (_ fastpathT) EncSliceIntV(v []int, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeInt(int64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceInt8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceInt8R(rv reflect.Value) {
 	fastpathTV.EncSliceInt8V(rv.Interface().([]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceInt8V(v []int8, checkNil bool, e *Encoder) {
@@ -2994,22 +2913,13 @@ func (_ fastpathT) EncSliceInt8V(v []int8, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeInt(int64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceInt16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceInt16R(rv reflect.Value) {
 	fastpathTV.EncSliceInt16V(rv.Interface().([]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceInt16V(v []int16, checkNil bool, e *Encoder) {
@@ -3019,22 +2929,13 @@ func (_ fastpathT) EncSliceInt16V(v []int16, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeInt(int64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceInt32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceInt32R(rv reflect.Value) {
 	fastpathTV.EncSliceInt32V(rv.Interface().([]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceInt32V(v []int32, checkNil bool, e *Encoder) {
@@ -3044,22 +2945,13 @@ func (_ fastpathT) EncSliceInt32V(v []int32, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeInt(int64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceInt64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceInt64R(rv reflect.Value) {
 	fastpathTV.EncSliceInt64V(rv.Interface().([]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceInt64V(v []int64, checkNil bool, e *Encoder) {
@@ -3069,22 +2961,13 @@ func (_ fastpathT) EncSliceInt64V(v []int64, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeInt(int64(v2))
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncSliceBoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncSliceBoolR(rv reflect.Value) {
 	fastpathTV.EncSliceBoolV(rv.Interface().([]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncSliceBoolV(v []bool, checkNil bool, e *Encoder) {
@@ -3094,22 +2977,13 @@ func (_ fastpathT) EncSliceBoolV(v []bool, checkNil bool, e *Encoder) {
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			ee.EncodeBool(v2)
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			ee.EncodeBool(v2)
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfIntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfIntfR(rv reflect.Value) {
 	fastpathTV.EncMapIntfIntfV(rv.Interface().(map[interface{}]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfIntfV(v map[interface{}]interface{}, checkNil bool, e *Encoder) {
@@ -3120,27 +2994,14 @@ func (_ fastpathT) EncMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfStringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfStringR(rv reflect.Value) {
 	fastpathTV.EncMapIntfStringV(rv.Interface().(map[interface{}]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfStringV(v map[interface{}]string, checkNil bool, e *Encoder) {
@@ -3151,27 +3012,14 @@ func (_ fastpathT) EncMapIntfStringV(v map[interface{}]string, checkNil bool, e 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfUintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfUintR(rv reflect.Value) {
 	fastpathTV.EncMapIntfUintV(rv.Interface().(map[interface{}]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUintV(v map[interface{}]uint, checkNil bool, e *Encoder) {
@@ -3182,27 +3030,14 @@ func (_ fastpathT) EncMapIntfUintV(v map[interface{}]uint, checkNil bool, e *Enc
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfUint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfUint8R(rv reflect.Value) {
 	fastpathTV.EncMapIntfUint8V(rv.Interface().(map[interface{}]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUint8V(v map[interface{}]uint8, checkNil bool, e *Encoder) {
@@ -3213,27 +3048,14 @@ func (_ fastpathT) EncMapIntfUint8V(v map[interface{}]uint8, checkNil bool, e *E
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfUint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfUint16R(rv reflect.Value) {
 	fastpathTV.EncMapIntfUint16V(rv.Interface().(map[interface{}]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUint16V(v map[interface{}]uint16, checkNil bool, e *Encoder) {
@@ -3244,27 +3066,14 @@ func (_ fastpathT) EncMapIntfUint16V(v map[interface{}]uint16, checkNil bool, e 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfUint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfUint32R(rv reflect.Value) {
 	fastpathTV.EncMapIntfUint32V(rv.Interface().(map[interface{}]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUint32V(v map[interface{}]uint32, checkNil bool, e *Encoder) {
@@ -3275,27 +3084,14 @@ func (_ fastpathT) EncMapIntfUint32V(v map[interface{}]uint32, checkNil bool, e 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfUint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfUint64R(rv reflect.Value) {
 	fastpathTV.EncMapIntfUint64V(rv.Interface().(map[interface{}]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUint64V(v map[interface{}]uint64, checkNil bool, e *Encoder) {
@@ -3306,27 +3102,14 @@ func (_ fastpathT) EncMapIntfUint64V(v map[interface{}]uint64, checkNil bool, e 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfIntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfIntR(rv reflect.Value) {
 	fastpathTV.EncMapIntfIntV(rv.Interface().(map[interface{}]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfIntV(v map[interface{}]int, checkNil bool, e *Encoder) {
@@ -3337,27 +3120,14 @@ func (_ fastpathT) EncMapIntfIntV(v map[interface{}]int, checkNil bool, e *Encod
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfInt8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfInt8R(rv reflect.Value) {
 	fastpathTV.EncMapIntfInt8V(rv.Interface().(map[interface{}]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfInt8V(v map[interface{}]int8, checkNil bool, e *Encoder) {
@@ -3368,27 +3138,14 @@ func (_ fastpathT) EncMapIntfInt8V(v map[interface{}]int8, checkNil bool, e *Enc
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfInt16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfInt16R(rv reflect.Value) {
 	fastpathTV.EncMapIntfInt16V(rv.Interface().(map[interface{}]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfInt16V(v map[interface{}]int16, checkNil bool, e *Encoder) {
@@ -3399,27 +3156,14 @@ func (_ fastpathT) EncMapIntfInt16V(v map[interface{}]int16, checkNil bool, e *E
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfInt32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfInt32R(rv reflect.Value) {
 	fastpathTV.EncMapIntfInt32V(rv.Interface().(map[interface{}]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfInt32V(v map[interface{}]int32, checkNil bool, e *Encoder) {
@@ -3430,27 +3174,14 @@ func (_ fastpathT) EncMapIntfInt32V(v map[interface{}]int32, checkNil bool, e *E
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfInt64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfInt64R(rv reflect.Value) {
 	fastpathTV.EncMapIntfInt64V(rv.Interface().(map[interface{}]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfInt64V(v map[interface{}]int64, checkNil bool, e *Encoder) {
@@ -3461,27 +3192,14 @@ func (_ fastpathT) EncMapIntfInt64V(v map[interface{}]int64, checkNil bool, e *E
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfFloat32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfFloat32R(rv reflect.Value) {
 	fastpathTV.EncMapIntfFloat32V(rv.Interface().(map[interface{}]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfFloat32V(v map[interface{}]float32, checkNil bool, e *Encoder) {
@@ -3492,27 +3210,14 @@ func (_ fastpathT) EncMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfFloat64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfFloat64R(rv reflect.Value) {
 	fastpathTV.EncMapIntfFloat64V(rv.Interface().(map[interface{}]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfFloat64V(v map[interface{}]float64, checkNil bool, e *Encoder) {
@@ -3523,27 +3228,14 @@ func (_ fastpathT) EncMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntfBoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntfBoolR(rv reflect.Value) {
 	fastpathTV.EncMapIntfBoolV(rv.Interface().(map[interface{}]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfBoolV(v map[interface{}]bool, checkNil bool, e *Encoder) {
@@ -3554,27 +3246,14 @@ func (_ fastpathT) EncMapIntfBoolV(v map[interface{}]bool, checkNil bool, e *Enc
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			e.encode(k2)
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			e.encode(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		e.encode(k2)
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringIntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringIntfR(rv reflect.Value) {
 	fastpathTV.EncMapStringIntfV(rv.Interface().(map[string]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringIntfV(v map[string]interface{}, checkNil bool, e *Encoder) {
@@ -3585,35 +3264,18 @@ func (_ fastpathT) EncMapStringIntfV(v map[string]interface{}, checkNil bool, e 
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			e.encode(v2)
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringStringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringStringR(rv reflect.Value) {
 	fastpathTV.EncMapStringStringV(rv.Interface().(map[string]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringStringV(v map[string]string, checkNil bool, e *Encoder) {
@@ -3624,35 +3286,18 @@ func (_ fastpathT) EncMapStringStringV(v map[string]string, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeString(c_UTF8, v2)
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringUintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringUintR(rv reflect.Value) {
 	fastpathTV.EncMapStringUintV(rv.Interface().(map[string]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUintV(v map[string]uint, checkNil bool, e *Encoder) {
@@ -3663,35 +3308,18 @@ func (_ fastpathT) EncMapStringUintV(v map[string]uint, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeUint(uint64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringUint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringUint8R(rv reflect.Value) {
 	fastpathTV.EncMapStringUint8V(rv.Interface().(map[string]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUint8V(v map[string]uint8, checkNil bool, e *Encoder) {
@@ -3702,35 +3330,18 @@ func (_ fastpathT) EncMapStringUint8V(v map[string]uint8, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeUint(uint64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringUint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringUint16R(rv reflect.Value) {
 	fastpathTV.EncMapStringUint16V(rv.Interface().(map[string]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUint16V(v map[string]uint16, checkNil bool, e *Encoder) {
@@ -3741,35 +3352,18 @@ func (_ fastpathT) EncMapStringUint16V(v map[string]uint16, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeUint(uint64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringUint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringUint32R(rv reflect.Value) {
 	fastpathTV.EncMapStringUint32V(rv.Interface().(map[string]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUint32V(v map[string]uint32, checkNil bool, e *Encoder) {
@@ -3780,35 +3374,18 @@ func (_ fastpathT) EncMapStringUint32V(v map[string]uint32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeUint(uint64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringUint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringUint64R(rv reflect.Value) {
 	fastpathTV.EncMapStringUint64V(rv.Interface().(map[string]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUint64V(v map[string]uint64, checkNil bool, e *Encoder) {
@@ -3819,35 +3396,18 @@ func (_ fastpathT) EncMapStringUint64V(v map[string]uint64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeUint(uint64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringIntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringIntR(rv reflect.Value) {
 	fastpathTV.EncMapStringIntV(rv.Interface().(map[string]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringIntV(v map[string]int, checkNil bool, e *Encoder) {
@@ -3858,35 +3418,18 @@ func (_ fastpathT) EncMapStringIntV(v map[string]int, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeInt(int64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringInt8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringInt8R(rv reflect.Value) {
 	fastpathTV.EncMapStringInt8V(rv.Interface().(map[string]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringInt8V(v map[string]int8, checkNil bool, e *Encoder) {
@@ -3897,35 +3440,18 @@ func (_ fastpathT) EncMapStringInt8V(v map[string]int8, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeInt(int64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringInt16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringInt16R(rv reflect.Value) {
 	fastpathTV.EncMapStringInt16V(rv.Interface().(map[string]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringInt16V(v map[string]int16, checkNil bool, e *Encoder) {
@@ -3936,35 +3462,18 @@ func (_ fastpathT) EncMapStringInt16V(v map[string]int16, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeInt(int64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringInt32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringInt32R(rv reflect.Value) {
 	fastpathTV.EncMapStringInt32V(rv.Interface().(map[string]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringInt32V(v map[string]int32, checkNil bool, e *Encoder) {
@@ -3975,35 +3484,18 @@ func (_ fastpathT) EncMapStringInt32V(v map[string]int32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeInt(int64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringInt64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringInt64R(rv reflect.Value) {
 	fastpathTV.EncMapStringInt64V(rv.Interface().(map[string]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringInt64V(v map[string]int64, checkNil bool, e *Encoder) {
@@ -4014,35 +3506,18 @@ func (_ fastpathT) EncMapStringInt64V(v map[string]int64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeInt(int64(v2))
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringFloat32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringFloat32R(rv reflect.Value) {
 	fastpathTV.EncMapStringFloat32V(rv.Interface().(map[string]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringFloat32V(v map[string]float32, checkNil bool, e *Encoder) {
@@ -4053,35 +3528,18 @@ func (_ fastpathT) EncMapStringFloat32V(v map[string]float32, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeFloat32(v2)
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringFloat64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringFloat64R(rv reflect.Value) {
 	fastpathTV.EncMapStringFloat64V(rv.Interface().(map[string]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringFloat64V(v map[string]float64, checkNil bool, e *Encoder) {
@@ -4092,35 +3550,18 @@ func (_ fastpathT) EncMapStringFloat64V(v map[string]float64, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeFloat64(v2)
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapStringBoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapStringBoolR(rv reflect.Value) {
 	fastpathTV.EncMapStringBoolV(rv.Interface().(map[string]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringBoolV(v map[string]bool, checkNil bool, e *Encoder) {
@@ -4131,35 +3572,18 @@ func (_ fastpathT) EncMapStringBoolV(v map[string]bool, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 	asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0
-	if e.be {
-		for k2, v2 := range v {
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeBool(v2)
+	for k2, v2 := range v {
+		if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
 		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32IntfR(rv reflect.Value) {
 	fastpathTV.EncMapFloat32IntfV(rv.Interface().(map[float32]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32IntfV(v map[float32]interface{}, checkNil bool, e *Encoder) {
@@ -4170,27 +3594,14 @@ func (_ fastpathT) EncMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32StringR(rv reflect.Value) {
 	fastpathTV.EncMapFloat32StringV(rv.Interface().(map[float32]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32StringV(v map[float32]string, checkNil bool, e *Encoder) {
@@ -4201,27 +3612,14 @@ func (_ fastpathT) EncMapFloat32StringV(v map[float32]string, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32UintR(rv reflect.Value) {
 	fastpathTV.EncMapFloat32UintV(rv.Interface().(map[float32]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32UintV(v map[float32]uint, checkNil bool, e *Encoder) {
@@ -4232,27 +3630,14 @@ func (_ fastpathT) EncMapFloat32UintV(v map[float32]uint, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Uint8V(rv.Interface().(map[float32]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Uint8V(v map[float32]uint8, checkNil bool, e *Encoder) {
@@ -4263,27 +3648,14 @@ func (_ fastpathT) EncMapFloat32Uint8V(v map[float32]uint8, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Uint16V(rv.Interface().(map[float32]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Uint16V(v map[float32]uint16, checkNil bool, e *Encoder) {
@@ -4294,27 +3666,14 @@ func (_ fastpathT) EncMapFloat32Uint16V(v map[float32]uint16, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Uint32V(rv.Interface().(map[float32]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Uint32V(v map[float32]uint32, checkNil bool, e *Encoder) {
@@ -4325,27 +3684,14 @@ func (_ fastpathT) EncMapFloat32Uint32V(v map[float32]uint32, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Uint64V(rv.Interface().(map[float32]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Uint64V(v map[float32]uint64, checkNil bool, e *Encoder) {
@@ -4356,27 +3702,14 @@ func (_ fastpathT) EncMapFloat32Uint64V(v map[float32]uint64, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32IntR(rv reflect.Value) {
 	fastpathTV.EncMapFloat32IntV(rv.Interface().(map[float32]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32IntV(v map[float32]int, checkNil bool, e *Encoder) {
@@ -4387,27 +3720,14 @@ func (_ fastpathT) EncMapFloat32IntV(v map[float32]int, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Int8R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Int8V(rv.Interface().(map[float32]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Int8V(v map[float32]int8, checkNil bool, e *Encoder) {
@@ -4418,27 +3738,14 @@ func (_ fastpathT) EncMapFloat32Int8V(v map[float32]int8, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Int16R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Int16V(rv.Interface().(map[float32]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Int16V(v map[float32]int16, checkNil bool, e *Encoder) {
@@ -4449,27 +3756,14 @@ func (_ fastpathT) EncMapFloat32Int16V(v map[float32]int16, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Int32R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Int32V(rv.Interface().(map[float32]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Int32V(v map[float32]int32, checkNil bool, e *Encoder) {
@@ -4480,27 +3774,14 @@ func (_ fastpathT) EncMapFloat32Int32V(v map[float32]int32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Int64R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Int64V(rv.Interface().(map[float32]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Int64V(v map[float32]int64, checkNil bool, e *Encoder) {
@@ -4511,27 +3792,14 @@ func (_ fastpathT) EncMapFloat32Int64V(v map[float32]int64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Float32R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Float32V(rv.Interface().(map[float32]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Float32V(v map[float32]float32, checkNil bool, e *Encoder) {
@@ -4542,27 +3810,14 @@ func (_ fastpathT) EncMapFloat32Float32V(v map[float32]float32, checkNil bool, e
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32Float64R(rv reflect.Value) {
 	fastpathTV.EncMapFloat32Float64V(rv.Interface().(map[float32]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Float64V(v map[float32]float64, checkNil bool, e *Encoder) {
@@ -4573,27 +3828,14 @@ func (_ fastpathT) EncMapFloat32Float64V(v map[float32]float64, checkNil bool, e
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat32BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat32BoolR(rv reflect.Value) {
 	fastpathTV.EncMapFloat32BoolV(rv.Interface().(map[float32]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32BoolV(v map[float32]bool, checkNil bool, e *Encoder) {
@@ -4604,27 +3846,14 @@ func (_ fastpathT) EncMapFloat32BoolV(v map[float32]bool, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat32(k2)
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat32(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat32(k2)
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64IntfR(rv reflect.Value) {
 	fastpathTV.EncMapFloat64IntfV(rv.Interface().(map[float64]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64IntfV(v map[float64]interface{}, checkNil bool, e *Encoder) {
@@ -4635,27 +3864,14 @@ func (_ fastpathT) EncMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64StringR(rv reflect.Value) {
 	fastpathTV.EncMapFloat64StringV(rv.Interface().(map[float64]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64StringV(v map[float64]string, checkNil bool, e *Encoder) {
@@ -4666,27 +3882,14 @@ func (_ fastpathT) EncMapFloat64StringV(v map[float64]string, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64UintR(rv reflect.Value) {
 	fastpathTV.EncMapFloat64UintV(rv.Interface().(map[float64]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64UintV(v map[float64]uint, checkNil bool, e *Encoder) {
@@ -4697,27 +3900,14 @@ func (_ fastpathT) EncMapFloat64UintV(v map[float64]uint, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Uint8V(rv.Interface().(map[float64]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Uint8V(v map[float64]uint8, checkNil bool, e *Encoder) {
@@ -4728,27 +3918,14 @@ func (_ fastpathT) EncMapFloat64Uint8V(v map[float64]uint8, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Uint16V(rv.Interface().(map[float64]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Uint16V(v map[float64]uint16, checkNil bool, e *Encoder) {
@@ -4759,27 +3936,14 @@ func (_ fastpathT) EncMapFloat64Uint16V(v map[float64]uint16, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Uint32V(rv.Interface().(map[float64]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Uint32V(v map[float64]uint32, checkNil bool, e *Encoder) {
@@ -4790,27 +3954,14 @@ func (_ fastpathT) EncMapFloat64Uint32V(v map[float64]uint32, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Uint64V(rv.Interface().(map[float64]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Uint64V(v map[float64]uint64, checkNil bool, e *Encoder) {
@@ -4821,27 +3972,14 @@ func (_ fastpathT) EncMapFloat64Uint64V(v map[float64]uint64, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64IntR(rv reflect.Value) {
 	fastpathTV.EncMapFloat64IntV(rv.Interface().(map[float64]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64IntV(v map[float64]int, checkNil bool, e *Encoder) {
@@ -4852,27 +3990,14 @@ func (_ fastpathT) EncMapFloat64IntV(v map[float64]int, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Int8R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Int8V(rv.Interface().(map[float64]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Int8V(v map[float64]int8, checkNil bool, e *Encoder) {
@@ -4883,27 +4008,14 @@ func (_ fastpathT) EncMapFloat64Int8V(v map[float64]int8, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Int16R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Int16V(rv.Interface().(map[float64]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Int16V(v map[float64]int16, checkNil bool, e *Encoder) {
@@ -4914,27 +4026,14 @@ func (_ fastpathT) EncMapFloat64Int16V(v map[float64]int16, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Int32R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Int32V(rv.Interface().(map[float64]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Int32V(v map[float64]int32, checkNil bool, e *Encoder) {
@@ -4945,27 +4044,14 @@ func (_ fastpathT) EncMapFloat64Int32V(v map[float64]int32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Int64R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Int64V(rv.Interface().(map[float64]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Int64V(v map[float64]int64, checkNil bool, e *Encoder) {
@@ -4976,27 +4062,14 @@ func (_ fastpathT) EncMapFloat64Int64V(v map[float64]int64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Float32R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Float32V(rv.Interface().(map[float64]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Float32V(v map[float64]float32, checkNil bool, e *Encoder) {
@@ -5007,27 +4080,14 @@ func (_ fastpathT) EncMapFloat64Float32V(v map[float64]float32, checkNil bool, e
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64Float64R(rv reflect.Value) {
 	fastpathTV.EncMapFloat64Float64V(rv.Interface().(map[float64]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Float64V(v map[float64]float64, checkNil bool, e *Encoder) {
@@ -5038,27 +4098,14 @@ func (_ fastpathT) EncMapFloat64Float64V(v map[float64]float64, checkNil bool, e
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapFloat64BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapFloat64BoolR(rv reflect.Value) {
 	fastpathTV.EncMapFloat64BoolV(rv.Interface().(map[float64]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64BoolV(v map[float64]bool, checkNil bool, e *Encoder) {
@@ -5069,27 +4116,14 @@ func (_ fastpathT) EncMapFloat64BoolV(v map[float64]bool, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeFloat64(k2)
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeFloat64(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeFloat64(k2)
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintIntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintIntfR(rv reflect.Value) {
 	fastpathTV.EncMapUintIntfV(rv.Interface().(map[uint]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintIntfV(v map[uint]interface{}, checkNil bool, e *Encoder) {
@@ -5100,27 +4134,14 @@ func (_ fastpathT) EncMapUintIntfV(v map[uint]interface{}, checkNil bool, e *Enc
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintStringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintStringR(rv reflect.Value) {
 	fastpathTV.EncMapUintStringV(rv.Interface().(map[uint]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintStringV(v map[uint]string, checkNil bool, e *Encoder) {
@@ -5131,27 +4152,14 @@ func (_ fastpathT) EncMapUintStringV(v map[uint]string, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintUintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintUintR(rv reflect.Value) {
 	fastpathTV.EncMapUintUintV(rv.Interface().(map[uint]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUintV(v map[uint]uint, checkNil bool, e *Encoder) {
@@ -5162,27 +4170,14 @@ func (_ fastpathT) EncMapUintUintV(v map[uint]uint, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintUint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintUint8R(rv reflect.Value) {
 	fastpathTV.EncMapUintUint8V(rv.Interface().(map[uint]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUint8V(v map[uint]uint8, checkNil bool, e *Encoder) {
@@ -5193,27 +4188,14 @@ func (_ fastpathT) EncMapUintUint8V(v map[uint]uint8, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintUint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintUint16R(rv reflect.Value) {
 	fastpathTV.EncMapUintUint16V(rv.Interface().(map[uint]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUint16V(v map[uint]uint16, checkNil bool, e *Encoder) {
@@ -5224,27 +4206,14 @@ func (_ fastpathT) EncMapUintUint16V(v map[uint]uint16, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintUint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintUint32R(rv reflect.Value) {
 	fastpathTV.EncMapUintUint32V(rv.Interface().(map[uint]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUint32V(v map[uint]uint32, checkNil bool, e *Encoder) {
@@ -5255,27 +4224,14 @@ func (_ fastpathT) EncMapUintUint32V(v map[uint]uint32, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintUint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintUint64R(rv reflect.Value) {
 	fastpathTV.EncMapUintUint64V(rv.Interface().(map[uint]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUint64V(v map[uint]uint64, checkNil bool, e *Encoder) {
@@ -5286,27 +4242,14 @@ func (_ fastpathT) EncMapUintUint64V(v map[uint]uint64, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintIntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintIntR(rv reflect.Value) {
 	fastpathTV.EncMapUintIntV(rv.Interface().(map[uint]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintIntV(v map[uint]int, checkNil bool, e *Encoder) {
@@ -5317,27 +4260,14 @@ func (_ fastpathT) EncMapUintIntV(v map[uint]int, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintInt8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintInt8R(rv reflect.Value) {
 	fastpathTV.EncMapUintInt8V(rv.Interface().(map[uint]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintInt8V(v map[uint]int8, checkNil bool, e *Encoder) {
@@ -5348,27 +4278,14 @@ func (_ fastpathT) EncMapUintInt8V(v map[uint]int8, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintInt16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintInt16R(rv reflect.Value) {
 	fastpathTV.EncMapUintInt16V(rv.Interface().(map[uint]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintInt16V(v map[uint]int16, checkNil bool, e *Encoder) {
@@ -5379,27 +4296,14 @@ func (_ fastpathT) EncMapUintInt16V(v map[uint]int16, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintInt32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintInt32R(rv reflect.Value) {
 	fastpathTV.EncMapUintInt32V(rv.Interface().(map[uint]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintInt32V(v map[uint]int32, checkNil bool, e *Encoder) {
@@ -5410,27 +4314,14 @@ func (_ fastpathT) EncMapUintInt32V(v map[uint]int32, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintInt64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintInt64R(rv reflect.Value) {
 	fastpathTV.EncMapUintInt64V(rv.Interface().(map[uint]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintInt64V(v map[uint]int64, checkNil bool, e *Encoder) {
@@ -5441,27 +4332,14 @@ func (_ fastpathT) EncMapUintInt64V(v map[uint]int64, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintFloat32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintFloat32R(rv reflect.Value) {
 	fastpathTV.EncMapUintFloat32V(rv.Interface().(map[uint]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintFloat32V(v map[uint]float32, checkNil bool, e *Encoder) {
@@ -5472,27 +4350,14 @@ func (_ fastpathT) EncMapUintFloat32V(v map[uint]float32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintFloat64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintFloat64R(rv reflect.Value) {
 	fastpathTV.EncMapUintFloat64V(rv.Interface().(map[uint]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintFloat64V(v map[uint]float64, checkNil bool, e *Encoder) {
@@ -5503,27 +4368,14 @@ func (_ fastpathT) EncMapUintFloat64V(v map[uint]float64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUintBoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUintBoolR(rv reflect.Value) {
 	fastpathTV.EncMapUintBoolV(rv.Interface().(map[uint]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintBoolV(v map[uint]bool, checkNil bool, e *Encoder) {
@@ -5534,27 +4386,14 @@ func (_ fastpathT) EncMapUintBoolV(v map[uint]bool, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8IntfR(rv reflect.Value) {
 	fastpathTV.EncMapUint8IntfV(rv.Interface().(map[uint8]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8IntfV(v map[uint8]interface{}, checkNil bool, e *Encoder) {
@@ -5565,27 +4404,14 @@ func (_ fastpathT) EncMapUint8IntfV(v map[uint8]interface{}, checkNil bool, e *E
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8StringR(rv reflect.Value) {
 	fastpathTV.EncMapUint8StringV(rv.Interface().(map[uint8]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8StringV(v map[uint8]string, checkNil bool, e *Encoder) {
@@ -5596,27 +4422,14 @@ func (_ fastpathT) EncMapUint8StringV(v map[uint8]string, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8UintR(rv reflect.Value) {
 	fastpathTV.EncMapUint8UintV(rv.Interface().(map[uint8]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8UintV(v map[uint8]uint, checkNil bool, e *Encoder) {
@@ -5627,27 +4440,14 @@ func (_ fastpathT) EncMapUint8UintV(v map[uint8]uint, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Uint8V(rv.Interface().(map[uint8]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Uint8V(v map[uint8]uint8, checkNil bool, e *Encoder) {
@@ -5658,27 +4458,14 @@ func (_ fastpathT) EncMapUint8Uint8V(v map[uint8]uint8, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Uint16V(rv.Interface().(map[uint8]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Uint16V(v map[uint8]uint16, checkNil bool, e *Encoder) {
@@ -5689,27 +4476,14 @@ func (_ fastpathT) EncMapUint8Uint16V(v map[uint8]uint16, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Uint32V(rv.Interface().(map[uint8]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Uint32V(v map[uint8]uint32, checkNil bool, e *Encoder) {
@@ -5720,27 +4494,14 @@ func (_ fastpathT) EncMapUint8Uint32V(v map[uint8]uint32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Uint64V(rv.Interface().(map[uint8]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Uint64V(v map[uint8]uint64, checkNil bool, e *Encoder) {
@@ -5751,27 +4512,14 @@ func (_ fastpathT) EncMapUint8Uint64V(v map[uint8]uint64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8IntR(rv reflect.Value) {
 	fastpathTV.EncMapUint8IntV(rv.Interface().(map[uint8]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8IntV(v map[uint8]int, checkNil bool, e *Encoder) {
@@ -5782,27 +4530,14 @@ func (_ fastpathT) EncMapUint8IntV(v map[uint8]int, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Int8R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Int8V(rv.Interface().(map[uint8]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Int8V(v map[uint8]int8, checkNil bool, e *Encoder) {
@@ -5813,27 +4548,14 @@ func (_ fastpathT) EncMapUint8Int8V(v map[uint8]int8, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Int16R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Int16V(rv.Interface().(map[uint8]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Int16V(v map[uint8]int16, checkNil bool, e *Encoder) {
@@ -5844,27 +4566,14 @@ func (_ fastpathT) EncMapUint8Int16V(v map[uint8]int16, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Int32R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Int32V(rv.Interface().(map[uint8]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Int32V(v map[uint8]int32, checkNil bool, e *Encoder) {
@@ -5875,27 +4584,14 @@ func (_ fastpathT) EncMapUint8Int32V(v map[uint8]int32, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Int64R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Int64V(rv.Interface().(map[uint8]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Int64V(v map[uint8]int64, checkNil bool, e *Encoder) {
@@ -5906,27 +4602,14 @@ func (_ fastpathT) EncMapUint8Int64V(v map[uint8]int64, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Float32R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Float32V(rv.Interface().(map[uint8]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Float32V(v map[uint8]float32, checkNil bool, e *Encoder) {
@@ -5937,27 +4620,14 @@ func (_ fastpathT) EncMapUint8Float32V(v map[uint8]float32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8Float64R(rv reflect.Value) {
 	fastpathTV.EncMapUint8Float64V(rv.Interface().(map[uint8]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Float64V(v map[uint8]float64, checkNil bool, e *Encoder) {
@@ -5968,27 +4638,14 @@ func (_ fastpathT) EncMapUint8Float64V(v map[uint8]float64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint8BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint8BoolR(rv reflect.Value) {
 	fastpathTV.EncMapUint8BoolV(rv.Interface().(map[uint8]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8BoolV(v map[uint8]bool, checkNil bool, e *Encoder) {
@@ -5999,27 +4656,14 @@ func (_ fastpathT) EncMapUint8BoolV(v map[uint8]bool, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16IntfR(rv reflect.Value) {
 	fastpathTV.EncMapUint16IntfV(rv.Interface().(map[uint16]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16IntfV(v map[uint16]interface{}, checkNil bool, e *Encoder) {
@@ -6030,27 +4674,14 @@ func (_ fastpathT) EncMapUint16IntfV(v map[uint16]interface{}, checkNil bool, e 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16StringR(rv reflect.Value) {
 	fastpathTV.EncMapUint16StringV(rv.Interface().(map[uint16]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16StringV(v map[uint16]string, checkNil bool, e *Encoder) {
@@ -6061,27 +4692,14 @@ func (_ fastpathT) EncMapUint16StringV(v map[uint16]string, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16UintR(rv reflect.Value) {
 	fastpathTV.EncMapUint16UintV(rv.Interface().(map[uint16]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16UintV(v map[uint16]uint, checkNil bool, e *Encoder) {
@@ -6092,27 +4710,14 @@ func (_ fastpathT) EncMapUint16UintV(v map[uint16]uint, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Uint8V(rv.Interface().(map[uint16]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Uint8V(v map[uint16]uint8, checkNil bool, e *Encoder) {
@@ -6123,27 +4728,14 @@ func (_ fastpathT) EncMapUint16Uint8V(v map[uint16]uint8, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Uint16V(rv.Interface().(map[uint16]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Uint16V(v map[uint16]uint16, checkNil bool, e *Encoder) {
@@ -6154,27 +4746,14 @@ func (_ fastpathT) EncMapUint16Uint16V(v map[uint16]uint16, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Uint32V(rv.Interface().(map[uint16]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Uint32V(v map[uint16]uint32, checkNil bool, e *Encoder) {
@@ -6185,27 +4764,14 @@ func (_ fastpathT) EncMapUint16Uint32V(v map[uint16]uint32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Uint64V(rv.Interface().(map[uint16]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Uint64V(v map[uint16]uint64, checkNil bool, e *Encoder) {
@@ -6216,27 +4782,14 @@ func (_ fastpathT) EncMapUint16Uint64V(v map[uint16]uint64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16IntR(rv reflect.Value) {
 	fastpathTV.EncMapUint16IntV(rv.Interface().(map[uint16]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16IntV(v map[uint16]int, checkNil bool, e *Encoder) {
@@ -6247,27 +4800,14 @@ func (_ fastpathT) EncMapUint16IntV(v map[uint16]int, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Int8R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Int8V(rv.Interface().(map[uint16]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Int8V(v map[uint16]int8, checkNil bool, e *Encoder) {
@@ -6278,27 +4818,14 @@ func (_ fastpathT) EncMapUint16Int8V(v map[uint16]int8, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Int16R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Int16V(rv.Interface().(map[uint16]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Int16V(v map[uint16]int16, checkNil bool, e *Encoder) {
@@ -6309,27 +4836,14 @@ func (_ fastpathT) EncMapUint16Int16V(v map[uint16]int16, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Int32R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Int32V(rv.Interface().(map[uint16]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Int32V(v map[uint16]int32, checkNil bool, e *Encoder) {
@@ -6340,27 +4854,14 @@ func (_ fastpathT) EncMapUint16Int32V(v map[uint16]int32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Int64R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Int64V(rv.Interface().(map[uint16]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Int64V(v map[uint16]int64, checkNil bool, e *Encoder) {
@@ -6371,27 +4872,14 @@ func (_ fastpathT) EncMapUint16Int64V(v map[uint16]int64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Float32R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Float32V(rv.Interface().(map[uint16]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Float32V(v map[uint16]float32, checkNil bool, e *Encoder) {
@@ -6402,27 +4890,14 @@ func (_ fastpathT) EncMapUint16Float32V(v map[uint16]float32, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16Float64R(rv reflect.Value) {
 	fastpathTV.EncMapUint16Float64V(rv.Interface().(map[uint16]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Float64V(v map[uint16]float64, checkNil bool, e *Encoder) {
@@ -6433,27 +4908,14 @@ func (_ fastpathT) EncMapUint16Float64V(v map[uint16]float64, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint16BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint16BoolR(rv reflect.Value) {
 	fastpathTV.EncMapUint16BoolV(rv.Interface().(map[uint16]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16BoolV(v map[uint16]bool, checkNil bool, e *Encoder) {
@@ -6464,27 +4926,14 @@ func (_ fastpathT) EncMapUint16BoolV(v map[uint16]bool, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32IntfR(rv reflect.Value) {
 	fastpathTV.EncMapUint32IntfV(rv.Interface().(map[uint32]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32IntfV(v map[uint32]interface{}, checkNil bool, e *Encoder) {
@@ -6495,27 +4944,14 @@ func (_ fastpathT) EncMapUint32IntfV(v map[uint32]interface{}, checkNil bool, e 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32StringR(rv reflect.Value) {
 	fastpathTV.EncMapUint32StringV(rv.Interface().(map[uint32]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32StringV(v map[uint32]string, checkNil bool, e *Encoder) {
@@ -6526,27 +4962,14 @@ func (_ fastpathT) EncMapUint32StringV(v map[uint32]string, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32UintR(rv reflect.Value) {
 	fastpathTV.EncMapUint32UintV(rv.Interface().(map[uint32]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32UintV(v map[uint32]uint, checkNil bool, e *Encoder) {
@@ -6557,27 +4980,14 @@ func (_ fastpathT) EncMapUint32UintV(v map[uint32]uint, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Uint8V(rv.Interface().(map[uint32]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Uint8V(v map[uint32]uint8, checkNil bool, e *Encoder) {
@@ -6588,27 +4998,14 @@ func (_ fastpathT) EncMapUint32Uint8V(v map[uint32]uint8, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Uint16V(rv.Interface().(map[uint32]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Uint16V(v map[uint32]uint16, checkNil bool, e *Encoder) {
@@ -6619,27 +5016,14 @@ func (_ fastpathT) EncMapUint32Uint16V(v map[uint32]uint16, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Uint32V(rv.Interface().(map[uint32]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Uint32V(v map[uint32]uint32, checkNil bool, e *Encoder) {
@@ -6650,27 +5034,14 @@ func (_ fastpathT) EncMapUint32Uint32V(v map[uint32]uint32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Uint64V(rv.Interface().(map[uint32]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Uint64V(v map[uint32]uint64, checkNil bool, e *Encoder) {
@@ -6681,27 +5052,14 @@ func (_ fastpathT) EncMapUint32Uint64V(v map[uint32]uint64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32IntR(rv reflect.Value) {
 	fastpathTV.EncMapUint32IntV(rv.Interface().(map[uint32]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32IntV(v map[uint32]int, checkNil bool, e *Encoder) {
@@ -6712,27 +5070,14 @@ func (_ fastpathT) EncMapUint32IntV(v map[uint32]int, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Int8R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Int8V(rv.Interface().(map[uint32]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Int8V(v map[uint32]int8, checkNil bool, e *Encoder) {
@@ -6743,27 +5088,14 @@ func (_ fastpathT) EncMapUint32Int8V(v map[uint32]int8, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Int16R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Int16V(rv.Interface().(map[uint32]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Int16V(v map[uint32]int16, checkNil bool, e *Encoder) {
@@ -6774,27 +5106,14 @@ func (_ fastpathT) EncMapUint32Int16V(v map[uint32]int16, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Int32R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Int32V(rv.Interface().(map[uint32]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Int32V(v map[uint32]int32, checkNil bool, e *Encoder) {
@@ -6805,27 +5124,14 @@ func (_ fastpathT) EncMapUint32Int32V(v map[uint32]int32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Int64R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Int64V(rv.Interface().(map[uint32]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Int64V(v map[uint32]int64, checkNil bool, e *Encoder) {
@@ -6836,27 +5142,14 @@ func (_ fastpathT) EncMapUint32Int64V(v map[uint32]int64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Float32R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Float32V(rv.Interface().(map[uint32]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Float32V(v map[uint32]float32, checkNil bool, e *Encoder) {
@@ -6867,27 +5160,14 @@ func (_ fastpathT) EncMapUint32Float32V(v map[uint32]float32, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32Float64R(rv reflect.Value) {
 	fastpathTV.EncMapUint32Float64V(rv.Interface().(map[uint32]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Float64V(v map[uint32]float64, checkNil bool, e *Encoder) {
@@ -6898,27 +5178,14 @@ func (_ fastpathT) EncMapUint32Float64V(v map[uint32]float64, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint32BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint32BoolR(rv reflect.Value) {
 	fastpathTV.EncMapUint32BoolV(rv.Interface().(map[uint32]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32BoolV(v map[uint32]bool, checkNil bool, e *Encoder) {
@@ -6929,27 +5196,14 @@ func (_ fastpathT) EncMapUint32BoolV(v map[uint32]bool, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64IntfR(rv reflect.Value) {
 	fastpathTV.EncMapUint64IntfV(rv.Interface().(map[uint64]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64IntfV(v map[uint64]interface{}, checkNil bool, e *Encoder) {
@@ -6960,27 +5214,14 @@ func (_ fastpathT) EncMapUint64IntfV(v map[uint64]interface{}, checkNil bool, e 
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64StringR(rv reflect.Value) {
 	fastpathTV.EncMapUint64StringV(rv.Interface().(map[uint64]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64StringV(v map[uint64]string, checkNil bool, e *Encoder) {
@@ -6991,27 +5232,14 @@ func (_ fastpathT) EncMapUint64StringV(v map[uint64]string, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64UintR(rv reflect.Value) {
 	fastpathTV.EncMapUint64UintV(rv.Interface().(map[uint64]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64UintV(v map[uint64]uint, checkNil bool, e *Encoder) {
@@ -7022,27 +5250,14 @@ func (_ fastpathT) EncMapUint64UintV(v map[uint64]uint, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Uint8V(rv.Interface().(map[uint64]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Uint8V(v map[uint64]uint8, checkNil bool, e *Encoder) {
@@ -7053,27 +5268,14 @@ func (_ fastpathT) EncMapUint64Uint8V(v map[uint64]uint8, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Uint16V(rv.Interface().(map[uint64]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Uint16V(v map[uint64]uint16, checkNil bool, e *Encoder) {
@@ -7084,27 +5286,14 @@ func (_ fastpathT) EncMapUint64Uint16V(v map[uint64]uint16, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Uint32V(rv.Interface().(map[uint64]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Uint32V(v map[uint64]uint32, checkNil bool, e *Encoder) {
@@ -7115,27 +5304,14 @@ func (_ fastpathT) EncMapUint64Uint32V(v map[uint64]uint32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Uint64V(rv.Interface().(map[uint64]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Uint64V(v map[uint64]uint64, checkNil bool, e *Encoder) {
@@ -7146,27 +5322,14 @@ func (_ fastpathT) EncMapUint64Uint64V(v map[uint64]uint64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64IntR(rv reflect.Value) {
 	fastpathTV.EncMapUint64IntV(rv.Interface().(map[uint64]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64IntV(v map[uint64]int, checkNil bool, e *Encoder) {
@@ -7177,27 +5340,14 @@ func (_ fastpathT) EncMapUint64IntV(v map[uint64]int, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Int8R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Int8V(rv.Interface().(map[uint64]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Int8V(v map[uint64]int8, checkNil bool, e *Encoder) {
@@ -7208,27 +5358,14 @@ func (_ fastpathT) EncMapUint64Int8V(v map[uint64]int8, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Int16R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Int16V(rv.Interface().(map[uint64]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Int16V(v map[uint64]int16, checkNil bool, e *Encoder) {
@@ -7239,27 +5376,14 @@ func (_ fastpathT) EncMapUint64Int16V(v map[uint64]int16, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Int32R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Int32V(rv.Interface().(map[uint64]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Int32V(v map[uint64]int32, checkNil bool, e *Encoder) {
@@ -7270,27 +5394,14 @@ func (_ fastpathT) EncMapUint64Int32V(v map[uint64]int32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Int64R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Int64V(rv.Interface().(map[uint64]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Int64V(v map[uint64]int64, checkNil bool, e *Encoder) {
@@ -7301,27 +5412,14 @@ func (_ fastpathT) EncMapUint64Int64V(v map[uint64]int64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Float32R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Float32V(rv.Interface().(map[uint64]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Float32V(v map[uint64]float32, checkNil bool, e *Encoder) {
@@ -7332,27 +5430,14 @@ func (_ fastpathT) EncMapUint64Float32V(v map[uint64]float32, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64Float64R(rv reflect.Value) {
 	fastpathTV.EncMapUint64Float64V(rv.Interface().(map[uint64]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Float64V(v map[uint64]float64, checkNil bool, e *Encoder) {
@@ -7363,27 +5448,14 @@ func (_ fastpathT) EncMapUint64Float64V(v map[uint64]float64, checkNil bool, e *
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapUint64BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapUint64BoolR(rv reflect.Value) {
 	fastpathTV.EncMapUint64BoolV(rv.Interface().(map[uint64]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64BoolV(v map[uint64]bool, checkNil bool, e *Encoder) {
@@ -7394,27 +5466,14 @@ func (_ fastpathT) EncMapUint64BoolV(v map[uint64]bool, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeUint(uint64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeUint(uint64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntIntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntIntfR(rv reflect.Value) {
 	fastpathTV.EncMapIntIntfV(rv.Interface().(map[int]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntIntfV(v map[int]interface{}, checkNil bool, e *Encoder) {
@@ -7425,27 +5484,14 @@ func (_ fastpathT) EncMapIntIntfV(v map[int]interface{}, checkNil bool, e *Encod
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntStringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntStringR(rv reflect.Value) {
 	fastpathTV.EncMapIntStringV(rv.Interface().(map[int]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntStringV(v map[int]string, checkNil bool, e *Encoder) {
@@ -7456,27 +5502,14 @@ func (_ fastpathT) EncMapIntStringV(v map[int]string, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntUintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntUintR(rv reflect.Value) {
 	fastpathTV.EncMapIntUintV(rv.Interface().(map[int]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUintV(v map[int]uint, checkNil bool, e *Encoder) {
@@ -7487,27 +5520,14 @@ func (_ fastpathT) EncMapIntUintV(v map[int]uint, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntUint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntUint8R(rv reflect.Value) {
 	fastpathTV.EncMapIntUint8V(rv.Interface().(map[int]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUint8V(v map[int]uint8, checkNil bool, e *Encoder) {
@@ -7518,27 +5538,14 @@ func (_ fastpathT) EncMapIntUint8V(v map[int]uint8, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntUint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntUint16R(rv reflect.Value) {
 	fastpathTV.EncMapIntUint16V(rv.Interface().(map[int]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUint16V(v map[int]uint16, checkNil bool, e *Encoder) {
@@ -7549,27 +5556,14 @@ func (_ fastpathT) EncMapIntUint16V(v map[int]uint16, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntUint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntUint32R(rv reflect.Value) {
 	fastpathTV.EncMapIntUint32V(rv.Interface().(map[int]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUint32V(v map[int]uint32, checkNil bool, e *Encoder) {
@@ -7580,27 +5574,14 @@ func (_ fastpathT) EncMapIntUint32V(v map[int]uint32, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntUint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntUint64R(rv reflect.Value) {
 	fastpathTV.EncMapIntUint64V(rv.Interface().(map[int]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUint64V(v map[int]uint64, checkNil bool, e *Encoder) {
@@ -7611,27 +5592,14 @@ func (_ fastpathT) EncMapIntUint64V(v map[int]uint64, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntIntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntIntR(rv reflect.Value) {
 	fastpathTV.EncMapIntIntV(rv.Interface().(map[int]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntIntV(v map[int]int, checkNil bool, e *Encoder) {
@@ -7642,27 +5610,14 @@ func (_ fastpathT) EncMapIntIntV(v map[int]int, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntInt8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntInt8R(rv reflect.Value) {
 	fastpathTV.EncMapIntInt8V(rv.Interface().(map[int]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntInt8V(v map[int]int8, checkNil bool, e *Encoder) {
@@ -7673,27 +5628,14 @@ func (_ fastpathT) EncMapIntInt8V(v map[int]int8, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntInt16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntInt16R(rv reflect.Value) {
 	fastpathTV.EncMapIntInt16V(rv.Interface().(map[int]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntInt16V(v map[int]int16, checkNil bool, e *Encoder) {
@@ -7704,27 +5646,14 @@ func (_ fastpathT) EncMapIntInt16V(v map[int]int16, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntInt32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntInt32R(rv reflect.Value) {
 	fastpathTV.EncMapIntInt32V(rv.Interface().(map[int]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntInt32V(v map[int]int32, checkNil bool, e *Encoder) {
@@ -7735,27 +5664,14 @@ func (_ fastpathT) EncMapIntInt32V(v map[int]int32, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntInt64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntInt64R(rv reflect.Value) {
 	fastpathTV.EncMapIntInt64V(rv.Interface().(map[int]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntInt64V(v map[int]int64, checkNil bool, e *Encoder) {
@@ -7766,27 +5682,14 @@ func (_ fastpathT) EncMapIntInt64V(v map[int]int64, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntFloat32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntFloat32R(rv reflect.Value) {
 	fastpathTV.EncMapIntFloat32V(rv.Interface().(map[int]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntFloat32V(v map[int]float32, checkNil bool, e *Encoder) {
@@ -7797,27 +5700,14 @@ func (_ fastpathT) EncMapIntFloat32V(v map[int]float32, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntFloat64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntFloat64R(rv reflect.Value) {
 	fastpathTV.EncMapIntFloat64V(rv.Interface().(map[int]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntFloat64V(v map[int]float64, checkNil bool, e *Encoder) {
@@ -7828,27 +5718,14 @@ func (_ fastpathT) EncMapIntFloat64V(v map[int]float64, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapIntBoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapIntBoolR(rv reflect.Value) {
 	fastpathTV.EncMapIntBoolV(rv.Interface().(map[int]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntBoolV(v map[int]bool, checkNil bool, e *Encoder) {
@@ -7859,27 +5736,14 @@ func (_ fastpathT) EncMapIntBoolV(v map[int]bool, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8IntfR(rv reflect.Value) {
 	fastpathTV.EncMapInt8IntfV(rv.Interface().(map[int8]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8IntfV(v map[int8]interface{}, checkNil bool, e *Encoder) {
@@ -7890,27 +5754,14 @@ func (_ fastpathT) EncMapInt8IntfV(v map[int8]interface{}, checkNil bool, e *Enc
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8StringR(rv reflect.Value) {
 	fastpathTV.EncMapInt8StringV(rv.Interface().(map[int8]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8StringV(v map[int8]string, checkNil bool, e *Encoder) {
@@ -7921,27 +5772,14 @@ func (_ fastpathT) EncMapInt8StringV(v map[int8]string, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8UintR(rv reflect.Value) {
 	fastpathTV.EncMapInt8UintV(rv.Interface().(map[int8]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8UintV(v map[int8]uint, checkNil bool, e *Encoder) {
@@ -7952,27 +5790,14 @@ func (_ fastpathT) EncMapInt8UintV(v map[int8]uint, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Uint8V(rv.Interface().(map[int8]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Uint8V(v map[int8]uint8, checkNil bool, e *Encoder) {
@@ -7983,27 +5808,14 @@ func (_ fastpathT) EncMapInt8Uint8V(v map[int8]uint8, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Uint16V(rv.Interface().(map[int8]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Uint16V(v map[int8]uint16, checkNil bool, e *Encoder) {
@@ -8014,27 +5826,14 @@ func (_ fastpathT) EncMapInt8Uint16V(v map[int8]uint16, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Uint32V(rv.Interface().(map[int8]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Uint32V(v map[int8]uint32, checkNil bool, e *Encoder) {
@@ -8045,27 +5844,14 @@ func (_ fastpathT) EncMapInt8Uint32V(v map[int8]uint32, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Uint64V(rv.Interface().(map[int8]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Uint64V(v map[int8]uint64, checkNil bool, e *Encoder) {
@@ -8076,27 +5862,14 @@ func (_ fastpathT) EncMapInt8Uint64V(v map[int8]uint64, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8IntR(rv reflect.Value) {
 	fastpathTV.EncMapInt8IntV(rv.Interface().(map[int8]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8IntV(v map[int8]int, checkNil bool, e *Encoder) {
@@ -8107,27 +5880,14 @@ func (_ fastpathT) EncMapInt8IntV(v map[int8]int, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Int8R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Int8V(rv.Interface().(map[int8]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Int8V(v map[int8]int8, checkNil bool, e *Encoder) {
@@ -8138,27 +5898,14 @@ func (_ fastpathT) EncMapInt8Int8V(v map[int8]int8, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Int16R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Int16V(rv.Interface().(map[int8]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Int16V(v map[int8]int16, checkNil bool, e *Encoder) {
@@ -8169,27 +5916,14 @@ func (_ fastpathT) EncMapInt8Int16V(v map[int8]int16, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Int32R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Int32V(rv.Interface().(map[int8]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Int32V(v map[int8]int32, checkNil bool, e *Encoder) {
@@ -8200,27 +5934,14 @@ func (_ fastpathT) EncMapInt8Int32V(v map[int8]int32, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Int64R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Int64V(rv.Interface().(map[int8]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Int64V(v map[int8]int64, checkNil bool, e *Encoder) {
@@ -8231,27 +5952,14 @@ func (_ fastpathT) EncMapInt8Int64V(v map[int8]int64, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Float32R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Float32V(rv.Interface().(map[int8]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Float32V(v map[int8]float32, checkNil bool, e *Encoder) {
@@ -8262,27 +5970,14 @@ func (_ fastpathT) EncMapInt8Float32V(v map[int8]float32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8Float64R(rv reflect.Value) {
 	fastpathTV.EncMapInt8Float64V(rv.Interface().(map[int8]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Float64V(v map[int8]float64, checkNil bool, e *Encoder) {
@@ -8293,27 +5988,14 @@ func (_ fastpathT) EncMapInt8Float64V(v map[int8]float64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt8BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt8BoolR(rv reflect.Value) {
 	fastpathTV.EncMapInt8BoolV(rv.Interface().(map[int8]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8BoolV(v map[int8]bool, checkNil bool, e *Encoder) {
@@ -8324,27 +6006,14 @@ func (_ fastpathT) EncMapInt8BoolV(v map[int8]bool, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16IntfR(rv reflect.Value) {
 	fastpathTV.EncMapInt16IntfV(rv.Interface().(map[int16]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16IntfV(v map[int16]interface{}, checkNil bool, e *Encoder) {
@@ -8355,27 +6024,14 @@ func (_ fastpathT) EncMapInt16IntfV(v map[int16]interface{}, checkNil bool, e *E
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16StringR(rv reflect.Value) {
 	fastpathTV.EncMapInt16StringV(rv.Interface().(map[int16]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16StringV(v map[int16]string, checkNil bool, e *Encoder) {
@@ -8386,27 +6042,14 @@ func (_ fastpathT) EncMapInt16StringV(v map[int16]string, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16UintR(rv reflect.Value) {
 	fastpathTV.EncMapInt16UintV(rv.Interface().(map[int16]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16UintV(v map[int16]uint, checkNil bool, e *Encoder) {
@@ -8417,27 +6060,14 @@ func (_ fastpathT) EncMapInt16UintV(v map[int16]uint, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Uint8V(rv.Interface().(map[int16]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Uint8V(v map[int16]uint8, checkNil bool, e *Encoder) {
@@ -8448,27 +6078,14 @@ func (_ fastpathT) EncMapInt16Uint8V(v map[int16]uint8, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Uint16V(rv.Interface().(map[int16]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Uint16V(v map[int16]uint16, checkNil bool, e *Encoder) {
@@ -8479,27 +6096,14 @@ func (_ fastpathT) EncMapInt16Uint16V(v map[int16]uint16, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Uint32V(rv.Interface().(map[int16]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Uint32V(v map[int16]uint32, checkNil bool, e *Encoder) {
@@ -8510,27 +6114,14 @@ func (_ fastpathT) EncMapInt16Uint32V(v map[int16]uint32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Uint64V(rv.Interface().(map[int16]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Uint64V(v map[int16]uint64, checkNil bool, e *Encoder) {
@@ -8541,27 +6132,14 @@ func (_ fastpathT) EncMapInt16Uint64V(v map[int16]uint64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16IntR(rv reflect.Value) {
 	fastpathTV.EncMapInt16IntV(rv.Interface().(map[int16]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16IntV(v map[int16]int, checkNil bool, e *Encoder) {
@@ -8572,27 +6150,14 @@ func (_ fastpathT) EncMapInt16IntV(v map[int16]int, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Int8R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Int8V(rv.Interface().(map[int16]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Int8V(v map[int16]int8, checkNil bool, e *Encoder) {
@@ -8603,27 +6168,14 @@ func (_ fastpathT) EncMapInt16Int8V(v map[int16]int8, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Int16R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Int16V(rv.Interface().(map[int16]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Int16V(v map[int16]int16, checkNil bool, e *Encoder) {
@@ -8634,27 +6186,14 @@ func (_ fastpathT) EncMapInt16Int16V(v map[int16]int16, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Int32R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Int32V(rv.Interface().(map[int16]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Int32V(v map[int16]int32, checkNil bool, e *Encoder) {
@@ -8665,27 +6204,14 @@ func (_ fastpathT) EncMapInt16Int32V(v map[int16]int32, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Int64R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Int64V(rv.Interface().(map[int16]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Int64V(v map[int16]int64, checkNil bool, e *Encoder) {
@@ -8696,27 +6222,14 @@ func (_ fastpathT) EncMapInt16Int64V(v map[int16]int64, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Float32R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Float32V(rv.Interface().(map[int16]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Float32V(v map[int16]float32, checkNil bool, e *Encoder) {
@@ -8727,27 +6240,14 @@ func (_ fastpathT) EncMapInt16Float32V(v map[int16]float32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16Float64R(rv reflect.Value) {
 	fastpathTV.EncMapInt16Float64V(rv.Interface().(map[int16]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Float64V(v map[int16]float64, checkNil bool, e *Encoder) {
@@ -8758,27 +6258,14 @@ func (_ fastpathT) EncMapInt16Float64V(v map[int16]float64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt16BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt16BoolR(rv reflect.Value) {
 	fastpathTV.EncMapInt16BoolV(rv.Interface().(map[int16]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16BoolV(v map[int16]bool, checkNil bool, e *Encoder) {
@@ -8789,27 +6276,14 @@ func (_ fastpathT) EncMapInt16BoolV(v map[int16]bool, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32IntfR(rv reflect.Value) {
 	fastpathTV.EncMapInt32IntfV(rv.Interface().(map[int32]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32IntfV(v map[int32]interface{}, checkNil bool, e *Encoder) {
@@ -8820,27 +6294,14 @@ func (_ fastpathT) EncMapInt32IntfV(v map[int32]interface{}, checkNil bool, e *E
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32StringR(rv reflect.Value) {
 	fastpathTV.EncMapInt32StringV(rv.Interface().(map[int32]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32StringV(v map[int32]string, checkNil bool, e *Encoder) {
@@ -8851,27 +6312,14 @@ func (_ fastpathT) EncMapInt32StringV(v map[int32]string, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32UintR(rv reflect.Value) {
 	fastpathTV.EncMapInt32UintV(rv.Interface().(map[int32]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32UintV(v map[int32]uint, checkNil bool, e *Encoder) {
@@ -8882,27 +6330,14 @@ func (_ fastpathT) EncMapInt32UintV(v map[int32]uint, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Uint8V(rv.Interface().(map[int32]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Uint8V(v map[int32]uint8, checkNil bool, e *Encoder) {
@@ -8913,27 +6348,14 @@ func (_ fastpathT) EncMapInt32Uint8V(v map[int32]uint8, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Uint16V(rv.Interface().(map[int32]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Uint16V(v map[int32]uint16, checkNil bool, e *Encoder) {
@@ -8944,27 +6366,14 @@ func (_ fastpathT) EncMapInt32Uint16V(v map[int32]uint16, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Uint32V(rv.Interface().(map[int32]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Uint32V(v map[int32]uint32, checkNil bool, e *Encoder) {
@@ -8975,27 +6384,14 @@ func (_ fastpathT) EncMapInt32Uint32V(v map[int32]uint32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Uint64V(rv.Interface().(map[int32]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Uint64V(v map[int32]uint64, checkNil bool, e *Encoder) {
@@ -9006,27 +6402,14 @@ func (_ fastpathT) EncMapInt32Uint64V(v map[int32]uint64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32IntR(rv reflect.Value) {
 	fastpathTV.EncMapInt32IntV(rv.Interface().(map[int32]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32IntV(v map[int32]int, checkNil bool, e *Encoder) {
@@ -9037,27 +6420,14 @@ func (_ fastpathT) EncMapInt32IntV(v map[int32]int, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Int8R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Int8V(rv.Interface().(map[int32]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Int8V(v map[int32]int8, checkNil bool, e *Encoder) {
@@ -9068,27 +6438,14 @@ func (_ fastpathT) EncMapInt32Int8V(v map[int32]int8, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Int16R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Int16V(rv.Interface().(map[int32]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Int16V(v map[int32]int16, checkNil bool, e *Encoder) {
@@ -9099,27 +6456,14 @@ func (_ fastpathT) EncMapInt32Int16V(v map[int32]int16, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Int32R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Int32V(rv.Interface().(map[int32]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Int32V(v map[int32]int32, checkNil bool, e *Encoder) {
@@ -9130,27 +6474,14 @@ func (_ fastpathT) EncMapInt32Int32V(v map[int32]int32, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Int64R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Int64V(rv.Interface().(map[int32]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Int64V(v map[int32]int64, checkNil bool, e *Encoder) {
@@ -9161,27 +6492,14 @@ func (_ fastpathT) EncMapInt32Int64V(v map[int32]int64, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Float32R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Float32V(rv.Interface().(map[int32]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Float32V(v map[int32]float32, checkNil bool, e *Encoder) {
@@ -9192,27 +6510,14 @@ func (_ fastpathT) EncMapInt32Float32V(v map[int32]float32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32Float64R(rv reflect.Value) {
 	fastpathTV.EncMapInt32Float64V(rv.Interface().(map[int32]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Float64V(v map[int32]float64, checkNil bool, e *Encoder) {
@@ -9223,27 +6528,14 @@ func (_ fastpathT) EncMapInt32Float64V(v map[int32]float64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt32BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt32BoolR(rv reflect.Value) {
 	fastpathTV.EncMapInt32BoolV(rv.Interface().(map[int32]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32BoolV(v map[int32]bool, checkNil bool, e *Encoder) {
@@ -9254,27 +6546,14 @@ func (_ fastpathT) EncMapInt32BoolV(v map[int32]bool, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64IntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64IntfR(rv reflect.Value) {
 	fastpathTV.EncMapInt64IntfV(rv.Interface().(map[int64]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64IntfV(v map[int64]interface{}, checkNil bool, e *Encoder) {
@@ -9285,27 +6564,14 @@ func (_ fastpathT) EncMapInt64IntfV(v map[int64]interface{}, checkNil bool, e *E
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64StringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64StringR(rv reflect.Value) {
 	fastpathTV.EncMapInt64StringV(rv.Interface().(map[int64]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64StringV(v map[int64]string, checkNil bool, e *Encoder) {
@@ -9316,27 +6582,14 @@ func (_ fastpathT) EncMapInt64StringV(v map[int64]string, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64UintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64UintR(rv reflect.Value) {
 	fastpathTV.EncMapInt64UintV(rv.Interface().(map[int64]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64UintV(v map[int64]uint, checkNil bool, e *Encoder) {
@@ -9347,27 +6600,14 @@ func (_ fastpathT) EncMapInt64UintV(v map[int64]uint, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Uint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Uint8R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Uint8V(rv.Interface().(map[int64]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Uint8V(v map[int64]uint8, checkNil bool, e *Encoder) {
@@ -9378,27 +6618,14 @@ func (_ fastpathT) EncMapInt64Uint8V(v map[int64]uint8, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Uint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Uint16R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Uint16V(rv.Interface().(map[int64]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Uint16V(v map[int64]uint16, checkNil bool, e *Encoder) {
@@ -9409,27 +6636,14 @@ func (_ fastpathT) EncMapInt64Uint16V(v map[int64]uint16, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Uint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Uint32R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Uint32V(rv.Interface().(map[int64]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Uint32V(v map[int64]uint32, checkNil bool, e *Encoder) {
@@ -9440,27 +6654,14 @@ func (_ fastpathT) EncMapInt64Uint32V(v map[int64]uint32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Uint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Uint64R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Uint64V(rv.Interface().(map[int64]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Uint64V(v map[int64]uint64, checkNil bool, e *Encoder) {
@@ -9471,27 +6672,14 @@ func (_ fastpathT) EncMapInt64Uint64V(v map[int64]uint64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64IntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64IntR(rv reflect.Value) {
 	fastpathTV.EncMapInt64IntV(rv.Interface().(map[int64]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64IntV(v map[int64]int, checkNil bool, e *Encoder) {
@@ -9502,27 +6690,14 @@ func (_ fastpathT) EncMapInt64IntV(v map[int64]int, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Int8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Int8R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Int8V(rv.Interface().(map[int64]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Int8V(v map[int64]int8, checkNil bool, e *Encoder) {
@@ -9533,27 +6708,14 @@ func (_ fastpathT) EncMapInt64Int8V(v map[int64]int8, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Int16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Int16R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Int16V(rv.Interface().(map[int64]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Int16V(v map[int64]int16, checkNil bool, e *Encoder) {
@@ -9564,27 +6726,14 @@ func (_ fastpathT) EncMapInt64Int16V(v map[int64]int16, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Int32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Int32R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Int32V(rv.Interface().(map[int64]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Int32V(v map[int64]int32, checkNil bool, e *Encoder) {
@@ -9595,27 +6744,14 @@ func (_ fastpathT) EncMapInt64Int32V(v map[int64]int32, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Int64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Int64R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Int64V(rv.Interface().(map[int64]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Int64V(v map[int64]int64, checkNil bool, e *Encoder) {
@@ -9626,27 +6762,14 @@ func (_ fastpathT) EncMapInt64Int64V(v map[int64]int64, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Float32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Float32R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Float32V(rv.Interface().(map[int64]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Float32V(v map[int64]float32, checkNil bool, e *Encoder) {
@@ -9657,27 +6780,14 @@ func (_ fastpathT) EncMapInt64Float32V(v map[int64]float32, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64Float64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64Float64R(rv reflect.Value) {
 	fastpathTV.EncMapInt64Float64V(rv.Interface().(map[int64]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Float64V(v map[int64]float64, checkNil bool, e *Encoder) {
@@ -9688,27 +6798,14 @@ func (_ fastpathT) EncMapInt64Float64V(v map[int64]float64, checkNil bool, e *En
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapInt64BoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapInt64BoolR(rv reflect.Value) {
 	fastpathTV.EncMapInt64BoolV(rv.Interface().(map[int64]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64BoolV(v map[int64]bool, checkNil bool, e *Encoder) {
@@ -9719,27 +6816,14 @@ func (_ fastpathT) EncMapInt64BoolV(v map[int64]bool, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeInt(int64(k2))
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeInt(int64(k2))
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeInt(int64(k2))
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolIntfR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolIntfR(rv reflect.Value) {
 	fastpathTV.EncMapBoolIntfV(rv.Interface().(map[bool]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolIntfV(v map[bool]interface{}, checkNil bool, e *Encoder) {
@@ -9750,27 +6834,14 @@ func (_ fastpathT) EncMapBoolIntfV(v map[bool]interface{}, checkNil bool, e *Enc
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			e.encode(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			e.encode(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		e.encode(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolStringR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolStringR(rv reflect.Value) {
 	fastpathTV.EncMapBoolStringV(rv.Interface().(map[bool]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolStringV(v map[bool]string, checkNil bool, e *Encoder) {
@@ -9781,27 +6852,14 @@ func (_ fastpathT) EncMapBoolStringV(v map[bool]string, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeString(c_UTF8, v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeString(c_UTF8, v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeString(c_UTF8, v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolUintR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolUintR(rv reflect.Value) {
 	fastpathTV.EncMapBoolUintV(rv.Interface().(map[bool]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUintV(v map[bool]uint, checkNil bool, e *Encoder) {
@@ -9812,27 +6870,14 @@ func (_ fastpathT) EncMapBoolUintV(v map[bool]uint, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolUint8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolUint8R(rv reflect.Value) {
 	fastpathTV.EncMapBoolUint8V(rv.Interface().(map[bool]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUint8V(v map[bool]uint8, checkNil bool, e *Encoder) {
@@ -9843,27 +6888,14 @@ func (_ fastpathT) EncMapBoolUint8V(v map[bool]uint8, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolUint16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolUint16R(rv reflect.Value) {
 	fastpathTV.EncMapBoolUint16V(rv.Interface().(map[bool]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUint16V(v map[bool]uint16, checkNil bool, e *Encoder) {
@@ -9874,27 +6906,14 @@ func (_ fastpathT) EncMapBoolUint16V(v map[bool]uint16, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolUint32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolUint32R(rv reflect.Value) {
 	fastpathTV.EncMapBoolUint32V(rv.Interface().(map[bool]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUint32V(v map[bool]uint32, checkNil bool, e *Encoder) {
@@ -9905,27 +6924,14 @@ func (_ fastpathT) EncMapBoolUint32V(v map[bool]uint32, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolUint64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolUint64R(rv reflect.Value) {
 	fastpathTV.EncMapBoolUint64V(rv.Interface().(map[bool]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUint64V(v map[bool]uint64, checkNil bool, e *Encoder) {
@@ -9936,27 +6942,14 @@ func (_ fastpathT) EncMapBoolUint64V(v map[bool]uint64, checkNil bool, e *Encode
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeUint(uint64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeUint(uint64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeUint(uint64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolIntR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolIntR(rv reflect.Value) {
 	fastpathTV.EncMapBoolIntV(rv.Interface().(map[bool]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolIntV(v map[bool]int, checkNil bool, e *Encoder) {
@@ -9967,27 +6960,14 @@ func (_ fastpathT) EncMapBoolIntV(v map[bool]int, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolInt8R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolInt8R(rv reflect.Value) {
 	fastpathTV.EncMapBoolInt8V(rv.Interface().(map[bool]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolInt8V(v map[bool]int8, checkNil bool, e *Encoder) {
@@ -9998,27 +6978,14 @@ func (_ fastpathT) EncMapBoolInt8V(v map[bool]int8, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolInt16R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolInt16R(rv reflect.Value) {
 	fastpathTV.EncMapBoolInt16V(rv.Interface().(map[bool]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolInt16V(v map[bool]int16, checkNil bool, e *Encoder) {
@@ -10029,27 +6996,14 @@ func (_ fastpathT) EncMapBoolInt16V(v map[bool]int16, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolInt32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolInt32R(rv reflect.Value) {
 	fastpathTV.EncMapBoolInt32V(rv.Interface().(map[bool]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolInt32V(v map[bool]int32, checkNil bool, e *Encoder) {
@@ -10060,27 +7014,14 @@ func (_ fastpathT) EncMapBoolInt32V(v map[bool]int32, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolInt64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolInt64R(rv reflect.Value) {
 	fastpathTV.EncMapBoolInt64V(rv.Interface().(map[bool]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolInt64V(v map[bool]int64, checkNil bool, e *Encoder) {
@@ -10091,27 +7032,14 @@ func (_ fastpathT) EncMapBoolInt64V(v map[bool]int64, checkNil bool, e *Encoder)
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeInt(int64(v2))
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeInt(int64(v2))
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeInt(int64(v2))
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolFloat32R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolFloat32R(rv reflect.Value) {
 	fastpathTV.EncMapBoolFloat32V(rv.Interface().(map[bool]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolFloat32V(v map[bool]float32, checkNil bool, e *Encoder) {
@@ -10122,27 +7050,14 @@ func (_ fastpathT) EncMapBoolFloat32V(v map[bool]float32, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeFloat32(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat32(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeFloat32(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolFloat64R(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolFloat64R(rv reflect.Value) {
 	fastpathTV.EncMapBoolFloat64V(rv.Interface().(map[bool]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolFloat64V(v map[bool]float64, checkNil bool, e *Encoder) {
@@ -10153,27 +7068,14 @@ func (_ fastpathT) EncMapBoolFloat64V(v map[bool]float64, checkNil bool, e *Enco
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeFloat64(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeFloat64(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeFloat64(v2)
 	}
+	ee.EncodeEnd()
 }
 
-func (f encFnInfo) fastpathEncMapBoolBoolR(rv reflect.Value) {
+func (f *encFnInfo) fastpathEncMapBoolBoolR(rv reflect.Value) {
 	fastpathTV.EncMapBoolBoolV(rv.Interface().(map[bool]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolBoolV(v map[bool]bool, checkNil bool, e *Encoder) {
@@ -10184,24 +7086,11 @@ func (_ fastpathT) EncMapBoolBoolV(v map[bool]bool, checkNil bool, e *Encoder) {
 	}
 	ee.EncodeMapStart(len(v))
 
-	if e.be {
-		for k2, v2 := range v {
-			ee.EncodeBool(k2)
-			ee.EncodeBool(v2)
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			ee.EncodeBool(k2)
-			ee.EncodeMapKVSeparator()
-			ee.EncodeBool(v2)
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		ee.EncodeBool(k2)
+		ee.EncodeBool(v2)
 	}
+	ee.EncodeEnd()
 }
 
 // -- decode
@@ -12130,9 +9019,9 @@ func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
 
 // -- -- fast path functions
 
-func (f decFnInfo) fastpathDecSliceIntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceIntfR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]interface{})
 		v, changed := fastpathTV.DecSliceIntfV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12153,7 +9042,7 @@ func (f fastpathT) DecSliceIntfX(vp *[]interface{}, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ []interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12162,12 +9051,14 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []interface{}{}
-		} else {
-			v = make([]interface{}, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16); xtrunc {
+			x2read = xlen
 		}
+		v = make([]interface{}, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12178,29 +9069,34 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]interface{}, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16); xtrunc {
+					x2read = xlen
+				}
+				v = make([]interface{}, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			d.decode(&v[j])
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, nil)
+				d.decode(&v[j])
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -12216,10 +9112,7 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				d.decode(&v[j])
 
 			} else {
@@ -12231,9 +9124,9 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceStringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceStringR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]string)
 		v, changed := fastpathTV.DecSliceStringV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12254,7 +9147,7 @@ func (f fastpathT) DecSliceStringX(vp *[]string, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool,
 	d *Decoder) (_ []string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12263,12 +9156,14 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []string{}
-		} else {
-			v = make([]string, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16); xtrunc {
+			x2read = xlen
 		}
+		v = make([]string, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12279,29 +9174,34 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]string, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16); xtrunc {
+					x2read = xlen
+				}
+				v = make([]string, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = dd.DecodeString()
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, "")
+				v[j] = dd.DecodeString()
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -12317,10 +9217,7 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = dd.DecodeString()
 			} else {
 				d.swallow()
@@ -12331,9 +9228,9 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceFloat32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceFloat32R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]float32)
 		v, changed := fastpathTV.DecSliceFloat32V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12354,7 +9251,7 @@ func (f fastpathT) DecSliceFloat32X(vp *[]float32, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool,
 	d *Decoder) (_ []float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12363,12 +9260,14 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []float32{}
-		} else {
-			v = make([]float32, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
+			x2read = xlen
 		}
+		v = make([]float32, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12379,29 +9278,34 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]float32, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
+					x2read = xlen
+				}
+				v = make([]float32, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = float32(dd.DecodeFloat(true))
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = float32(dd.DecodeFloat(true))
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -12417,10 +9321,7 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = float32(dd.DecodeFloat(true))
 			} else {
 				d.swallow()
@@ -12431,9 +9332,9 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceFloat64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceFloat64R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]float64)
 		v, changed := fastpathTV.DecSliceFloat64V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12454,7 +9355,7 @@ func (f fastpathT) DecSliceFloat64X(vp *[]float64, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool,
 	d *Decoder) (_ []float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12463,12 +9364,14 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []float64{}
-		} else {
-			v = make([]float64, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+			x2read = xlen
 		}
+		v = make([]float64, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12479,29 +9382,34 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]float64, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+					x2read = xlen
+				}
+				v = make([]float64, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = dd.DecodeFloat(false)
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = dd.DecodeFloat(false)
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -12517,10 +9425,7 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = dd.DecodeFloat(false)
 			} else {
 				d.swallow()
@@ -12531,9 +9436,9 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceUintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceUintR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]uint)
 		v, changed := fastpathTV.DecSliceUintV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12554,7 +9459,7 @@ func (f fastpathT) DecSliceUintX(vp *[]uint, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool,
 	d *Decoder) (_ []uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12563,12 +9468,14 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []uint{}
-		} else {
-			v = make([]uint, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+			x2read = xlen
 		}
+		v = make([]uint, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12579,29 +9486,34 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]uint, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+					x2read = xlen
+				}
+				v = make([]uint, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = uint(dd.DecodeUint(uintBitsize))
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = uint(dd.DecodeUint(uintBitsize))
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -12617,10 +9529,7 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = uint(dd.DecodeUint(uintBitsize))
 			} else {
 				d.swallow()
@@ -12631,9 +9540,9 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceUint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceUint16R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]uint16)
 		v, changed := fastpathTV.DecSliceUint16V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12654,7 +9563,7 @@ func (f fastpathT) DecSliceUint16X(vp *[]uint16, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ []uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12663,12 +9572,14 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []uint16{}
-		} else {
-			v = make([]uint16, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2); xtrunc {
+			x2read = xlen
 		}
+		v = make([]uint16, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12679,29 +9590,34 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]uint16, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2); xtrunc {
+					x2read = xlen
+				}
+				v = make([]uint16, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = uint16(dd.DecodeUint(16))
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = uint16(dd.DecodeUint(16))
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -12717,10 +9633,7 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = uint16(dd.DecodeUint(16))
 			} else {
 				d.swallow()
@@ -12731,9 +9644,9 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceUint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceUint32R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]uint32)
 		v, changed := fastpathTV.DecSliceUint32V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12754,7 +9667,7 @@ func (f fastpathT) DecSliceUint32X(vp *[]uint32, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ []uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12763,12 +9676,14 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []uint32{}
-		} else {
-			v = make([]uint32, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
+			x2read = xlen
 		}
+		v = make([]uint32, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12779,29 +9694,34 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]uint32, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
+					x2read = xlen
+				}
+				v = make([]uint32, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = uint32(dd.DecodeUint(32))
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = uint32(dd.DecodeUint(32))
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -12817,10 +9737,7 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = uint32(dd.DecodeUint(32))
 			} else {
 				d.swallow()
@@ -12831,9 +9748,9 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceUint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceUint64R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]uint64)
 		v, changed := fastpathTV.DecSliceUint64V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12854,7 +9771,7 @@ func (f fastpathT) DecSliceUint64X(vp *[]uint64, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ []uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12863,12 +9780,14 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []uint64{}
-		} else {
-			v = make([]uint64, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+			x2read = xlen
 		}
+		v = make([]uint64, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12879,29 +9798,34 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]uint64, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+					x2read = xlen
+				}
+				v = make([]uint64, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = dd.DecodeUint(64)
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = dd.DecodeUint(64)
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -12917,10 +9841,7 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = dd.DecodeUint(64)
 			} else {
 				d.swallow()
@@ -12931,9 +9852,9 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceIntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceIntR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]int)
 		v, changed := fastpathTV.DecSliceIntV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -12954,7 +9875,7 @@ func (f fastpathT) DecSliceIntX(vp *[]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool,
 	d *Decoder) (_ []int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -12963,12 +9884,14 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []int{}
-		} else {
-			v = make([]int, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+			x2read = xlen
 		}
+		v = make([]int, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -12979,29 +9902,34 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]int, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+					x2read = xlen
+				}
+				v = make([]int, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = int(dd.DecodeInt(intBitsize))
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = int(dd.DecodeInt(intBitsize))
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -13017,10 +9945,7 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = int(dd.DecodeInt(intBitsize))
 			} else {
 				d.swallow()
@@ -13031,9 +9956,9 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceInt8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceInt8R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]int8)
 		v, changed := fastpathTV.DecSliceInt8V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -13054,7 +9979,7 @@ func (f fastpathT) DecSliceInt8X(vp *[]int8, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool,
 	d *Decoder) (_ []int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13063,12 +9988,14 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []int8{}
-		} else {
-			v = make([]int8, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1); xtrunc {
+			x2read = xlen
 		}
+		v = make([]int8, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -13079,29 +10006,34 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]int8, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1); xtrunc {
+					x2read = xlen
+				}
+				v = make([]int8, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = int8(dd.DecodeInt(8))
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = int8(dd.DecodeInt(8))
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -13117,10 +10049,7 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = int8(dd.DecodeInt(8))
 			} else {
 				d.swallow()
@@ -13131,9 +10060,9 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceInt16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceInt16R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]int16)
 		v, changed := fastpathTV.DecSliceInt16V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -13154,7 +10083,7 @@ func (f fastpathT) DecSliceInt16X(vp *[]int16, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool,
 	d *Decoder) (_ []int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13163,12 +10092,14 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []int16{}
-		} else {
-			v = make([]int16, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2); xtrunc {
+			x2read = xlen
 		}
+		v = make([]int16, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -13179,29 +10110,34 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]int16, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2); xtrunc {
+					x2read = xlen
+				}
+				v = make([]int16, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = int16(dd.DecodeInt(16))
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = int16(dd.DecodeInt(16))
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -13217,10 +10153,7 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = int16(dd.DecodeInt(16))
 			} else {
 				d.swallow()
@@ -13231,9 +10164,9 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceInt32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceInt32R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]int32)
 		v, changed := fastpathTV.DecSliceInt32V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -13254,7 +10187,7 @@ func (f fastpathT) DecSliceInt32X(vp *[]int32, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool,
 	d *Decoder) (_ []int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13263,12 +10196,14 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []int32{}
-		} else {
-			v = make([]int32, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
+			x2read = xlen
 		}
+		v = make([]int32, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -13279,29 +10214,34 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]int32, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4); xtrunc {
+					x2read = xlen
+				}
+				v = make([]int32, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = int32(dd.DecodeInt(32))
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = int32(dd.DecodeInt(32))
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -13317,10 +10257,7 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = int32(dd.DecodeInt(32))
 			} else {
 				d.swallow()
@@ -13331,9 +10268,9 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceInt64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceInt64R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]int64)
 		v, changed := fastpathTV.DecSliceInt64V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -13354,7 +10291,7 @@ func (f fastpathT) DecSliceInt64X(vp *[]int64, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool,
 	d *Decoder) (_ []int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13363,12 +10300,14 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []int64{}
-		} else {
-			v = make([]int64, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+			x2read = xlen
 		}
+		v = make([]int64, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -13379,29 +10318,34 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]int64, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8); xtrunc {
+					x2read = xlen
+				}
+				v = make([]int64, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = dd.DecodeInt(64)
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, 0)
+				v[j] = dd.DecodeInt(64)
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -13417,10 +10361,7 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = dd.DecodeInt(64)
 			} else {
 				d.swallow()
@@ -13431,9 +10372,9 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecSliceBoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecSliceBoolR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported
+	if !array && rv.CanAddr() {
 		vp := rv.Addr().Interface().(*[]bool)
 		v, changed := fastpathTV.DecSliceBoolV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -13454,7 +10395,7 @@ func (f fastpathT) DecSliceBoolX(vp *[]bool, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool,
 	d *Decoder) (_ []bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13463,12 +10404,14 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool,
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+	x2read := containerLenS
+	var xtrunc bool
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []bool{}
-		} else {
-			v = make([]bool, containerLenS, containerLenS)
+		var xlen int
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1); xtrunc {
+			x2read = xlen
 		}
+		v = make([]bool, xlen)
 		changed = true
 	}
 	if containerLenS == 0 {
@@ -13479,29 +10422,34 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	// for j := 0; j < containerLenS; j++ {
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
 			if canChange {
-				s := make([]bool, containerLenS, containerLenS)
-				// copy(s, v[:cap(v)])
-				v = s
+				var xlen int
+				if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1); xtrunc {
+					x2read = xlen
+				}
+				v = make([]bool, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+
 		j := 0
-		for ; j < decLen; j++ {
+		for ; j < x2read; j++ {
 			v[j] = dd.DecodeBool()
 		}
-		if !canChange {
+		if xtrunc {
+			for ; j < containerLenS; j++ {
+				v = append(v, false)
+				v[j] = dd.DecodeBool()
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ {
 				d.swallow()
 			}
@@ -13517,10 +10465,7 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool,
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			}
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) {
 				v[j] = dd.DecodeBool()
 			} else {
 				d.swallow()
@@ -13531,7 +10476,7 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool,
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfIntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]interface{})
 		v, changed := fastpathTV.DecMapIntfIntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -13552,7 +10497,7 @@ func (f fastpathT) DecMapIntfIntfX(vp *map[interface{}]interface{}, checkNil boo
 func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13562,11 +10507,8 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]interface{}, containerLen)
-		} else {
-			v = make(map[interface{}]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		v = make(map[interface{}]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -13574,7 +10516,7 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			d.decode(&mv)
@@ -13585,15 +10527,11 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -13601,12 +10539,12 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfStringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfStringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]string)
 		v, changed := fastpathTV.DecMapIntfStringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -13627,7 +10565,7 @@ func (f fastpathT) DecMapIntfStringX(vp *map[interface{}]string, checkNil bool, 
 func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13637,11 +10575,8 @@ func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, ca
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]string, containerLen)
-		} else {
-			v = make(map[interface{}]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		v = make(map[interface{}]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -13649,7 +10584,7 @@ func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, ca
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = dd.DecodeString()
@@ -13659,27 +10594,23 @@ func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfUintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfUintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]uint)
 		v, changed := fastpathTV.DecMapIntfUintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -13700,7 +10631,7 @@ func (f fastpathT) DecMapIntfUintX(vp *map[interface{}]uint, checkNil bool, d *D
 func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13710,11 +10641,8 @@ func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canCha
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]uint, containerLen)
-		} else {
-			v = make(map[interface{}]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -13722,7 +10650,7 @@ func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canCha
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
@@ -13732,27 +10660,23 @@ func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfUint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]uint8)
 		v, changed := fastpathTV.DecMapIntfUint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -13773,7 +10697,7 @@ func (f fastpathT) DecMapIntfUint8X(vp *map[interface{}]uint8, checkNil bool, d 
 func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13783,11 +10707,8 @@ func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canC
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]uint8, containerLen)
-		} else {
-			v = make(map[interface{}]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[interface{}]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -13795,7 +10716,7 @@ func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canC
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
@@ -13805,27 +10726,23 @@ func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfUint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]uint16)
 		v, changed := fastpathTV.DecMapIntfUint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -13846,7 +10763,7 @@ func (f fastpathT) DecMapIntfUint16X(vp *map[interface{}]uint16, checkNil bool, 
 func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13856,11 +10773,8 @@ func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, ca
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]uint16, containerLen)
-		} else {
-			v = make(map[interface{}]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[interface{}]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -13868,7 +10782,7 @@ func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, ca
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
@@ -13878,27 +10792,23 @@ func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfUint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]uint32)
 		v, changed := fastpathTV.DecMapIntfUint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -13919,7 +10829,7 @@ func (f fastpathT) DecMapIntfUint32X(vp *map[interface{}]uint32, checkNil bool, 
 func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -13929,11 +10839,8 @@ func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, ca
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]uint32, containerLen)
-		} else {
-			v = make(map[interface{}]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[interface{}]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -13941,7 +10848,7 @@ func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, ca
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
@@ -13951,27 +10858,23 @@ func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfUint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]uint64)
 		v, changed := fastpathTV.DecMapIntfUint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -13992,7 +10895,7 @@ func (f fastpathT) DecMapIntfUint64X(vp *map[interface{}]uint64, checkNil bool, 
 func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14002,11 +10905,8 @@ func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, ca
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]uint64, containerLen)
-		} else {
-			v = make(map[interface{}]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14014,7 +10914,7 @@ func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, ca
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
@@ -14024,27 +10924,23 @@ func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfIntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfIntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]int)
 		v, changed := fastpathTV.DecMapIntfIntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14065,7 +10961,7 @@ func (f fastpathT) DecMapIntfIntX(vp *map[interface{}]int, checkNil bool, d *Dec
 func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14075,11 +10971,8 @@ func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChang
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]int, containerLen)
-		} else {
-			v = make(map[interface{}]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14087,7 +10980,7 @@ func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChang
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
@@ -14097,27 +10990,23 @@ func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChang
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfInt8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]int8)
 		v, changed := fastpathTV.DecMapIntfInt8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14138,7 +11027,7 @@ func (f fastpathT) DecMapIntfInt8X(vp *map[interface{}]int8, checkNil bool, d *D
 func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14148,11 +11037,8 @@ func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canCha
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]int8, containerLen)
-		} else {
-			v = make(map[interface{}]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[interface{}]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14160,7 +11046,7 @@ func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canCha
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
@@ -14170,27 +11056,23 @@ func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfInt16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]int16)
 		v, changed := fastpathTV.DecMapIntfInt16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14211,7 +11093,7 @@ func (f fastpathT) DecMapIntfInt16X(vp *map[interface{}]int16, checkNil bool, d 
 func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14221,11 +11103,8 @@ func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canC
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]int16, containerLen)
-		} else {
-			v = make(map[interface{}]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[interface{}]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14233,7 +11112,7 @@ func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canC
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
@@ -14243,27 +11122,23 @@ func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfInt32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]int32)
 		v, changed := fastpathTV.DecMapIntfInt32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14284,7 +11159,7 @@ func (f fastpathT) DecMapIntfInt32X(vp *map[interface{}]int32, checkNil bool, d 
 func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14294,11 +11169,8 @@ func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canC
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]int32, containerLen)
-		} else {
-			v = make(map[interface{}]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[interface{}]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14306,7 +11178,7 @@ func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canC
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
@@ -14316,27 +11188,23 @@ func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfInt64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]int64)
 		v, changed := fastpathTV.DecMapIntfInt64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14357,7 +11225,7 @@ func (f fastpathT) DecMapIntfInt64X(vp *map[interface{}]int64, checkNil bool, d 
 func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14367,11 +11235,8 @@ func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canC
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]int64, containerLen)
-		} else {
-			v = make(map[interface{}]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14379,7 +11244,7 @@ func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canC
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
@@ -14389,27 +11254,23 @@ func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfFloat32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]float32)
 		v, changed := fastpathTV.DecMapIntfFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14430,7 +11291,7 @@ func (f fastpathT) DecMapIntfFloat32X(vp *map[interface{}]float32, checkNil bool
 func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14440,11 +11301,8 @@ func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]float32, containerLen)
-		} else {
-			v = make(map[interface{}]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[interface{}]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14452,7 +11310,7 @@ func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
@@ -14462,27 +11320,23 @@ func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfFloat64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]float64)
 		v, changed := fastpathTV.DecMapIntfFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14503,7 +11357,7 @@ func (f fastpathT) DecMapIntfFloat64X(vp *map[interface{}]float64, checkNil bool
 func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14513,11 +11367,8 @@ func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]float64, containerLen)
-		} else {
-			v = make(map[interface{}]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[interface{}]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14525,7 +11376,7 @@ func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
@@ -14535,27 +11386,23 @@ func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntfBoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntfBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[interface{}]bool)
 		v, changed := fastpathTV.DecMapIntfBoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14576,7 +11423,7 @@ func (f fastpathT) DecMapIntfBoolX(vp *map[interface{}]bool, checkNil bool, d *D
 func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[interface{}]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14586,11 +11433,8 @@ func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canCha
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[interface{}]bool, containerLen)
-		} else {
-			v = make(map[interface{}]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[interface{}]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14598,7 +11442,7 @@ func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canCha
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
 			mv := v[mk]
 			mv = dd.DecodeBool()
@@ -14608,27 +11452,23 @@ func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv)
 			}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringIntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]interface{})
 		v, changed := fastpathTV.DecMapStringIntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14649,7 +11489,7 @@ func (f fastpathT) DecMapStringIntfX(vp *map[string]interface{}, checkNil bool, 
 func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14659,11 +11499,8 @@ func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, ca
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]interface{}, containerLen)
-		} else {
-			v = make(map[string]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		v = make(map[string]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14678,11 +11515,7 @@ func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -14690,12 +11523,12 @@ func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, ca
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringStringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringStringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]string)
 		v, changed := fastpathTV.DecMapStringStringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14716,7 +11549,7 @@ func (f fastpathT) DecMapStringStringX(vp *map[string]string, checkNil bool, d *
 func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14726,11 +11559,8 @@ func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]string, containerLen)
-		} else {
-			v = make(map[string]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		v = make(map[string]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14744,23 +11574,19 @@ func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringUintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringUintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]uint)
 		v, changed := fastpathTV.DecMapStringUintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14781,7 +11607,7 @@ func (f fastpathT) DecMapStringUintX(vp *map[string]uint, checkNil bool, d *Deco
 func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14791,11 +11617,8 @@ func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]uint, containerLen)
-		} else {
-			v = make(map[string]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14809,23 +11632,19 @@ func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringUint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]uint8)
 		v, changed := fastpathTV.DecMapStringUint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14846,7 +11665,7 @@ func (f fastpathT) DecMapStringUint8X(vp *map[string]uint8, checkNil bool, d *De
 func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14856,11 +11675,8 @@ func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]uint8, containerLen)
-		} else {
-			v = make(map[string]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[string]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14874,23 +11690,19 @@ func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringUint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]uint16)
 		v, changed := fastpathTV.DecMapStringUint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14911,7 +11723,7 @@ func (f fastpathT) DecMapStringUint16X(vp *map[string]uint16, checkNil bool, d *
 func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14921,11 +11733,8 @@ func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]uint16, containerLen)
-		} else {
-			v = make(map[string]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[string]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -14939,23 +11748,19 @@ func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringUint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]uint32)
 		v, changed := fastpathTV.DecMapStringUint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -14976,7 +11781,7 @@ func (f fastpathT) DecMapStringUint32X(vp *map[string]uint32, checkNil bool, d *
 func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -14986,11 +11791,8 @@ func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]uint32, containerLen)
-		} else {
-			v = make(map[string]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[string]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15004,23 +11806,19 @@ func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringUint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]uint64)
 		v, changed := fastpathTV.DecMapStringUint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15041,7 +11839,7 @@ func (f fastpathT) DecMapStringUint64X(vp *map[string]uint64, checkNil bool, d *
 func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15051,11 +11849,8 @@ func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]uint64, containerLen)
-		} else {
-			v = make(map[string]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15069,23 +11864,19 @@ func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringIntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringIntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]int)
 		v, changed := fastpathTV.DecMapStringIntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15106,7 +11897,7 @@ func (f fastpathT) DecMapStringIntX(vp *map[string]int, checkNil bool, d *Decode
 func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15116,11 +11907,8 @@ func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]int, containerLen)
-		} else {
-			v = make(map[string]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15134,23 +11922,19 @@ func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringInt8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]int8)
 		v, changed := fastpathTV.DecMapStringInt8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15171,7 +11955,7 @@ func (f fastpathT) DecMapStringInt8X(vp *map[string]int8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15181,11 +11965,8 @@ func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]int8, containerLen)
-		} else {
-			v = make(map[string]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[string]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15199,23 +11980,19 @@ func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringInt16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]int16)
 		v, changed := fastpathTV.DecMapStringInt16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15236,7 +12013,7 @@ func (f fastpathT) DecMapStringInt16X(vp *map[string]int16, checkNil bool, d *De
 func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15246,11 +12023,8 @@ func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]int16, containerLen)
-		} else {
-			v = make(map[string]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[string]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15264,23 +12038,19 @@ func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringInt32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]int32)
 		v, changed := fastpathTV.DecMapStringInt32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15301,7 +12071,7 @@ func (f fastpathT) DecMapStringInt32X(vp *map[string]int32, checkNil bool, d *De
 func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15311,11 +12081,8 @@ func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]int32, containerLen)
-		} else {
-			v = make(map[string]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[string]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15329,23 +12096,19 @@ func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringInt64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]int64)
 		v, changed := fastpathTV.DecMapStringInt64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15366,7 +12129,7 @@ func (f fastpathT) DecMapStringInt64X(vp *map[string]int64, checkNil bool, d *De
 func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15376,11 +12139,8 @@ func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]int64, containerLen)
-		} else {
-			v = make(map[string]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15394,23 +12154,19 @@ func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringFloat32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]float32)
 		v, changed := fastpathTV.DecMapStringFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15431,7 +12187,7 @@ func (f fastpathT) DecMapStringFloat32X(vp *map[string]float32, checkNil bool, d
 func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15441,11 +12197,8 @@ func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]float32, containerLen)
-		} else {
-			v = make(map[string]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[string]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15459,23 +12212,19 @@ func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringFloat64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]float64)
 		v, changed := fastpathTV.DecMapStringFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15496,7 +12245,7 @@ func (f fastpathT) DecMapStringFloat64X(vp *map[string]float64, checkNil bool, d
 func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15506,11 +12255,8 @@ func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]float64, containerLen)
-		} else {
-			v = make(map[string]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[string]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15524,23 +12270,19 @@ func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapStringBoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapStringBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[string]bool)
 		v, changed := fastpathTV.DecMapStringBoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15561,7 +12303,7 @@ func (f fastpathT) DecMapStringBoolX(vp *map[string]bool, checkNil bool, d *Deco
 func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[string]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15571,11 +12313,8 @@ func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[string]bool, containerLen)
-		} else {
-			v = make(map[string]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[string]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15589,23 +12328,19 @@ func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeString()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]interface{})
 		v, changed := fastpathTV.DecMapFloat32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15626,7 +12361,7 @@ func (f fastpathT) DecMapFloat32IntfX(vp *map[float32]interface{}, checkNil bool
 func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15636,11 +12371,8 @@ func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]interface{}, containerLen)
-		} else {
-			v = make(map[float32]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[float32]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15655,11 +12387,7 @@ func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -15667,12 +12395,12 @@ func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]string)
 		v, changed := fastpathTV.DecMapFloat32StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15693,7 +12421,7 @@ func (f fastpathT) DecMapFloat32StringX(vp *map[float32]string, checkNil bool, d
 func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15703,11 +12431,8 @@ func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]string, containerLen)
-		} else {
-			v = make(map[float32]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[float32]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15721,23 +12446,19 @@ func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]uint)
 		v, changed := fastpathTV.DecMapFloat32UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15758,7 +12479,7 @@ func (f fastpathT) DecMapFloat32UintX(vp *map[float32]uint, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15768,11 +12489,8 @@ func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]uint, containerLen)
-		} else {
-			v = make(map[float32]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15786,23 +12504,19 @@ func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]uint8)
 		v, changed := fastpathTV.DecMapFloat32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15823,7 +12537,7 @@ func (f fastpathT) DecMapFloat32Uint8X(vp *map[float32]uint8, checkNil bool, d *
 func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15833,11 +12547,8 @@ func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]uint8, containerLen)
-		} else {
-			v = make(map[float32]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[float32]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15851,23 +12562,19 @@ func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]uint16)
 		v, changed := fastpathTV.DecMapFloat32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15888,7 +12595,7 @@ func (f fastpathT) DecMapFloat32Uint16X(vp *map[float32]uint16, checkNil bool, d
 func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15898,11 +12605,8 @@ func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]uint16, containerLen)
-		} else {
-			v = make(map[float32]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[float32]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15916,23 +12620,19 @@ func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]uint32)
 		v, changed := fastpathTV.DecMapFloat32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -15953,7 +12653,7 @@ func (f fastpathT) DecMapFloat32Uint32X(vp *map[float32]uint32, checkNil bool, d
 func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -15963,11 +12663,8 @@ func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]uint32, containerLen)
-		} else {
-			v = make(map[float32]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[float32]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -15981,23 +12678,19 @@ func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]uint64)
 		v, changed := fastpathTV.DecMapFloat32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16018,7 +12711,7 @@ func (f fastpathT) DecMapFloat32Uint64X(vp *map[float32]uint64, checkNil bool, d
 func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16028,11 +12721,8 @@ func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]uint64, containerLen)
-		} else {
-			v = make(map[float32]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16046,23 +12736,19 @@ func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]int)
 		v, changed := fastpathTV.DecMapFloat32IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16083,7 +12769,7 @@ func (f fastpathT) DecMapFloat32IntX(vp *map[float32]int, checkNil bool, d *Deco
 func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16093,11 +12779,8 @@ func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]int, containerLen)
-		} else {
-			v = make(map[float32]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16111,23 +12794,19 @@ func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]int8)
 		v, changed := fastpathTV.DecMapFloat32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16148,7 +12827,7 @@ func (f fastpathT) DecMapFloat32Int8X(vp *map[float32]int8, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16158,11 +12837,8 @@ func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]int8, containerLen)
-		} else {
-			v = make(map[float32]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[float32]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16176,23 +12852,19 @@ func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]int16)
 		v, changed := fastpathTV.DecMapFloat32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16213,7 +12885,7 @@ func (f fastpathT) DecMapFloat32Int16X(vp *map[float32]int16, checkNil bool, d *
 func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16223,11 +12895,8 @@ func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]int16, containerLen)
-		} else {
-			v = make(map[float32]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[float32]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16241,23 +12910,19 @@ func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]int32)
 		v, changed := fastpathTV.DecMapFloat32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16278,7 +12943,7 @@ func (f fastpathT) DecMapFloat32Int32X(vp *map[float32]int32, checkNil bool, d *
 func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16288,11 +12953,8 @@ func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]int32, containerLen)
-		} else {
-			v = make(map[float32]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[float32]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16306,23 +12968,19 @@ func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]int64)
 		v, changed := fastpathTV.DecMapFloat32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16343,7 +13001,7 @@ func (f fastpathT) DecMapFloat32Int64X(vp *map[float32]int64, checkNil bool, d *
 func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16353,11 +13011,8 @@ func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]int64, containerLen)
-		} else {
-			v = make(map[float32]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16371,23 +13026,19 @@ func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]float32)
 		v, changed := fastpathTV.DecMapFloat32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16408,7 +13059,7 @@ func (f fastpathT) DecMapFloat32Float32X(vp *map[float32]float32, checkNil bool,
 func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16418,11 +13069,8 @@ func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, c
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]float32, containerLen)
-		} else {
-			v = make(map[float32]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[float32]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16436,23 +13084,19 @@ func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]float64)
 		v, changed := fastpathTV.DecMapFloat32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16473,7 +13117,7 @@ func (f fastpathT) DecMapFloat32Float64X(vp *map[float32]float64, checkNil bool,
 func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16483,11 +13127,8 @@ func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, c
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]float64, containerLen)
-		} else {
-			v = make(map[float32]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float32]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16501,23 +13142,19 @@ func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat32BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat32BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float32]bool)
 		v, changed := fastpathTV.DecMapFloat32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16538,7 +13175,7 @@ func (f fastpathT) DecMapFloat32BoolX(vp *map[float32]bool, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float32]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16548,11 +13185,8 @@ func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float32]bool, containerLen)
-		} else {
-			v = make(map[float32]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[float32]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16566,23 +13200,19 @@ func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := float32(dd.DecodeFloat(true))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]interface{})
 		v, changed := fastpathTV.DecMapFloat64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16603,7 +13233,7 @@ func (f fastpathT) DecMapFloat64IntfX(vp *map[float64]interface{}, checkNil bool
 func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16613,11 +13243,8 @@ func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]interface{}, containerLen)
-		} else {
-			v = make(map[float64]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[float64]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16632,11 +13259,7 @@ func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -16644,12 +13267,12 @@ func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]string)
 		v, changed := fastpathTV.DecMapFloat64StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16670,7 +13293,7 @@ func (f fastpathT) DecMapFloat64StringX(vp *map[float64]string, checkNil bool, d
 func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16680,11 +13303,8 @@ func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]string, containerLen)
-		} else {
-			v = make(map[float64]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[float64]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16698,23 +13318,19 @@ func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]uint)
 		v, changed := fastpathTV.DecMapFloat64UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16735,7 +13351,7 @@ func (f fastpathT) DecMapFloat64UintX(vp *map[float64]uint, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16745,11 +13361,8 @@ func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]uint, containerLen)
-		} else {
-			v = make(map[float64]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16763,23 +13376,19 @@ func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]uint8)
 		v, changed := fastpathTV.DecMapFloat64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16800,7 +13409,7 @@ func (f fastpathT) DecMapFloat64Uint8X(vp *map[float64]uint8, checkNil bool, d *
 func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16810,11 +13419,8 @@ func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]uint8, containerLen)
-		} else {
-			v = make(map[float64]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[float64]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16828,23 +13434,19 @@ func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]uint16)
 		v, changed := fastpathTV.DecMapFloat64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16865,7 +13467,7 @@ func (f fastpathT) DecMapFloat64Uint16X(vp *map[float64]uint16, checkNil bool, d
 func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16875,11 +13477,8 @@ func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]uint16, containerLen)
-		} else {
-			v = make(map[float64]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[float64]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16893,23 +13492,19 @@ func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]uint32)
 		v, changed := fastpathTV.DecMapFloat64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16930,7 +13525,7 @@ func (f fastpathT) DecMapFloat64Uint32X(vp *map[float64]uint32, checkNil bool, d
 func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -16940,11 +13535,8 @@ func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]uint32, containerLen)
-		} else {
-			v = make(map[float64]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float64]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -16958,23 +13550,19 @@ func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]uint64)
 		v, changed := fastpathTV.DecMapFloat64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -16995,7 +13583,7 @@ func (f fastpathT) DecMapFloat64Uint64X(vp *map[float64]uint64, checkNil bool, d
 func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17005,11 +13593,8 @@ func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]uint64, containerLen)
-		} else {
-			v = make(map[float64]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17023,23 +13608,19 @@ func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]int)
 		v, changed := fastpathTV.DecMapFloat64IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17060,7 +13641,7 @@ func (f fastpathT) DecMapFloat64IntX(vp *map[float64]int, checkNil bool, d *Deco
 func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17070,11 +13651,8 @@ func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]int, containerLen)
-		} else {
-			v = make(map[float64]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17088,23 +13666,19 @@ func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]int8)
 		v, changed := fastpathTV.DecMapFloat64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17125,7 +13699,7 @@ func (f fastpathT) DecMapFloat64Int8X(vp *map[float64]int8, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17135,11 +13709,8 @@ func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]int8, containerLen)
-		} else {
-			v = make(map[float64]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[float64]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17153,23 +13724,19 @@ func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]int16)
 		v, changed := fastpathTV.DecMapFloat64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17190,7 +13757,7 @@ func (f fastpathT) DecMapFloat64Int16X(vp *map[float64]int16, checkNil bool, d *
 func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17200,11 +13767,8 @@ func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]int16, containerLen)
-		} else {
-			v = make(map[float64]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[float64]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17218,23 +13782,19 @@ func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]int32)
 		v, changed := fastpathTV.DecMapFloat64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17255,7 +13815,7 @@ func (f fastpathT) DecMapFloat64Int32X(vp *map[float64]int32, checkNil bool, d *
 func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17265,11 +13825,8 @@ func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]int32, containerLen)
-		} else {
-			v = make(map[float64]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float64]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17283,23 +13840,19 @@ func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]int64)
 		v, changed := fastpathTV.DecMapFloat64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17320,7 +13873,7 @@ func (f fastpathT) DecMapFloat64Int64X(vp *map[float64]int64, checkNil bool, d *
 func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17330,11 +13883,8 @@ func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]int64, containerLen)
-		} else {
-			v = make(map[float64]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17348,23 +13898,19 @@ func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]float32)
 		v, changed := fastpathTV.DecMapFloat64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17385,7 +13931,7 @@ func (f fastpathT) DecMapFloat64Float32X(vp *map[float64]float32, checkNil bool,
 func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17395,11 +13941,8 @@ func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, c
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]float32, containerLen)
-		} else {
-			v = make(map[float64]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[float64]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17413,23 +13956,19 @@ func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]float64)
 		v, changed := fastpathTV.DecMapFloat64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17450,7 +13989,7 @@ func (f fastpathT) DecMapFloat64Float64X(vp *map[float64]float64, checkNil bool,
 func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17460,11 +13999,8 @@ func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, c
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]float64, containerLen)
-		} else {
-			v = make(map[float64]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[float64]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17478,23 +14014,19 @@ func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, c
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapFloat64BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapFloat64BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[float64]bool)
 		v, changed := fastpathTV.DecMapFloat64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17515,7 +14047,7 @@ func (f fastpathT) DecMapFloat64BoolX(vp *map[float64]bool, checkNil bool, d *De
 func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[float64]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17525,11 +14057,8 @@ func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[float64]bool, containerLen)
-		} else {
-			v = make(map[float64]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[float64]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17543,23 +14072,19 @@ func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeFloat(false)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintIntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]interface{})
 		v, changed := fastpathTV.DecMapUintIntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17580,7 +14105,7 @@ func (f fastpathT) DecMapUintIntfX(vp *map[uint]interface{}, checkNil bool, d *D
 func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17590,11 +14115,8 @@ func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canCha
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]interface{}, containerLen)
-		} else {
-			v = make(map[uint]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uint]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17609,11 +14131,7 @@ func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -17621,12 +14139,12 @@ func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canCha
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintStringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintStringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]string)
 		v, changed := fastpathTV.DecMapUintStringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17647,7 +14165,7 @@ func (f fastpathT) DecMapUintStringX(vp *map[uint]string, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17657,11 +14175,8 @@ func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]string, containerLen)
-		} else {
-			v = make(map[uint]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uint]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17675,23 +14190,19 @@ func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintUintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintUintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]uint)
 		v, changed := fastpathTV.DecMapUintUintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17712,7 +14223,7 @@ func (f fastpathT) DecMapUintUintX(vp *map[uint]uint, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17722,11 +14233,8 @@ func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]uint, containerLen)
-		} else {
-			v = make(map[uint]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17740,23 +14248,19 @@ func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintUint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]uint8)
 		v, changed := fastpathTV.DecMapUintUint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17777,7 +14281,7 @@ func (f fastpathT) DecMapUintUint8X(vp *map[uint]uint8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17787,11 +14291,8 @@ func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]uint8, containerLen)
-		} else {
-			v = make(map[uint]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17805,23 +14306,19 @@ func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintUint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]uint16)
 		v, changed := fastpathTV.DecMapUintUint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17842,7 +14339,7 @@ func (f fastpathT) DecMapUintUint16X(vp *map[uint]uint16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17852,11 +14349,8 @@ func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]uint16, containerLen)
-		} else {
-			v = make(map[uint]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17870,23 +14364,19 @@ func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintUint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]uint32)
 		v, changed := fastpathTV.DecMapUintUint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17907,7 +14397,7 @@ func (f fastpathT) DecMapUintUint32X(vp *map[uint]uint32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17917,11 +14407,8 @@ func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]uint32, containerLen)
-		} else {
-			v = make(map[uint]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -17935,23 +14422,19 @@ func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintUint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]uint64)
 		v, changed := fastpathTV.DecMapUintUint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -17972,7 +14455,7 @@ func (f fastpathT) DecMapUintUint64X(vp *map[uint]uint64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -17982,11 +14465,8 @@ func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]uint64, containerLen)
-		} else {
-			v = make(map[uint]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18000,23 +14480,19 @@ func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintIntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintIntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]int)
 		v, changed := fastpathTV.DecMapUintIntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18037,7 +14513,7 @@ func (f fastpathT) DecMapUintIntX(vp *map[uint]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18047,11 +14523,8 @@ func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]int, containerLen)
-		} else {
-			v = make(map[uint]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18065,23 +14538,19 @@ func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintInt8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]int8)
 		v, changed := fastpathTV.DecMapUintInt8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18102,7 +14571,7 @@ func (f fastpathT) DecMapUintInt8X(vp *map[uint]int8, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18112,11 +14581,8 @@ func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]int8, containerLen)
-		} else {
-			v = make(map[uint]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18130,23 +14596,19 @@ func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintInt16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]int16)
 		v, changed := fastpathTV.DecMapUintInt16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18167,7 +14629,7 @@ func (f fastpathT) DecMapUintInt16X(vp *map[uint]int16, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18177,11 +14639,8 @@ func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]int16, containerLen)
-		} else {
-			v = make(map[uint]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18195,23 +14654,19 @@ func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintInt32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]int32)
 		v, changed := fastpathTV.DecMapUintInt32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18232,7 +14687,7 @@ func (f fastpathT) DecMapUintInt32X(vp *map[uint]int32, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18242,11 +14697,8 @@ func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]int32, containerLen)
-		} else {
-			v = make(map[uint]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18260,23 +14712,19 @@ func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintInt64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]int64)
 		v, changed := fastpathTV.DecMapUintInt64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18297,7 +14745,7 @@ func (f fastpathT) DecMapUintInt64X(vp *map[uint]int64, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18307,11 +14755,8 @@ func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]int64, containerLen)
-		} else {
-			v = make(map[uint]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18325,23 +14770,19 @@ func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintFloat32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]float32)
 		v, changed := fastpathTV.DecMapUintFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18362,7 +14803,7 @@ func (f fastpathT) DecMapUintFloat32X(vp *map[uint]float32, checkNil bool, d *De
 func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18372,11 +14813,8 @@ func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]float32, containerLen)
-		} else {
-			v = make(map[uint]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18390,23 +14828,19 @@ func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintFloat64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]float64)
 		v, changed := fastpathTV.DecMapUintFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18427,7 +14861,7 @@ func (f fastpathT) DecMapUintFloat64X(vp *map[uint]float64, checkNil bool, d *De
 func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18437,11 +14871,8 @@ func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]float64, containerLen)
-		} else {
-			v = make(map[uint]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18455,23 +14886,19 @@ func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUintBoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUintBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint]bool)
 		v, changed := fastpathTV.DecMapUintBoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18492,7 +14919,7 @@ func (f fastpathT) DecMapUintBoolX(vp *map[uint]bool, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18502,11 +14929,8 @@ func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint]bool, containerLen)
-		} else {
-			v = make(map[uint]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18520,23 +14944,19 @@ func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint(dd.DecodeUint(uintBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]interface{})
 		v, changed := fastpathTV.DecMapUint8IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18557,7 +14977,7 @@ func (f fastpathT) DecMapUint8IntfX(vp *map[uint8]interface{}, checkNil bool, d 
 func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18567,11 +14987,8 @@ func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canC
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]interface{}, containerLen)
-		} else {
-			v = make(map[uint8]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[uint8]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18586,11 +15003,7 @@ func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -18598,12 +15011,12 @@ func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canC
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]string)
 		v, changed := fastpathTV.DecMapUint8StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18624,7 +15037,7 @@ func (f fastpathT) DecMapUint8StringX(vp *map[uint8]string, checkNil bool, d *De
 func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18634,11 +15047,8 @@ func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]string, containerLen)
-		} else {
-			v = make(map[uint8]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[uint8]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18652,23 +15062,19 @@ func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]uint)
 		v, changed := fastpathTV.DecMapUint8UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18689,7 +15095,7 @@ func (f fastpathT) DecMapUint8UintX(vp *map[uint8]uint, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18699,11 +15105,8 @@ func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]uint, containerLen)
-		} else {
-			v = make(map[uint8]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18717,23 +15120,19 @@ func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]uint8)
 		v, changed := fastpathTV.DecMapUint8Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18754,7 +15153,7 @@ func (f fastpathT) DecMapUint8Uint8X(vp *map[uint8]uint8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18764,11 +15163,8 @@ func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]uint8, containerLen)
-		} else {
-			v = make(map[uint8]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[uint8]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18782,23 +15178,19 @@ func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]uint16)
 		v, changed := fastpathTV.DecMapUint8Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18819,7 +15211,7 @@ func (f fastpathT) DecMapUint8Uint16X(vp *map[uint8]uint16, checkNil bool, d *De
 func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18829,11 +15221,8 @@ func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]uint16, containerLen)
-		} else {
-			v = make(map[uint8]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint8]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18847,23 +15236,19 @@ func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]uint32)
 		v, changed := fastpathTV.DecMapUint8Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18884,7 +15269,7 @@ func (f fastpathT) DecMapUint8Uint32X(vp *map[uint8]uint32, checkNil bool, d *De
 func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18894,11 +15279,8 @@ func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]uint32, containerLen)
-		} else {
-			v = make(map[uint8]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint8]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18912,23 +15294,19 @@ func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]uint64)
 		v, changed := fastpathTV.DecMapUint8Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -18949,7 +15327,7 @@ func (f fastpathT) DecMapUint8Uint64X(vp *map[uint8]uint64, checkNil bool, d *De
 func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -18959,11 +15337,8 @@ func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]uint64, containerLen)
-		} else {
-			v = make(map[uint8]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -18977,23 +15352,19 @@ func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]int)
 		v, changed := fastpathTV.DecMapUint8IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19014,7 +15385,7 @@ func (f fastpathT) DecMapUint8IntX(vp *map[uint8]int, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19024,11 +15395,8 @@ func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]int, containerLen)
-		} else {
-			v = make(map[uint8]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19042,23 +15410,19 @@ func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]int8)
 		v, changed := fastpathTV.DecMapUint8Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19079,7 +15443,7 @@ func (f fastpathT) DecMapUint8Int8X(vp *map[uint8]int8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19089,11 +15453,8 @@ func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]int8, containerLen)
-		} else {
-			v = make(map[uint8]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[uint8]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19107,23 +15468,19 @@ func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]int16)
 		v, changed := fastpathTV.DecMapUint8Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19144,7 +15501,7 @@ func (f fastpathT) DecMapUint8Int16X(vp *map[uint8]int16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19154,11 +15511,8 @@ func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]int16, containerLen)
-		} else {
-			v = make(map[uint8]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint8]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19172,23 +15526,19 @@ func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]int32)
 		v, changed := fastpathTV.DecMapUint8Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19209,7 +15559,7 @@ func (f fastpathT) DecMapUint8Int32X(vp *map[uint8]int32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19219,11 +15569,8 @@ func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]int32, containerLen)
-		} else {
-			v = make(map[uint8]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint8]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19237,23 +15584,19 @@ func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]int64)
 		v, changed := fastpathTV.DecMapUint8Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19274,7 +15617,7 @@ func (f fastpathT) DecMapUint8Int64X(vp *map[uint8]int64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19284,11 +15627,8 @@ func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]int64, containerLen)
-		} else {
-			v = make(map[uint8]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19302,23 +15642,19 @@ func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]float32)
 		v, changed := fastpathTV.DecMapUint8Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19339,7 +15675,7 @@ func (f fastpathT) DecMapUint8Float32X(vp *map[uint8]float32, checkNil bool, d *
 func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19349,11 +15685,8 @@ func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]float32, containerLen)
-		} else {
-			v = make(map[uint8]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint8]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19367,23 +15700,19 @@ func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]float64)
 		v, changed := fastpathTV.DecMapUint8Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19404,7 +15733,7 @@ func (f fastpathT) DecMapUint8Float64X(vp *map[uint8]float64, checkNil bool, d *
 func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19414,11 +15743,8 @@ func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]float64, containerLen)
-		} else {
-			v = make(map[uint8]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint8]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19432,23 +15758,19 @@ func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint8BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint8BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint8]bool)
 		v, changed := fastpathTV.DecMapUint8BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19469,7 +15791,7 @@ func (f fastpathT) DecMapUint8BoolX(vp *map[uint8]bool, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint8]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19479,11 +15801,8 @@ func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint8]bool, containerLen)
-		} else {
-			v = make(map[uint8]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[uint8]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19497,23 +15816,19 @@ func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint8(dd.DecodeUint(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]interface{})
 		v, changed := fastpathTV.DecMapUint16IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19534,7 +15849,7 @@ func (f fastpathT) DecMapUint16IntfX(vp *map[uint16]interface{}, checkNil bool, 
 func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19544,11 +15859,8 @@ func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, ca
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]interface{}, containerLen)
-		} else {
-			v = make(map[uint16]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[uint16]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19563,11 +15875,7 @@ func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -19575,12 +15883,12 @@ func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, ca
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]string)
 		v, changed := fastpathTV.DecMapUint16StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19601,7 +15909,7 @@ func (f fastpathT) DecMapUint16StringX(vp *map[uint16]string, checkNil bool, d *
 func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19611,11 +15919,8 @@ func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]string, containerLen)
-		} else {
-			v = make(map[uint16]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[uint16]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19629,23 +15934,19 @@ func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]uint)
 		v, changed := fastpathTV.DecMapUint16UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19666,7 +15967,7 @@ func (f fastpathT) DecMapUint16UintX(vp *map[uint16]uint, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19676,11 +15977,8 @@ func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]uint, containerLen)
-		} else {
-			v = make(map[uint16]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19694,23 +15992,19 @@ func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]uint8)
 		v, changed := fastpathTV.DecMapUint16Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19731,7 +16025,7 @@ func (f fastpathT) DecMapUint16Uint8X(vp *map[uint16]uint8, checkNil bool, d *De
 func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19741,11 +16035,8 @@ func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]uint8, containerLen)
-		} else {
-			v = make(map[uint16]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint16]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19759,23 +16050,19 @@ func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]uint16)
 		v, changed := fastpathTV.DecMapUint16Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19796,7 +16083,7 @@ func (f fastpathT) DecMapUint16Uint16X(vp *map[uint16]uint16, checkNil bool, d *
 func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19806,11 +16093,8 @@ func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]uint16, containerLen)
-		} else {
-			v = make(map[uint16]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		v = make(map[uint16]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19824,23 +16108,19 @@ func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]uint32)
 		v, changed := fastpathTV.DecMapUint16Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19861,7 +16141,7 @@ func (f fastpathT) DecMapUint16Uint32X(vp *map[uint16]uint32, checkNil bool, d *
 func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19871,11 +16151,8 @@ func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]uint32, containerLen)
-		} else {
-			v = make(map[uint16]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint16]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19889,23 +16166,19 @@ func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]uint64)
 		v, changed := fastpathTV.DecMapUint16Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19926,7 +16199,7 @@ func (f fastpathT) DecMapUint16Uint64X(vp *map[uint16]uint64, checkNil bool, d *
 func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -19936,11 +16209,8 @@ func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]uint64, containerLen)
-		} else {
-			v = make(map[uint16]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -19954,23 +16224,19 @@ func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]int)
 		v, changed := fastpathTV.DecMapUint16IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -19991,7 +16257,7 @@ func (f fastpathT) DecMapUint16IntX(vp *map[uint16]int, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20001,11 +16267,8 @@ func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]int, containerLen)
-		} else {
-			v = make(map[uint16]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20019,23 +16282,19 @@ func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]int8)
 		v, changed := fastpathTV.DecMapUint16Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20056,7 +16315,7 @@ func (f fastpathT) DecMapUint16Int8X(vp *map[uint16]int8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20066,11 +16325,8 @@ func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]int8, containerLen)
-		} else {
-			v = make(map[uint16]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint16]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20084,23 +16340,19 @@ func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]int16)
 		v, changed := fastpathTV.DecMapUint16Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20121,7 +16373,7 @@ func (f fastpathT) DecMapUint16Int16X(vp *map[uint16]int16, checkNil bool, d *De
 func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20131,11 +16383,8 @@ func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]int16, containerLen)
-		} else {
-			v = make(map[uint16]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		v = make(map[uint16]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20149,23 +16398,19 @@ func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]int32)
 		v, changed := fastpathTV.DecMapUint16Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20186,7 +16431,7 @@ func (f fastpathT) DecMapUint16Int32X(vp *map[uint16]int32, checkNil bool, d *De
 func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20196,11 +16441,8 @@ func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]int32, containerLen)
-		} else {
-			v = make(map[uint16]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint16]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20214,23 +16456,19 @@ func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]int64)
 		v, changed := fastpathTV.DecMapUint16Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20251,7 +16489,7 @@ func (f fastpathT) DecMapUint16Int64X(vp *map[uint16]int64, checkNil bool, d *De
 func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20261,11 +16499,8 @@ func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]int64, containerLen)
-		} else {
-			v = make(map[uint16]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20279,23 +16514,19 @@ func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]float32)
 		v, changed := fastpathTV.DecMapUint16Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20316,7 +16547,7 @@ func (f fastpathT) DecMapUint16Float32X(vp *map[uint16]float32, checkNil bool, d
 func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20326,11 +16557,8 @@ func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]float32, containerLen)
-		} else {
-			v = make(map[uint16]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint16]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20344,23 +16572,19 @@ func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]float64)
 		v, changed := fastpathTV.DecMapUint16Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20381,7 +16605,7 @@ func (f fastpathT) DecMapUint16Float64X(vp *map[uint16]float64, checkNil bool, d
 func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20391,11 +16615,8 @@ func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]float64, containerLen)
-		} else {
-			v = make(map[uint16]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint16]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20409,23 +16630,19 @@ func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint16BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint16BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint16]bool)
 		v, changed := fastpathTV.DecMapUint16BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20446,7 +16663,7 @@ func (f fastpathT) DecMapUint16BoolX(vp *map[uint16]bool, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint16]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20456,11 +16673,8 @@ func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint16]bool, containerLen)
-		} else {
-			v = make(map[uint16]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[uint16]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20474,23 +16688,19 @@ func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint16(dd.DecodeUint(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]interface{})
 		v, changed := fastpathTV.DecMapUint32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20511,7 +16721,7 @@ func (f fastpathT) DecMapUint32IntfX(vp *map[uint32]interface{}, checkNil bool, 
 func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20521,11 +16731,8 @@ func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, ca
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]interface{}, containerLen)
-		} else {
-			v = make(map[uint32]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[uint32]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20540,11 +16747,7 @@ func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -20552,12 +16755,12 @@ func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, ca
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]string)
 		v, changed := fastpathTV.DecMapUint32StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20578,7 +16781,7 @@ func (f fastpathT) DecMapUint32StringX(vp *map[uint32]string, checkNil bool, d *
 func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20588,11 +16791,8 @@ func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]string, containerLen)
-		} else {
-			v = make(map[uint32]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[uint32]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20606,23 +16806,19 @@ func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]uint)
 		v, changed := fastpathTV.DecMapUint32UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20643,7 +16839,7 @@ func (f fastpathT) DecMapUint32UintX(vp *map[uint32]uint, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20653,11 +16849,8 @@ func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]uint, containerLen)
-		} else {
-			v = make(map[uint32]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20671,23 +16864,19 @@ func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]uint8)
 		v, changed := fastpathTV.DecMapUint32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20708,7 +16897,7 @@ func (f fastpathT) DecMapUint32Uint8X(vp *map[uint32]uint8, checkNil bool, d *De
 func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20718,11 +16907,8 @@ func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]uint8, containerLen)
-		} else {
-			v = make(map[uint32]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint32]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20736,23 +16922,19 @@ func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]uint16)
 		v, changed := fastpathTV.DecMapUint32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20773,7 +16955,7 @@ func (f fastpathT) DecMapUint32Uint16X(vp *map[uint32]uint16, checkNil bool, d *
 func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20783,11 +16965,8 @@ func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]uint16, containerLen)
-		} else {
-			v = make(map[uint32]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint32]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20801,23 +16980,19 @@ func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]uint32)
 		v, changed := fastpathTV.DecMapUint32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20838,7 +17013,7 @@ func (f fastpathT) DecMapUint32Uint32X(vp *map[uint32]uint32, checkNil bool, d *
 func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20848,11 +17023,8 @@ func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]uint32, containerLen)
-		} else {
-			v = make(map[uint32]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[uint32]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20866,23 +17038,19 @@ func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]uint64)
 		v, changed := fastpathTV.DecMapUint32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20903,7 +17071,7 @@ func (f fastpathT) DecMapUint32Uint64X(vp *map[uint32]uint64, checkNil bool, d *
 func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20913,11 +17081,8 @@ func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]uint64, containerLen)
-		} else {
-			v = make(map[uint32]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20931,23 +17096,19 @@ func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]int)
 		v, changed := fastpathTV.DecMapUint32IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -20968,7 +17129,7 @@ func (f fastpathT) DecMapUint32IntX(vp *map[uint32]int, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -20978,11 +17139,8 @@ func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]int, containerLen)
-		} else {
-			v = make(map[uint32]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -20996,23 +17154,19 @@ func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]int8)
 		v, changed := fastpathTV.DecMapUint32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21033,7 +17187,7 @@ func (f fastpathT) DecMapUint32Int8X(vp *map[uint32]int8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21043,11 +17197,8 @@ func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]int8, containerLen)
-		} else {
-			v = make(map[uint32]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint32]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21061,23 +17212,19 @@ func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]int16)
 		v, changed := fastpathTV.DecMapUint32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21098,7 +17245,7 @@ func (f fastpathT) DecMapUint32Int16X(vp *map[uint32]int16, checkNil bool, d *De
 func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21108,11 +17255,8 @@ func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]int16, containerLen)
-		} else {
-			v = make(map[uint32]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[uint32]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21126,23 +17270,19 @@ func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]int32)
 		v, changed := fastpathTV.DecMapUint32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21163,7 +17303,7 @@ func (f fastpathT) DecMapUint32Int32X(vp *map[uint32]int32, checkNil bool, d *De
 func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21173,11 +17313,8 @@ func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]int32, containerLen)
-		} else {
-			v = make(map[uint32]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[uint32]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21191,23 +17328,19 @@ func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]int64)
 		v, changed := fastpathTV.DecMapUint32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21228,7 +17361,7 @@ func (f fastpathT) DecMapUint32Int64X(vp *map[uint32]int64, checkNil bool, d *De
 func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21238,11 +17371,8 @@ func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]int64, containerLen)
-		} else {
-			v = make(map[uint32]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21256,23 +17386,19 @@ func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]float32)
 		v, changed := fastpathTV.DecMapUint32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21293,7 +17419,7 @@ func (f fastpathT) DecMapUint32Float32X(vp *map[uint32]float32, checkNil bool, d
 func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21303,11 +17429,8 @@ func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]float32, containerLen)
-		} else {
-			v = make(map[uint32]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[uint32]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21321,23 +17444,19 @@ func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]float64)
 		v, changed := fastpathTV.DecMapUint32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21358,7 +17477,7 @@ func (f fastpathT) DecMapUint32Float64X(vp *map[uint32]float64, checkNil bool, d
 func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21368,11 +17487,8 @@ func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]float64, containerLen)
-		} else {
-			v = make(map[uint32]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint32]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21386,23 +17502,19 @@ func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint32BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint32BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint32]bool)
 		v, changed := fastpathTV.DecMapUint32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21423,7 +17535,7 @@ func (f fastpathT) DecMapUint32BoolX(vp *map[uint32]bool, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint32]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21433,11 +17545,8 @@ func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint32]bool, containerLen)
-		} else {
-			v = make(map[uint32]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[uint32]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21451,23 +17560,19 @@ func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := uint32(dd.DecodeUint(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]interface{})
 		v, changed := fastpathTV.DecMapUint64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21488,7 +17593,7 @@ func (f fastpathT) DecMapUint64IntfX(vp *map[uint64]interface{}, checkNil bool, 
 func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21498,11 +17603,8 @@ func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, ca
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]interface{}, containerLen)
-		} else {
-			v = make(map[uint64]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uint64]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21517,11 +17619,7 @@ func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, ca
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -21529,12 +17627,12 @@ func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, ca
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]string)
 		v, changed := fastpathTV.DecMapUint64StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21555,7 +17653,7 @@ func (f fastpathT) DecMapUint64StringX(vp *map[uint64]string, checkNil bool, d *
 func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21565,11 +17663,8 @@ func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]string, containerLen)
-		} else {
-			v = make(map[uint64]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[uint64]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21583,23 +17678,19 @@ func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]uint)
 		v, changed := fastpathTV.DecMapUint64UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21620,7 +17711,7 @@ func (f fastpathT) DecMapUint64UintX(vp *map[uint64]uint, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21630,11 +17721,8 @@ func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]uint, containerLen)
-		} else {
-			v = make(map[uint64]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21648,23 +17736,19 @@ func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]uint8)
 		v, changed := fastpathTV.DecMapUint64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21685,7 +17769,7 @@ func (f fastpathT) DecMapUint64Uint8X(vp *map[uint64]uint8, checkNil bool, d *De
 func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21695,11 +17779,8 @@ func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]uint8, containerLen)
-		} else {
-			v = make(map[uint64]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint64]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21713,23 +17794,19 @@ func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]uint16)
 		v, changed := fastpathTV.DecMapUint64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21750,7 +17827,7 @@ func (f fastpathT) DecMapUint64Uint16X(vp *map[uint64]uint16, checkNil bool, d *
 func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21760,11 +17837,8 @@ func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]uint16, containerLen)
-		} else {
-			v = make(map[uint64]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint64]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21778,23 +17852,19 @@ func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]uint32)
 		v, changed := fastpathTV.DecMapUint64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21815,7 +17885,7 @@ func (f fastpathT) DecMapUint64Uint32X(vp *map[uint64]uint32, checkNil bool, d *
 func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21825,11 +17895,8 @@ func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]uint32, containerLen)
-		} else {
-			v = make(map[uint64]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint64]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21843,23 +17910,19 @@ func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]uint64)
 		v, changed := fastpathTV.DecMapUint64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21880,7 +17943,7 @@ func (f fastpathT) DecMapUint64Uint64X(vp *map[uint64]uint64, checkNil bool, d *
 func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21890,11 +17953,8 @@ func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]uint64, containerLen)
-		} else {
-			v = make(map[uint64]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21908,23 +17968,19 @@ func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]int)
 		v, changed := fastpathTV.DecMapUint64IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -21945,7 +18001,7 @@ func (f fastpathT) DecMapUint64IntX(vp *map[uint64]int, checkNil bool, d *Decode
 func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -21955,11 +18011,8 @@ func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]int, containerLen)
-		} else {
-			v = make(map[uint64]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -21973,23 +18026,19 @@ func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]int8)
 		v, changed := fastpathTV.DecMapUint64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22010,7 +18059,7 @@ func (f fastpathT) DecMapUint64Int8X(vp *map[uint64]int8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22020,11 +18069,8 @@ func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]int8, containerLen)
-		} else {
-			v = make(map[uint64]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint64]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22038,23 +18084,19 @@ func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]int16)
 		v, changed := fastpathTV.DecMapUint64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22075,7 +18117,7 @@ func (f fastpathT) DecMapUint64Int16X(vp *map[uint64]int16, checkNil bool, d *De
 func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22085,11 +18127,8 @@ func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]int16, containerLen)
-		} else {
-			v = make(map[uint64]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[uint64]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22103,23 +18142,19 @@ func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]int32)
 		v, changed := fastpathTV.DecMapUint64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22140,7 +18175,7 @@ func (f fastpathT) DecMapUint64Int32X(vp *map[uint64]int32, checkNil bool, d *De
 func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22150,11 +18185,8 @@ func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]int32, containerLen)
-		} else {
-			v = make(map[uint64]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint64]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22168,23 +18200,19 @@ func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]int64)
 		v, changed := fastpathTV.DecMapUint64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22205,7 +18233,7 @@ func (f fastpathT) DecMapUint64Int64X(vp *map[uint64]int64, checkNil bool, d *De
 func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22215,11 +18243,8 @@ func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]int64, containerLen)
-		} else {
-			v = make(map[uint64]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22233,23 +18258,19 @@ func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]float32)
 		v, changed := fastpathTV.DecMapUint64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22270,7 +18291,7 @@ func (f fastpathT) DecMapUint64Float32X(vp *map[uint64]float32, checkNil bool, d
 func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22280,11 +18301,8 @@ func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]float32, containerLen)
-		} else {
-			v = make(map[uint64]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[uint64]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22298,23 +18316,19 @@ func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]float64)
 		v, changed := fastpathTV.DecMapUint64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22335,7 +18349,7 @@ func (f fastpathT) DecMapUint64Float64X(vp *map[uint64]float64, checkNil bool, d
 func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22345,11 +18359,8 @@ func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, can
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]float64, containerLen)
-		} else {
-			v = make(map[uint64]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[uint64]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22363,23 +18374,19 @@ func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, can
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapUint64BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapUint64BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[uint64]bool)
 		v, changed := fastpathTV.DecMapUint64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22400,7 +18407,7 @@ func (f fastpathT) DecMapUint64BoolX(vp *map[uint64]bool, checkNil bool, d *Deco
 func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[uint64]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22410,11 +18417,8 @@ func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[uint64]bool, containerLen)
-		} else {
-			v = make(map[uint64]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[uint64]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22428,23 +18432,19 @@ func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeUint(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntIntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]interface{})
 		v, changed := fastpathTV.DecMapIntIntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22465,7 +18465,7 @@ func (f fastpathT) DecMapIntIntfX(vp *map[int]interface{}, checkNil bool, d *Dec
 func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22475,11 +18475,8 @@ func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChang
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]interface{}, containerLen)
-		} else {
-			v = make(map[int]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[int]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22494,11 +18491,7 @@ func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChang
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -22506,12 +18499,12 @@ func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChang
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntStringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntStringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]string)
 		v, changed := fastpathTV.DecMapIntStringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22532,7 +18525,7 @@ func (f fastpathT) DecMapIntStringX(vp *map[int]string, checkNil bool, d *Decode
 func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22542,11 +18535,8 @@ func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]string, containerLen)
-		} else {
-			v = make(map[int]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[int]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22560,23 +18550,19 @@ func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntUintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntUintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]uint)
 		v, changed := fastpathTV.DecMapIntUintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22597,7 +18583,7 @@ func (f fastpathT) DecMapIntUintX(vp *map[int]uint, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22607,11 +18593,8 @@ func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]uint, containerLen)
-		} else {
-			v = make(map[int]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22625,23 +18608,19 @@ func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntUint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]uint8)
 		v, changed := fastpathTV.DecMapIntUint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22662,7 +18641,7 @@ func (f fastpathT) DecMapIntUint8X(vp *map[int]uint8, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22672,11 +18651,8 @@ func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]uint8, containerLen)
-		} else {
-			v = make(map[int]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22690,23 +18666,19 @@ func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntUint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]uint16)
 		v, changed := fastpathTV.DecMapIntUint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22727,7 +18699,7 @@ func (f fastpathT) DecMapIntUint16X(vp *map[int]uint16, checkNil bool, d *Decode
 func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22737,11 +18709,8 @@ func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]uint16, containerLen)
-		} else {
-			v = make(map[int]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22755,23 +18724,19 @@ func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntUint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]uint32)
 		v, changed := fastpathTV.DecMapIntUint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22792,7 +18757,7 @@ func (f fastpathT) DecMapIntUint32X(vp *map[int]uint32, checkNil bool, d *Decode
 func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22802,11 +18767,8 @@ func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]uint32, containerLen)
-		} else {
-			v = make(map[int]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22820,23 +18782,19 @@ func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntUint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]uint64)
 		v, changed := fastpathTV.DecMapIntUint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22857,7 +18815,7 @@ func (f fastpathT) DecMapIntUint64X(vp *map[int]uint64, checkNil bool, d *Decode
 func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22867,11 +18825,8 @@ func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]uint64, containerLen)
-		} else {
-			v = make(map[int]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22885,23 +18840,19 @@ func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntIntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntIntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]int)
 		v, changed := fastpathTV.DecMapIntIntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22922,7 +18873,7 @@ func (f fastpathT) DecMapIntIntX(vp *map[int]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22932,11 +18883,8 @@ func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]int, containerLen)
-		} else {
-			v = make(map[int]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -22950,23 +18898,19 @@ func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntInt8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]int8)
 		v, changed := fastpathTV.DecMapIntInt8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -22987,7 +18931,7 @@ func (f fastpathT) DecMapIntInt8X(vp *map[int]int8, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -22997,11 +18941,8 @@ func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]int8, containerLen)
-		} else {
-			v = make(map[int]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23015,23 +18956,19 @@ func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntInt16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]int16)
 		v, changed := fastpathTV.DecMapIntInt16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23052,7 +18989,7 @@ func (f fastpathT) DecMapIntInt16X(vp *map[int]int16, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23062,11 +18999,8 @@ func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]int16, containerLen)
-		} else {
-			v = make(map[int]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23080,23 +19014,19 @@ func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntInt32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]int32)
 		v, changed := fastpathTV.DecMapIntInt32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23117,7 +19047,7 @@ func (f fastpathT) DecMapIntInt32X(vp *map[int]int32, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23127,11 +19057,8 @@ func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]int32, containerLen)
-		} else {
-			v = make(map[int]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23145,23 +19072,19 @@ func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntInt64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]int64)
 		v, changed := fastpathTV.DecMapIntInt64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23182,7 +19105,7 @@ func (f fastpathT) DecMapIntInt64X(vp *map[int]int64, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23192,11 +19115,8 @@ func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]int64, containerLen)
-		} else {
-			v = make(map[int]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23210,23 +19130,19 @@ func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntFloat32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]float32)
 		v, changed := fastpathTV.DecMapIntFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23247,7 +19163,7 @@ func (f fastpathT) DecMapIntFloat32X(vp *map[int]float32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23257,11 +19173,8 @@ func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]float32, containerLen)
-		} else {
-			v = make(map[int]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23275,23 +19188,19 @@ func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntFloat64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]float64)
 		v, changed := fastpathTV.DecMapIntFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23312,7 +19221,7 @@ func (f fastpathT) DecMapIntFloat64X(vp *map[int]float64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23322,11 +19231,8 @@ func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]float64, containerLen)
-		} else {
-			v = make(map[int]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23340,23 +19246,19 @@ func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapIntBoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapIntBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int]bool)
 		v, changed := fastpathTV.DecMapIntBoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23377,7 +19279,7 @@ func (f fastpathT) DecMapIntBoolX(vp *map[int]bool, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23387,11 +19289,8 @@ func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int]bool, containerLen)
-		} else {
-			v = make(map[int]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23405,23 +19304,19 @@ func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int(dd.DecodeInt(intBitsize))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]interface{})
 		v, changed := fastpathTV.DecMapInt8IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23442,7 +19337,7 @@ func (f fastpathT) DecMapInt8IntfX(vp *map[int8]interface{}, checkNil bool, d *D
 func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23452,11 +19347,8 @@ func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canCha
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]interface{}, containerLen)
-		} else {
-			v = make(map[int8]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[int8]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23471,11 +19363,7 @@ func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -23483,12 +19371,12 @@ func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canCha
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]string)
 		v, changed := fastpathTV.DecMapInt8StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23509,7 +19397,7 @@ func (f fastpathT) DecMapInt8StringX(vp *map[int8]string, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23519,11 +19407,8 @@ func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]string, containerLen)
-		} else {
-			v = make(map[int8]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[int8]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23537,23 +19422,19 @@ func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]uint)
 		v, changed := fastpathTV.DecMapInt8UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23574,7 +19455,7 @@ func (f fastpathT) DecMapInt8UintX(vp *map[int8]uint, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23584,11 +19465,8 @@ func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]uint, containerLen)
-		} else {
-			v = make(map[int8]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23602,23 +19480,19 @@ func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]uint8)
 		v, changed := fastpathTV.DecMapInt8Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23639,7 +19513,7 @@ func (f fastpathT) DecMapInt8Uint8X(vp *map[int8]uint8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23649,11 +19523,8 @@ func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]uint8, containerLen)
-		} else {
-			v = make(map[int8]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[int8]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23667,23 +19538,19 @@ func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]uint16)
 		v, changed := fastpathTV.DecMapInt8Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23704,7 +19571,7 @@ func (f fastpathT) DecMapInt8Uint16X(vp *map[int8]uint16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23714,11 +19581,8 @@ func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]uint16, containerLen)
-		} else {
-			v = make(map[int8]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int8]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23732,23 +19596,19 @@ func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]uint32)
 		v, changed := fastpathTV.DecMapInt8Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23769,7 +19629,7 @@ func (f fastpathT) DecMapInt8Uint32X(vp *map[int8]uint32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23779,11 +19639,8 @@ func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]uint32, containerLen)
-		} else {
-			v = make(map[int8]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int8]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23797,23 +19654,19 @@ func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]uint64)
 		v, changed := fastpathTV.DecMapInt8Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23834,7 +19687,7 @@ func (f fastpathT) DecMapInt8Uint64X(vp *map[int8]uint64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23844,11 +19697,8 @@ func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]uint64, containerLen)
-		} else {
-			v = make(map[int8]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23862,23 +19712,19 @@ func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]int)
 		v, changed := fastpathTV.DecMapInt8IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23899,7 +19745,7 @@ func (f fastpathT) DecMapInt8IntX(vp *map[int8]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23909,11 +19755,8 @@ func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]int, containerLen)
-		} else {
-			v = make(map[int8]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23927,23 +19770,19 @@ func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]int8)
 		v, changed := fastpathTV.DecMapInt8Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -23964,7 +19803,7 @@ func (f fastpathT) DecMapInt8Int8X(vp *map[int8]int8, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -23974,11 +19813,8 @@ func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]int8, containerLen)
-		} else {
-			v = make(map[int8]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[int8]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -23992,23 +19828,19 @@ func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]int16)
 		v, changed := fastpathTV.DecMapInt8Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24029,7 +19861,7 @@ func (f fastpathT) DecMapInt8Int16X(vp *map[int8]int16, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24039,11 +19871,8 @@ func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]int16, containerLen)
-		} else {
-			v = make(map[int8]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int8]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24057,23 +19886,19 @@ func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]int32)
 		v, changed := fastpathTV.DecMapInt8Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24094,7 +19919,7 @@ func (f fastpathT) DecMapInt8Int32X(vp *map[int8]int32, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24104,11 +19929,8 @@ func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]int32, containerLen)
-		} else {
-			v = make(map[int8]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int8]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24122,23 +19944,19 @@ func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]int64)
 		v, changed := fastpathTV.DecMapInt8Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24159,7 +19977,7 @@ func (f fastpathT) DecMapInt8Int64X(vp *map[int8]int64, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24169,11 +19987,8 @@ func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]int64, containerLen)
-		} else {
-			v = make(map[int8]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24187,23 +20002,19 @@ func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]float32)
 		v, changed := fastpathTV.DecMapInt8Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24224,7 +20035,7 @@ func (f fastpathT) DecMapInt8Float32X(vp *map[int8]float32, checkNil bool, d *De
 func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24234,11 +20045,8 @@ func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]float32, containerLen)
-		} else {
-			v = make(map[int8]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int8]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24252,23 +20060,19 @@ func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]float64)
 		v, changed := fastpathTV.DecMapInt8Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24289,7 +20093,7 @@ func (f fastpathT) DecMapInt8Float64X(vp *map[int8]float64, checkNil bool, d *De
 func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24299,11 +20103,8 @@ func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]float64, containerLen)
-		} else {
-			v = make(map[int8]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int8]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24317,23 +20118,19 @@ func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt8BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt8BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int8]bool)
 		v, changed := fastpathTV.DecMapInt8BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24354,7 +20151,7 @@ func (f fastpathT) DecMapInt8BoolX(vp *map[int8]bool, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int8]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24364,11 +20161,8 @@ func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int8]bool, containerLen)
-		} else {
-			v = make(map[int8]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[int8]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24382,23 +20176,19 @@ func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int8(dd.DecodeInt(8))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]interface{})
 		v, changed := fastpathTV.DecMapInt16IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24419,7 +20209,7 @@ func (f fastpathT) DecMapInt16IntfX(vp *map[int16]interface{}, checkNil bool, d 
 func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24429,11 +20219,8 @@ func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canC
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]interface{}, containerLen)
-		} else {
-			v = make(map[int16]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[int16]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24448,11 +20235,7 @@ func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -24460,12 +20243,12 @@ func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canC
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]string)
 		v, changed := fastpathTV.DecMapInt16StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24486,7 +20269,7 @@ func (f fastpathT) DecMapInt16StringX(vp *map[int16]string, checkNil bool, d *De
 func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24496,11 +20279,8 @@ func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]string, containerLen)
-		} else {
-			v = make(map[int16]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		v = make(map[int16]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24514,23 +20294,19 @@ func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]uint)
 		v, changed := fastpathTV.DecMapInt16UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24551,7 +20327,7 @@ func (f fastpathT) DecMapInt16UintX(vp *map[int16]uint, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24561,11 +20337,8 @@ func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]uint, containerLen)
-		} else {
-			v = make(map[int16]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24579,23 +20352,19 @@ func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]uint8)
 		v, changed := fastpathTV.DecMapInt16Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24616,7 +20385,7 @@ func (f fastpathT) DecMapInt16Uint8X(vp *map[int16]uint8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24626,11 +20395,8 @@ func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]uint8, containerLen)
-		} else {
-			v = make(map[int16]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int16]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24644,23 +20410,19 @@ func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]uint16)
 		v, changed := fastpathTV.DecMapInt16Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24681,7 +20443,7 @@ func (f fastpathT) DecMapInt16Uint16X(vp *map[int16]uint16, checkNil bool, d *De
 func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24691,11 +20453,8 @@ func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]uint16, containerLen)
-		} else {
-			v = make(map[int16]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		v = make(map[int16]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24709,23 +20468,19 @@ func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]uint32)
 		v, changed := fastpathTV.DecMapInt16Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24746,7 +20501,7 @@ func (f fastpathT) DecMapInt16Uint32X(vp *map[int16]uint32, checkNil bool, d *De
 func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24756,11 +20511,8 @@ func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]uint32, containerLen)
-		} else {
-			v = make(map[int16]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int16]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24774,23 +20526,19 @@ func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]uint64)
 		v, changed := fastpathTV.DecMapInt16Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24811,7 +20559,7 @@ func (f fastpathT) DecMapInt16Uint64X(vp *map[int16]uint64, checkNil bool, d *De
 func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24821,11 +20569,8 @@ func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]uint64, containerLen)
-		} else {
-			v = make(map[int16]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24839,23 +20584,19 @@ func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]int)
 		v, changed := fastpathTV.DecMapInt16IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24876,7 +20617,7 @@ func (f fastpathT) DecMapInt16IntX(vp *map[int16]int, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24886,11 +20627,8 @@ func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]int, containerLen)
-		} else {
-			v = make(map[int16]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24904,23 +20642,19 @@ func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]int8)
 		v, changed := fastpathTV.DecMapInt16Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -24941,7 +20675,7 @@ func (f fastpathT) DecMapInt16Int8X(vp *map[int16]int8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -24951,11 +20685,8 @@ func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]int8, containerLen)
-		} else {
-			v = make(map[int16]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int16]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -24969,23 +20700,19 @@ func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]int16)
 		v, changed := fastpathTV.DecMapInt16Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25006,7 +20733,7 @@ func (f fastpathT) DecMapInt16Int16X(vp *map[int16]int16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25016,11 +20743,8 @@ func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]int16, containerLen)
-		} else {
-			v = make(map[int16]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		v = make(map[int16]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25034,23 +20758,19 @@ func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]int32)
 		v, changed := fastpathTV.DecMapInt16Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25071,7 +20791,7 @@ func (f fastpathT) DecMapInt16Int32X(vp *map[int16]int32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25081,11 +20801,8 @@ func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]int32, containerLen)
-		} else {
-			v = make(map[int16]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int16]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25099,23 +20816,19 @@ func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]int64)
 		v, changed := fastpathTV.DecMapInt16Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25136,7 +20849,7 @@ func (f fastpathT) DecMapInt16Int64X(vp *map[int16]int64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25146,11 +20859,8 @@ func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]int64, containerLen)
-		} else {
-			v = make(map[int16]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25164,23 +20874,19 @@ func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]float32)
 		v, changed := fastpathTV.DecMapInt16Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25201,7 +20907,7 @@ func (f fastpathT) DecMapInt16Float32X(vp *map[int16]float32, checkNil bool, d *
 func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25211,11 +20917,8 @@ func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]float32, containerLen)
-		} else {
-			v = make(map[int16]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int16]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25229,23 +20932,19 @@ func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]float64)
 		v, changed := fastpathTV.DecMapInt16Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25266,7 +20965,7 @@ func (f fastpathT) DecMapInt16Float64X(vp *map[int16]float64, checkNil bool, d *
 func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25276,11 +20975,8 @@ func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]float64, containerLen)
-		} else {
-			v = make(map[int16]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int16]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25294,23 +20990,19 @@ func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt16BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt16BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int16]bool)
 		v, changed := fastpathTV.DecMapInt16BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25331,7 +21023,7 @@ func (f fastpathT) DecMapInt16BoolX(vp *map[int16]bool, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int16]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25341,11 +21033,8 @@ func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int16]bool, containerLen)
-		} else {
-			v = make(map[int16]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[int16]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25359,23 +21048,19 @@ func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int16(dd.DecodeInt(16))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]interface{})
 		v, changed := fastpathTV.DecMapInt32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25396,7 +21081,7 @@ func (f fastpathT) DecMapInt32IntfX(vp *map[int32]interface{}, checkNil bool, d 
 func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25406,11 +21091,8 @@ func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canC
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]interface{}, containerLen)
-		} else {
-			v = make(map[int32]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[int32]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25425,11 +21107,7 @@ func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -25437,12 +21115,12 @@ func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canC
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]string)
 		v, changed := fastpathTV.DecMapInt32StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25463,7 +21141,7 @@ func (f fastpathT) DecMapInt32StringX(vp *map[int32]string, checkNil bool, d *De
 func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25473,11 +21151,8 @@ func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]string, containerLen)
-		} else {
-			v = make(map[int32]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		v = make(map[int32]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25491,23 +21166,19 @@ func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]uint)
 		v, changed := fastpathTV.DecMapInt32UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25528,7 +21199,7 @@ func (f fastpathT) DecMapInt32UintX(vp *map[int32]uint, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25538,11 +21209,8 @@ func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]uint, containerLen)
-		} else {
-			v = make(map[int32]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25556,23 +21224,19 @@ func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]uint8)
 		v, changed := fastpathTV.DecMapInt32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25593,7 +21257,7 @@ func (f fastpathT) DecMapInt32Uint8X(vp *map[int32]uint8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25603,11 +21267,8 @@ func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]uint8, containerLen)
-		} else {
-			v = make(map[int32]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int32]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25621,23 +21282,19 @@ func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]uint16)
 		v, changed := fastpathTV.DecMapInt32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25658,7 +21315,7 @@ func (f fastpathT) DecMapInt32Uint16X(vp *map[int32]uint16, checkNil bool, d *De
 func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25668,11 +21325,8 @@ func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]uint16, containerLen)
-		} else {
-			v = make(map[int32]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int32]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25686,23 +21340,19 @@ func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]uint32)
 		v, changed := fastpathTV.DecMapInt32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25723,7 +21373,7 @@ func (f fastpathT) DecMapInt32Uint32X(vp *map[int32]uint32, checkNil bool, d *De
 func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25733,11 +21383,8 @@ func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]uint32, containerLen)
-		} else {
-			v = make(map[int32]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[int32]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25751,23 +21398,19 @@ func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]uint64)
 		v, changed := fastpathTV.DecMapInt32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25788,7 +21431,7 @@ func (f fastpathT) DecMapInt32Uint64X(vp *map[int32]uint64, checkNil bool, d *De
 func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25798,11 +21441,8 @@ func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]uint64, containerLen)
-		} else {
-			v = make(map[int32]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25816,23 +21456,19 @@ func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]int)
 		v, changed := fastpathTV.DecMapInt32IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25853,7 +21489,7 @@ func (f fastpathT) DecMapInt32IntX(vp *map[int32]int, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25863,11 +21499,8 @@ func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]int, containerLen)
-		} else {
-			v = make(map[int32]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25881,23 +21514,19 @@ func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]int8)
 		v, changed := fastpathTV.DecMapInt32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25918,7 +21547,7 @@ func (f fastpathT) DecMapInt32Int8X(vp *map[int32]int8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25928,11 +21557,8 @@ func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]int8, containerLen)
-		} else {
-			v = make(map[int32]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int32]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -25946,23 +21572,19 @@ func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]int16)
 		v, changed := fastpathTV.DecMapInt32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -25983,7 +21605,7 @@ func (f fastpathT) DecMapInt32Int16X(vp *map[int32]int16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -25993,11 +21615,8 @@ func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]int16, containerLen)
-		} else {
-			v = make(map[int32]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		v = make(map[int32]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26011,23 +21630,19 @@ func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]int32)
 		v, changed := fastpathTV.DecMapInt32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26048,7 +21663,7 @@ func (f fastpathT) DecMapInt32Int32X(vp *map[int32]int32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26058,11 +21673,8 @@ func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]int32, containerLen)
-		} else {
-			v = make(map[int32]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[int32]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26076,23 +21688,19 @@ func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]int64)
 		v, changed := fastpathTV.DecMapInt32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26113,7 +21721,7 @@ func (f fastpathT) DecMapInt32Int64X(vp *map[int32]int64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26123,11 +21731,8 @@ func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]int64, containerLen)
-		} else {
-			v = make(map[int32]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26141,23 +21746,19 @@ func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]float32)
 		v, changed := fastpathTV.DecMapInt32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26178,7 +21779,7 @@ func (f fastpathT) DecMapInt32Float32X(vp *map[int32]float32, checkNil bool, d *
 func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26188,11 +21789,8 @@ func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]float32, containerLen)
-		} else {
-			v = make(map[int32]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		v = make(map[int32]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26206,23 +21804,19 @@ func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]float64)
 		v, changed := fastpathTV.DecMapInt32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26243,7 +21837,7 @@ func (f fastpathT) DecMapInt32Float64X(vp *map[int32]float64, checkNil bool, d *
 func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26253,11 +21847,8 @@ func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]float64, containerLen)
-		} else {
-			v = make(map[int32]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int32]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26271,23 +21862,19 @@ func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt32BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt32BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int32]bool)
 		v, changed := fastpathTV.DecMapInt32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26308,7 +21895,7 @@ func (f fastpathT) DecMapInt32BoolX(vp *map[int32]bool, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int32]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26318,11 +21905,8 @@ func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int32]bool, containerLen)
-		} else {
-			v = make(map[int32]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[int32]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26336,23 +21920,19 @@ func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := int32(dd.DecodeInt(32))
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64IntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]interface{})
 		v, changed := fastpathTV.DecMapInt64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26373,7 +21953,7 @@ func (f fastpathT) DecMapInt64IntfX(vp *map[int64]interface{}, checkNil bool, d 
 func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26383,11 +21963,8 @@ func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canC
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]interface{}, containerLen)
-		} else {
-			v = make(map[int64]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[int64]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26402,11 +21979,7 @@ func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canC
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -26414,12 +21987,12 @@ func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canC
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64StringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64StringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]string)
 		v, changed := fastpathTV.DecMapInt64StringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26440,7 +22013,7 @@ func (f fastpathT) DecMapInt64StringX(vp *map[int64]string, checkNil bool, d *De
 func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26450,11 +22023,8 @@ func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]string, containerLen)
-		} else {
-			v = make(map[int64]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		v = make(map[int64]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26468,23 +22038,19 @@ func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64UintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64UintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]uint)
 		v, changed := fastpathTV.DecMapInt64UintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26505,7 +22071,7 @@ func (f fastpathT) DecMapInt64UintX(vp *map[int64]uint, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26515,11 +22081,8 @@ func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]uint, containerLen)
-		} else {
-			v = make(map[int64]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26533,23 +22096,19 @@ func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Uint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]uint8)
 		v, changed := fastpathTV.DecMapInt64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26570,7 +22129,7 @@ func (f fastpathT) DecMapInt64Uint8X(vp *map[int64]uint8, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26580,11 +22139,8 @@ func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]uint8, containerLen)
-		} else {
-			v = make(map[int64]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int64]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26598,23 +22154,19 @@ func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Uint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]uint16)
 		v, changed := fastpathTV.DecMapInt64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26635,7 +22187,7 @@ func (f fastpathT) DecMapInt64Uint16X(vp *map[int64]uint16, checkNil bool, d *De
 func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26645,11 +22197,8 @@ func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]uint16, containerLen)
-		} else {
-			v = make(map[int64]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int64]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26663,23 +22212,19 @@ func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Uint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]uint32)
 		v, changed := fastpathTV.DecMapInt64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26700,7 +22245,7 @@ func (f fastpathT) DecMapInt64Uint32X(vp *map[int64]uint32, checkNil bool, d *De
 func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26710,11 +22255,8 @@ func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]uint32, containerLen)
-		} else {
-			v = make(map[int64]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int64]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26728,23 +22270,19 @@ func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Uint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]uint64)
 		v, changed := fastpathTV.DecMapInt64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26765,7 +22303,7 @@ func (f fastpathT) DecMapInt64Uint64X(vp *map[int64]uint64, checkNil bool, d *De
 func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26775,11 +22313,8 @@ func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]uint64, containerLen)
-		} else {
-			v = make(map[int64]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26793,23 +22328,19 @@ func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64IntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64IntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]int)
 		v, changed := fastpathTV.DecMapInt64IntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26830,7 +22361,7 @@ func (f fastpathT) DecMapInt64IntX(vp *map[int64]int, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26840,11 +22371,8 @@ func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]int, containerLen)
-		} else {
-			v = make(map[int64]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26858,23 +22386,19 @@ func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Int8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]int8)
 		v, changed := fastpathTV.DecMapInt64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26895,7 +22419,7 @@ func (f fastpathT) DecMapInt64Int8X(vp *map[int64]int8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26905,11 +22429,8 @@ func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]int8, containerLen)
-		} else {
-			v = make(map[int64]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int64]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26923,23 +22444,19 @@ func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Int16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]int16)
 		v, changed := fastpathTV.DecMapInt64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -26960,7 +22477,7 @@ func (f fastpathT) DecMapInt64Int16X(vp *map[int64]int16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -26970,11 +22487,8 @@ func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]int16, containerLen)
-		} else {
-			v = make(map[int64]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		v = make(map[int64]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -26988,23 +22502,19 @@ func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Int32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]int32)
 		v, changed := fastpathTV.DecMapInt64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27025,7 +22535,7 @@ func (f fastpathT) DecMapInt64Int32X(vp *map[int64]int32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27035,11 +22545,8 @@ func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]int32, containerLen)
-		} else {
-			v = make(map[int64]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int64]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27053,23 +22560,19 @@ func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Int64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]int64)
 		v, changed := fastpathTV.DecMapInt64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27090,7 +22593,7 @@ func (f fastpathT) DecMapInt64Int64X(vp *map[int64]int64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27100,11 +22603,8 @@ func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]int64, containerLen)
-		} else {
-			v = make(map[int64]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27118,23 +22618,19 @@ func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Float32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]float32)
 		v, changed := fastpathTV.DecMapInt64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27155,7 +22651,7 @@ func (f fastpathT) DecMapInt64Float32X(vp *map[int64]float32, checkNil bool, d *
 func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27165,11 +22661,8 @@ func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]float32, containerLen)
-		} else {
-			v = make(map[int64]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		v = make(map[int64]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27183,23 +22676,19 @@ func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64Float64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]float64)
 		v, changed := fastpathTV.DecMapInt64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27220,7 +22709,7 @@ func (f fastpathT) DecMapInt64Float64X(vp *map[int64]float64, checkNil bool, d *
 func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27230,11 +22719,8 @@ func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canCh
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]float64, containerLen)
-		} else {
-			v = make(map[int64]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		v = make(map[int64]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27248,23 +22734,19 @@ func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canCh
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapInt64BoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapInt64BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[int64]bool)
 		v, changed := fastpathTV.DecMapInt64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27285,7 +22767,7 @@ func (f fastpathT) DecMapInt64BoolX(vp *map[int64]bool, checkNil bool, d *Decode
 func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[int64]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27295,11 +22777,8 @@ func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[int64]bool, containerLen)
-		} else {
-			v = make(map[int64]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[int64]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27313,23 +22792,19 @@ func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeInt(64)
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolIntfR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]interface{})
 		v, changed := fastpathTV.DecMapBoolIntfV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27350,7 +22825,7 @@ func (f fastpathT) DecMapBoolIntfX(vp *map[bool]interface{}, checkNil bool, d *D
 func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]interface{}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27360,11 +22835,8 @@ func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canCha
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]interface{}, containerLen)
-		} else {
-			v = make(map[bool]interface{}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[bool]interface{}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27379,11 +22851,7 @@ func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canCha
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			d.decode(&mv)
 
@@ -27391,12 +22859,12 @@ func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canCha
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolStringR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolStringR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]string)
 		v, changed := fastpathTV.DecMapBoolStringV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27417,7 +22885,7 @@ func (f fastpathT) DecMapBoolStringX(vp *map[bool]string, checkNil bool, d *Deco
 func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]string, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27427,11 +22895,8 @@ func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]string, containerLen)
-		} else {
-			v = make(map[bool]string) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		v = make(map[bool]string, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27445,23 +22910,19 @@ func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeString()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolUintR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolUintR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]uint)
 		v, changed := fastpathTV.DecMapBoolUintV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27482,7 +22943,7 @@ func (f fastpathT) DecMapBoolUintX(vp *map[bool]uint, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27492,11 +22953,8 @@ func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]uint, containerLen)
-		} else {
-			v = make(map[bool]uint) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]uint, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27510,23 +22968,19 @@ func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint(dd.DecodeUint(uintBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolUint8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]uint8)
 		v, changed := fastpathTV.DecMapBoolUint8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27547,7 +23001,7 @@ func (f fastpathT) DecMapBoolUint8X(vp *map[bool]uint8, checkNil bool, d *Decode
 func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27557,11 +23011,8 @@ func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]uint8, containerLen)
-		} else {
-			v = make(map[bool]uint8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[bool]uint8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27575,23 +23026,19 @@ func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint8(dd.DecodeUint(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolUint16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]uint16)
 		v, changed := fastpathTV.DecMapBoolUint16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27612,7 +23059,7 @@ func (f fastpathT) DecMapBoolUint16X(vp *map[bool]uint16, checkNil bool, d *Deco
 func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27622,11 +23069,8 @@ func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]uint16, containerLen)
-		} else {
-			v = make(map[bool]uint16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[bool]uint16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27640,23 +23084,19 @@ func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint16(dd.DecodeUint(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolUint32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]uint32)
 		v, changed := fastpathTV.DecMapBoolUint32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27677,7 +23117,7 @@ func (f fastpathT) DecMapBoolUint32X(vp *map[bool]uint32, checkNil bool, d *Deco
 func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27687,11 +23127,8 @@ func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]uint32, containerLen)
-		} else {
-			v = make(map[bool]uint32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[bool]uint32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27705,23 +23142,19 @@ func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = uint32(dd.DecodeUint(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolUint64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]uint64)
 		v, changed := fastpathTV.DecMapBoolUint64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27742,7 +23175,7 @@ func (f fastpathT) DecMapBoolUint64X(vp *map[bool]uint64, checkNil bool, d *Deco
 func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]uint64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27752,11 +23185,8 @@ func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]uint64, containerLen)
-		} else {
-			v = make(map[bool]uint64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]uint64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27770,23 +23200,19 @@ func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeUint(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolIntR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolIntR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]int)
 		v, changed := fastpathTV.DecMapBoolIntV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27807,7 +23233,7 @@ func (f fastpathT) DecMapBoolIntX(vp *map[bool]int, checkNil bool, d *Decoder) {
 func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27817,11 +23243,8 @@ func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]int, containerLen)
-		} else {
-			v = make(map[bool]int) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]int, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27835,23 +23258,19 @@ func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int(dd.DecodeInt(intBitsize))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolInt8R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]int8)
 		v, changed := fastpathTV.DecMapBoolInt8V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27872,7 +23291,7 @@ func (f fastpathT) DecMapBoolInt8X(vp *map[bool]int8, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int8, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27882,11 +23301,8 @@ func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]int8, containerLen)
-		} else {
-			v = make(map[bool]int8) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[bool]int8, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27900,23 +23316,19 @@ func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int8(dd.DecodeInt(8))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolInt16R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]int16)
 		v, changed := fastpathTV.DecMapBoolInt16V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -27937,7 +23349,7 @@ func (f fastpathT) DecMapBoolInt16X(vp *map[bool]int16, checkNil bool, d *Decode
 func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int16, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -27947,11 +23359,8 @@ func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]int16, containerLen)
-		} else {
-			v = make(map[bool]int16) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		v = make(map[bool]int16, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -27965,23 +23374,19 @@ func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int16(dd.DecodeInt(16))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolInt32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]int32)
 		v, changed := fastpathTV.DecMapBoolInt32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -28002,7 +23407,7 @@ func (f fastpathT) DecMapBoolInt32X(vp *map[bool]int32, checkNil bool, d *Decode
 func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -28012,11 +23417,8 @@ func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]int32, containerLen)
-		} else {
-			v = make(map[bool]int32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[bool]int32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -28030,23 +23432,19 @@ func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = int32(dd.DecodeInt(32))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolInt64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]int64)
 		v, changed := fastpathTV.DecMapBoolInt64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -28067,7 +23465,7 @@ func (f fastpathT) DecMapBoolInt64X(vp *map[bool]int64, checkNil bool, d *Decode
 func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]int64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -28077,11 +23475,8 @@ func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange b
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]int64, containerLen)
-		} else {
-			v = make(map[bool]int64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]int64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -28095,23 +23490,19 @@ func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange b
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeInt(64)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolFloat32R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]float32)
 		v, changed := fastpathTV.DecMapBoolFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -28132,7 +23523,7 @@ func (f fastpathT) DecMapBoolFloat32X(vp *map[bool]float32, checkNil bool, d *De
 func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]float32, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -28142,11 +23533,8 @@ func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]float32, containerLen)
-		} else {
-			v = make(map[bool]float32) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		v = make(map[bool]float32, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -28160,23 +23548,19 @@ func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = float32(dd.DecodeFloat(true))
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolFloat64R(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]float64)
 		v, changed := fastpathTV.DecMapBoolFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -28197,7 +23581,7 @@ func (f fastpathT) DecMapBoolFloat64X(vp *map[bool]float64, checkNil bool, d *De
 func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]float64, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -28207,11 +23591,8 @@ func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChan
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]float64, containerLen)
-		} else {
-			v = make(map[bool]float64) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		v = make(map[bool]float64, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -28225,23 +23606,19 @@ func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChan
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeFloat(false)
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }
 
-func (f decFnInfo) fastpathDecMapBoolBoolR(rv reflect.Value) {
+func (f *decFnInfo) fastpathDecMapBoolBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[bool]bool)
 		v, changed := fastpathTV.DecMapBoolBoolV(*vp, fastpathCheckNilFalse, true, f.d)
@@ -28262,7 +23639,7 @@ func (f fastpathT) DecMapBoolBoolX(vp *map[bool]bool, checkNil bool, d *Decoder)
 func (_ fastpathT) DecMapBoolBoolV(v map[bool]bool, checkNil bool, canChange bool,
 	d *Decoder) (_ map[bool]bool, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -28272,11 +23649,8 @@ func (_ fastpathT) DecMapBoolBoolV(v map[bool]bool, checkNil bool, canChange boo
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[bool]bool, containerLen)
-		} else {
-			v = make(map[bool]bool) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		v = make(map[bool]bool, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -28290,18 +23664,14 @@ func (_ fastpathT) DecMapBoolBoolV(v map[bool]bool, checkNil bool, canChange boo
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			mk := dd.DecodeBool()
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			mv = dd.DecodeBool()
 			if v != nil {
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/fast-path.go.tmpl
@@ -48,8 +48,8 @@ var fastpathTV fastpathT
 type fastpathE struct {
 	rtid uintptr
 	rt reflect.Type 
-	encfn func(encFnInfo, reflect.Value)
-	decfn func(decFnInfo, reflect.Value)
+	encfn func(*encFnInfo, reflect.Value)
+	decfn func(*decFnInfo, reflect.Value)
 }
 
 type fastpathA [{{ .FastpathLen }}]fastpathE
@@ -85,7 +85,7 @@ func init() {
 		return
 	}
 	i := 0
-	fn := func(v interface{}, fe func(encFnInfo, reflect.Value), fd func(decFnInfo, reflect.Value)) (f fastpathE) {
+	fn := func(v interface{}, fe func(*encFnInfo, reflect.Value), fd func(*decFnInfo, reflect.Value)) (f fastpathE) {
 		xrt := reflect.TypeOf(v)
 		xptr := reflect.ValueOf(xrt).Pointer()
 		fastpathAV[i] = fastpathE{xptr, xrt, fe, fd}
@@ -93,11 +93,11 @@ func init() {
 		return
 	}
 	
-	{{range .Values}}{{if not .Primitive}}{{if .Slice }}
-	fn([]{{ .Elem }}(nil), (encFnInfo).{{ .MethodNamePfx "fastpathEnc" false }}R, (decFnInfo).{{ .MethodNamePfx "fastpathDec" false }}R){{end}}{{end}}{{end}}
+	{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
+	fn([]{{ .Elem }}(nil), (*encFnInfo).{{ .MethodNamePfx "fastpathEnc" false }}R, (*decFnInfo).{{ .MethodNamePfx "fastpathDec" false }}R){{end}}{{end}}{{end}}
 	
-	{{range .Values}}{{if not .Primitive}}{{if not .Slice }}
-	fn(map[{{ .MapKey }}]{{ .Elem }}(nil), (encFnInfo).{{ .MethodNamePfx "fastpathEnc" false }}R, (decFnInfo).{{ .MethodNamePfx "fastpathDec" false }}R){{end}}{{end}}{{end}}
+	{{range .Values}}{{if not .Primitive}}{{if .MapKey }}
+	fn(map[{{ .MapKey }}]{{ .Elem }}(nil), (*encFnInfo).{{ .MethodNamePfx "fastpathEnc" false }}R, (*decFnInfo).{{ .MethodNamePfx "fastpathDec" false }}R){{end}}{{end}}{{end}}
 	
 	sort.Sort(fastpathAslice(fastpathAV[:]))
 }
@@ -107,10 +107,10 @@ func init() {
 // -- -- fast path type switch
 func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool {
 	switch v := iv.(type) {
-{{range .Values}}{{if not .Primitive}}{{if .Slice }}
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
 	case []{{ .Elem }}:{{else}}
 	case map[{{ .MapKey }}]{{ .Elem }}:{{end}}
-		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(v, fastpathCheckNilTrue, e){{if .Slice }}
+		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(v, fastpathCheckNilTrue, e){{if not .MapKey }}
 	case *[]{{ .Elem }}:{{else}}
 	case *map[{{ .MapKey }}]{{ .Elem }}:{{end}}
 		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(*v, fastpathCheckNilTrue, e)
@@ -123,7 +123,7 @@ func fastpathEncodeTypeSwitch(iv interface{}, e *Encoder) bool {
 
 func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool {
 	switch v := iv.(type) {
-{{range .Values}}{{if not .Primitive}}{{if .Slice }}
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
 	case []{{ .Elem }}:
 		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(v, fastpathCheckNilTrue, e)
 	case *[]{{ .Elem }}:
@@ -137,7 +137,7 @@ func fastpathEncodeTypeSwitchSlice(iv interface{}, e *Encoder) bool {
 
 func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
 	switch v := iv.(type) {
-{{range .Values}}{{if not .Primitive}}{{if not .Slice }}
+{{range .Values}}{{if not .Primitive}}{{if .MapKey }}
 	case map[{{ .MapKey }}]{{ .Elem }}:
 		fastpathTV.{{ .MethodNamePfx "Enc" false }}V(v, fastpathCheckNilTrue, e)
 	case *map[{{ .MapKey }}]{{ .Elem }}:
@@ -150,9 +150,9 @@ func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
 }
 
 // -- -- fast path functions
-{{range .Values}}{{if not .Primitive}}{{if .Slice }} 
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }} 
 
-func (f encFnInfo) {{ .MethodNamePfx "fastpathEnc" false }}R(rv reflect.Value) {
+func (f *encFnInfo) {{ .MethodNamePfx "fastpathEnc" false }}R(rv reflect.Value) {
 	fastpathTV.{{ .MethodNamePfx "Enc" false }}V(rv.Interface().([]{{ .Elem }}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v []{{ .Elem }}, checkNil bool, e *Encoder) {
@@ -162,26 +162,17 @@ func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v []{{ .Elem }}, checkNil b
 		return
 	}
 	ee.EncodeArrayStart(len(v))
-	if e.be {
-		for _, v2 := range v {
-			{{ encmd .Elem "v2"}}
-		}
-	} else {
-		for j, v2 := range v {
-			if j > 0 {
-				ee.EncodeArrayEntrySeparator()
-			}
-			{{ encmd .Elem "v2"}}
-		}
-		ee.EncodeArrayEnd()
+	for _, v2 := range v {
+		{{ encmd .Elem "v2"}}
 	}
+	ee.EncodeEnd()
 }
 
 {{end}}{{end}}{{end}}
 
-{{range .Values}}{{if not .Primitive}}{{if not .Slice }}
+{{range .Values}}{{if not .Primitive}}{{if .MapKey }}
 
-func (f encFnInfo) {{ .MethodNamePfx "fastpathEnc" false }}R(rv reflect.Value) {
+func (f *encFnInfo) {{ .MethodNamePfx "fastpathEnc" false }}R(rv reflect.Value) {
 	fastpathTV.{{ .MethodNamePfx "Enc" false }}V(rv.Interface().(map[{{ .MapKey }}]{{ .Elem }}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v map[{{ .MapKey }}]{{ .Elem }}, checkNil bool, e *Encoder) {
@@ -192,32 +183,15 @@ func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v map[{{ .MapKey }}]{{ .Ele
 	}
 	ee.EncodeMapStart(len(v))
 	{{if eq .MapKey "string"}}asSymbols := e.h.AsSymbols&AsSymbolMapStringKeysFlag != 0{{end}}
-	if e.be {
-		for k2, v2 := range v {
-			{{if eq .MapKey "string"}}if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}{{else}}{{ encmd .MapKey "k2"}}{{end}}
-			{{ encmd .Elem "v2"}}
-		}
-	} else {
-		j := 0
-		for k2, v2 := range v {
-			if j > 0 {
-				ee.EncodeMapEntrySeparator()
-			}
-			{{if eq .MapKey "string"}}if asSymbols {
-				ee.EncodeSymbol(k2)
-			} else {
-				ee.EncodeString(c_UTF8, k2)
-			}{{else}}{{ encmd .MapKey "k2"}}{{end}}
-			ee.EncodeMapKVSeparator()
-			{{ encmd .Elem "v2"}}
-			j++
-		}
-		ee.EncodeMapEnd()
+	for k2, v2 := range v {
+		{{if eq .MapKey "string"}}if asSymbols {
+			ee.EncodeSymbol(k2)
+		} else {
+			ee.EncodeString(c_UTF8, k2)
+		}{{else}}{{ encmd .MapKey "k2"}}{{end}}
+		{{ encmd .Elem "v2"}}
 	}
+	ee.EncodeEnd()
 }
 
 {{end}}{{end}}{{end}}
@@ -227,10 +201,10 @@ func (_ fastpathT) {{ .MethodNamePfx "Enc" false }}V(v map[{{ .MapKey }}]{{ .Ele
 // -- -- fast path type switch
 func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
 	switch v := iv.(type) {
-{{range .Values}}{{if not .Primitive}}{{if .Slice }}
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
 	case []{{ .Elem }}:{{else}}
 	case map[{{ .MapKey }}]{{ .Elem }}:{{end}}
-		fastpathTV.{{ .MethodNamePfx "Dec" false }}V(v, fastpathCheckNilFalse, false, d){{if .Slice }}
+		fastpathTV.{{ .MethodNamePfx "Dec" false }}V(v, fastpathCheckNilFalse, false, d){{if not .MapKey }}
 	case *[]{{ .Elem }}:{{else}}
 	case *map[{{ .MapKey }}]{{ .Elem }}:{{end}}
 		v2, changed2 := fastpathTV.{{ .MethodNamePfx "Dec" false }}V(*v, fastpathCheckNilFalse, true, d)
@@ -245,16 +219,16 @@ func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
 }
 
 // -- -- fast path functions
-{{range .Values}}{{if not .Primitive}}{{if .Slice }}
+{{range .Values}}{{if not .Primitive}}{{if not .MapKey }}
 {{/*
 Slices can change if they 
 - did not come from an array
 - are addressable (from a ptr)
 - are settable (e.g. contained in an interface{})
 */}}
-func (f decFnInfo) {{ .MethodNamePfx "fastpathDec" false }}R(rv reflect.Value) { 
+func (f *decFnInfo) {{ .MethodNamePfx "fastpathDec" false }}R(rv reflect.Value) { 
 	array := f.seq == seqTypeArray
-	if !array && rv.CanAddr() { // CanSet => CanAddr + Exported 
+	if !array && rv.CanAddr() { {{/* // CanSet => CanAddr + Exported */}}
 		vp := rv.Addr().Interface().(*[]{{ .Elem }})
 		v, changed := fastpathTV.{{ .MethodNamePfx "Dec" false }}V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
@@ -275,7 +249,7 @@ func (f fastpathT) {{ .MethodNamePfx "Dec" false }}X(vp *[]{{ .Elem }}, checkNil
 func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil bool, canChange bool, 
 	d *Decoder) (_ []{{ .Elem }}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil()
+	{{/* // if dd.isContainerType(valueTypeNil) { dd.TryDecodeAsNil() */}}
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true 
@@ -284,47 +258,59 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil b
 	}
 
 	slh, containerLenS := d.decSliceHelperStart()
+    x2read := containerLenS
+    var xtrunc bool 
 	if canChange && v == nil {
-		if containerLenS <= 0 {
-			v = []{{ .Elem }}{}
-		} else {
-			v = make([]{{ .Elem }}, containerLenS, containerLenS)
+		var xlen int 
+		if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, {{ .Size }}); xtrunc {
+			x2read = xlen
 		}
+		v = make([]{{ .Elem }}, xlen)
 		changed = true
-	}
+	} 
 	if containerLenS == 0 {
 		if canChange && len(v) != 0 {
 			v = v[:0]
 			changed = true 
 		}{{/*
-		// slh.End() // dd.ReadArrayEnd()
+			// slh.End() // dd.ReadArrayEnd()
 		*/}}
 		return v, changed 
 	}
 	
-	// for j := 0; j < containerLenS; j++ {
+	{{/* // for j := 0; j < containerLenS; j++ { */}}
 	if containerLenS > 0 {
-		decLen := containerLenS
 		if containerLenS > cap(v) {
-			if canChange {
-				s := make([]{{ .Elem }}, containerLenS, containerLenS)
+			if canChange { {{/*
+				// fast-path is for "basic" immutable types, so no need to copy them over
+				// s := make([]{{ .Elem }}, decInferLen(containerLenS, d.h.MaxInitLen))
 				// copy(s, v[:cap(v)])
-				v = s
+				// v = s */}}
+				var xlen int 
+                if xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, {{ .Size }}); xtrunc {
+					x2read = xlen
+				}
+                v = make([]{{ .Elem }}, xlen)
 				changed = true
 			} else {
 				d.arrayCannotExpand(len(v), containerLenS)
-				decLen = len(v)
+				x2read = len(v)
 			}
 		} else if containerLenS != len(v) {
 			v = v[:containerLenS]
 			changed = true
 		}
-		// all checks done. cannot go past len.
+		{{/* // all checks done. cannot go past len. */}}
 		j := 0
-		for ; j < decLen; j++ { 
+		for ; j < x2read; j++ { 
 			{{ if eq .Elem "interface{}" }}d.decode(&v[j]){{ else }}v[j] = {{ decmd .Elem }}{{ end }}
 		}
-		if !canChange {
+		if xtrunc { {{/* // means canChange=true, changed=true already. */}}
+			for ; j < containerLenS; j++ {
+				v = append(v, {{ zerocmd .Elem }})
+				{{ if eq .Elem "interface{}" }}d.decode(&v[j]){{ else }}v[j] = {{ decmd .Elem }}{{ end }}
+			}
+		} else if !canChange {
 			for ; j < containerLenS; j++ { 
 				d.swallow()
 			}
@@ -340,10 +326,7 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil b
 					d.arrayCannotExpand(len(v), j+1)
 				}
 			} 
-			if j > 0 {
-				slh.Sep(j)
-			}
-			if j < len(v) { // all checks done. cannot go past len.
+			if j < len(v) { {{/* // all checks done. cannot go past len. */}}
 				{{ if eq .Elem "interface{}" }}d.decode(&v[j])
 				{{ else }}v[j] = {{ decmd .Elem }}{{ end }}
 			} else {
@@ -358,13 +341,13 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v []{{ .Elem }}, checkNil b
 {{end}}{{end}}{{end}}
 
 
-{{range .Values}}{{if not .Primitive}}{{if not .Slice }}
+{{range .Values}}{{if not .Primitive}}{{if .MapKey }}
 {{/*
 Maps can change if they are
 - addressable (from a ptr)
 - settable (e.g. contained in an interface{})
 */}}
-func (f decFnInfo) {{ .MethodNamePfx "fastpathDec" false }}R(rv reflect.Value) { 
+func (f *decFnInfo) {{ .MethodNamePfx "fastpathDec" false }}R(rv reflect.Value) { 
 	if rv.CanAddr() {
 		vp := rv.Addr().Interface().(*map[{{ .MapKey }}]{{ .Elem }})
 		v, changed := fastpathTV.{{ .MethodNamePfx "Dec" false }}V(*vp, fastpathCheckNilFalse, true, f.d)
@@ -385,7 +368,7 @@ func (f fastpathT) {{ .MethodNamePfx "Dec" false }}X(vp *map[{{ .MapKey }}]{{ .E
 func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Elem }}, checkNil bool, canChange bool, 
 	d *Decoder) (_ map[{{ .MapKey }}]{{ .Elem }}, changed bool) {
 	dd := d.d
-	// if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil()
+	{{/* // if dd.isContainerType(valueTypeNil) {dd.TryDecodeAsNil() */}}
 	if checkNil && dd.TryDecodeAsNil() {
 		if v != nil {
 			changed = true
@@ -395,11 +378,8 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Ele
 
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		if containerLen > 0 {
-			v = make(map[{{ .MapKey }}]{{ .Elem }}, containerLen)
-		} else {
-			v = make(map[{{ .MapKey }}]{{ .Elem }}) // supports indefinite-length, etc
-		}
+		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, {{ .Size }})
+		v = make(map[{{ .MapKey }}]{{ .Elem }}, xlen)
 		changed = true
 	}
 	if containerLen > 0 {
@@ -407,7 +387,7 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Ele
 			{{ if eq .MapKey "interface{}" }}var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv) {{/* // maps cannot have []byte as key. switch to string. */}}
 			}{{ else }}mk := {{ decmd .MapKey }}{{ end }}
 			mv := v[mk]
 			{{ if eq .Elem "interface{}" }}d.decode(&mv)
@@ -418,15 +398,11 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Ele
 		}
 	} else if containerLen < 0 {
 		for j := 0; !dd.CheckBreak(); j++ {
-			if j > 0 {
-				dd.ReadMapEntrySeparator()
-			}
 			{{ if eq .MapKey "interface{}" }}var mk interface{}
 			d.decode(&mk)
 			if bv, bok := mk.([]byte); bok {
-				mk = string(bv) // maps cannot have []byte as key. switch to string.
+				mk = string(bv) {{/* // maps cannot have []byte as key. switch to string. */}}
 			}{{ else }}mk := {{ decmd .MapKey }}{{ end }}
-			dd.ReadMapKVSeparator()
 			mv := v[mk]
 			{{ if eq .Elem "interface{}" }}d.decode(&mv)
 			{{ else }}mv = {{ decmd .Elem }}{{ end }}
@@ -434,7 +410,7 @@ func (_ fastpathT) {{ .MethodNamePfx "Dec" false }}V(v map[{{ .MapKey }}]{{ .Ele
 				v[mk] = mv
 			}
 		}
-		dd.ReadMapEnd()
+		dd.ReadEnd()
 	}
 	return v, changed
 }

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-dec-array.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-dec-array.go.tmpl
@@ -1,15 +1,17 @@
 {{var "v"}} := {{ if not isArray}}*{{ end }}{{ .Varname }}
-{{var "h"}}, {{var "l"}} := z.DecSliceHelperStart()
+{{var "h"}}, {{var "l"}} := z.DecSliceHelperStart() {{/* // helper, containerLenS */}}
 
-var {{var "c"}} bool
-_ = {{var "c"}}
+var {{var "rr"}}, {{var "rl"}} int {{/* // num2read, length of slice/array/chan */}}
+var {{var "c"}}, {{var "rt"}} bool {{/* // changed, truncated */}}
+_, _, _ = {{var "c"}}, {{var "rt"}}, {{var "rl"}}
+{{var "rr"}} = {{var "l"}}
+{{/* rl is NOT used. Only used for getting DecInferLen. len(r) used directly in code */}}
 
 {{ if not isArray }}if {{var "v"}} == nil {
-	if {{var "l"}} <= 0 {
-        {{var "v"}} = make({{ .CTyp }}, 0)
-	} else {
-		{{var "v"}} = make({{ .CTyp }}, {{var "l"}})
+	if {{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }}); {{var "rt"}} {
+		{{var "rr"}} = {{var "rl"}}
 	}
+	{{var "v"}} = make({{ .CTyp }}, {{var "rl"}})
 	{{var "c"}} = true 
 } 
 {{ end }}
@@ -25,40 +27,44 @@ if {{var "l"}} == 0 { {{ if isSlice }}
 		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
 		{{var "v"}} <- {{var "t"}} 
 	{{ else }} 
-	{{var "n"}} := {{var "l"}} 
 	if {{var "l"}} > cap({{var "v"}}) {
 		{{ if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "l"}})
-		{{var "n"}} = len({{var "v"}})
-		{{ else }}{{ if .Immutable }}
+		{{ else }}{{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		{{ if .Immutable }}
 		{{var "v2"}} := {{var "v"}}
-		{{var "v"}} = make([]{{ .Typ }}, {{var "l"}}, {{var "l"}})
+		{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
 		if len({{var "v"}}) > 0 {
 			copy({{var "v"}}, {{var "v2"}}[:cap({{var "v2"}})])
 		}
-		{{ else }}{{var "v"}} = make([]{{ .Typ }}, {{var "l"}}, {{var "l"}})
+		{{ else }}{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
 		{{ end }}{{var "c"}} = true 
 		{{ end }}
+		{{var "rr"}} = len({{var "v"}})
 	} else if {{var "l"}} != len({{var "v"}}) {
 		{{ if isSlice }}{{var "v"}} = {{var "v"}}[:{{var "l"}}]
 		{{var "c"}} = true {{ end }}
 	}
 	{{var "j"}} := 0
-	for ; {{var "j"}} < {{var "n"}} ; {{var "j"}}++ {
+	for ; {{var "j"}} < {{var "rr"}} ; {{var "j"}}++ {
 		{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
-	} {{ if isArray }}
-	for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+	}
+	{{ if isArray }}for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
 		z.DecSwallow()
-	}{{ end }}
-	{{ end }}{{/* closing if not chan */}}
+	}
+	{{ else }}if {{var "rt"}} { {{/* means that it is mutable and slice */}}
+		for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+			{{var "v"}} = append({{var "v"}}, {{ zero}})
+			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+		}
+	}
+	{{ end }}
+	{{ end }}{{/* closing 'if not chan' */}}
 } else {
 	for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
 		if {{var "j"}} >= len({{var "v"}}) {
 			{{ if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "j"}}+1)
 			{{ else if isSlice}}{{var "v"}} = append({{var "v"}}, {{zero}})// var {{var "z"}} {{ .Typ }}
 			{{var "c"}} = true {{ end }}
-		}
-		if {{var "j"}} > 0 {
-			{{var "h"}}.Sep({{var "j"}})
 		}
 		{{ if isChan}}
 		var {{var "t"}} {{ .Typ }}

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-dec-map.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-dec-map.go.tmpl
@@ -1,11 +1,8 @@
 {{var "v"}} := *{{ .Varname }}
 {{var "l"}} := r.ReadMapStart()
 if {{var "v"}} == nil {
-	if {{var "l"}} > 0 {
-		{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}, {{var "l"}})
-	} else {
-		{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}) // supports indefinite-length, etc
-	}
+	{{var "rl"}}, _ := z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+	{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}, {{var "rl"}})
 	*{{ .Varname }} = {{var "v"}}
 }
 if {{var "l"}} > 0  {
@@ -25,9 +22,6 @@ for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
 }
 } else if {{var "l"}} < 0  {
 for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
-	if {{var "j"}} > 0 {
-		r.ReadMapEntrySeparator()
-	}
 	var {{var "mk"}} {{ .KTyp }} 
 	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
 {{ if eq .KTyp "interface{}" }}// special case if a byte array.
@@ -35,12 +29,11 @@ for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
 		{{var "mk"}} = string({{var "bv"}})
 	}
 {{ end }}
-	r.ReadMapKVSeparator()
 	{{var "mv"}} := {{var "v"}}[{{var "mk"}}]
 	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
 	if {{var "v"}} != nil {
 		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
 	}
 }
-r.ReadMapEnd()
+r.ReadEnd()
 } // else len==0: TODO: Should we clear map entries?

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-helper.generated.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-helper.generated.go
@@ -10,6 +10,11 @@
 
 package codec
 
+import (
+	"encoding"
+	"reflect"
+)
+
 // This file is used to generate helper code for codecgen.
 // The values here i.e. genHelper(En|De)coder are not to be used directly by
 // library users. They WILL change continously and without notice.
@@ -61,6 +66,56 @@ func (f genHelperEncoder) EncFallback(iv interface{}) {
 }
 
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncTextMarshal(iv encoding.TextMarshaler) {
+	bs, fnerr := iv.MarshalText()
+	f.e.marshal(bs, fnerr, false, c_UTF8)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncJSONMarshal(iv jsonMarshaler) {
+	bs, fnerr := iv.MarshalJSON()
+	f.e.marshal(bs, fnerr, true, c_UTF8)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBinaryMarshal(iv encoding.BinaryMarshaler) {
+	bs, fnerr := iv.MarshalBinary()
+	f.e.marshal(bs, fnerr, false, c_RAW)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) TimeRtidIfBinc() uintptr {
+	if _, ok := f.e.hh.(*BincHandle); ok {
+		return timeTypId
+	}
+	return 0
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) IsJSONHandle() bool {
+	return f.e.js
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) HasExtensions() bool {
+	return len(f.e.h.extHandle) != 0
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncExt(v interface{}) (r bool) {
+	rt := reflect.TypeOf(v)
+	if rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	rtid := reflect.ValueOf(rt).Pointer()
+	if xfFn := f.e.h.getExt(rtid); xfFn != nil {
+		f.e.e.EncodeExt(v, xfFn.tag, xfFn.ext, f.e)
+		return true
+	}
+	return false
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperDecoder) DecBasicHandle() *BasicHandle {
 	return f.d.h
 }
@@ -99,4 +154,67 @@ func (f genHelperDecoder) DecStructFieldNotFound(index int, name string) {
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperDecoder) DecArrayCannotExpand(sliceLen, streamLen int) {
 	f.d.arrayCannotExpand(sliceLen, streamLen)
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecTextUnmarshal(tm encoding.TextUnmarshaler) {
+	fnerr := tm.UnmarshalText(f.d.d.DecodeBytes(f.d.b[:], true, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecJSONUnmarshal(tm jsonUnmarshaler) {
+	// bs := f.dd.DecodeBytes(f.d.b[:], true, true)
+	f.d.r.track()
+	f.d.swallow()
+	bs := f.d.r.stopTrack()
+	// fmt.Printf(">>>>>> CODECGEN JSON: %s\n", bs)
+	fnerr := tm.UnmarshalJSON(bs)
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBinaryUnmarshal(bm encoding.BinaryUnmarshaler) {
+	fnerr := bm.UnmarshalBinary(f.d.d.DecodeBytes(nil, false, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) TimeRtidIfBinc() uintptr {
+	if _, ok := f.d.hh.(*BincHandle); ok {
+		return timeTypId
+	}
+	return 0
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) IsJSONHandle() bool {
+	return f.d.js
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) HasExtensions() bool {
+	return len(f.d.h.extHandle) != 0
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecExt(v interface{}) (r bool) {
+	rt := reflect.TypeOf(v).Elem()
+	rtid := reflect.ValueOf(rt).Pointer()
+	if xfFn := f.d.h.getExt(rtid); xfFn != nil {
+		f.d.d.DecodeExt(v, xfFn.tag, xfFn.ext)
+		return true
+	}
+	return false
+}
+
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecInferLen(clen, maxlen, unit int) (rvlen int, truncated bool) {
+	return decInferLen(clen, maxlen, unit)
 }

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-helper.go.tmpl
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen-helper.go.tmpl
@@ -10,6 +10,11 @@
 
 package codec
 
+import (
+	"encoding"
+	"reflect"
+)
+
 // This file is used to generate helper code for codecgen. 
 // The values here i.e. genHelper(En|De)coder are not to be used directly by 
 // library users. They WILL change continously and without notice.
@@ -48,6 +53,7 @@ type genHelperDecoder struct {
 func (f genHelperEncoder) EncBasicHandle() *BasicHandle {
 	return f.e.h
 }
+
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
 func (f genHelperEncoder) EncBinary() bool {
 	return f.e.be // f.e.hh.isBinaryEncoding()
@@ -56,6 +62,49 @@ func (f genHelperEncoder) EncBinary() bool {
 func (f genHelperEncoder) EncFallback(iv interface{}) {
 	// println(">>>>>>>>> EncFallback")
 	f.e.encodeI(iv, false, false)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncTextMarshal(iv encoding.TextMarshaler) {
+	bs, fnerr := iv.MarshalText()
+	f.e.marshal(bs, fnerr, false, c_UTF8)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncJSONMarshal(iv jsonMarshaler) {
+	bs, fnerr := iv.MarshalJSON()
+	f.e.marshal(bs, fnerr, true, c_UTF8)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncBinaryMarshal(iv encoding.BinaryMarshaler) {
+	bs, fnerr := iv.MarshalBinary()
+	f.e.marshal(bs, fnerr, false, c_RAW)
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) TimeRtidIfBinc() uintptr {
+	if _, ok := f.e.hh.(*BincHandle); ok {
+		return timeTypId 
+	}
+	return 0
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) IsJSONHandle() bool {
+	return f.e.js
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) HasExtensions() bool {
+	return len(f.e.h.extHandle) != 0
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperEncoder) EncExt(v interface{}) (r bool) {
+	rt := reflect.TypeOf(v)
+	if rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+	rtid := reflect.ValueOf(rt).Pointer()
+	if xfFn := f.e.h.getExt(rtid); xfFn != nil {
+		f.e.e.EncodeExt(v, xfFn.tag, xfFn.ext, f.e)
+		return true
+	}
+	return false 
 }
 
 // FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
@@ -91,7 +140,61 @@ func (f genHelperDecoder) DecStructFieldNotFound(index int, name string) {
 func (f genHelperDecoder) DecArrayCannotExpand(sliceLen, streamLen int) {
 	f.d.arrayCannotExpand(sliceLen, streamLen)
 }
-
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecTextUnmarshal(tm encoding.TextUnmarshaler) {
+	fnerr := tm.UnmarshalText(f.d.d.DecodeBytes(f.d.b[:], true, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecJSONUnmarshal(tm jsonUnmarshaler) {
+	// bs := f.dd.DecodeBytes(f.d.b[:], true, true)
+	f.d.r.track()
+	f.d.swallow()
+	bs := f.d.r.stopTrack()
+	// fmt.Printf(">>>>>> CODECGEN JSON: %s\n", bs)
+	fnerr := tm.UnmarshalJSON(bs)
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecBinaryUnmarshal(bm encoding.BinaryUnmarshaler) {
+	fnerr := bm.UnmarshalBinary(f.d.d.DecodeBytes(nil, false, true))
+	if fnerr != nil {
+		panic(fnerr)
+	}
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) TimeRtidIfBinc() uintptr {
+	if _, ok := f.d.hh.(*BincHandle); ok {
+		return timeTypId 
+	}
+	return 0
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) IsJSONHandle() bool {
+	return f.d.js 
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) HasExtensions() bool {
+	return len(f.d.h.extHandle) != 0
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecExt(v interface{}) (r bool) {
+	rt := reflect.TypeOf(v).Elem()
+	rtid := reflect.ValueOf(rt).Pointer()
+	if xfFn := f.d.h.getExt(rtid); xfFn != nil {
+		f.d.d.DecodeExt(v, xfFn.tag, xfFn.ext)
+		return true
+	}
+	return false 
+}
+// FOR USE BY CODECGEN ONLY. IT *WILL* CHANGE WITHOUT NOTICE. *DO NOT USE*
+func (f genHelperDecoder) DecInferLen(clen, maxlen, unit int) (rvlen int, truncated bool) {
+	return decInferLen(clen, maxlen, unit)
+}
 
 {{/*
 

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen.generated.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen.generated.go
@@ -9,11 +9,8 @@ const genDecMapTmpl = `
 {{var "v"}} := *{{ .Varname }}
 {{var "l"}} := r.ReadMapStart()
 if {{var "v"}} == nil {
-	if {{var "l"}} > 0 {
-		{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}, {{var "l"}})
-	} else {
-		{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}) // supports indefinite-length, etc
-	}
+	{{var "rl"}}, _ := z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+	{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}, {{var "rl"}})
 	*{{ .Varname }} = {{var "v"}}
 }
 if {{var "l"}} > 0  {
@@ -33,9 +30,6 @@ for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
 }
 } else if {{var "l"}} < 0  {
 for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
-	if {{var "j"}} > 0 {
-		r.ReadMapEntrySeparator()
-	}
 	var {{var "mk"}} {{ .KTyp }} 
 	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
 {{ if eq .KTyp "interface{}" }}// special case if a byte array.
@@ -43,30 +37,31 @@ for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
 		{{var "mk"}} = string({{var "bv"}})
 	}
 {{ end }}
-	r.ReadMapKVSeparator()
 	{{var "mv"}} := {{var "v"}}[{{var "mk"}}]
 	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
 	if {{var "v"}} != nil {
 		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
 	}
 }
-r.ReadMapEnd()
+r.ReadEnd()
 } // else len==0: TODO: Should we clear map entries?
 `
 
 const genDecListTmpl = `
 {{var "v"}} := {{ if not isArray}}*{{ end }}{{ .Varname }}
-{{var "h"}}, {{var "l"}} := z.DecSliceHelperStart()
+{{var "h"}}, {{var "l"}} := z.DecSliceHelperStart() {{/* // helper, containerLenS */}}
 
-var {{var "c"}} bool
-_ = {{var "c"}}
+var {{var "rr"}}, {{var "rl"}} int {{/* // num2read, length of slice/array/chan */}}
+var {{var "c"}}, {{var "rt"}} bool {{/* // changed, truncated */}}
+_, _, _ = {{var "c"}}, {{var "rt"}}, {{var "rl"}}
+{{var "rr"}} = {{var "l"}}
+{{/* rl is NOT used. Only used for getting DecInferLen. len(r) used directly in code */}}
 
 {{ if not isArray }}if {{var "v"}} == nil {
-	if {{var "l"}} <= 0 {
-        {{var "v"}} = make({{ .CTyp }}, 0)
-	} else {
-		{{var "v"}} = make({{ .CTyp }}, {{var "l"}})
+	if {{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }}); {{var "rt"}} {
+		{{var "rr"}} = {{var "rl"}}
 	}
+	{{var "v"}} = make({{ .CTyp }}, {{var "rl"}})
 	{{var "c"}} = true 
 } 
 {{ end }}
@@ -82,40 +77,44 @@ if {{var "l"}} == 0 { {{ if isSlice }}
 		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
 		{{var "v"}} <- {{var "t"}} 
 	{{ else }} 
-	{{var "n"}} := {{var "l"}} 
 	if {{var "l"}} > cap({{var "v"}}) {
 		{{ if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "l"}})
-		{{var "n"}} = len({{var "v"}})
-		{{ else }}{{ if .Immutable }}
+		{{ else }}{{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		{{ if .Immutable }}
 		{{var "v2"}} := {{var "v"}}
-		{{var "v"}} = make([]{{ .Typ }}, {{var "l"}}, {{var "l"}})
+		{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
 		if len({{var "v"}}) > 0 {
 			copy({{var "v"}}, {{var "v2"}}[:cap({{var "v2"}})])
 		}
-		{{ else }}{{var "v"}} = make([]{{ .Typ }}, {{var "l"}}, {{var "l"}})
+		{{ else }}{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
 		{{ end }}{{var "c"}} = true 
 		{{ end }}
+		{{var "rr"}} = len({{var "v"}})
 	} else if {{var "l"}} != len({{var "v"}}) {
 		{{ if isSlice }}{{var "v"}} = {{var "v"}}[:{{var "l"}}]
 		{{var "c"}} = true {{ end }}
 	}
 	{{var "j"}} := 0
-	for ; {{var "j"}} < {{var "n"}} ; {{var "j"}}++ {
+	for ; {{var "j"}} < {{var "rr"}} ; {{var "j"}}++ {
 		{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
-	} {{ if isArray }}
-	for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+	}
+	{{ if isArray }}for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
 		z.DecSwallow()
-	}{{ end }}
-	{{ end }}{{/* closing if not chan */}}
+	}
+	{{ else }}if {{var "rt"}} { {{/* means that it is mutable and slice */}}
+		for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
+			{{var "v"}} = append({{var "v"}}, {{ zero}})
+			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+		}
+	}
+	{{ end }}
+	{{ end }}{{/* closing 'if not chan' */}}
 } else {
 	for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
 		if {{var "j"}} >= len({{var "v"}}) {
 			{{ if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "j"}}+1)
 			{{ else if isSlice}}{{var "v"}} = append({{var "v"}}, {{zero}})// var {{var "z"}} {{ .Typ }}
 			{{var "c"}} = true {{ end }}
-		}
-		if {{var "j"}} > 0 {
-			{{var "h"}}.Sep({{var "j"}})
 		}
 		{{ if isChan}}
 		var {{var "t"}} {{ .Typ }}

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/gen.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/gen.go
@@ -12,8 +12,10 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,14 +24,25 @@ import (
 )
 
 // ---------------------------------------------------
-// codecgen only works in the following:
-//   - extensions are not supported. Do not make a type a Selfer and an extension.
-//   - Selfer takes precedence.
-//     Any type that implements it knows how to encode/decode itself statically.
-//     Extensions are only known at runtime.
-//     codecgen only looks at the Kind of the type.
+// codecgen supports the full cycle of reflection-based codec:
+//    - RawExt
+//    - Builtins
+//    - Extensions
+//    - (Binary|Text|JSON)(Unm|M)arshal
+//    - generic by-kind
 //
-//   - the following types are supported:
+// This means that, for dynamic things, we MUST use reflection to at least get the reflect.Type.
+// In those areas, we try to only do reflection or interface-conversion when NECESSARY:
+//    - Extensions, only if Extensions are configured.
+//
+// However, codecgen doesn't support the following:
+//   - Canonical option. (codecgen IGNORES it currently)
+//     This is just because it has not been implemented.
+//
+// During encode/decode, Selfer takes precedence.
+// A type implementing Selfer will know how to encode/decode itself statically.
+//
+// The following field types are supported:
 //     array: [n]T
 //     slice: []T
 //     map: map[K]V
@@ -66,11 +79,24 @@ import (
 //   It was a concious decision to have gen.go always explicitly call EncodeNil or TryDecodeAsNil.
 //   This way, there isn't a function call overhead just to see that we should not enter a block of code.
 
-const GenVersion = 2 // increment this value each time codecgen changes fundamentally.
+// GenVersion is the current version of codecgen.
+//
+// NOTE: Increment this value each time codecgen changes fundamentally.
+// Fundamental changes are:
+//   - helper methods change (signature change, new ones added, some removed, etc)
+//   - codecgen command line changes
+//
+// v1: Initial Version
+// v2:
+// v3: Changes for Kubernetes:
+//     changes in signature of some unpublished helper methods and codecgen cmdline arguments.
+// v4: Removed separator support from (en|de)cDriver, and refactored codec(gen)
+const GenVersion = 4
 
 const (
-	genCodecPkg   = "codec1978"
-	genTempVarPfx = "yy"
+	genCodecPkg        = "codec1978"
+	genTempVarPfx      = "yy"
+	genTopLevelVarName = "x"
 
 	// ignore canBeNil parameter, and always set to true.
 	// This is because nil can appear anywhere, so we should always check.
@@ -94,30 +120,38 @@ var (
 // genRunner holds some state used during a Gen run.
 type genRunner struct {
 	w io.Writer      // output
-	c uint64         // ctr used for generating varsfx
+	c uint64         // counter used for generating varsfx
 	t []reflect.Type // list of types to run selfer on
 
-	tc reflect.Type              // currently running selfer on this type
-	te map[uintptr]bool          // types for which the encoder has been created
-	td map[uintptr]bool          // types for which the decoder has been created
-	cp string                    // codec import path
-	im map[string]reflect.Type   // imports to add
+	tc reflect.Type     // currently running selfer on this type
+	te map[uintptr]bool // types for which the encoder has been created
+	td map[uintptr]bool // types for which the decoder has been created
+	cp string           // codec import path
+
+	im  map[string]reflect.Type // imports to add
+	imn map[string]string       // package names of imports to add
+	imc uint64                  // counter for import numbers
+
 	is map[reflect.Type]struct{} // types seen during import search
 	bp string                    // base PkgPath, for which we are generating for
 
 	cpfx   string // codec package prefix
 	unsafe bool   // is unsafe to be used in generated code?
 
-	ts map[reflect.Type]struct{} // types for which enc/dec must be generated
-	xs string                    // top level variable/constant suffix
-	hn string                    // fn helper type name
+	tm map[reflect.Type]struct{} // types for which enc/dec must be generated
+	ts []reflect.Type            // types for which enc/dec must be generated
 
-	rr *rand.Rand // random generator for file-specific types
+	xs string // top level variable/constant suffix
+	hn string // fn helper type name
+
+	// rr *rand.Rand // random generator for file-specific types
 }
 
 // Gen will write a complete go file containing Selfer implementations for each
 // type passed. All the types must be in the same package.
-func Gen(w io.Writer, buildTags, pkgName string, useUnsafe bool, typ ...reflect.Type) {
+//
+// Library users: *DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.*
+func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, typ ...reflect.Type) {
 	if len(typ) == 0 {
 		return
 	}
@@ -128,17 +162,24 @@ func Gen(w io.Writer, buildTags, pkgName string, useUnsafe bool, typ ...reflect.
 		te:     make(map[uintptr]bool),
 		td:     make(map[uintptr]bool),
 		im:     make(map[string]reflect.Type),
+		imn:    make(map[string]string),
 		is:     make(map[reflect.Type]struct{}),
-		ts:     make(map[reflect.Type]struct{}),
-		bp:     typ[0].PkgPath(),
-		rr:     rand.New(rand.NewSource(time.Now().UnixNano())),
+		tm:     make(map[reflect.Type]struct{}),
+		ts:     []reflect.Type{},
+		bp:     genImportPath(typ[0]),
+		xs:     uid,
+	}
+	if x.xs == "" {
+		rr := rand.New(rand.NewSource(time.Now().UnixNano()))
+		x.xs = strconv.FormatInt(rr.Int63n(9999), 10)
 	}
 
 	// gather imports first:
-	x.cp = reflect.TypeOf(x).PkgPath()
+	x.cp = genImportPath(reflect.TypeOf(x))
+	x.imn[x.cp] = genCodecPkg
 	for _, t := range typ {
-		// fmt.Printf("###########: PkgPath: '%v', Name: '%s'\n", t.PkgPath(), t.Name())
-		if t.PkgPath() != x.bp {
+		// fmt.Printf("###########: PkgPath: '%v', Name: '%s'\n", genImportPath(t), t.Name())
+		if genImportPath(t) != x.bp {
 			panic(genAllTypesSamePkgErr)
 		}
 		x.genRefPkgs(t)
@@ -162,8 +203,14 @@ func Gen(w io.Writer, buildTags, pkgName string, useUnsafe bool, typ ...reflect.
 		x.cpfx = genCodecPkg + "."
 		x.linef("%s \"%s\"", genCodecPkg, x.cp)
 	}
+	// use a sorted set of im keys, so that we can get consistent output
+	imKeys := make([]string, 0, len(x.im))
 	for k, _ := range x.im {
-		x.line("\"" + k + "\"")
+		imKeys = append(imKeys, k)
+	}
+	sort.Strings(imKeys)
+	for _, k := range imKeys { // for k, _ := range x.im {
+		x.linef("%s \"%s\"", x.imn[k], k)
 	}
 	// add required packages
 	for _, k := range [...]string{"reflect", "unsafe", "runtime", "fmt", "errors"} {
@@ -177,13 +224,11 @@ func Gen(w io.Writer, buildTags, pkgName string, useUnsafe bool, typ ...reflect.
 	x.line(")")
 	x.line("")
 
-	x.xs = strconv.FormatInt(x.rr.Int63n(9999), 10)
-
 	x.line("const (")
 	x.linef("codecSelferC_UTF8%s = %v", x.xs, int64(c_UTF8))
 	x.linef("codecSelferC_RAW%s = %v", x.xs, int64(c_RAW))
-	x.linef("codecSelverValueTypeArray%s = %v", x.xs, int64(valueTypeArray))
-	x.linef("codecSelverValueTypeMap%s = %v", x.xs, int64(valueTypeMap))
+	x.linef("codecSelferValueTypeArray%s = %v", x.xs, int64(valueTypeArray))
+	x.linef("codecSelferValueTypeMap%s = %v", x.xs, int64(valueTypeMap))
 	x.line(")")
 	x.line("var (")
 	x.line("codecSelferBitsize" + x.xs + " = uint8(reflect.TypeOf(uint(0)).Bits())")
@@ -210,8 +255,10 @@ func Gen(w io.Writer, buildTags, pkgName string, useUnsafe bool, typ ...reflect.
 	x.linef("}")
 	x.line("if false { // reference the types, but skip this branch at build/run time")
 	var n int
-	for _, t := range x.im {
-		x.linef("var v%v %s", n, t.String())
+	// for k, t := range x.im {
+	for _, k := range imKeys {
+		t := x.im[k]
+		x.linef("var v%v %s.%s", n, x.imn[k], t.Name())
 		n++
 	}
 	if x.unsafe {
@@ -239,7 +286,7 @@ func Gen(w io.Writer, buildTags, pkgName string, useUnsafe bool, typ ...reflect.
 		x.selfer(false)
 	}
 
-	for t, _ := range x.ts {
+	for _, t := range x.ts {
 		rtid := reflect.ValueOf(t).Pointer()
 		// generate enc functions for all these slice/map types.
 		x.linef("func (x %s) enc%s(v %s%s, e *%sEncoder) {", x.hn, x.genMethodNameT(t), x.arr2str(t, "*"), x.genTypeName(t), x.cpfx)
@@ -273,6 +320,12 @@ func Gen(w io.Writer, buildTags, pkgName string, useUnsafe bool, typ ...reflect.
 	x.line("")
 }
 
+func (x *genRunner) checkForSelfer(t reflect.Type, varname string) bool {
+	// return varname != genTopLevelVarName && t != x.tc
+	// the only time we checkForSelfer is if we are not at the TOP of the generated code.
+	return varname != genTopLevelVarName
+}
+
 func (x *genRunner) arr2str(t reflect.Type, s string) string {
 	if t.Kind() == reflect.Array {
 		return s
@@ -294,11 +347,19 @@ func (x *genRunner) genRefPkgs(t reflect.Type) {
 	if _, ok := x.is[t]; ok {
 		return
 	}
-	// fmt.Printf(">>>>>>: PkgPath: '%v', Name: '%s'\n", t.PkgPath(), t.Name())
+	// fmt.Printf(">>>>>>: PkgPath: '%v', Name: '%s'\n", genImportPath(t), t.Name())
 	x.is[t] = struct{}{}
-	tpkg, tname := t.PkgPath(), t.Name()
+	tpkg, tname := genImportPath(t), t.Name()
 	if tpkg != "" && tpkg != x.bp && tpkg != x.cp && tname != "" && tname[0] >= 'A' && tname[0] <= 'Z' {
-		x.im[tpkg] = t
+		if _, ok := x.im[tpkg]; !ok {
+			x.im[tpkg] = t
+			if idx := strings.LastIndex(tpkg, "/"); idx < 0 {
+				x.imn[tpkg] = tpkg
+			} else {
+				x.imc++
+				x.imn[tpkg] = "pkg" + strconv.FormatUint(x.imc, 10) + "_" + tpkg[idx+1:]
+			}
+		}
 	}
 	switch t.Kind() {
 	case reflect.Array, reflect.Slice, reflect.Ptr, reflect.Chan:
@@ -342,7 +403,65 @@ func (x *genRunner) outf(s string, params ...interface{}) {
 }
 
 func (x *genRunner) genTypeName(t reflect.Type) (n string) {
-	return genTypeName(t, x.tc)
+	// defer func() { fmt.Printf(">>>> ####: genTypeName: t: %v, name: '%s'\n", t, n) }()
+
+	// if the type has a PkgPath, which doesn't match the current package,
+	// then include it.
+	// We cannot depend on t.String() because it includes current package,
+	// or t.PkgPath because it includes full import path,
+	//
+	var ptrPfx string
+	for t.Kind() == reflect.Ptr {
+		ptrPfx += "*"
+		t = t.Elem()
+	}
+	if tn := t.Name(); tn != "" {
+		return ptrPfx + x.genTypeNamePrim(t)
+	}
+	switch t.Kind() {
+	case reflect.Map:
+		return ptrPfx + "map[" + x.genTypeName(t.Key()) + "]" + x.genTypeName(t.Elem())
+	case reflect.Slice:
+		return ptrPfx + "[]" + x.genTypeName(t.Elem())
+	case reflect.Array:
+		return ptrPfx + "[" + strconv.FormatInt(int64(t.Len()), 10) + "]" + x.genTypeName(t.Elem())
+	case reflect.Chan:
+		return ptrPfx + t.ChanDir().String() + " " + x.genTypeName(t.Elem())
+	default:
+		if t == intfTyp {
+			return ptrPfx + "interface{}"
+		} else {
+			return ptrPfx + x.genTypeNamePrim(t)
+		}
+	}
+}
+
+func (x *genRunner) genTypeNamePrim(t reflect.Type) (n string) {
+	if t.Name() == "" {
+		return t.String()
+	} else if genImportPath(t) == "" || genImportPath(t) == genImportPath(x.tc) {
+		return t.Name()
+	} else {
+		return x.imn[genImportPath(t)] + "." + t.Name()
+		// return t.String() // best way to get the package name inclusive
+	}
+}
+
+func (x *genRunner) genZeroValueR(t reflect.Type) string {
+	// if t is a named type, w
+	switch t.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func,
+		reflect.Slice, reflect.Map, reflect.Invalid:
+		return "nil"
+	case reflect.Bool:
+		return "false"
+	case reflect.String:
+		return `""`
+	case reflect.Struct, reflect.Array:
+		return x.genTypeName(t) + "{}"
+	default: // all numbers
+		return "0"
+	}
 }
 
 func (x *genRunner) genMethodNameT(t reflect.Type) (s string) {
@@ -368,16 +487,16 @@ func (x *genRunner) selfer(encode bool) {
 	if encode {
 		x.line(") CodecEncodeSelf(e *" + x.cpfx + "Encoder) {")
 		x.genRequiredMethodVars(true)
-		// x.enc("x", t)
-		x.encVar("x", t)
+		// x.enc(genTopLevelVarName, t)
+		x.encVar(genTopLevelVarName, t)
 	} else {
 		x.line(") CodecDecodeSelf(d *" + x.cpfx + "Decoder) {")
 		x.genRequiredMethodVars(false)
 		// do not use decVar, as there is no need to check TryDecodeAsNil
 		// or way to elegantly handle that, and also setting it to a
 		// non-nil value doesn't affect the pointer passed.
-		// x.decVar("x", t, false)
-		x.dec("x", t0)
+		// x.decVar(genTopLevelVarName, t, false)
+		x.dec(genTopLevelVarName, t0)
 	}
 	x.line("}")
 	x.line("")
@@ -391,21 +510,21 @@ func (x *genRunner) selfer(encode bool) {
 		x.out(fnSigPfx)
 		x.line(") codecDecodeSelfFromMap(l int, d *" + x.cpfx + "Decoder) {")
 		x.genRequiredMethodVars(false)
-		x.decStructMap("x", "l", reflect.ValueOf(t0).Pointer(), t0, 0)
+		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, 0)
 		x.line("}")
 		x.line("")
 	} else {
 		x.out(fnSigPfx)
 		x.line(") codecDecodeSelfFromMapLenPrefix(l int, d *" + x.cpfx + "Decoder) {")
 		x.genRequiredMethodVars(false)
-		x.decStructMap("x", "l", reflect.ValueOf(t0).Pointer(), t0, 1)
+		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, 1)
 		x.line("}")
 		x.line("")
 
 		x.out(fnSigPfx)
 		x.line(") codecDecodeSelfFromMapCheckBreak(l int, d *" + x.cpfx + "Decoder) {")
 		x.genRequiredMethodVars(false)
-		x.decStructMap("x", "l", reflect.ValueOf(t0).Pointer(), t0, 2)
+		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, 2)
 		x.line("}")
 		x.line("")
 	}
@@ -414,7 +533,7 @@ func (x *genRunner) selfer(encode bool) {
 	x.out(fnSigPfx)
 	x.line(") codecDecodeSelfFromArray(l int, d *" + x.cpfx + "Decoder) {")
 	x.genRequiredMethodVars(false)
-	x.decStructArray("x", "l", "return", reflect.ValueOf(t0).Pointer(), t0)
+	x.decStructArray(genTopLevelVarName, "l", "return", reflect.ValueOf(t0).Pointer(), t0)
 	x.line("}")
 	x.line("")
 
@@ -429,12 +548,16 @@ func (x *genRunner) xtraSM(varname string, encode bool, t reflect.Type) {
 		x.linef("h.dec%s((*%s)(%s), d)", x.genMethodNameT(t), x.genTypeName(t), varname)
 		// x.line("h.dec" + x.genMethodNameT(t) + "((*" + x.genTypeName(t) + ")(" + varname + "), d)")
 	}
-	x.ts[t] = struct{}{}
+	if _, ok := x.tm[t]; !ok {
+		x.tm[t] = struct{}{}
+		x.ts = append(x.ts, t)
+	}
 }
 
 // encVar will encode a variable.
 // The parameter, t, is the reflect.Type of the variable itself
 func (x *genRunner) encVar(varname string, t reflect.Type) {
+	// fmt.Printf(">>>>>> varname: %s, t: %v\n", varname, t)
 	var checkNil bool
 	switch t.Kind() {
 	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map, reflect.Chan:
@@ -470,46 +593,86 @@ func (x *genRunner) encVar(varname string, t reflect.Type) {
 // enc will encode a variable (varname) of type T,
 // except t is of kind reflect.Struct or reflect.Array, wherein varname is of type *T (to prevent copying)
 func (x *genRunner) enc(varname string, t reflect.Type) {
-	// varName here must be to a pointer to a struct, or to a value directly.
+	// varName here must be to a pointer to a struct/array, or to a value directly.
 	rtid := reflect.ValueOf(t).Pointer()
 	// We call CodecEncodeSelf if one of the following are honored:
 	//   - the type already implements Selfer, call that
 	//   - the type has a Selfer implementation just created, use that
 	//   - the type is in the list of the ones we will generate for, but it is not currently being generated
-	if t.Implements(selferTyp) {
-		x.line(varname + ".CodecEncodeSelf(e)")
-		return
-	}
-	if t.Kind() == reflect.Struct && reflect.PtrTo(t).Implements(selferTyp) {
-		x.line(varname + ".CodecEncodeSelf(e)")
-		return
-	}
-	if _, ok := x.te[rtid]; ok {
-		x.line(varname + ".CodecEncodeSelf(e)")
-		return
+
+	tptr := reflect.PtrTo(t)
+	tk := t.Kind()
+	if x.checkForSelfer(t, varname) {
+		if t.Implements(selferTyp) || (tptr.Implements(selferTyp) && (tk == reflect.Array || tk == reflect.Struct)) {
+			x.line(varname + ".CodecEncodeSelf(e)")
+			return
+		}
+
+		if _, ok := x.te[rtid]; ok {
+			x.line(varname + ".CodecEncodeSelf(e)")
+			return
+		}
 	}
 
 	inlist := false
 	for _, t0 := range x.t {
 		if t == t0 {
 			inlist = true
-			if t != x.tc {
+			if x.checkForSelfer(t, varname) {
 				x.line(varname + ".CodecEncodeSelf(e)")
 				return
 			}
 			break
 		}
 	}
+
 	var rtidAdded bool
 	if t == x.tc {
 		x.te[rtid] = true
 		rtidAdded = true
 	}
 
+	// check if
+	//   - type is RawExt
+	//   - the type implements (Text|JSON|Binary)(Unm|M)arshal
+	mi := x.varsfx()
+	x.linef("%sm%s := z.EncBinary()", genTempVarPfx, mi)
+	x.linef("_ = %sm%s", genTempVarPfx, mi)
+	x.line("if false {")           //start if block
+	defer func() { x.line("}") }() //end if block
+
+	if t == rawExtTyp {
+		x.linef("} else { r.EncodeRawExt(%v, e)", varname)
+		return
+	}
+	// HACK: Support for Builtins.
+	//       Currently, only Binc supports builtins, and the only builtin type is time.Time.
+	//       Have a method that returns the rtid for time.Time if Handle is Binc.
+	if t == timeTyp {
+		vrtid := genTempVarPfx + "m" + x.varsfx()
+		x.linef("} else if %s := z.TimeRtidIfBinc(); %s != 0 { ", vrtid, vrtid)
+		x.linef("r.EncodeBuiltin(%s, %s)", vrtid, varname)
+	}
+	// only check for extensions if the type is named, and has a packagePath.
+	if genImportPath(t) != "" && t.Name() != "" {
+		// first check if extensions are configued, before doing the interface conversion
+		x.linef("} else if z.HasExtensions() && z.EncExt(%s) {", varname)
+	}
+	if t.Implements(binaryMarshalerTyp) || tptr.Implements(binaryMarshalerTyp) {
+		x.linef("} else if %sm%s { z.EncBinaryMarshal(%v) ", genTempVarPfx, mi, varname)
+	}
+	if t.Implements(jsonMarshalerTyp) || tptr.Implements(jsonMarshalerTyp) {
+		x.linef("} else if !%sm%s && z.IsJSONHandle() { z.EncJSONMarshal(%v) ", genTempVarPfx, mi, varname)
+	} else if t.Implements(textMarshalerTyp) || tptr.Implements(textMarshalerTyp) {
+		x.linef("} else if !%sm%s { z.EncTextMarshal(%v) ", genTempVarPfx, mi, varname)
+	}
+
+	x.line("} else {")
+
 	switch t.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		x.line("r.EncodeInt(int64(" + varname + "))")
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		x.line("r.EncodeUint(uint64(" + varname + "))")
 	case reflect.Float32:
 		x.line("r.EncodeFloat32(float32(" + varname + "))")
@@ -534,7 +697,7 @@ func (x *genRunner) enc(varname string, t reflect.Type) {
 		if rtid == uint8SliceTypId {
 			x.line("r.EncodeStringBytes(codecSelferC_RAW" + x.xs + ", []byte(" + varname + "))")
 		} else if fastpathAV.index(rtid) != -1 {
-			g := genV{Slice: true, Elem: x.genTypeName(t.Elem())}
+			g := x.newGenV(t)
 			x.line("z.F." + g.MethodNamePfx("Enc", false) + "V(" + varname + ", false, e)")
 		} else {
 			x.xtraSM(varname, true, t)
@@ -548,9 +711,7 @@ func (x *genRunner) enc(varname string, t reflect.Type) {
 		// - else call Encoder.encode(XXX) on it.
 		// x.line("if " + varname + " == nil { \nr.EncodeNil()\n } else { ")
 		if fastpathAV.index(rtid) != -1 {
-			g := genV{Slice: false,
-				Elem:   x.genTypeName(t.Elem()),
-				MapKey: x.genTypeName(t.Key())}
+			g := x.newGenV(t)
 			x.line("z.F." + g.MethodNamePfx("Enc", false) + "V(" + varname + ", false, e)")
 		} else {
 			x.xtraSM(varname, true, t)
@@ -575,7 +736,7 @@ func (x *genRunner) encZero(t reflect.Type) {
 	switch t.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		x.line("r.EncodeInt(0)")
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		x.line("r.EncodeUint(0)")
 	case reflect.Float32:
 		x.line("r.EncodeFloat32(0)")
@@ -598,21 +759,19 @@ func (x *genRunner) encStruct(varname string, rtid uintptr, t reflect.Type) {
 	ti := getTypeInfo(rtid, t)
 	i := x.varsfx()
 	sepVarname := genTempVarPfx + "sep" + i
-	firstVarname := genTempVarPfx + "first" + i
 	numfieldsvar := genTempVarPfx + "q" + i
 	ti2arrayvar := genTempVarPfx + "r" + i
 	struct2arrvar := genTempVarPfx + "2arr" + i
 
 	x.line(sepVarname + " := !z.EncBinary()")
 	x.linef("%s := z.EncBasicHandle().StructToArray", struct2arrvar)
-	x.line("var " + firstVarname + " bool")
 	tisfi := ti.sfip // always use sequence from file. decStruct expects same thing.
 	// due to omitEmpty, we need to calculate the
 	// number of non-empty things we write out first.
 	// This is required as we need to pre-determine the size of the container,
 	// to support length-prefixing.
 	x.linef("var %s [%v]bool", numfieldsvar, len(tisfi))
-	x.linef("_, _, _, _ = %s, %s, %s, %s", sepVarname, firstVarname, numfieldsvar, struct2arrvar)
+	x.linef("_, _, _ = %s, %s, %s", sepVarname, numfieldsvar, struct2arrvar)
 	x.linef("const %s bool = %v", ti2arrayvar, ti.toArray)
 	nn := 0
 	for j, si := range tisfi {
@@ -647,7 +806,7 @@ func (x *genRunner) encStruct(varname string, rtid uintptr, t reflect.Type) {
 		case reflect.Map, reflect.Slice, reflect.Array, reflect.Chan:
 			omitline += "len(" + varname + "." + t2.Name + ") != 0"
 		default:
-			omitline += varname + "." + t2.Name + " != " + genZeroValueR(t2.Type, x.tc)
+			omitline += varname + "." + t2.Name + " != " + x.genZeroValueR(t2.Type)
 		}
 		x.linef("%s[%v] = %s", numfieldsvar, j, omitline)
 	}
@@ -697,11 +856,6 @@ func (x *genRunner) encStruct(varname string, rtid uintptr, t reflect.Type) {
 		// if the type of the field is a Selfer, or one of the ones
 
 		x.linef("if %s || %s {", ti2arrayvar, struct2arrvar) // if ti.toArray
-		if j > 0 {
-			x.line("if " + sepVarname + " {")
-			x.line("r.EncodeArrayEntrySeparator()")
-			x.line("}")
-		}
 		if labelUsed {
 			x.line("if " + isNilVarName + " { r.EncodeNil() } else { ")
 		}
@@ -733,17 +887,8 @@ func (x *genRunner) encStruct(varname string, rtid uintptr, t reflect.Type) {
 			// }
 			// x.line(varname + "." + t2.Name + " != " + genZeroValueR(t2.Type, x.tc) + " {")
 		}
-		if j == 0 {
-			x.linef("%s = true", firstVarname)
-		} else {
-			x.linef("if %s { r.EncodeMapEntrySeparator() } else { %s = true }", firstVarname, firstVarname)
-		}
-
 		// x.line("r.EncodeString(codecSelferC_UTF8" + x.xs + ", string(\"" + t2.Name + "\"))")
 		x.line("r.EncodeString(codecSelferC_UTF8" + x.xs + ", string(\"" + si.encName + "\"))")
-		x.line("if " + sepVarname + " {")
-		x.line("r.EncodeMapKVSeparator()")
-		x.line("}")
 		if labelUsed {
 			x.line("if " + isNilVarName + " { r.EncodeNil() } else { ")
 			x.encVar(varname+"."+t2.Name, t2.Type)
@@ -757,11 +902,7 @@ func (x *genRunner) encStruct(varname string, rtid uintptr, t reflect.Type) {
 		x.linef("} ") // end if/else ti.toArray
 	}
 	x.line("if " + sepVarname + " {")
-	x.linef("if %s || %s {", ti2arrayvar, struct2arrvar) // if ti.toArray {
-	x.line("r.EncodeArrayEnd()")
-	x.linef("} else {") // if not ti.toArray
-	x.line("r.EncodeMapEnd()")
-	x.linef("} ") // end if/else ti.toArray
+	x.line("r.EncodeEnd()")
 	x.line("}")
 }
 
@@ -769,56 +910,27 @@ func (x *genRunner) encListFallback(varname string, t reflect.Type) {
 	i := x.varsfx()
 	g := genTempVarPfx
 	x.line("r.EncodeArrayStart(len(" + varname + "))")
-	x.line(genTempVarPfx + "s" + i + " := !z.EncBinary()")
-	x.line("if " + genTempVarPfx + "s" + i + " {")
 	if t.Kind() == reflect.Chan {
 		x.linef("for %si%s, %si2%s := 0, len(%s); %si%s < %si2%s; %si%s++ {", g, i, g, i, varname, g, i, g, i, g, i)
 		x.linef("%sv%s := <-%s", g, i, varname)
 	} else {
-		x.linef("for %si%s, %sv%s := range %s {", genTempVarPfx, i, genTempVarPfx, i, varname)
-	}
-	x.linef("if %si%s > 0 { r.EncodeArrayEntrySeparator() }", genTempVarPfx, i)
-	x.encVar(genTempVarPfx+"v"+i, t.Elem())
-	x.line("}")
-	x.line("r.EncodeArrayEnd()")
-	x.line("} else {")
-	if t.Kind() == reflect.Chan {
-		x.linef("for %si%s, %si2%s := 0, len(%s); %si%s < %si2%s; %si%s++ {", g, i, g, i, varname, g, i, g, i, g, i)
-		x.linef("%sv%s := <-%s", g, i, varname)
-	} else {
-		x.line("for _, " + genTempVarPfx + "v" + i + " := range " + varname + " {")
+		// x.linef("for %si%s, %sv%s := range %s {", genTempVarPfx, i, genTempVarPfx, i, varname)
+		x.linef("for _, %sv%s := range %s {", genTempVarPfx, i, varname)
 	}
 	x.encVar(genTempVarPfx+"v"+i, t.Elem())
 	x.line("}")
-	x.line("}")
+	x.line("r.EncodeEnd()")
 }
 
 func (x *genRunner) encMapFallback(varname string, t reflect.Type) {
 	i := x.varsfx()
 	x.line("r.EncodeMapStart(len(" + varname + "))")
-	x.line(genTempVarPfx + "s" + i + " := !z.EncBinary()")
-
-	x.line(genTempVarPfx + "j" + i + " := 0")
-
-	x.line("if " + genTempVarPfx + "s" + i + " {")
-
-	x.line("for " + genTempVarPfx + "k" + i + ", " +
-		genTempVarPfx + "v" + i + " := range " + varname + " {")
-	x.line("if " + genTempVarPfx + "j" + i + " > 0 { r.EncodeMapEntrySeparator() }")
-	x.encVar(genTempVarPfx+"k"+i, t.Key())
-	x.line("r.EncodeMapKVSeparator()")
-	x.encVar(genTempVarPfx+"v"+i, t.Elem())
-	x.line(genTempVarPfx + "j" + i + "++")
-	x.line("}")
-	x.line("r.EncodeMapEnd()")
-
-	x.line("} else {")
 	x.linef("for %sk%s, %sv%s := range %s {", genTempVarPfx, i, genTempVarPfx, i, varname)
+	// x.line("for " + genTempVarPfx + "k" + i + ", " + genTempVarPfx + "v" + i + " := range " + varname + " {")
 	x.encVar(genTempVarPfx+"k"+i, t.Key())
 	x.encVar(genTempVarPfx+"v"+i, t.Elem())
 	x.line("}")
-
-	x.line("}")
+	x.line("r.EncodeEnd()")
 }
 
 func (x *genRunner) decVar(varname string, t reflect.Type, canBeNil bool) {
@@ -844,7 +956,7 @@ func (x *genRunner) decVar(varname string, t reflect.Type, canBeNil bool) {
 			if strings.IndexByte(varname, '.') != -1 {
 				x.line(varname + " = nil")
 			} else {
-				x.line("*" + varname + " = " + genZeroValueR(t.Elem(), x.tc))
+				x.line("*" + varname + " = " + x.genZeroValueR(t.Elem()))
 			}
 			// x.line("*" + varname + " = nil")
 			x.line("}")
@@ -852,7 +964,7 @@ func (x *genRunner) decVar(varname string, t reflect.Type, canBeNil bool) {
 		} else {
 			// x.line("var " + genTempVarPfx + i + " " + x.genTypeName(t))
 			// x.line(varname + " = " + genTempVarPfx + i)
-			x.line(varname + " = " + genZeroValueR(t, x.tc))
+			x.line(varname + " = " + x.genZeroValueR(t))
 		}
 		x.line("} else {")
 	} else {
@@ -897,34 +1009,76 @@ func (x *genRunner) decVar(varname string, t reflect.Type, canBeNil bool) {
 func (x *genRunner) dec(varname string, t reflect.Type) {
 	// assumptions:
 	//   - the varname is to a pointer already. No need to take address of it
-
+	//   - t is always a baseType T (not a *T, etc).
 	rtid := reflect.ValueOf(t).Pointer()
-	if t.Implements(selferTyp) || (t.Kind() == reflect.Struct &&
-		reflect.PtrTo(t).Implements(selferTyp)) {
-		x.line(varname + ".CodecDecodeSelf(d)")
-		return
-	}
-	if _, ok := x.td[rtid]; ok {
-		x.line(varname + ".CodecDecodeSelf(d)")
-		return
+	tptr := reflect.PtrTo(t)
+	if x.checkForSelfer(t, varname) {
+		if t.Implements(selferTyp) || tptr.Implements(selferTyp) {
+			x.line(varname + ".CodecDecodeSelf(d)")
+			return
+		}
+		if _, ok := x.td[rtid]; ok {
+			x.line(varname + ".CodecDecodeSelf(d)")
+			return
+		}
 	}
 
 	inlist := false
 	for _, t0 := range x.t {
 		if t == t0 {
 			inlist = true
-			if t != x.tc {
+			if x.checkForSelfer(t, varname) {
 				x.line(varname + ".CodecDecodeSelf(d)")
 				return
 			}
 			break
 		}
 	}
+
 	var rtidAdded bool
 	if t == x.tc {
 		x.td[rtid] = true
 		rtidAdded = true
 	}
+
+	// check if
+	//   - type is RawExt
+	//   - the type implements (Text|JSON|Binary)(Unm|M)arshal
+	mi := x.varsfx()
+	x.linef("%sm%s := z.DecBinary()", genTempVarPfx, mi)
+	x.linef("_ = %sm%s", genTempVarPfx, mi)
+	x.line("if false {")           //start if block
+	defer func() { x.line("}") }() //end if block
+
+	if t == rawExtTyp {
+		x.linef("} else { r.DecodeExt(%v, 0, nil)", varname)
+		return
+	}
+
+	// HACK: Support for Builtins.
+	//       Currently, only Binc supports builtins, and the only builtin type is time.Time.
+	//       Have a method that returns the rtid for time.Time if Handle is Binc.
+	if t == timeTyp {
+		vrtid := genTempVarPfx + "m" + x.varsfx()
+		x.linef("} else if %s := z.TimeRtidIfBinc(); %s != 0 { ", vrtid, vrtid)
+		x.linef("r.DecodeBuiltin(%s, %s)", vrtid, varname)
+	}
+	// only check for extensions if the type is named, and has a packagePath.
+	if genImportPath(t) != "" && t.Name() != "" {
+		// first check if extensions are configued, before doing the interface conversion
+		x.linef("} else if z.HasExtensions() && z.DecExt(%s) {", varname)
+	}
+
+	if t.Implements(binaryUnmarshalerTyp) || tptr.Implements(binaryUnmarshalerTyp) {
+		x.linef("} else if %sm%s { z.DecBinaryUnmarshal(%v) ", genTempVarPfx, mi, varname)
+	}
+	if t.Implements(jsonUnmarshalerTyp) || tptr.Implements(jsonUnmarshalerTyp) {
+		x.linef("} else if !%sm%s && z.IsJSONHandle() { z.DecJSONUnmarshal(%v)", genTempVarPfx, mi, varname)
+	} else if t.Implements(textUnmarshalerTyp) || tptr.Implements(textUnmarshalerTyp) {
+		x.linef("} else if !%sm%s { z.DecTextUnmarshal(%v)", genTempVarPfx, mi, varname)
+	}
+
+	x.line("} else {")
 
 	// Since these are pointers, we cannot share, and have to use them one by one
 	switch t.Kind() {
@@ -959,6 +1113,8 @@ func (x *genRunner) dec(varname string, t reflect.Type) {
 	case reflect.Uint64:
 		x.line("*((*uint64)(" + varname + ")) = uint64(r.DecodeUint(64))")
 		//x.line("z.DecUint64((*uint64)(" + varname + "))")
+	case reflect.Uintptr:
+		x.line("*((*uintptr)(" + varname + ")) = uintptr(r.DecodeUint(codecSelferBitsize" + x.xs + "))")
 
 	case reflect.Float32:
 		x.line("*((*float32)(" + varname + ")) = float32(r.DecodeFloat(true))")
@@ -985,7 +1141,7 @@ func (x *genRunner) dec(varname string, t reflect.Type) {
 		if rtid == uint8SliceTypId {
 			x.line("*" + varname + " = r.DecodeBytes(*(*[]byte)(" + varname + "), false, false)")
 		} else if fastpathAV.index(rtid) != -1 {
-			g := genV{Slice: true, Elem: x.genTypeName(t.Elem())}
+			g := x.newGenV(t)
 			x.line("z.F." + g.MethodNamePfx("Dec", false) + "X(" + varname + ", false, d)")
 			// x.line("z." + g.MethodNamePfx("Dec", false) + "(" + varname + ")")
 			// x.line(g.FastpathName(false) + "(" + varname + ", d)")
@@ -999,7 +1155,7 @@ func (x *genRunner) dec(varname string, t reflect.Type) {
 		// - if elements are primitives or Selfers, call dedicated function on each member.
 		// - else call Encoder.encode(XXX) on it.
 		if fastpathAV.index(rtid) != -1 {
-			g := genV{Slice: false, Elem: x.genTypeName(t.Elem()), MapKey: x.genTypeName(t.Key())}
+			g := x.newGenV(t)
 			x.line("z.F." + g.MethodNamePfx("Dec", false) + "X(" + varname + ", false, d)")
 			// x.line("z." + g.MethodNamePfx("Dec", false) + "(" + varname + ")")
 			// x.line(g.FastpathName(false) + "(" + varname + ", d)")
@@ -1037,10 +1193,10 @@ func (x *genRunner) decTryAssignPrimitive(varname string, t reflect.Type) (tryAs
 	// Consequently, we replace:
 	//      case reflect.Uint32: x.line(varname + " = uint32(r.DecodeUint(32))")
 	// with:
-	//      case reflect.Uint32: x.line(varname + " = " + genTypeNamePrimitiveKind(t, x.tc) + "(r.DecodeUint(32))")
+	//      case reflect.Uint32: x.line(varname + " = " + genTypeNamePrim(t, x.tc) + "(r.DecodeUint(32))")
 
 	xfn := func(t reflect.Type) string {
-		return genTypeNamePrimitiveKind(t, x.tc)
+		return x.genTypeNamePrim(t)
 	}
 	switch t.Kind() {
 	case reflect.Int:
@@ -1064,6 +1220,8 @@ func (x *genRunner) decTryAssignPrimitive(varname string, t reflect.Type) (tryAs
 		x.linef("%s = %s(r.DecodeUint(32))", varname, xfn(t))
 	case reflect.Uint64:
 		x.linef("%s = %s(r.DecodeUint(64))", varname, xfn(t))
+	case reflect.Uintptr:
+		x.linef("%s = %s(r.DecodeUint(codecSelferBitsize%s))", varname, xfn(t), x.xs)
 
 	case reflect.Float32:
 		x.linef("%s = %s(r.DecodeFloat(true))", varname, xfn(t))
@@ -1088,11 +1246,13 @@ func (x *genRunner) decListFallback(varname string, rtid uintptr, t reflect.Type
 		CTyp      string
 		Typ       string
 		Immutable bool
+		Size      int
 	}
 	telem := t.Elem()
-	ts := tstruc{genTempVarPfx, x.varsfx(), varname, x.genTypeName(t), x.genTypeName(telem), genIsImmutable(telem)}
+	ts := tstruc{genTempVarPfx, x.varsfx(), varname, x.genTypeName(t), x.genTypeName(telem), genIsImmutable(telem), int(telem.Size())}
 
 	funcs := make(template.FuncMap)
+
 	funcs["decLineVar"] = func(varname string) string {
 		x.decVar(varname, telem, false)
 		return ""
@@ -1105,7 +1265,7 @@ func (x *genRunner) decListFallback(varname string, rtid uintptr, t reflect.Type
 		return ts.TempVar + s + ts.Rand
 	}
 	funcs["zero"] = func() string {
-		return genZeroValueR(telem, x.tc)
+		return x.genZeroValueR(telem)
 	}
 	funcs["isArray"] = func() bool {
 		return t.Kind() == reflect.Array
@@ -1132,10 +1292,11 @@ func (x *genRunner) decMapFallback(varname string, rtid uintptr, t reflect.Type)
 		Varname string
 		KTyp    string
 		Typ     string
+		Size    int
 	}
 	telem := t.Elem()
 	tkey := t.Key()
-	ts := tstruc{genTempVarPfx, x.varsfx(), varname, x.genTypeName(tkey), x.genTypeName(telem)}
+	ts := tstruc{genTempVarPfx, x.varsfx(), varname, x.genTypeName(tkey), x.genTypeName(telem), int(telem.Size() + tkey.Size())}
 	funcs := make(template.FuncMap)
 	funcs["decLineVarK"] = func(varname string) string {
 		x.decVar(varname, tkey, false)
@@ -1232,13 +1393,11 @@ func (x *genRunner) decStructMap(varname, lenvarname string, rtid uintptr, t ref
 		x.linef("for %sj%s := 0; %sj%s < %s; %sj%s++ {", tpfx, i, tpfx, i, lenvarname, tpfx, i)
 	case 2:
 		x.linef("for %sj%s := 0; !r.CheckBreak(); %sj%s++ {", tpfx, i, tpfx, i)
-		x.linef("if %sj%s > 0 { r.ReadMapEntrySeparator() }", tpfx, i)
 	default: // 0, otherwise.
 		x.linef("var %shl%s bool = %s >= 0", tpfx, i, lenvarname) // has length
 		x.linef("for %sj%s := 0; ; %sj%s++ {", tpfx, i, tpfx, i)
 		x.linef("if %shl%s { if %sj%s >= %s { break }", tpfx, i, tpfx, i, lenvarname)
-		x.linef("} else { if r.CheckBreak() { break }; if %sj%s > 0 { r.ReadMapEntrySeparator() } }",
-			tpfx, i)
+		x.line("} else { if r.CheckBreak() { break }; }")
 	}
 	// x.line(kName + " = z.ReadStringAsBytes(" + kName + ")")
 	// x.line(kName + " = z.ReadString()")
@@ -1252,22 +1411,15 @@ func (x *genRunner) decStructMap(varname, lenvarname string, rtid uintptr, t ref
 	} else {
 		x.line(kName + " := string(" + kName + "Slc)")
 	}
-	switch style {
-	case 1:
-	case 2:
-		x.line("r.ReadMapKVSeparator()")
-	default:
-		x.linef("if !%shl%s { r.ReadMapKVSeparator() }", tpfx, i)
-	}
 	x.decStructMapSwitch(kName, varname, rtid, t)
 
 	x.line("} // end for " + tpfx + "j" + i)
 	switch style {
 	case 1:
 	case 2:
-		x.line("r.ReadMapEnd()")
+		x.line("r.ReadEnd()")
 	default:
-		x.linef("if !%shl%s { r.ReadMapEnd() }", tpfx, i)
+		x.linef("if !%shl%s { r.ReadEnd() }", tpfx, i)
 	}
 }
 
@@ -1280,7 +1432,7 @@ func (x *genRunner) decStructArray(varname, lenvarname, breakString string, rtid
 	x.linef("var %sb%s bool", tpfx, i) // break
 	// x.linef("var %sl%s := r.ReadArrayStart()", tpfx, i)
 	x.linef("var %shl%s bool = %s >= 0", tpfx, i, lenvarname) // has length
-	for j, si := range tisfi {
+	for _, si := range tisfi {
 		var t2 reflect.StructField
 		if si.i != -1 {
 			t2 = t.Field(int(si.i))
@@ -1293,10 +1445,7 @@ func (x *genRunner) decStructArray(varname, lenvarname, breakString string, rtid
 			tpfx, i, lenvarname, tpfx, i)
 		// x.line("if " + tpfx + "j" + i + "++; " + tpfx + "j" +
 		// i + " <=  " + tpfx + "l" + i + " {")
-		x.linef("if %sb%s { r.ReadArrayEnd(); %s }", tpfx, i, breakString)
-		if j > 0 {
-			x.line("r.ReadArrayEntrySeparator()")
-		}
+		x.linef("if %sb%s { r.ReadEnd(); %s }", tpfx, i, breakString)
 		x.decVar(varname+"."+t2.Name, t2.Type, true)
 		// x.line("} // end if " + tpfx + "j" + i + " <=  " + tpfx + "l" + i)
 	}
@@ -1306,20 +1455,19 @@ func (x *genRunner) decStructArray(varname, lenvarname, breakString string, rtid
 		tpfx, i, tpfx, i, tpfx, i,
 		tpfx, i, lenvarname, tpfx, i)
 	x.linef("if %sb%s { break }", tpfx, i)
-	x.linef("if %sj%s > 1 { r.ReadArrayEntrySeparator() }", tpfx, i)
 	x.linef(`z.DecStructFieldNotFound(%sj%s - 1, "")`, tpfx, i)
 	x.line("}")
-	x.line("r.ReadArrayEnd()")
+	x.line("r.ReadEnd()")
 }
 
 func (x *genRunner) decStruct(varname string, rtid uintptr, t reflect.Type) {
 	// if container is map
 	// x.line("if z.DecContainerIsMap() { ")
 	i := x.varsfx()
-	x.line("if r.IsContainerType(codecSelverValueTypeMap" + x.xs + ") {")
+	x.line("if r.IsContainerType(codecSelferValueTypeMap" + x.xs + ") {")
 	x.line(genTempVarPfx + "l" + i + " := r.ReadMapStart()")
 	x.linef("if %sl%s == 0 {", genTempVarPfx, i)
-	x.line("r.ReadMapEnd()")
+	x.line("r.ReadEnd()")
 	if genUseOneFunctionForDecStructMap {
 		x.line("} else { ")
 		x.linef("x.codecDecodeSelfFromMap(%sl%s, d)", genTempVarPfx, i)
@@ -1333,10 +1481,10 @@ func (x *genRunner) decStruct(varname string, rtid uintptr, t reflect.Type) {
 
 	// else if container is array
 	// x.line("} else if z.DecContainerIsArray() { ")
-	x.line("} else if r.IsContainerType(codecSelverValueTypeArray" + x.xs + ") {")
+	x.line("} else if r.IsContainerType(codecSelferValueTypeArray" + x.xs + ") {")
 	x.line(genTempVarPfx + "l" + i + " := r.ReadArrayStart()")
 	x.linef("if %sl%s == 0 {", genTempVarPfx, i)
-	x.line("r.ReadArrayEnd()")
+	x.line("r.ReadEnd()")
 	x.line("} else { ")
 	x.linef("x.codecDecodeSelfFromArray(%sl%s, d)", genTempVarPfx, i)
 	x.line("}")
@@ -1350,11 +1498,28 @@ func (x *genRunner) decStruct(varname string, rtid uintptr, t reflect.Type) {
 // --------
 
 type genV struct {
-	// genV is either a primitive (Primitive != "") or a slice (Slice = true) or a map.
-	Slice     bool
+	// genV is either a primitive (Primitive != "") or a map (MapKey != "") or a slice
 	MapKey    string
 	Elem      string
 	Primitive string
+	Size      int
+}
+
+func (x *genRunner) newGenV(t reflect.Type) (v genV) {
+	switch t.Kind() {
+	case reflect.Slice, reflect.Array:
+		te := t.Elem()
+		v.Elem = x.genTypeName(te)
+		v.Size = int(te.Size())
+	case reflect.Map:
+		te, tk := t.Elem(), t.Key()
+		v.Elem = x.genTypeName(te)
+		v.MapKey = x.genTypeName(tk)
+		v.Size = int(te.Size() + tk.Size())
+	default:
+		panic("unexpected type for newGenV. Requires map or slice type")
+	}
+	return
 }
 
 func (x *genV) MethodNamePfx(prefix string, prim bool) string {
@@ -1365,7 +1530,7 @@ func (x *genV) MethodNamePfx(prefix string, prim bool) string {
 	if prim {
 		name = append(name, genTitleCaseName(x.Primitive)...)
 	} else {
-		if x.Slice {
+		if x.MapKey == "" {
 			name = append(name, "Slice"...)
 		} else {
 			name = append(name, "Map"...)
@@ -1375,6 +1540,29 @@ func (x *genV) MethodNamePfx(prefix string, prim bool) string {
 	}
 	return string(name)
 
+}
+
+var genCheckVendor = os.Getenv("GO15VENDOREXPERIMENT") == "1"
+
+// genImportPath returns import path of a non-predeclared named typed, or an empty string otherwise.
+//
+// This handles the misbehaviour that occurs when 1.5-style vendoring is enabled,
+// where PkgPath returns the full path, including the vendoring pre-fix that should have been stripped.
+// We strip it here.
+func genImportPath(t reflect.Type) (s string) {
+	s = t.PkgPath()
+	if genCheckVendor {
+		// HACK: Misbehaviour occurs in go 1.5. May have to re-visit this later.
+		// if s contains /vendor/ OR startsWith vendor/, then return everything after it.
+		const vendorStart = "vendor/"
+		const vendorInline = "/vendor/"
+		if i := strings.LastIndex(s, vendorInline); i >= 0 {
+			s = s[i+len(vendorInline):]
+		} else if strings.HasPrefix(s, vendorStart) {
+			s = s[len(vendorStart):]
+		}
+	}
+	return
 }
 
 func genNonPtr(t reflect.Type) reflect.Type {
@@ -1393,59 +1581,17 @@ func genTitleCaseName(s string) string {
 	}
 }
 
-func genTypeNamePrimitiveKind(t reflect.Type, tRef reflect.Type) (n string) {
-	if tRef != nil && t.PkgPath() == tRef.PkgPath() && t.Name() != "" {
-		return t.Name()
-	} else {
-		return t.String() // best way to get the package name inclusive
-	}
-}
-
-func genTypeName(t reflect.Type, tRef reflect.Type) (n string) {
-	// defer func() { fmt.Printf(">>>> ####: genTypeName: t: %v, name: '%s'\n", t, n) }()
-
-	// if the type has a PkgPath, which doesn't match the current package,
-	// then include it.
-	// We cannot depend on t.String() because it includes current package,
-	// or t.PkgPath because it includes full import path,
-	//
-	var ptrPfx string
-	for t.Kind() == reflect.Ptr {
-		ptrPfx += "*"
-		t = t.Elem()
-	}
-	if tn := t.Name(); tn != "" {
-		return ptrPfx + genTypeNamePrimitiveKind(t, tRef)
-	}
-	switch t.Kind() {
-	case reflect.Map:
-		return ptrPfx + "map[" + genTypeName(t.Key(), tRef) + "]" + genTypeName(t.Elem(), tRef)
-	case reflect.Slice:
-		return ptrPfx + "[]" + genTypeName(t.Elem(), tRef)
-	case reflect.Array:
-		return ptrPfx + "[" + strconv.FormatInt(int64(t.Len()), 10) + "]" + genTypeName(t.Elem(), tRef)
-	case reflect.Chan:
-		return ptrPfx + t.ChanDir().String() + " " + genTypeName(t.Elem(), tRef)
-	default:
-		if t == intfTyp {
-			return ptrPfx + "interface{}"
-		} else {
-			return ptrPfx + genTypeNamePrimitiveKind(t, tRef)
-		}
-	}
-}
-
 func genMethodNameT(t reflect.Type, tRef reflect.Type) (n string) {
 	var ptrPfx string
 	for t.Kind() == reflect.Ptr {
 		ptrPfx += "Ptrto"
 		t = t.Elem()
 	}
+	tstr := t.String()
 	if tn := t.Name(); tn != "" {
-		if tRef != nil && t.PkgPath() == tRef.PkgPath() {
+		if tRef != nil && genImportPath(t) == genImportPath(tRef) {
 			return ptrPfx + tn
 		} else {
-			tstr := t.String()
 			if genQNameRegex.MatchString(tstr) {
 				return ptrPfx + strings.Replace(tstr, ".", "_", 1000)
 			} else {
@@ -1475,17 +1621,16 @@ func genMethodNameT(t reflect.Type, tRef reflect.Type) (n string) {
 		if t == intfTyp {
 			return ptrPfx + "Interface"
 		} else {
-			if tRef != nil && t.PkgPath() == tRef.PkgPath() {
+			if tRef != nil && genImportPath(t) == genImportPath(tRef) {
 				if t.Name() != "" {
 					return ptrPfx + t.Name()
 				} else {
-					return ptrPfx + genCustomTypeName(t.String())
+					return ptrPfx + genCustomTypeName(tstr)
 				}
 			} else {
 				// best way to get the package name inclusive
-				// return ptrPfx + strings.Replace(t.String(), ".", "_", 1000)
-				// return ptrPfx + genBase64enc.EncodeToString([]byte(t.String()))
-				tstr := t.String()
+				// return ptrPfx + strings.Replace(tstr, ".", "_", 1000)
+				// return ptrPfx + genBase64enc.EncodeToString([]byte(tstr))
 				if t.Name() != "" && genQNameRegex.MatchString(tstr) {
 					return ptrPfx + strings.Replace(tstr, ".", "_", 1000)
 				} else {
@@ -1513,24 +1658,7 @@ func genCustomTypeName(tstr string) string {
 }
 
 func genIsImmutable(t reflect.Type) (v bool) {
-	return isMutableKind(t.Kind())
-}
-
-func genZeroValueR(t reflect.Type, tRef reflect.Type) string {
-	// if t is a named type, w
-	switch t.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func,
-		reflect.Slice, reflect.Map, reflect.Invalid:
-		return "nil"
-	case reflect.Bool:
-		return "false"
-	case reflect.String:
-		return `""`
-	case reflect.Struct, reflect.Array:
-		return genTypeName(t, tRef) + "{}"
-	default: // all numbers
-		return "0"
-	}
+	return isImmutableKind(t.Kind())
 }
 
 type genInternal struct {
@@ -1660,23 +1788,42 @@ func genInternalInit() {
 		"float64",
 		"bool",
 	}
-	mapvaltypes2 := make(map[string]bool)
-	for _, s := range mapvaltypes {
-		mapvaltypes2[s] = true
+	wordSizeBytes := int(intBitsize) / 8
+
+	mapvaltypes2 := map[string]int{
+		"interface{}": 2 * wordSizeBytes,
+		"string":      2 * wordSizeBytes,
+		"uint":        1 * wordSizeBytes,
+		"uint8":       1,
+		"uint16":      2,
+		"uint32":      4,
+		"uint64":      8,
+		"int":         1 * wordSizeBytes,
+		"int8":        1,
+		"int16":       2,
+		"int32":       4,
+		"int64":       8,
+		"float32":     4,
+		"float64":     8,
+		"bool":        1,
 	}
+	// mapvaltypes2 := make(map[string]bool)
+	// for _, s := range mapvaltypes {
+	// 	mapvaltypes2[s] = true
+	// }
 	var gt genInternal
 
 	// For each slice or map type, there must be a (symetrical) Encode and Decode fast-path function
 	for _, s := range types {
-		gt.Values = append(gt.Values, genV{false, "", "", s})
+		gt.Values = append(gt.Values, genV{Primitive: s, Size: mapvaltypes2[s]})
 		if s != "uint8" { // do not generate fast path for slice of bytes. Treat specially already.
-			gt.Values = append(gt.Values, genV{true, "", s, ""})
+			gt.Values = append(gt.Values, genV{Elem: s, Size: mapvaltypes2[s]})
 		}
-		if !mapvaltypes2[s] {
-			gt.Values = append(gt.Values, genV{false, s, s, ""})
+		if _, ok := mapvaltypes2[s]; !ok {
+			gt.Values = append(gt.Values, genV{MapKey: s, Elem: s, Size: 2 * mapvaltypes2[s]})
 		}
 		for _, ms := range mapvaltypes {
-			gt.Values = append(gt.Values, genV{false, s, ms, ""})
+			gt.Values = append(gt.Values, genV{MapKey: s, Elem: ms, Size: mapvaltypes2[s] + mapvaltypes2[ms]})
 		}
 	}
 

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/helper_internal.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/helper_internal.go
@@ -149,3 +149,94 @@ func halfFloatToFloatBits(yy uint16) (d uint32) {
 	m = m << 13
 	return (s << 31) | (e << 23) | m
 }
+
+// GrowCap will return a new capacity for a slice, given the following:
+//   - oldCap: current capacity
+//   - unit: in-memory size of an element
+//   - num: number of elements to add
+func growCap(oldCap, unit, num int) (newCap int) {
+	// appendslice logic (if cap < 1024, *2, else *1.25):
+	//   leads to many copy calls, especially when copying bytes.
+	//   bytes.Buffer model (2*cap + n): much better for bytes.
+	// smarter way is to take the byte-size of the appended element(type) into account
+
+	// maintain 3 thresholds:
+	// t1: if cap <= t1, newcap = 2x
+	// t2: if cap <= t2, newcap = 1.75x
+	// t3: if cap <= t3, newcap = 1.5x
+	//     else          newcap = 1.25x
+	//
+	// t1, t2, t3 >= 1024 always.
+	// i.e. if unit size >= 16, then always do 2x or 1.25x (ie t1, t2, t3 are all same)
+	//
+	// With this, appending for bytes increase by:
+	//    100% up to 4K
+	//     75% up to 8K
+	//     50% up to 16K
+	//     25% beyond that
+
+	// unit can be 0 e.g. for struct{}{}; handle that appropriately
+	var t1, t2, t3 int // thresholds
+	if unit <= 1 {
+		t1, t2, t3 = 4*1024, 8*1024, 16*1024
+	} else if unit < 16 {
+		t3 = 16 / unit * 1024
+		t1 = t3 * 1 / 4
+		t2 = t3 * 2 / 4
+	} else {
+		t1, t2, t3 = 1024, 1024, 1024
+	}
+
+	var x int // temporary variable
+
+	// x is multiplier here: one of 5, 6, 7 or 8; incr of 25%, 50%, 75% or 100% respectively
+	if oldCap <= t1 { // [0,t1]
+		x = 8
+	} else if oldCap > t3 { // (t3,infinity]
+		x = 5
+	} else if oldCap <= t2 { // (t1,t2]
+		x = 7
+	} else { // (t2,t3]
+		x = 6
+	}
+	newCap = x * oldCap / 4
+
+	if num > 0 {
+		newCap += num
+	}
+
+	// ensure newCap is a multiple of 64 (if it is > 64) or 16.
+	if newCap > 64 {
+		if x = newCap % 64; x != 0 {
+			x = newCap / 64
+			newCap = 64 * (x + 1)
+		}
+	} else {
+		if x = newCap % 16; x != 0 {
+			x = newCap / 16
+			newCap = 16 * (x + 1)
+		}
+	}
+	return
+}
+
+func expandSliceValue(s reflect.Value, num int) reflect.Value {
+	if num <= 0 {
+		return s
+	}
+	l0 := s.Len()
+	l1 := l0 + num // new slice length
+	if l1 < l0 {
+		panic("ExpandSlice: slice overflow")
+	}
+	c0 := s.Cap()
+	if l1 <= c0 {
+		return s.Slice(0, l1)
+	}
+	st := s.Type()
+	c1 := growCap(c0, int(st.Elem().Size()), num)
+	s2 := reflect.MakeSlice(st, l1, c1)
+	// println("expandslicevalue: cap-old: ", c0, ", cap-new: ", c1, ", len-new: ", l1)
+	reflect.Copy(s2, s)
+	return s2
+}

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/helper_unsafe.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/helper_unsafe.go
@@ -26,6 +26,9 @@ type unsafeBytes struct {
 // In unsafe mode, it doesn't incur allocation and copying caused by conversion.
 // In regular safe mode, it is an allocation and copy.
 func stringView(v []byte) string {
+	if len(v) == 0 {
+		return ""
+	}
 	x := unsafeString{uintptr(unsafe.Pointer(&v[0])), len(v)}
 	return *(*string)(unsafe.Pointer(&x))
 }
@@ -34,6 +37,9 @@ func stringView(v []byte) string {
 // In unsafe mode, it doesn't incur allocation and copying caused by conversion.
 // In regular safe mode, it is an allocation and copy.
 func bytesView(v string) []byte {
+	if len(v) == 0 {
+		return zeroByteSlice
+	}
 	x := unsafeBytes{uintptr(unsafe.Pointer(&v)), len(v), len(v)}
 	return *(*[]byte)(unsafe.Pointer(&x))
 }

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/json.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/json.go
@@ -3,8 +3,9 @@
 
 package codec
 
-// This json support uses base64 encoding for bytes, because you cannot
+// By default, this json support uses base64 encoding for bytes, because you cannot
 // store and read any arbitrary string in json (only unicode).
+// However, the user can configre how to encode/decode bytes.
 //
 // This library specifically supports UTF-8 for encoding and decoding only.
 //
@@ -27,11 +28,18 @@ package codec
 //   - encode does not beautify. There is no whitespace when encoding.
 //   - rpc calls which take single integer arguments or write single numeric arguments will need care.
 
+// Top-level methods of json(End|Dec)Driver (which are implementations of (en|de)cDriver
+// MUST not call one-another.
+// They all must call sep(), and sep() MUST NOT be called more than once for each read.
+// If sep() is called and read is not done, you MUST call retryRead so separator wouldn't be read/written twice.
+
 import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"strconv"
+	"sync"
 	"unicode/utf16"
 	"unicode/utf8"
 )
@@ -81,20 +89,122 @@ const (
 	// jsonNumDigitsUint64Largest = 19
 )
 
+// A stack is used to keep track of where we are in the tree.
+// This is necessary, as the Handle must know whether to consume or emit a separator.
+
+type jsonStackElem struct {
+	st byte // top of stack (either '}' or ']' or 0 for map, array or neither).
+	sf bool // NOT first time in that container at top of stack
+	so bool // stack ctr odd
+	sr bool // value has NOT been read, so do not re-send separator
+}
+
+func (x *jsonStackElem) retryRead() {
+	if x != nil && !x.sr {
+		x.sr = true
+	}
+}
+
+func (x *jsonStackElem) sep() (c byte) {
+	// do not use switch, so it's a candidate for inlining.
+	// to inline effectively, this must not be called from within another method.
+	// v := j.st
+	if x == nil || x.st == 0 {
+		return
+	}
+	if x.sr {
+		x.sr = false
+		return
+	}
+	// v == '}' OR ']'
+	if x.st == '}' {
+		// put , or : depending on if even or odd respectively
+		if x.so {
+			c = ':'
+			if !x.sf {
+				x.sf = true
+			}
+		} else if x.sf {
+			c = ','
+		}
+	} else {
+		if x.sf {
+			c = ','
+		} else {
+			x.sf = true
+		}
+	}
+	x.so = !x.so
+	// Note: Anything more, and this function doesn't inline. Keep it tight.
+	// if x.sr {
+	// 	x.sr = false
+	// }
+	return
+}
+
+const jsonStackPoolArrayLen = 32
+
+// pool used to prevent constant allocation of stacks.
+var jsonStackPool = sync.Pool{
+	New: func() interface{} {
+		return new([jsonStackPoolArrayLen]jsonStackElem)
+	},
+}
+
+// jsonStack contains the stack for tracking the state of the container (branch).
+// The same data structure is used during encode and decode, as it is similar functionality.
+type jsonStack struct {
+	s  []jsonStackElem // stack for map or array end tag. map=}, array=]
+	sc *jsonStackElem  // pointer to current (top) element on the stack.
+	sp *[jsonStackPoolArrayLen]jsonStackElem
+}
+
+func (j *jsonStack) start(c byte) {
+	if j.s == nil {
+		// j.s = make([]jsonStackElem, 0, 8)
+		j.sp = jsonStackPool.Get().(*[jsonStackPoolArrayLen]jsonStackElem)
+		j.s = j.sp[:0]
+	}
+	j.s = append(j.s, jsonStackElem{st: c})
+	j.sc = &(j.s[len(j.s)-1])
+}
+
+func (j *jsonStack) end() {
+	l := len(j.s) - 1 // length of new stack after pop'ing
+	if l == 0 {
+		jsonStackPool.Put(j.sp)
+		j.s = nil
+		j.sp = nil
+		j.sc = nil
+	} else {
+		j.s = j.s[:l]
+		j.sc = &(j.s[l-1])
+	}
+	//j.sc = &(j.s[len(j.s)-1])
+}
+
 type jsonEncDriver struct {
 	e  *Encoder
 	w  encWriter
 	h  *JsonHandle
 	b  [64]byte // scratch
 	bs []byte   // scratch
+	se setExtWrapper
+	s  jsonStack
 	noBuiltInTypes
 }
 
 func (e *jsonEncDriver) EncodeNil() {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	e.w.writeb(jsonLiterals[9:13]) // null
 }
 
 func (e *jsonEncDriver) EncodeBool(b bool) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	if b {
 		e.w.writeb(jsonLiterals[0:4]) // true
 	} else {
@@ -103,78 +213,106 @@ func (e *jsonEncDriver) EncodeBool(b bool) {
 }
 
 func (e *jsonEncDriver) EncodeFloat32(f float32) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	e.w.writeb(strconv.AppendFloat(e.b[:0], float64(f), 'E', -1, 32))
 }
 
 func (e *jsonEncDriver) EncodeFloat64(f float64) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	// e.w.writestr(strconv.FormatFloat(f, 'E', -1, 64))
 	e.w.writeb(strconv.AppendFloat(e.b[:0], f, 'E', -1, 64))
 }
 
 func (e *jsonEncDriver) EncodeInt(v int64) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	e.w.writeb(strconv.AppendInt(e.b[:0], v, 10))
 }
 
 func (e *jsonEncDriver) EncodeUint(v uint64) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	e.w.writeb(strconv.AppendUint(e.b[:0], v, 10))
 }
 
 func (e *jsonEncDriver) EncodeExt(rv interface{}, xtag uint64, ext Ext, en *Encoder) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	if v := ext.ConvertExt(rv); v == nil {
-		e.EncodeNil()
+		e.w.writeb(jsonLiterals[9:13]) // null // e.EncodeNil()
 	} else {
+		e.s.sc.retryRead()
 		en.encode(v)
 	}
 }
 
 func (e *jsonEncDriver) EncodeRawExt(re *RawExt, en *Encoder) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	// only encodes re.Value (never re.Data)
 	if re.Value == nil {
-		e.EncodeNil()
+		e.w.writeb(jsonLiterals[9:13]) // null // e.EncodeNil()
 	} else {
+		e.s.sc.retryRead()
 		en.encode(re.Value)
 	}
 }
 
 func (e *jsonEncDriver) EncodeArrayStart(length int) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
+	e.s.start(']')
 	e.w.writen1('[')
 }
 
-func (e *jsonEncDriver) EncodeArrayEntrySeparator() {
-	e.w.writen1(',')
-}
-
-func (e *jsonEncDriver) EncodeArrayEnd() {
-	e.w.writen1(']')
-}
-
 func (e *jsonEncDriver) EncodeMapStart(length int) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
+	e.s.start('}')
 	e.w.writen1('{')
 }
 
-func (e *jsonEncDriver) EncodeMapEntrySeparator() {
-	e.w.writen1(',')
-}
-
-func (e *jsonEncDriver) EncodeMapKVSeparator() {
-	e.w.writen1(':')
-}
-
-func (e *jsonEncDriver) EncodeMapEnd() {
-	e.w.writen1('}')
+func (e *jsonEncDriver) EncodeEnd() {
+	b := e.s.sc.st
+	e.s.end()
+	e.w.writen1(b)
 }
 
 func (e *jsonEncDriver) EncodeString(c charEncoding, v string) {
 	// e.w.writestr(strconv.Quote(v))
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	e.quoteStr(v)
 }
 
 func (e *jsonEncDriver) EncodeSymbol(v string) {
 	// e.EncodeString(c_UTF8, v)
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	e.quoteStr(v)
 }
 
 func (e *jsonEncDriver) EncodeStringBytes(c charEncoding, v []byte) {
+	// if encoding raw bytes and RawBytesExt is configured, use it to encode
+	if c == c_RAW && e.se.i != nil {
+		e.EncodeExt(v, 0, &e.se, e.e)
+		return
+	}
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
 	if c == c_RAW {
 		slen := base64.StdEncoding.EncodedLen(len(v))
 		if e.bs == nil {
@@ -193,6 +331,13 @@ func (e *jsonEncDriver) EncodeStringBytes(c charEncoding, v []byte) {
 		// e.EncodeString(c, string(v))
 		e.quoteStr(stringView(v))
 	}
+}
+
+func (e *jsonEncDriver) EncodeAsis(v []byte) {
+	if c := e.s.sc.sep(); c != 0 {
+		e.w.writen1(c)
+	}
+	e.w.writeb(v)
 }
 
 func (e *jsonEncDriver) quoteStr(s string) {
@@ -356,8 +501,13 @@ type jsonDecDriver struct {
 	ct   valueType // container type. one of unset, array or map.
 	bstr [8]byte   // scratch used for string \UXXX parsing
 	b    [64]byte  // scratch
+	b2   [64]byte
 
 	wsSkipped bool // whitespace skipped
+
+	se setExtWrapper
+
+	s jsonStack
 
 	n jsonNum
 	noBuiltInTypes
@@ -402,16 +552,27 @@ func (d *jsonDecDriver) readStrIdx(fromIdx, toIdx uint8) {
 }
 
 func (d *jsonDecDriver) TryDecodeAsNil() bool {
-	b := d.skipWhitespace(true)
+	// we mustn't consume the state here, and end up trying to read separator twice.
+	// Instead, we keep track of the state and restore it if we couldn't decode as nil.
+
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
+	b := d.skipWhitespace(false)
 	if b == 'n' {
-		d.readStrIdx(9, 13) // null
+		d.readStrIdx(10, 13) // ull
 		d.ct = valueTypeNil
 		return true
 	}
+	d.r.unreadn1()
+	d.s.sc.retryRead()
 	return false
 }
 
 func (d *jsonDecDriver) DecodeBool() bool {
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
 	b := d.skipWhitespace(false)
 	if b == 'f' {
 		d.readStrIdx(5, 9) // alse
@@ -426,41 +587,52 @@ func (d *jsonDecDriver) DecodeBool() bool {
 }
 
 func (d *jsonDecDriver) ReadMapStart() int {
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
+	d.s.start('}')
 	d.expectChar('{')
 	d.ct = valueTypeMap
 	return -1
 }
 
 func (d *jsonDecDriver) ReadArrayStart() int {
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
+	d.s.start(']')
 	d.expectChar('[')
 	d.ct = valueTypeArray
 	return -1
 }
-func (d *jsonDecDriver) ReadMapEnd() {
-	d.expectChar('}')
+
+func (d *jsonDecDriver) ReadEnd() {
+	b := d.s.sc.st
+	d.s.end()
+	d.expectChar(b)
 }
-func (d *jsonDecDriver) ReadArrayEnd() {
-	d.expectChar(']')
-}
-func (d *jsonDecDriver) ReadArrayEntrySeparator() {
-	d.expectChar(',')
-}
-func (d *jsonDecDriver) ReadMapEntrySeparator() {
-	d.expectChar(',')
-}
-func (d *jsonDecDriver) ReadMapKVSeparator() {
-	d.expectChar(':')
-}
+
 func (d *jsonDecDriver) expectChar(c uint8) {
 	b := d.skipWhitespace(false)
 	if b != c {
-		d.d.errorf("json: expect char %c but got char %c", c, b)
+		d.d.errorf("json: expect char '%c' but got char '%c'", c, b)
 		return
 	}
 	if jsonTrackSkipWhitespace {
 		d.wsSkipped = false
 	}
 }
+
+// func (d *jsonDecDriver) maybeChar(c uint8) {
+// 	b := d.skipWhitespace(false)
+// 	if b != c {
+// 		d.r.unreadn1()
+// 		return
+// 	}
+// 	if jsonTrackSkipWhitespace {
+// 		d.wsSkipped = false
+// 	}
+// }
 
 func (d *jsonDecDriver) IsContainerType(vt valueType) bool {
 	// check container type by checking the first char
@@ -635,6 +807,9 @@ LOOP:
 }
 
 func (d *jsonDecDriver) DecodeInt(bitsize uint8) (i int64) {
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
 	d.decNum(false)
 	n := &d.n
 	if n.manOverflow {
@@ -667,6 +842,9 @@ func (d *jsonDecDriver) DecodeInt(bitsize uint8) (i int64) {
 }
 
 func (d *jsonDecDriver) DecodeUint(bitsize uint8) (u uint64) {
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
 	d.decNum(false)
 	n := &d.n
 	if n.neg {
@@ -698,6 +876,9 @@ func (d *jsonDecDriver) DecodeUint(bitsize uint8) (u uint64) {
 }
 
 func (d *jsonDecDriver) DecodeFloat(chkOverflow32 bool) (f float64) {
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
 	d.decNum(true)
 	n := &d.n
 	f = n.floatVal()
@@ -709,6 +890,10 @@ func (d *jsonDecDriver) DecodeFloat(chkOverflow32 bool) (f float64) {
 }
 
 func (d *jsonDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxtag uint64) {
+	// No need to call sep here, as d.d.decode() handles it
+	// if c := d.s.sc.sep(); c != 0 {
+	// 	d.expectChar(c)
+	// }
 	if ext == nil {
 		re := rv.(*RawExt)
 		re.Tag = xtag
@@ -722,14 +907,26 @@ func (d *jsonDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxta
 }
 
 func (d *jsonDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
-	// zerocopy doesn't matter for json, as the bytes must be parsed.
+	// if decoding into raw bytes, and the RawBytesExt is configured, use it to decode.
+	if !isstring && d.se.i != nil {
+		bsOut = bs
+		d.DecodeExt(&bsOut, 0, &d.se)
+		return
+	}
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
 	bs0 := d.appendStringAsBytes(d.b[:0])
+	// if isstring, then just return the bytes, even if it is using the scratch buffer.
+	// the bytes will be converted to a string as needed.
 	if isstring {
 		return bs0
 	}
 	slen := base64.StdEncoding.DecodedLen(len(bs0))
-	if cap(bs) >= slen {
+	if slen <= cap(bs) {
 		bsOut = bs[:slen]
+	} else if zerocopy && slen <= cap(d.b2) {
+		bsOut = d.b2[:slen]
 	} else {
 		bsOut = make([]byte, slen)
 	}
@@ -745,6 +942,9 @@ func (d *jsonDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut [
 }
 
 func (d *jsonDecDriver) DecodeString() (s string) {
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
 	return string(d.appendStringAsBytes(d.b[:0]))
 }
 
@@ -816,6 +1016,9 @@ func (d *jsonDecDriver) jsonU4(checkSlashU bool) rune {
 }
 
 func (d *jsonDecDriver) DecodeNaked() (v interface{}, vt valueType, decodeFurther bool) {
+	if c := d.s.sc.sep(); c != 0 {
+		d.expectChar(c)
+	}
 	n := d.skipWhitespace(true)
 	switch n {
 	case 'n':
@@ -837,7 +1040,7 @@ func (d *jsonDecDriver) DecodeNaked() (v interface{}, vt valueType, decodeFurthe
 		decodeFurther = true
 	case '"':
 		vt = valueTypeString
-		v = d.DecodeString()
+		v = string(d.appendStringAsBytes(d.b[:0])) // same as d.DecodeString(), but skipping sep() call.
 	default: // number
 		d.decNum(true)
 		n := &d.n
@@ -878,6 +1081,9 @@ func (d *jsonDecDriver) DecodeNaked() (v interface{}, vt valueType, decodeFurthe
 		}
 		// fmt.Printf("DecodeNaked: Number: %T, %v\n", v, v)
 	}
+	if decodeFurther {
+		d.s.sc.retryRead()
+	}
 	return
 }
 
@@ -887,7 +1093,8 @@ func (d *jsonDecDriver) DecodeNaked() (v interface{}, vt valueType, decodeFurthe
 //
 // Json is comprehensively supported:
 //    - decodes numbers into interface{} as int, uint or float64
-//    - encodes and decodes []byte using base64 Std Encoding
+//    - configurable way to encode/decode []byte .
+//      by default, encodes and decodes []byte using base64 Std Encoding
 //    - UTF-8 support for encoding and decoding
 //
 // It has better performance than the json library in the standard library,
@@ -901,17 +1108,27 @@ func (d *jsonDecDriver) DecodeNaked() (v interface{}, vt valueType, decodeFurthe
 type JsonHandle struct {
 	BasicHandle
 	textEncodingType
+	// RawBytesExt, if configured, is used to encode and decode raw bytes in a custom way.
+	// If not configured, raw bytes are encoded to/from base64 text.
+	RawBytesExt InterfaceExt
 }
 
 func (h *JsonHandle) newEncDriver(e *Encoder) encDriver {
-	return &jsonEncDriver{e: e, w: e.w, h: h}
+	hd := jsonEncDriver{e: e, w: e.w, h: h}
+	hd.se.i = h.RawBytesExt
+	return &hd
 }
 
 func (h *JsonHandle) newDecDriver(d *Decoder) decDriver {
 	// d := jsonDecDriver{r: r.(*bytesDecReader), h: h}
 	hd := jsonDecDriver{d: d, r: d.r, h: h}
+	hd.se.i = h.RawBytesExt
 	hd.n.bytes = d.b[:]
 	return &hd
+}
+
+func (h *JsonHandle) SetInterfaceExt(rt reflect.Type, tag uint64, ext InterfaceExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{i: ext})
 }
 
 var jsonEncodeTerminate = []byte{' '}

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/msgpack.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/msgpack.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"math"
 	"net/rpc"
+	"reflect"
 )
 
 const (
@@ -536,15 +537,11 @@ func (d *msgpackDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOu
 		d.readNextBd()
 	}
 	var clen int
-	if isstring {
-		clen = d.readContainerLen(msgpackContainerStr)
+	// ignore isstring. Expect that the bytes may be found from msgpackContainerStr or msgpackContainerBin
+	if bd := d.bd; bd == mpBin8 || bd == mpBin16 || bd == mpBin32 {
+		clen = d.readContainerLen(msgpackContainerBin)
 	} else {
-		// bytes can be decoded from msgpackContainerStr or msgpackContainerBin
-		if bd := d.bd; bd == mpBin8 || bd == mpBin16 || bd == mpBin32 {
-			clen = d.readContainerLen(msgpackContainerBin)
-		} else {
-			clen = d.readContainerLen(msgpackContainerStr)
-		}
+		clen = d.readContainerLen(msgpackContainerStr)
 	}
 	// println("DecodeBytes: clen: ", clen)
 	d.bdRead = false
@@ -617,7 +614,7 @@ func (d *msgpackDecDriver) readContainerLen(ct msgpackContainerType) (clen int) 
 	} else if (ct.bFixMin & bd) == ct.bFixMin {
 		clen = int(ct.bFixMin ^ bd)
 	} else {
-		d.d.errorf("readContainerLen: %s: hex: %x, dec: %d", msgBadDesc, bd, bd)
+		d.d.errorf("readContainerLen: %s: hex: %x, decimal: %d", msgBadDesc, bd, bd)
 		return
 	}
 	d.bdRead = false
@@ -728,6 +725,10 @@ func (h *MsgpackHandle) newEncDriver(e *Encoder) encDriver {
 
 func (h *MsgpackHandle) newDecDriver(d *Decoder) decDriver {
 	return &msgpackDecDriver{d: d, r: d.r, h: h, br: d.bytes}
+}
+
+func (h *MsgpackHandle) SetBytesExt(rt reflect.Type, tag uint64, ext BytesExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{b: ext})
 }
 
 //--------------------------------------------------

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/noop.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/noop.go
@@ -11,6 +11,7 @@ import (
 // NoopHandle returns a no-op handle. It basically does nothing.
 // It is only useful for benchmarking, as it gives an idea of the
 // overhead from the codec framework.
+//
 // LIBRARY USERS: *** DO NOT USE ***
 func NoopHandle(slen int) *noopHandle {
 	h := noopHandle{}
@@ -40,7 +41,8 @@ type noopDrv struct {
 	i    int
 	S    []string
 	B    [][]byte
-	mk   bool      // are we about to read a map key?
+	mks  []bool    // stack. if map (true), else if array (false)
+	mk   bool      // top of stack. what container are we on? map or array?
 	ct   valueType // last request for IsContainerType.
 	cb   bool      // last response for IsContainerType.
 	rand *rand.Rand
@@ -54,21 +56,34 @@ func (h *noopDrv) newDecDriver(_ *Decoder) decDriver { return h }
 
 // --- encDriver
 
-func (h *noopDrv) EncodeBuiltin(rt uintptr, v interface{})    {}
-func (h *noopDrv) EncodeNil()                                 {}
-func (h *noopDrv) EncodeInt(i int64)                          {}
-func (h *noopDrv) EncodeUint(i uint64)                        {}
-func (h *noopDrv) EncodeBool(b bool)                          {}
-func (h *noopDrv) EncodeFloat32(f float32)                    {}
-func (h *noopDrv) EncodeFloat64(f float64)                    {}
-func (h *noopDrv) EncodeRawExt(re *RawExt, e *Encoder)        {}
-func (h *noopDrv) EncodeArrayStart(length int)                {}
-func (h *noopDrv) EncodeArrayEnd()                            {}
-func (h *noopDrv) EncodeArrayEntrySeparator()                 {}
-func (h *noopDrv) EncodeMapStart(length int)                  {}
-func (h *noopDrv) EncodeMapEnd()                              {}
-func (h *noopDrv) EncodeMapEntrySeparator()                   {}
-func (h *noopDrv) EncodeMapKVSeparator()                      {}
+// stack functions (for map and array)
+func (h *noopDrv) start(b bool) {
+	// println("start", len(h.mks)+1)
+	h.mks = append(h.mks, b)
+	h.mk = b
+}
+func (h *noopDrv) end() {
+	// println("end: ", len(h.mks)-1)
+	h.mks = h.mks[:len(h.mks)-1]
+	if len(h.mks) > 0 {
+		h.mk = h.mks[len(h.mks)-1]
+	} else {
+		h.mk = false
+	}
+}
+
+func (h *noopDrv) EncodeBuiltin(rt uintptr, v interface{}) {}
+func (h *noopDrv) EncodeNil()                              {}
+func (h *noopDrv) EncodeInt(i int64)                       {}
+func (h *noopDrv) EncodeUint(i uint64)                     {}
+func (h *noopDrv) EncodeBool(b bool)                       {}
+func (h *noopDrv) EncodeFloat32(f float32)                 {}
+func (h *noopDrv) EncodeFloat64(f float64)                 {}
+func (h *noopDrv) EncodeRawExt(re *RawExt, e *Encoder)     {}
+func (h *noopDrv) EncodeArrayStart(length int)             { h.start(true) }
+func (h *noopDrv) EncodeMapStart(length int)               { h.start(false) }
+func (h *noopDrv) EncodeEnd()                              { h.end() }
+
 func (h *noopDrv) EncodeString(c charEncoding, v string)      {}
 func (h *noopDrv) EncodeSymbol(v string)                      {}
 func (h *noopDrv) EncodeStringBytes(c charEncoding, v []byte) {}
@@ -90,15 +105,11 @@ func (h *noopDrv) DecodeString() (s string)                   { return h.S[h.m(8
 
 func (h *noopDrv) DecodeBytes(bs []byte, isstring, zerocopy bool) []byte { return h.B[h.m(len(h.B))] }
 
-func (h *noopDrv) ReadMapEnd()              { h.mk = false }
-func (h *noopDrv) ReadArrayEnd()            {}
-func (h *noopDrv) ReadArrayEntrySeparator() {}
-func (h *noopDrv) ReadMapEntrySeparator()   { h.mk = true }
-func (h *noopDrv) ReadMapKVSeparator()      { h.mk = false }
+func (h *noopDrv) ReadEnd() { h.end() }
 
 // toggle map/slice
-func (h *noopDrv) ReadMapStart() int   { h.mk = true; return h.m(10) }
-func (h *noopDrv) ReadArrayStart() int { return h.m(10) }
+func (h *noopDrv) ReadMapStart() int   { h.start(true); return h.m(10) }
+func (h *noopDrv) ReadArrayStart() int { h.start(false); return h.m(10) }
 
 func (h *noopDrv) IsContainerType(vt valueType) bool {
 	// return h.m(2) == 0

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/prebuild.sh
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/prebuild.sh
@@ -90,8 +90,8 @@ func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool { return false
 type fastpathE struct {
 	rtid uintptr
 	rt reflect.Type 
-	encfn func(encFnInfo, reflect.Value)
-	decfn func(decFnInfo, reflect.Value)
+	encfn func(*encFnInfo, reflect.Value)
+	decfn func(*decFnInfo, reflect.Value)
 }
 type fastpathA [0]fastpathE
 func (x fastpathA) index(rtid uintptr) int { return -1 }
@@ -142,9 +142,9 @@ _codegenerators() {
     then
         true && \
             echo "codecgen - !unsafe ... " && \
-            codecgen -rt codecgen -t 'x,codecgen,!unsafe' -o values_codecgen${zsfx} $zfin && \
+            codecgen  -rt codecgen -t 'x,codecgen,!unsafe' -o values_codecgen${zsfx} -d 1978 $zfin && \
             echo "codecgen - unsafe ... " && \
-            codecgen -u -rt codecgen -t 'x,codecgen,unsafe' -o values_codecgen_unsafe${zsfx} $zfin && \
+            codecgen  -u -rt codecgen -t 'x,codecgen,unsafe' -o values_codecgen_unsafe${zsfx} -d 1978 $zfin && \
             echo "msgp ... " && \
             msgp -tests=false -pkg=codec -o=values_msgp${zsfx} -file=$zfin && \
             echo "ffjson ... " && \

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/py_test.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/py_test.go
@@ -6,7 +6,8 @@
 package codec
 
 // These tests are used to verify msgpack and cbor implementations against their python libraries.
-// If you have the library installed, you can enable the tests back by removing the //+build ignore.
+// If you have the library installed, you can enable the tests back by running: go test -tags=x .
+// Look at test.py for how to setup your environment.
 
 import (
 	"testing"

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/simple.go
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/simple.go
@@ -3,7 +3,10 @@
 
 package codec
 
-import "math"
+import (
+	"math"
+	"reflect"
+)
 
 const (
 	_               uint8 = iota
@@ -499,6 +502,10 @@ func (h *SimpleHandle) newEncDriver(e *Encoder) encDriver {
 
 func (h *SimpleHandle) newDecDriver(d *Decoder) decDriver {
 	return &simpleDecDriver{d: d, r: d.r, h: h, br: d.bytes}
+}
+
+func (h *SimpleHandle) SetBytesExt(rt reflect.Type, tag uint64, ext BytesExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{b: ext})
 }
 
 var _ decDriver = (*simpleDecDriver)(nil)

--- a/Godeps/_workspace/src/github.com/ugorji/go/codec/test.py
+++ b/Godeps/_workspace/src/github.com/ugorji/go/codec/test.py
@@ -5,8 +5,9 @@
 # So it can process them (so we don't have to checkin the files).
 
 # Ensure msgpack-python and cbor are installed first, using:
-#   pip install --user msgpack-python
-#   pip install --user cbor
+#   sudo apt-get install python-dev
+#   sudo apt-get install python-pip
+#   pip install --user msgpack-python msgpack-rpc-python cbor
 
 import cbor, msgpack, msgpackrpc, sys, os, threading
 

--- a/client/keys.generated.go
+++ b/client/keys.generated.go
@@ -11,14 +11,14 @@ import (
 	codec1978 "github.com/coreos/etcd/Godeps/_workspace/src/github.com/ugorji/go/codec"
 	"reflect"
 	"runtime"
-	"time"
+	time "time"
 )
 
 const (
 	codecSelferC_UTF81819         = 1
 	codecSelferC_RAW1819          = 0
-	codecSelverValueTypeArray1819 = 10
-	codecSelverValueTypeMap1819   = 9
+	codecSelferValueTypeArray1819 = 10
+	codecSelferValueTypeMap1819   = 9
 )
 
 var (
@@ -29,10 +29,10 @@ var (
 type codecSelfer1819 struct{}
 
 func init() {
-	if codec1978.GenVersion != 2 {
+	if codec1978.GenVersion != 4 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			2, codec1978.GenVersion, file)
+			4, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -48,88 +48,73 @@ func (x *Response) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yysep1 := !z.EncBinary()
-		yy2arr1 := z.EncBasicHandle().StructToArray
-		var yyfirst1 bool
-		var yyq1 [3]bool
-		_, _, _, _ = yysep1, yyfirst1, yyq1, yy2arr1
-		const yyr1 bool = false
-		if yyr1 || yy2arr1 {
-			r.EncodeArrayStart(3)
+		yym1 := z.EncBinary()
+		_ = yym1
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			var yynn1 int = 3
-			for _, b := range yyq1 {
-				if b {
-					yynn1++
+			yysep2 := !z.EncBinary()
+			yy2arr2 := z.EncBasicHandle().StructToArray
+			var yyq2 [3]bool
+			_, _, _ = yysep2, yyq2, yy2arr2
+			const yyr2 bool = false
+			if yyr2 || yy2arr2 {
+				r.EncodeArrayStart(3)
+			} else {
+				var yynn2 int = 3
+				for _, b := range yyq2 {
+					if b {
+						yynn2++
+					}
+				}
+				r.EncodeMapStart(yynn2)
+			}
+			if yyr2 || yy2arr2 {
+				yym4 := z.EncBinary()
+				_ = yym4
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81819, string(x.Action))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81819, string("action"))
+				yym5 := z.EncBinary()
+				_ = yym5
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81819, string(x.Action))
 				}
 			}
-			r.EncodeMapStart(yynn1)
-		}
-		if yyr1 || yy2arr1 {
-			r.EncodeString(codecSelferC_UTF81819, string(x.Action))
-		} else {
-			yyfirst1 = true
-			r.EncodeString(codecSelferC_UTF81819, string("action"))
-			if yysep1 {
-				r.EncodeMapKVSeparator()
-			}
-			r.EncodeString(codecSelferC_UTF81819, string(x.Action))
-		}
-		if yyr1 || yy2arr1 {
-			if yysep1 {
-				r.EncodeArrayEntrySeparator()
-			}
-			if x.Node == nil {
-				r.EncodeNil()
+			if yyr2 || yy2arr2 {
+				if x.Node == nil {
+					r.EncodeNil()
+				} else {
+					x.Node.CodecEncodeSelf(e)
+				}
 			} else {
-				x.Node.CodecEncodeSelf(e)
+				r.EncodeString(codecSelferC_UTF81819, string("node"))
+				if x.Node == nil {
+					r.EncodeNil()
+				} else {
+					x.Node.CodecEncodeSelf(e)
+				}
 			}
-		} else {
-			if yyfirst1 {
-				r.EncodeMapEntrySeparator()
+			if yyr2 || yy2arr2 {
+				if x.PrevNode == nil {
+					r.EncodeNil()
+				} else {
+					x.PrevNode.CodecEncodeSelf(e)
+				}
 			} else {
-				yyfirst1 = true
+				r.EncodeString(codecSelferC_UTF81819, string("prevNode"))
+				if x.PrevNode == nil {
+					r.EncodeNil()
+				} else {
+					x.PrevNode.CodecEncodeSelf(e)
+				}
 			}
-			r.EncodeString(codecSelferC_UTF81819, string("node"))
-			if yysep1 {
-				r.EncodeMapKVSeparator()
-			}
-			if x.Node == nil {
-				r.EncodeNil()
-			} else {
-				x.Node.CodecEncodeSelf(e)
-			}
-		}
-		if yyr1 || yy2arr1 {
-			if yysep1 {
-				r.EncodeArrayEntrySeparator()
-			}
-			if x.PrevNode == nil {
-				r.EncodeNil()
-			} else {
-				x.PrevNode.CodecEncodeSelf(e)
-			}
-		} else {
-			if yyfirst1 {
-				r.EncodeMapEntrySeparator()
-			} else {
-				yyfirst1 = true
-			}
-			r.EncodeString(codecSelferC_UTF81819, string("prevNode"))
-			if yysep1 {
-				r.EncodeMapKVSeparator()
-			}
-			if x.PrevNode == nil {
-				r.EncodeNil()
-			} else {
-				x.PrevNode.CodecEncodeSelf(e)
-			}
-		}
-		if yysep1 {
-			if yyr1 || yy2arr1 {
-				r.EncodeArrayEnd()
-			} else {
-				r.EncodeMapEnd()
+			if yysep2 {
+				r.EncodeEnd()
 			}
 		}
 	}
@@ -139,22 +124,28 @@ func (x *Response) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1819
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	if r.IsContainerType(codecSelverValueTypeMap1819) {
-		yyl5 := r.ReadMapStart()
-		if yyl5 == 0 {
-			r.ReadMapEnd()
-		} else {
-			x.codecDecodeSelfFromMap(yyl5, d)
-		}
-	} else if r.IsContainerType(codecSelverValueTypeArray1819) {
-		yyl5 := r.ReadArrayStart()
-		if yyl5 == 0 {
-			r.ReadArrayEnd()
-		} else {
-			x.codecDecodeSelfFromArray(yyl5, d)
-		}
+	yym8 := z.DecBinary()
+	_ = yym8
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		panic(codecSelferOnlyMapOrArrayEncodeToStructErr1819)
+		if r.IsContainerType(codecSelferValueTypeMap1819) {
+			yyl9 := r.ReadMapStart()
+			if yyl9 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl9, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1819) {
+			yyl9 := r.ReadArrayStart()
+			if yyl9 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl9, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1819)
+		}
 	}
 }
 
@@ -162,28 +153,22 @@ func (x *Response) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1819
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys6Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys6Slc
-	var yyhl6 bool = l >= 0
-	for yyj6 := 0; ; yyj6++ {
-		if yyhl6 {
-			if yyj6 >= l {
+	var yys10Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys10Slc
+	var yyhl10 bool = l >= 0
+	for yyj10 := 0; ; yyj10++ {
+		if yyhl10 {
+			if yyj10 >= l {
 				break
 			}
 		} else {
 			if r.CheckBreak() {
 				break
 			}
-			if yyj6 > 0 {
-				r.ReadMapEntrySeparator()
-			}
 		}
-		yys6Slc = r.DecodeBytes(yys6Slc, true, true)
-		yys6 := string(yys6Slc)
-		if !yyhl6 {
-			r.ReadMapKVSeparator()
-		}
-		switch yys6 {
+		yys10Slc = r.DecodeBytes(yys10Slc, true, true)
+		yys10 := string(yys10Slc)
+		switch yys10 {
 		case "action":
 			if r.TryDecodeAsNil() {
 				x.Action = ""
@@ -213,11 +198,11 @@ func (x *Response) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.PrevNode.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys6)
-		} // end switch yys6
-	} // end for yyj6
-	if !yyhl6 {
-		r.ReadMapEnd()
+			z.DecStructFieldNotFound(-1, yys10)
+		} // end switch yys10
+	} // end for yyj10
+	if !yyhl10 {
+		r.ReadEnd()
 	}
 }
 
@@ -225,17 +210,17 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1819
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj10 int
-	var yyb10 bool
-	var yyhl10 bool = l >= 0
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	var yyj14 int
+	var yyb14 bool
+	var yyhl14 bool = l >= 0
+	yyj14++
+	if yyhl14 {
+		yyb14 = yyj14 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb14 = r.CheckBreak()
 	}
-	if yyb10 {
-		r.ReadArrayEnd()
+	if yyb14 {
+		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
@@ -243,17 +228,16 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Action = string(r.DecodeString())
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj14++
+	if yyhl14 {
+		yyb14 = yyj14 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb14 = r.CheckBreak()
 	}
-	if yyb10 {
-		r.ReadArrayEnd()
+	if yyb14 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		if x.Node != nil {
 			x.Node = nil
@@ -264,17 +248,16 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Node.CodecDecodeSelf(d)
 	}
-	yyj10++
-	if yyhl10 {
-		yyb10 = yyj10 > l
+	yyj14++
+	if yyhl14 {
+		yyb14 = yyj14 > l
 	} else {
-		yyb10 = r.CheckBreak()
+		yyb14 = r.CheckBreak()
 	}
-	if yyb10 {
-		r.ReadArrayEnd()
+	if yyb14 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		if x.PrevNode != nil {
 			x.PrevNode = nil
@@ -286,21 +269,18 @@ func (x *Response) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.PrevNode.CodecDecodeSelf(d)
 	}
 	for {
-		yyj10++
-		if yyhl10 {
-			yyb10 = yyj10 > l
+		yyj14++
+		if yyhl14 {
+			yyb14 = yyj14 > l
 		} else {
-			yyb10 = r.CheckBreak()
+			yyb14 = r.CheckBreak()
 		}
-		if yyb10 {
+		if yyb14 {
 			break
 		}
-		if yyj10 > 1 {
-			r.ReadArrayEntrySeparator()
-		}
-		z.DecStructFieldNotFound(yyj10-1, "")
+		z.DecStructFieldNotFound(yyj14-1, "")
 	}
-	r.ReadArrayEnd()
+	r.ReadEnd()
 }
 
 func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -310,194 +290,198 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yysep14 := !z.EncBinary()
-		yy2arr14 := z.EncBasicHandle().StructToArray
-		var yyfirst14 bool
-		var yyq14 [8]bool
-		_, _, _, _ = yysep14, yyfirst14, yyq14, yy2arr14
-		const yyr14 bool = false
-		yyq14[1] = x.Dir != false
-		yyq14[6] = x.Expiration != nil
-		yyq14[7] = x.TTL != 0
-		if yyr14 || yy2arr14 {
-			r.EncodeArrayStart(8)
+		yym18 := z.EncBinary()
+		_ = yym18
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			var yynn14 int = 5
-			for _, b := range yyq14 {
-				if b {
-					yynn14++
-				}
-			}
-			r.EncodeMapStart(yynn14)
-		}
-		if yyr14 || yy2arr14 {
-			r.EncodeString(codecSelferC_UTF81819, string(x.Key))
-		} else {
-			yyfirst14 = true
-			r.EncodeString(codecSelferC_UTF81819, string("key"))
-			if yysep14 {
-				r.EncodeMapKVSeparator()
-			}
-			r.EncodeString(codecSelferC_UTF81819, string(x.Key))
-		}
-		if yyr14 || yy2arr14 {
-			if yysep14 {
-				r.EncodeArrayEntrySeparator()
-			}
-			if yyq14[1] {
-				r.EncodeBool(bool(x.Dir))
+			yysep19 := !z.EncBinary()
+			yy2arr19 := z.EncBasicHandle().StructToArray
+			var yyq19 [8]bool
+			_, _, _ = yysep19, yyq19, yy2arr19
+			const yyr19 bool = false
+			yyq19[1] = x.Dir != false
+			yyq19[6] = x.Expiration != nil
+			yyq19[7] = x.TTL != 0
+			if yyr19 || yy2arr19 {
+				r.EncodeArrayStart(8)
 			} else {
-				r.EncodeBool(false)
+				var yynn19 int = 5
+				for _, b := range yyq19 {
+					if b {
+						yynn19++
+					}
+				}
+				r.EncodeMapStart(yynn19)
 			}
-		} else {
-			if yyq14[1] {
-				if yyfirst14 {
-					r.EncodeMapEntrySeparator()
+			if yyr19 || yy2arr19 {
+				yym21 := z.EncBinary()
+				_ = yym21
+				if false {
 				} else {
-					yyfirst14 = true
+					r.EncodeString(codecSelferC_UTF81819, string(x.Key))
 				}
-				r.EncodeString(codecSelferC_UTF81819, string("dir"))
-				if yysep14 {
-					r.EncodeMapKVSeparator()
+			} else {
+				r.EncodeString(codecSelferC_UTF81819, string("key"))
+				yym22 := z.EncBinary()
+				_ = yym22
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81819, string(x.Key))
 				}
-				r.EncodeBool(bool(x.Dir))
 			}
-		}
-		if yyr14 || yy2arr14 {
-			if yysep14 {
-				r.EncodeArrayEntrySeparator()
-			}
-			r.EncodeString(codecSelferC_UTF81819, string(x.Value))
-		} else {
-			if yyfirst14 {
-				r.EncodeMapEntrySeparator()
+			if yyr19 || yy2arr19 {
+				if yyq19[1] {
+					yym24 := z.EncBinary()
+					_ = yym24
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Dir))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
 			} else {
-				yyfirst14 = true
+				if yyq19[1] {
+					r.EncodeString(codecSelferC_UTF81819, string("dir"))
+					yym25 := z.EncBinary()
+					_ = yym25
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Dir))
+					}
+				}
 			}
-			r.EncodeString(codecSelferC_UTF81819, string("value"))
-			if yysep14 {
-				r.EncodeMapKVSeparator()
-			}
-			r.EncodeString(codecSelferC_UTF81819, string(x.Value))
-		}
-		if yyr14 || yy2arr14 {
-			if yysep14 {
-				r.EncodeArrayEntrySeparator()
-			}
-			if x.Nodes == nil {
-				r.EncodeNil()
+			if yyr19 || yy2arr19 {
+				yym27 := z.EncBinary()
+				_ = yym27
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81819, string(x.Value))
+				}
 			} else {
-				x.Nodes.CodecEncodeSelf(e)
+				r.EncodeString(codecSelferC_UTF81819, string("value"))
+				yym28 := z.EncBinary()
+				_ = yym28
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81819, string(x.Value))
+				}
 			}
-		} else {
-			if yyfirst14 {
-				r.EncodeMapEntrySeparator()
-			} else {
-				yyfirst14 = true
-			}
-			r.EncodeString(codecSelferC_UTF81819, string("nodes"))
-			if yysep14 {
-				r.EncodeMapKVSeparator()
-			}
-			if x.Nodes == nil {
-				r.EncodeNil()
-			} else {
-				x.Nodes.CodecEncodeSelf(e)
-			}
-		}
-		if yyr14 || yy2arr14 {
-			if yysep14 {
-				r.EncodeArrayEntrySeparator()
-			}
-			r.EncodeUint(uint64(x.CreatedIndex))
-		} else {
-			if yyfirst14 {
-				r.EncodeMapEntrySeparator()
-			} else {
-				yyfirst14 = true
-			}
-			r.EncodeString(codecSelferC_UTF81819, string("createdIndex"))
-			if yysep14 {
-				r.EncodeMapKVSeparator()
-			}
-			r.EncodeUint(uint64(x.CreatedIndex))
-		}
-		if yyr14 || yy2arr14 {
-			if yysep14 {
-				r.EncodeArrayEntrySeparator()
-			}
-			r.EncodeUint(uint64(x.ModifiedIndex))
-		} else {
-			if yyfirst14 {
-				r.EncodeMapEntrySeparator()
-			} else {
-				yyfirst14 = true
-			}
-			r.EncodeString(codecSelferC_UTF81819, string("modifiedIndex"))
-			if yysep14 {
-				r.EncodeMapKVSeparator()
-			}
-			r.EncodeUint(uint64(x.ModifiedIndex))
-		}
-		if yyr14 || yy2arr14 {
-			if yysep14 {
-				r.EncodeArrayEntrySeparator()
-			}
-			if yyq14[6] {
-				if x.Expiration == nil {
+			if yyr19 || yy2arr19 {
+				if x.Nodes == nil {
 					r.EncodeNil()
 				} else {
-					z.EncFallback(x.Expiration)
+					x.Nodes.CodecEncodeSelf(e)
 				}
 			} else {
-				r.EncodeNil()
-			}
-		} else {
-			if yyq14[6] {
-				if yyfirst14 {
-					r.EncodeMapEntrySeparator()
-				} else {
-					yyfirst14 = true
-				}
-				r.EncodeString(codecSelferC_UTF81819, string("expiration"))
-				if yysep14 {
-					r.EncodeMapKVSeparator()
-				}
-				if x.Expiration == nil {
+				r.EncodeString(codecSelferC_UTF81819, string("nodes"))
+				if x.Nodes == nil {
 					r.EncodeNil()
 				} else {
-					z.EncFallback(x.Expiration)
+					x.Nodes.CodecEncodeSelf(e)
 				}
 			}
-		}
-		if yyr14 || yy2arr14 {
-			if yysep14 {
-				r.EncodeArrayEntrySeparator()
-			}
-			if yyq14[7] {
-				r.EncodeInt(int64(x.TTL))
-			} else {
-				r.EncodeInt(0)
-			}
-		} else {
-			if yyq14[7] {
-				if yyfirst14 {
-					r.EncodeMapEntrySeparator()
+			if yyr19 || yy2arr19 {
+				yym31 := z.EncBinary()
+				_ = yym31
+				if false {
 				} else {
-					yyfirst14 = true
+					r.EncodeUint(uint64(x.CreatedIndex))
 				}
-				r.EncodeString(codecSelferC_UTF81819, string("ttl"))
-				if yysep14 {
-					r.EncodeMapKVSeparator()
-				}
-				r.EncodeInt(int64(x.TTL))
-			}
-		}
-		if yysep14 {
-			if yyr14 || yy2arr14 {
-				r.EncodeArrayEnd()
 			} else {
-				r.EncodeMapEnd()
+				r.EncodeString(codecSelferC_UTF81819, string("createdIndex"))
+				yym32 := z.EncBinary()
+				_ = yym32
+				if false {
+				} else {
+					r.EncodeUint(uint64(x.CreatedIndex))
+				}
+			}
+			if yyr19 || yy2arr19 {
+				yym34 := z.EncBinary()
+				_ = yym34
+				if false {
+				} else {
+					r.EncodeUint(uint64(x.ModifiedIndex))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81819, string("modifiedIndex"))
+				yym35 := z.EncBinary()
+				_ = yym35
+				if false {
+				} else {
+					r.EncodeUint(uint64(x.ModifiedIndex))
+				}
+			}
+			if yyr19 || yy2arr19 {
+				if yyq19[6] {
+					if x.Expiration == nil {
+						r.EncodeNil()
+					} else {
+						yym37 := z.EncBinary()
+						_ = yym37
+						if false {
+						} else if yym38 := z.TimeRtidIfBinc(); yym38 != 0 {
+							r.EncodeBuiltin(yym38, x.Expiration)
+						} else if z.HasExtensions() && z.EncExt(x.Expiration) {
+						} else if yym37 {
+							z.EncBinaryMarshal(x.Expiration)
+						} else if !yym37 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.Expiration)
+						} else {
+							z.EncFallback(x.Expiration)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq19[6] {
+					r.EncodeString(codecSelferC_UTF81819, string("expiration"))
+					if x.Expiration == nil {
+						r.EncodeNil()
+					} else {
+						yym39 := z.EncBinary()
+						_ = yym39
+						if false {
+						} else if yym40 := z.TimeRtidIfBinc(); yym40 != 0 {
+							r.EncodeBuiltin(yym40, x.Expiration)
+						} else if z.HasExtensions() && z.EncExt(x.Expiration) {
+						} else if yym39 {
+							z.EncBinaryMarshal(x.Expiration)
+						} else if !yym39 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.Expiration)
+						} else {
+							z.EncFallback(x.Expiration)
+						}
+					}
+				}
+			}
+			if yyr19 || yy2arr19 {
+				if yyq19[7] {
+					yym42 := z.EncBinary()
+					_ = yym42
+					if false {
+					} else {
+						r.EncodeInt(int64(x.TTL))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq19[7] {
+					r.EncodeString(codecSelferC_UTF81819, string("ttl"))
+					yym43 := z.EncBinary()
+					_ = yym43
+					if false {
+					} else {
+						r.EncodeInt(int64(x.TTL))
+					}
+				}
+			}
+			if yysep19 {
+				r.EncodeEnd()
 			}
 		}
 	}
@@ -507,22 +491,28 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1819
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	if r.IsContainerType(codecSelverValueTypeMap1819) {
-		yyl23 := r.ReadMapStart()
-		if yyl23 == 0 {
-			r.ReadMapEnd()
-		} else {
-			x.codecDecodeSelfFromMap(yyl23, d)
-		}
-	} else if r.IsContainerType(codecSelverValueTypeArray1819) {
-		yyl23 := r.ReadArrayStart()
-		if yyl23 == 0 {
-			r.ReadArrayEnd()
-		} else {
-			x.codecDecodeSelfFromArray(yyl23, d)
-		}
+	yym44 := z.DecBinary()
+	_ = yym44
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
-		panic(codecSelferOnlyMapOrArrayEncodeToStructErr1819)
+		if r.IsContainerType(codecSelferValueTypeMap1819) {
+			yyl45 := r.ReadMapStart()
+			if yyl45 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl45, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1819) {
+			yyl45 := r.ReadArrayStart()
+			if yyl45 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl45, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1819)
+		}
 	}
 }
 
@@ -530,28 +520,22 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1819
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys24Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys24Slc
-	var yyhl24 bool = l >= 0
-	for yyj24 := 0; ; yyj24++ {
-		if yyhl24 {
-			if yyj24 >= l {
+	var yys46Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys46Slc
+	var yyhl46 bool = l >= 0
+	for yyj46 := 0; ; yyj46++ {
+		if yyhl46 {
+			if yyj46 >= l {
 				break
 			}
 		} else {
 			if r.CheckBreak() {
 				break
 			}
-			if yyj24 > 0 {
-				r.ReadMapEntrySeparator()
-			}
 		}
-		yys24Slc = r.DecodeBytes(yys24Slc, true, true)
-		yys24 := string(yys24Slc)
-		if !yyhl24 {
-			r.ReadMapKVSeparator()
-		}
-		switch yys24 {
+		yys46Slc = r.DecodeBytes(yys46Slc, true, true)
+		yys46 := string(yys46Slc)
+		switch yys46 {
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
@@ -574,8 +558,8 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Nodes = nil
 			} else {
-				yyv28 := &x.Nodes
-				yyv28.CodecDecodeSelf(d)
+				yyv50 := &x.Nodes
+				yyv50.CodecDecodeSelf(d)
 			}
 		case "createdIndex":
 			if r.TryDecodeAsNil() {
@@ -598,7 +582,19 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Expiration == nil {
 					x.Expiration = new(time.Time)
 				}
-				z.DecFallback(x.Expiration, false)
+				yym54 := z.DecBinary()
+				_ = yym54
+				if false {
+				} else if yym55 := z.TimeRtidIfBinc(); yym55 != 0 {
+					r.DecodeBuiltin(yym55, x.Expiration)
+				} else if z.HasExtensions() && z.DecExt(x.Expiration) {
+				} else if yym54 {
+					z.DecBinaryUnmarshal(x.Expiration)
+				} else if !yym54 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(x.Expiration)
+				} else {
+					z.DecFallback(x.Expiration, false)
+				}
 			}
 		case "ttl":
 			if r.TryDecodeAsNil() {
@@ -607,11 +603,11 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.TTL = int64(r.DecodeInt(64))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys24)
-		} // end switch yys24
-	} // end for yyj24
-	if !yyhl24 {
-		r.ReadMapEnd()
+			z.DecStructFieldNotFound(-1, yys46)
+		} // end switch yys46
+	} // end for yyj46
+	if !yyhl46 {
+		r.ReadEnd()
 	}
 }
 
@@ -619,17 +615,17 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1819
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj33 int
-	var yyb33 bool
-	var yyhl33 bool = l >= 0
-	yyj33++
-	if yyhl33 {
-		yyb33 = yyj33 > l
+	var yyj57 int
+	var yyb57 bool
+	var yyhl57 bool = l >= 0
+	yyj57++
+	if yyhl57 {
+		yyb57 = yyj57 > l
 	} else {
-		yyb33 = r.CheckBreak()
+		yyb57 = r.CheckBreak()
 	}
-	if yyb33 {
-		r.ReadArrayEnd()
+	if yyb57 {
+		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
@@ -637,98 +633,92 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj33++
-	if yyhl33 {
-		yyb33 = yyj33 > l
+	yyj57++
+	if yyhl57 {
+		yyb57 = yyj57 > l
 	} else {
-		yyb33 = r.CheckBreak()
+		yyb57 = r.CheckBreak()
 	}
-	if yyb33 {
-		r.ReadArrayEnd()
+	if yyb57 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		x.Dir = false
 	} else {
 		x.Dir = bool(r.DecodeBool())
 	}
-	yyj33++
-	if yyhl33 {
-		yyb33 = yyj33 > l
+	yyj57++
+	if yyhl57 {
+		yyb57 = yyj57 > l
 	} else {
-		yyb33 = r.CheckBreak()
+		yyb57 = r.CheckBreak()
 	}
-	if yyb33 {
-		r.ReadArrayEnd()
+	if yyb57 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		x.Value = ""
 	} else {
 		x.Value = string(r.DecodeString())
 	}
-	yyj33++
-	if yyhl33 {
-		yyb33 = yyj33 > l
+	yyj57++
+	if yyhl57 {
+		yyb57 = yyj57 > l
 	} else {
-		yyb33 = r.CheckBreak()
+		yyb57 = r.CheckBreak()
 	}
-	if yyb33 {
-		r.ReadArrayEnd()
+	if yyb57 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		x.Nodes = nil
 	} else {
-		yyv37 := &x.Nodes
-		yyv37.CodecDecodeSelf(d)
+		yyv61 := &x.Nodes
+		yyv61.CodecDecodeSelf(d)
 	}
-	yyj33++
-	if yyhl33 {
-		yyb33 = yyj33 > l
+	yyj57++
+	if yyhl57 {
+		yyb57 = yyj57 > l
 	} else {
-		yyb33 = r.CheckBreak()
+		yyb57 = r.CheckBreak()
 	}
-	if yyb33 {
-		r.ReadArrayEnd()
+	if yyb57 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		x.CreatedIndex = 0
 	} else {
 		x.CreatedIndex = uint64(r.DecodeUint(64))
 	}
-	yyj33++
-	if yyhl33 {
-		yyb33 = yyj33 > l
+	yyj57++
+	if yyhl57 {
+		yyb57 = yyj57 > l
 	} else {
-		yyb33 = r.CheckBreak()
+		yyb57 = r.CheckBreak()
 	}
-	if yyb33 {
-		r.ReadArrayEnd()
+	if yyb57 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		x.ModifiedIndex = 0
 	} else {
 		x.ModifiedIndex = uint64(r.DecodeUint(64))
 	}
-	yyj33++
-	if yyhl33 {
-		yyb33 = yyj33 > l
+	yyj57++
+	if yyhl57 {
+		yyb57 = yyj57 > l
 	} else {
-		yyb33 = r.CheckBreak()
+		yyb57 = r.CheckBreak()
 	}
-	if yyb33 {
-		r.ReadArrayEnd()
+	if yyb57 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		if x.Expiration != nil {
 			x.Expiration = nil
@@ -737,40 +727,48 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Expiration == nil {
 			x.Expiration = new(time.Time)
 		}
-		z.DecFallback(x.Expiration, false)
+		yym65 := z.DecBinary()
+		_ = yym65
+		if false {
+		} else if yym66 := z.TimeRtidIfBinc(); yym66 != 0 {
+			r.DecodeBuiltin(yym66, x.Expiration)
+		} else if z.HasExtensions() && z.DecExt(x.Expiration) {
+		} else if yym65 {
+			z.DecBinaryUnmarshal(x.Expiration)
+		} else if !yym65 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(x.Expiration)
+		} else {
+			z.DecFallback(x.Expiration, false)
+		}
 	}
-	yyj33++
-	if yyhl33 {
-		yyb33 = yyj33 > l
+	yyj57++
+	if yyhl57 {
+		yyb57 = yyj57 > l
 	} else {
-		yyb33 = r.CheckBreak()
+		yyb57 = r.CheckBreak()
 	}
-	if yyb33 {
-		r.ReadArrayEnd()
+	if yyb57 {
+		r.ReadEnd()
 		return
 	}
-	r.ReadArrayEntrySeparator()
 	if r.TryDecodeAsNil() {
 		x.TTL = 0
 	} else {
 		x.TTL = int64(r.DecodeInt(64))
 	}
 	for {
-		yyj33++
-		if yyhl33 {
-			yyb33 = yyj33 > l
+		yyj57++
+		if yyhl57 {
+			yyb57 = yyj57 > l
 		} else {
-			yyb33 = r.CheckBreak()
+			yyb57 = r.CheckBreak()
 		}
-		if yyb33 {
+		if yyb57 {
 			break
 		}
-		if yyj33 > 1 {
-			r.ReadArrayEntrySeparator()
-		}
-		z.DecStructFieldNotFound(yyj33-1, "")
+		z.DecStructFieldNotFound(yyj57-1, "")
 	}
-	r.ReadArrayEnd()
+	r.ReadEnd()
 }
 
 func (x Nodes) CodecEncodeSelf(e *codec1978.Encoder) {
@@ -780,7 +778,13 @@ func (x Nodes) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		h.encNodes((Nodes)(x), e)
+		yym68 := z.EncBinary()
+		_ = yym68
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			h.encNodes((Nodes)(x), e)
+		}
 	}
 }
 
@@ -788,7 +792,13 @@ func (x *Nodes) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1819
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	h.decNodes((*Nodes)(x), d)
+	yym69 := z.DecBinary()
+	_ = yym69
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		h.decNodes((*Nodes)(x), d)
+	}
 }
 
 func (x codecSelfer1819) encNodes(v Nodes, e *codec1978.Encoder) {
@@ -796,28 +806,14 @@ func (x codecSelfer1819) encNodes(v Nodes, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	yys42 := !z.EncBinary()
-	if yys42 {
-		for yyi42, yyv42 := range v {
-			if yyi42 > 0 {
-				r.EncodeArrayEntrySeparator()
-			}
-			if yyv42 == nil {
-				r.EncodeNil()
-			} else {
-				yyv42.CodecEncodeSelf(e)
-			}
-		}
-		r.EncodeArrayEnd()
-	} else {
-		for _, yyv42 := range v {
-			if yyv42 == nil {
-				r.EncodeNil()
-			} else {
-				yyv42.CodecEncodeSelf(e)
-			}
+	for _, yyv70 := range v {
+		if yyv70 == nil {
+			r.EncodeNil()
+		} else {
+			yyv70.CodecEncodeSelf(e)
 		}
 	}
+	r.EncodeEnd()
 }
 
 func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
@@ -825,74 +821,90 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv43 := *v
-	yyh43, yyl43 := z.DecSliceHelperStart()
+	yyv71 := *v
+	yyh71, yyl71 := z.DecSliceHelperStart()
 
-	var yyc43 bool
-	_ = yyc43
+	var yyrr71, yyrl71 int
+	var yyc71, yyrt71 bool
+	_, _, _ = yyc71, yyrt71, yyrl71
+	yyrr71 = yyl71
 
-	if yyv43 == nil {
-		if yyl43 <= 0 {
-			yyv43 = make(Nodes, 0)
-		} else {
-			yyv43 = make(Nodes, yyl43)
+	if yyv71 == nil {
+		if yyrl71, yyrt71 = z.DecInferLen(yyl71, z.DecBasicHandle().MaxInitLen, 8); yyrt71 {
+			yyrr71 = yyrl71
 		}
-		yyc43 = true
+		yyv71 = make(Nodes, yyrl71)
+		yyc71 = true
 	}
 
-	if yyl43 == 0 {
-		if len(yyv43) != 0 {
-			yyv43 = yyv43[:0]
-			yyc43 = true
+	if yyl71 == 0 {
+		if len(yyv71) != 0 {
+			yyv71 = yyv71[:0]
+			yyc71 = true
 		}
-	} else if yyl43 > 0 {
+	} else if yyl71 > 0 {
 
-		yyn43 := yyl43
-		if yyl43 > cap(yyv43) {
-			yyv43 = make([]*Node, yyl43, yyl43)
-			yyc43 = true
+		if yyl71 > cap(yyv71) {
+			yyrl71, yyrt71 = z.DecInferLen(yyl71, z.DecBasicHandle().MaxInitLen, 8)
+			yyv71 = make([]*Node, yyrl71)
+			yyc71 = true
 
-		} else if yyl43 != len(yyv43) {
-			yyv43 = yyv43[:yyl43]
-			yyc43 = true
+			yyrr71 = len(yyv71)
+		} else if yyl71 != len(yyv71) {
+			yyv71 = yyv71[:yyl71]
+			yyc71 = true
 		}
-		yyj43 := 0
-		for ; yyj43 < yyn43; yyj43++ {
+		yyj71 := 0
+		for ; yyj71 < yyrr71; yyj71++ {
 			if r.TryDecodeAsNil() {
-				if yyv43[yyj43] != nil {
-					*yyv43[yyj43] = Node{}
+				if yyv71[yyj71] != nil {
+					*yyv71[yyj71] = Node{}
 				}
 			} else {
-				if yyv43[yyj43] == nil {
-					yyv43[yyj43] = new(Node)
+				if yyv71[yyj71] == nil {
+					yyv71[yyj71] = new(Node)
 				}
-				yyw44 := yyv43[yyj43]
-				yyw44.CodecDecodeSelf(d)
+				yyw72 := yyv71[yyj71]
+				yyw72.CodecDecodeSelf(d)
 			}
 
+		}
+		if yyrt71 {
+			for ; yyj71 < yyl71; yyj71++ {
+				yyv71 = append(yyv71, nil)
+				if r.TryDecodeAsNil() {
+					if yyv71[yyj71] != nil {
+						*yyv71[yyj71] = Node{}
+					}
+				} else {
+					if yyv71[yyj71] == nil {
+						yyv71[yyj71] = new(Node)
+					}
+					yyw73 := yyv71[yyj71]
+					yyw73.CodecDecodeSelf(d)
+				}
+
+			}
 		}
 
 	} else {
-		for yyj43 := 0; !r.CheckBreak(); yyj43++ {
-			if yyj43 >= len(yyv43) {
-				yyv43 = append(yyv43, nil) // var yyz43 *Node
-				yyc43 = true
-			}
-			if yyj43 > 0 {
-				yyh43.Sep(yyj43)
+		for yyj71 := 0; !r.CheckBreak(); yyj71++ {
+			if yyj71 >= len(yyv71) {
+				yyv71 = append(yyv71, nil) // var yyz71 *Node
+				yyc71 = true
 			}
 
-			if yyj43 < len(yyv43) {
+			if yyj71 < len(yyv71) {
 				if r.TryDecodeAsNil() {
-					if yyv43[yyj43] != nil {
-						*yyv43[yyj43] = Node{}
+					if yyv71[yyj71] != nil {
+						*yyv71[yyj71] = Node{}
 					}
 				} else {
-					if yyv43[yyj43] == nil {
-						yyv43[yyj43] = new(Node)
+					if yyv71[yyj71] == nil {
+						yyv71[yyj71] = new(Node)
 					}
-					yyw45 := yyv43[yyj43]
-					yyw45.CodecDecodeSelf(d)
+					yyw74 := yyv71[yyj71]
+					yyw74.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -900,10 +912,10 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh43.End()
+		yyh71.End()
 	}
-	if yyc43 {
-		*v = yyv43
+	if yyc71 {
+		*v = yyv71
 	}
 
 }

--- a/client/keys.go
+++ b/client/keys.go
@@ -14,7 +14,7 @@
 
 package client
 
-//go:generate codecgen -r "Node|Response|Nodes" -o keys.generated.go keys.go
+//go:generate codecgen -d 1819 -r "Node|Response|Nodes" -o keys.generated.go keys.go
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Rationale behind this change:
I are going to use ugorji/go/codec in Kubernetes too. However - in the version that you are currently using there were some issues (that k8s code discovered) and fixing them made some backward incompatible changes. And having k8s and etcd depend on different version of that dependency that are incompatible would be a nightmare.

@xiang90 @yichengq 