### PR TITLE
WIP etcdserver: add starvation detector to monitor raft routines

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -148,6 +148,8 @@ func (r *raftNode) start(s *EtcdServer) {
 						if r.s.stats != nil {
 							r.s.stats.BecomeLeader()
 						}
+						// clear out the historical heartbeat result in detector.
+						r.s.sd.reset()
 					} else {
 						syncC = nil
 					}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -175,6 +175,8 @@ type EtcdServer struct {
 	// forceVersionC is used to force the version monitor loop
 	// to detect the cluster version immediately.
 	forceVersionC chan struct{}
+
+	sd starvationDetector
 }
 
 // NewServer creates a new EtcdServer from the supplied configuration. The
@@ -397,6 +399,10 @@ func (s *EtcdServer) Start() {
 	go s.purgeFile()
 	go monitorFileDescriptor(s.done)
 	go s.monitorVersions()
+
+	// set up starvation detectors for raft heartbeat message.
+	// expect to send a heartbeat within 2 heartbeat intervals.
+	s.sd.set(2*time.Duration(s.cfg.TickMs) * time.Millisecond)
 }
 
 // start prepares and starts server in a new goroutine. It is no longer safe to
@@ -415,6 +421,7 @@ func (s *EtcdServer) start() {
 	} else {
 		plog.Infof("starting server... [version: %v, cluster version: to_be_decided]", version.Version)
 	}
+
 	// TODO: if this is an empty log, writes all peer infos
 	// into the first entry
 	go s.run()
@@ -790,6 +797,13 @@ func (s *EtcdServer) send(ms []raftpb.Message) {
 	for i := range ms {
 		if s.cluster.IsIDRemoved(types.ID(ms[i].To)) {
 			ms[i].To = 0
+		}
+		if ms[i].Type == raftpb.MsgHeartbeat {
+			ok, exceed := s.sd.observe(ms[i].To)
+			if !ok {
+				plog.Warningf("etcdserver failed to send out heartbeat on time: deadline exceeded for %v", exceed)
+				plog.Warningf("etcdserver is overloaded or the heartbeat invertal is set too short.")
+			}
 		}
 	}
 	s.r.transport.Send(ms)

--- a/etcdserver/starvation_detector.go
+++ b/etcdserver/starvation_detector.go
@@ -1,0 +1,58 @@
+package etcdserver
+
+import (
+	"sync"
+	"time"
+)
+
+// starvationDetector detects routine starvations by
+// observing the actual time duration to finish an action
+// or between two events that should happen in a fixed
+// interval. If the observed duration is longer than
+// the expectation, the detector will report the result.
+
+// TODO: starvationDetector is designed for raft messaging
+// right now. So we keep the records type an uint64 for
+// efficiency
+type starvationDetector struct {
+	mu     sync.Mutex // protects all
+	expect time.Duration
+	// map from event to time
+	// time is the last seen time of the event.
+	records map[uint64]time.Time
+}
+
+func (sd *starvationDetector) set(expect time.Duration) {
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	sd.expect = expect
+	sd.records = make(map[uint64]time.Time)
+}
+
+func (sd *starvationDetector) reset() {
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	sd.records = make(map[uint64]time.Time)
+}
+
+// observe observes an event. It returns false and exceeded duration
+// if the interval is longer than the expectation.
+func (sd *starvationDetector) observe(which uint64) (bool, time.Duration) {
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	ok := true
+	now := time.Now()
+	exceed := time.Duration(0)
+
+	if pt, found := sd.records[which]; found {
+		exceed = now.Sub(pt) - sd.expect
+		if exceed > 0 {
+			ok = false
+		}
+	}
+	sd.records[which] = now
+	return ok, exceed
+}


### PR DESCRIPTION
We have seen raft routine starvation issues when etcd is under heavy load. It is really hard to locate the issue without a lot of effort. 

This pull request is the first step towards monitoring raft routines behavior. We will expose related metrics to prometheus as well as sends out internal marker message to collect the actual in-process raft processing end to end latencies for each raft processing stages. 