### PR TITLE
etcdctl: fix health check condition

### DIFF
--- a/etcdctl/command/cluster_health.go
+++ b/etcdctl/command/cluster_health.go
@@ -103,7 +103,7 @@ func handleClusterHealth(c *cli.Context) {
 				}
 
 				checked = true
-				if result.Health == "true" {
+				if result.Health == "true" || nresult.Health == true {
 					health = true
 					fmt.Printf("member %s is healthy: got healthy result from %s\n", m.ID, url)
 				} else {


### PR DESCRIPTION
This PR helps to fix the condition to determine if a member is healthy.

BTW, when determine if the whole cluster if healthy, it assumes that cluster is healthy as long as there is ***one*** member is healthy. Should we replace that condition to "iff ***most*** of the members are healthy". If your answer is YES, I am glad to help fix this. (After all, I don't know the implementation of  `health` endpoint, maybe all the member will response "false" if most of members are unhealthy)