### PR TITLE
client, etcdctl: mk command with Create command

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -115,7 +115,7 @@ type KeysAPI interface {
 	Delete(ctx context.Context, key string, opts *DeleteOptions) (*Response, error)
 
 	// Create is an alias for Set w/ PrevExist=false
-	Create(ctx context.Context, key, value string) (*Response, error)
+	Create(ctx context.Context, key, value string, opts *CreateOptions) (*Response, error)
 
 	// CreateInOrder is used to atomically create in-order keys within the given directory.
 	CreateInOrder(ctx context.Context, dir, value string, opts *CreateInOrderOptions) (*Response, error)
@@ -145,6 +145,14 @@ type WatcherOptions struct {
 	// to false (default), events will be limited to those that
 	// occur for the exact key.
 	Recursive bool
+}
+
+type CreateOptions struct {
+	// TTL defines a period of time after-which the Node should
+	// expire and no longer exist. Values <= 0 are ignored. Given
+	// that the zero-value is ignored, TTL cannot be used to set
+	// a TTL of 0.
+	TTL time.Duration
 }
 
 type CreateInOrderOptions struct {
@@ -338,7 +346,10 @@ func (k *httpKeysAPI) Set(ctx context.Context, key, val string, opts *SetOptions
 	return unmarshalHTTPResponse(resp.StatusCode, resp.Header, body)
 }
 
-func (k *httpKeysAPI) Create(ctx context.Context, key, val string) (*Response, error) {
+func (k *httpKeysAPI) Create(ctx context.Context, key, val string, opts *CreateOptions) (*Response, error) {
+	if opts != nil {
+		return k.Set(ctx, key, val, &SetOptions{TTL: opts.TTL, PrevExist: PrevNoExist})
+	}
 	return k.Set(ctx, key, val, &SetOptions{PrevExist: PrevNoExist})
 }
 

--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -1356,7 +1356,7 @@ func TestHTTPKeysAPICreateAction(t *testing.T) {
 	}
 
 	kAPI := httpKeysAPI{client: &actionAssertingHTTPClient{t: t, act: act}}
-	kAPI.Create(context.Background(), "/foo", "bar")
+	kAPI.Create(context.Background(), "/foo", "bar", nil)
 }
 
 func TestHTTPKeysAPICreateInOrderAction(t *testing.T) {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -193,7 +193,7 @@ func (d *discovery) getCluster() (string, error) {
 
 func (d *discovery) createSelf(contents string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
-	resp, err := d.c.Create(ctx, d.selfKey(), contents)
+	resp, err := d.c.Create(ctx, d.selfKey(), contents, nil)
 	cancel()
 	if err != nil {
 		if eerr, ok := err.(client.Error); ok && eerr.Code == client.ErrorCodeNodeExist {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -452,7 +452,7 @@ type clientWithResp struct {
 	client.KeysAPI
 }
 
-func (c *clientWithResp) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+func (c *clientWithResp) Create(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	if len(c.rs) == 0 {
 		return &client.Response{}, nil
 	}
@@ -480,7 +480,7 @@ type clientWithErr struct {
 	client.KeysAPI
 }
 
-func (c *clientWithErr) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+func (c *clientWithErr) Create(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	return &client.Response{}, c.err
 }
 
@@ -521,12 +521,12 @@ type clientWithRetry struct {
 	failTimes int
 }
 
-func (c *clientWithRetry) Create(ctx context.Context, key string, value string) (*client.Response, error) {
+func (c *clientWithRetry) Create(ctx context.Context, key string, value string, opts *client.CreateOptions) (*client.Response, error) {
 	if c.failCount < c.failTimes {
 		c.failCount++
 		return nil, &client.ClusterError{Errors: []error{context.DeadlineExceeded}}
 	}
-	return c.clientWithResp.Create(ctx, key, value)
+	return c.clientWithResp.Create(ctx, key, value, nil)
 }
 
 func (c *clientWithRetry) Get(ctx context.Context, key string, opts *client.GetOptions) (*client.Response, error) {

--- a/etcdctl/command/mk_command.go
+++ b/etcdctl/command/mk_command.go
@@ -51,7 +51,7 @@ func mkCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	ttl := c.Int("ttl")
 
-	resp, err := ki.Set(context.TODO(), key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevIgnore})
+	resp, err := ki.Create(context.TODO(), key, value, &client.CreateOptions{TTL: time.Duration(ttl) * time.Second})
 	if err != nil {
 		handleError(ExitServerError, err)
 	}

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -97,7 +97,7 @@ func testClusterUsingDiscovery(t *testing.T, size int) {
 	dcc := mustNewHTTPClient(t, dc.URLs())
 	dkapi := client.NewKeysAPI(dcc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	if _, err := dkapi.Create(ctx, "/_config/size", fmt.Sprintf("%d", size)); err != nil {
+	if _, err := dkapi.Create(ctx, "/_config/size", fmt.Sprintf("%d", size), nil); err != nil {
 		t.Fatal(err)
 	}
 	cancel()
@@ -117,7 +117,7 @@ func TestTLSClusterOf3UsingDiscovery(t *testing.T) {
 	dcc := mustNewHTTPClient(t, dc.URLs())
 	dkapi := client.NewKeysAPI(dcc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	if _, err := dkapi.Create(ctx, "/_config/size", fmt.Sprintf("%d", 3)); err != nil {
+	if _, err := dkapi.Create(ctx, "/_config/size", fmt.Sprintf("%d", 3), nil); err != nil {
 		t.Fatal(err)
 	}
 	cancel()
@@ -179,7 +179,7 @@ func TestForceNewCluster(t *testing.T) {
 	cc := mustNewHTTPClient(t, []string{c.Members[0].URL()})
 	kapi := client.NewKeysAPI(cc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	resp, err := kapi.Create(ctx, "/foo", "bar")
+	resp, err := kapi.Create(ctx, "/foo", "bar", nil)
 	if err != nil {
 		t.Fatalf("unexpected create error: %v", err)
 	}
@@ -318,7 +318,7 @@ func clusterMustProgress(t *testing.T, membs []*member) {
 	kapi := client.NewKeysAPI(cc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	key := fmt.Sprintf("foo%d", rand.Int())
-	resp, err := kapi.Create(ctx, "/"+key, "bar")
+	resp, err := kapi.Create(ctx, "/"+key, "bar", nil)
 	if err != nil {
 		t.Fatalf("create on %s error: %v", membs[0].URL(), err)
 	}

--- a/integration/member_test.go
+++ b/integration/member_test.go
@@ -95,7 +95,7 @@ func TestSnapshotAndRestartMember(t *testing.T) {
 		kapi := client.NewKeysAPI(cc)
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		key := fmt.Sprintf("foo%d", i)
-		resps[i], err = kapi.Create(ctx, "/"+key, "bar")
+		resps[i], err = kapi.Create(ctx, "/"+key, "bar", nil)
 		if err != nil {
 			t.Fatalf("#%d: create on %s error: %v", i, m.URL(), err)
 		}


### PR DESCRIPTION
This attempts to fix https://github.com/coreos/etcd/issues/3676. Or if we do not prefer the interface change, should we just delete the TTL flag? Then just fixing the typo from `ki.Set` to `ki.Create` seems to resolve this issue.

/cc @yichengq

Thanks,