### PR TITLE
pkg/transport: pass dial timeout to NewTransport

### DIFF
--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/bgentry/speakeasy"
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/codegangsta/cli"
@@ -33,6 +34,10 @@ import (
 
 var (
 	ErrNoAvailSrc = errors.New("no available argument and stdin")
+
+	// the maximum amount of time a dial will wait for a connection to setup.
+	// 30s is long enough for most of the network conditions.
+	defaultDialTimeout = 30 * time.Second
 )
 
 // trimsplit slices s into all substrings separated by sep and returns a
@@ -153,7 +158,7 @@ func getTransport(c *cli.Context) (*http.Transport, error) {
 		CertFile: certfile,
 		KeyFile:  keyfile,
 	}
-	return transport.NewTransport(tls)
+	return transport.NewTransport(tls, defaultDialTimeout)
 }
 
 func getUsernamePasswordFromFlag(usernameFlag string) (username string, password string, err error) {

--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -46,18 +46,19 @@ func NewListener(addr string, scheme string, info TLSInfo) (net.Listener, error)
 	return l, nil
 }
 
-func NewTransport(info TLSInfo) (*http.Transport, error) {
+func NewTransport(info TLSInfo, dialtimeoutd time.Duration) (*http.Transport, error) {
 	cfg, err := info.ClientConfig()
 	if err != nil {
 		return nil, err
 	}
 
 	t := &http.Transport{
-		// timeouts taken from http.DefaultTransport
 		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout: dialtimeoutd,
+			// value taken from http.DefaultTransport
 			KeepAlive: 30 * time.Second,
 		}).Dial,
+		// value taken from http.DefaultTransport
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     cfg,
 	}

--- a/pkg/transport/listener_test.go
+++ b/pkg/transport/listener_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 )
 
 func createTempFile(b []byte) (string, error) {
@@ -115,7 +116,7 @@ func TestNewTransportTLSInfo(t *testing.T) {
 
 	for i, tt := range tests {
 		tt.parseFunc = fakeCertificateParserFunc(tls.Certificate{}, nil)
-		trans, err := NewTransport(tt)
+		trans, err := NewTransport(tt, time.Second)
 		if err != nil {
 			t.Fatalf("Received unexpected error from NewTransport: %v", err)
 		}

--- a/pkg/transport/timeout_transport.go
+++ b/pkg/transport/timeout_transport.go
@@ -24,7 +24,7 @@ import (
 // If read/write on the created connection blocks longer than its time limit,
 // it will return timeout error.
 func NewTimeoutTransport(info TLSInfo, dialtimeoutd, rdtimeoutd, wtimeoutd time.Duration) (*http.Transport, error) {
-	tr, err := NewTransport(info)
+	tr, err := NewTransport(info, dialtimeoutd)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
So we could set dial timeout for new transport, which makes it
customizable according to max RTT.

This prepares for that NewTransport is going to be called in rafthttp, and it is required to set dial timeout.