### PR TITLE
etcdctl: fix mk command with PrevNoExist

### DIFF
--- a/etcdctl/command/mk_command.go
+++ b/etcdctl/command/mk_command.go
@@ -51,7 +51,11 @@ func mkCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	ttl := c.Int("ttl")
 
 	ctx, cancel := contextWithTotalTimeout(c)
-	resp, err := ki.Set(ctx, key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevIgnore})
+	// Since PrevNoExist means that the Node must not exist previously,
+	// this Set method always creates a new key. Therefore, mk command
+	// succeeds only if the key did not previously exist, and the command
+	// prevents one from overwriting values accidentally.
+	resp, err := ki.Set(ctx, key, value, &client.SetOptions{TTL: time.Duration(ttl) * time.Second, PrevExist: client.PrevNoExist})
 	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)


### PR DESCRIPTION
This attempts to fix #3676. `PrevNoExist` checks if the key previously exists and if so, it returns an error, which is how `mk` command is supposed to work. The previous code ignores the previous key and overwrites with the later value.

/cc @yichengq