### PR TITLE
client: improve API of role and user listings 

### DIFF
--- a/client/auth_role.go
+++ b/client/auth_role.go
@@ -72,7 +72,7 @@ type AuthRoleAPI interface {
 	RevokeRoleKV(ctx context.Context, role string, prefixes []string, permType PermissionType) (*Role, error)
 
 	// List roles.
-	ListRoles(ctx context.Context) ([]string, error)
+	ListRoles(ctx context.Context) ([]Role, error)
 }
 
 type httpAuthRoleAPI struct {
@@ -110,7 +110,7 @@ func (l *authRoleAPIAction) HTTPRequest(ep url.URL) *http.Request {
 	return req
 }
 
-func (r *httpAuthRoleAPI) ListRoles(ctx context.Context) ([]string, error) {
+func (r *httpAuthRoleAPI) ListRoles(ctx context.Context) ([]Role, error) {
 	resp, body, err := r.client.Do(ctx, &authRoleAPIList{})
 	if err != nil {
 		return nil, err
@@ -118,14 +118,14 @@ func (r *httpAuthRoleAPI) ListRoles(ctx context.Context) ([]string, error) {
 	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
 		return nil, err
 	}
-	var userList struct {
-		Roles []string `json:"roles"`
+	var roleList struct {
+		Roles []Role `json:"roles"`
 	}
-	err = json.Unmarshal(body, &userList)
+	err = json.Unmarshal(body, &roleList)
 	if err != nil {
 		return nil, err
 	}
-	return userList.Roles, nil
+	return roleList.Roles, nil
 }
 
 func (r *httpAuthRoleAPI) AddRole(ctx context.Context, rolename string) error {

--- a/etcdctl/command/user_commands.go
+++ b/etcdctl/command/user_commands.go
@@ -181,20 +181,28 @@ func userGrantRevoke(c *cli.Context, grant bool) {
 
 	api, user := mustUserAPIAndName(c)
 	currentUser, err := api.GetUser(ctx, user)
-	if currentUser == nil {
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 
-	var newUser *client.User
+	var newUser *client.UserRoles
 	if grant {
 		newUser, err = api.GrantUser(ctx, user, roles)
 	} else {
 		newUser, err = api.RevokeUser(ctx, user, roles)
 	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 	sort.Strings(newUser.Roles)
-	sort.Strings(currentUser.Roles)
-	if reflect.DeepEqual(newUser.Roles, currentUser.Roles) {
+	var currentRoleSet []string
+	for _, rl := range currentUser.Roles {
+		currentRoleSet = append(currentRoleSet, rl.Role)
+	}
+	sort.Strings(currentRoleSet)
+	if reflect.DeepEqual(newUser.Roles, currentRoleSet) {
 		if grant {
 			fmt.Printf("User unchanged; roles already granted")
 		} else {
@@ -219,7 +227,11 @@ func actionUserGet(c *cli.Context) {
 		os.Exit(1)
 	}
 	fmt.Printf("User: %s\n", user.User)
-	fmt.Printf("Roles: %s\n", strings.Join(user.Roles, " "))
+	var currentRoleSet []string
+	for _, rl := range user.Roles {
+		currentRoleSet = append(currentRoleSet, rl.Role)
+	}
+	fmt.Printf("Roles: %s\n", strings.Join(currentRoleSet, " "))
 
 }
 


### PR DESCRIPTION
AuthRoleAPI.ListRoles() and AuthUserAPI.ListUsers() return values of type []string.
Because server returns json (eg.
{"roles":[{"role":"root","permissions":{"kv":{"read":["*"],"write":["*"]}}}]}),
the result cannot be unmarshaled into []string.

This patch changes these functions to return []Role and []User.

