### PR TITLE
don't do a request with expired main context

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -387,11 +387,18 @@ func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Respon
 	reqcancel := requestCanceler(c.transport, req)
 
 	rtchan := make(chan roundTripResponse, 1)
-	go func() {
-		resp, err := c.transport.RoundTrip(req)
-		rtchan <- roundTripResponse{resp: resp, err: err}
+
+	select {
+	case <-ctx.Done():
+		rtchan <- roundTripResponse{err: ctx.Err()}
 		close(rtchan)
-	}()
+	default:
+		go func() {
+			resp, err := c.transport.RoundTrip(req)
+			rtchan <- roundTripResponse{resp: resp, err: err}
+			close(rtchan)
+		}()
+	}
 
 	var resp *http.Response
 	var err error


### PR DESCRIPTION
client: fix unnecessary request when context is expired

Following code should not delete key:
```
ctxStop, _ := context.WithTimeout(context.Background(), time.Nanosecond)
...
_, err := nkAPI.Delete(ctxStop, path, nil)
```