### PR TITLE
storage: remove the endRev of watcher

### DIFF
--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -733,7 +733,7 @@ func TestWatchableKVWatch(t *testing.T) {
 	s := newWatchableStore(tmpPath)
 	defer cleanup(s, tmpPath)
 
-	wa, cancel := s.Watcher([]byte("foo"), true, 0, 0)
+	wa, cancel := s.Watcher([]byte("foo"), true, 0)
 	defer cancel()
 
 	s.Put([]byte("foo"), []byte("bar"))
@@ -776,7 +776,7 @@ func TestWatchableKVWatch(t *testing.T) {
 		t.Fatalf("failed to watch the event")
 	}
 
-	wa, cancel = s.Watcher([]byte("foo1"), false, 1, 4)
+	wa, cancel = s.Watcher([]byte("foo1"), false, 1)
 	defer cancel()
 
 	select {
@@ -817,19 +817,6 @@ func TestWatchableKVWatch(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatalf("failed to watch the event")
 	}
-
-	select {
-	case ev := <-wa.Event():
-		if !reflect.DeepEqual(ev, storagepb.Event{}) {
-			t.Errorf("watched event = %+v, want %+v", ev, storagepb.Event{})
-		}
-		if g := wa.Err(); g != ExceedEnd {
-			t.Errorf("err = %+v, want %+v", g, ExceedEnd)
-		}
-	case <-time.After(time.Second):
-		t.Fatalf("failed to watch the event")
-	}
-
 }
 
 func cleanup(s KV, path string) {

--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -197,12 +197,11 @@ func (s *store) TxnDeleteRange(txnID int64, key, end []byte) (n, rev int64, err 
 	return n, rev, nil
 }
 
-// RangeEvents gets the events from key to end in [startRev, endRev).
+// RangeEvents gets the events from key to end starting from startRev.
 // If `end` is nil, the request only observes the events on key.
 // If `end` is not nil, it observes the events on key range [key, range_end).
 // Limit limits the number of events returned.
 // If startRev <=0, rangeEvents returns events from the beginning of uncompacted history.
-// If endRev <=0, it indicates there is no end revision.
 //
 // If the required start rev is compacted, ErrCompacted will be returned.
 // If the required start rev has not happened, ErrFutureRev will be returned.
@@ -215,7 +214,7 @@ func (s *store) TxnDeleteRange(txnID int64, key, end []byte) (n, rev int64, err 
 // has not progressed so far or it hits the event limit.
 //
 // TODO: return byte slices instead of events to avoid meaningless encode and decode.
-func (s *store) RangeEvents(key, end []byte, limit, startRev, endRev int64) (evs []storagepb.Event, nextRev int64, err error) {
+func (s *store) RangeEvents(key, end []byte, limit, startRev int64) (evs []storagepb.Event, nextRev int64, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -236,9 +235,6 @@ func (s *store) RangeEvents(key, end []byte, limit, startRev, endRev int64) (evs
 	defer tx.Unlock()
 	// fetch events from the backend using revisions
 	for _, rev := range revs {
-		if endRev > 0 && rev.main >= endRev {
-			return evs, rev.main, nil
-		}
 		revbytes := newRevBytes()
 		revToBytes(rev, revbytes)
 

--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -295,7 +295,7 @@ func TestStoreRangeEvents(t *testing.T) {
 		index.indexRangeEventsRespc <- tt.idxr
 		b.tx.rangeRespc <- tt.r
 
-		evs, _, err := s.RangeEvents([]byte("foo"), []byte("goo"), 1, 1, 4)
+		evs, _, err := s.RangeEvents([]byte("foo"), []byte("goo"), 1, 1)
 		if err != nil {
 			t.Errorf("#%d: err = %v, want nil", i, err)
 		}
@@ -469,7 +469,7 @@ func TestStoreRangeEventsEnd(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		evs, rev, err := s.RangeEvents(tt.key, tt.end, 0, 1, 100)
+		evs, rev, err := s.RangeEvents(tt.key, tt.end, 0, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -507,24 +507,17 @@ func TestStoreRangeEventsRev(t *testing.T) {
 
 	tests := []struct {
 		start int64
-		end   int64
+
 		wevs  []storagepb.Event
 		wnext int64
 	}{
-		{1, 1, nil, 1},
-		{1, 2, evs[:1], 2},
-		{1, 3, evs[:2], 3},
-		{1, 4, evs, 5},
-		{1, 5, evs, 5},
-		{1, 10, evs, 5},
-		{3, 4, evs[2:], 5},
-		{0, 10, evs, 5},
-		{1, 0, evs, 5},
-		{0, 0, evs, 5},
+		{0, evs, 5},
+		{1, evs, 5},
+		{3, evs[2:], 5},
 	}
 
 	for i, tt := range tests {
-		evs, next, err := s.RangeEvents([]byte("foo"), nil, 0, tt.start, tt.end)
+		evs, next, err := s.RangeEvents([]byte("foo"), nil, 0, tt.start)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -559,7 +552,7 @@ func TestStoreRangeEventsBad(t *testing.T) {
 		{10, ErrFutureRev},
 	}
 	for i, tt := range tests {
-		_, _, err := s.RangeEvents([]byte("foo"), nil, 0, tt.rev, 100)
+		_, _, err := s.RangeEvents([]byte("foo"), nil, 0, tt.rev)
 		if err != tt.werr {
 			t.Errorf("#%d: error = %v, want %v", i, err, tt.werr)
 		}
@@ -602,7 +595,7 @@ func TestStoreRangeEventsLimit(t *testing.T) {
 		{100, evs},
 	}
 	for i, tt := range tests {
-		evs, _, err := s.RangeEvents([]byte("foo"), nil, tt.limit, 1, 100)
+		evs, _, err := s.RangeEvents([]byte("foo"), nil, tt.limit, 1)
 		if err != nil {
 			t.Fatalf("#%d: range error (%v)", i, err)
 		}

--- a/storage/watcher.go
+++ b/storage/watcher.go
@@ -24,19 +24,17 @@ type watcher struct {
 	key    []byte
 	prefix bool
 	cur    int64
-	end    int64
 
 	ch  chan storagepb.Event
 	mu  sync.Mutex
 	err error
 }
 
-func newWatcher(key []byte, prefix bool, start, end int64) *watcher {
+func newWatcher(key []byte, prefix bool, start int64) *watcher {
 	return &watcher{
 		key:    key,
 		prefix: prefix,
 		cur:    start,
-		end:    end,
 		ch:     make(chan storagepb.Event, 10),
 	}
 }

--- a/storage/watcher_bench_test.go
+++ b/storage/watcher_bench_test.go
@@ -26,6 +26,6 @@ func BenchmarkKVWatcherMemoryUsage(b *testing.B) {
 	b.ReportAllocs()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		s.Watcher([]byte(fmt.Sprint("foo", i)), false, 0, 0)
+		s.Watcher([]byte(fmt.Sprint("foo", i)), false, 0)
 	}
 }


### PR DESCRIPTION
The watcher itself has the ability to cancel watching. Also we will add progress notification functionality. endRev is unnecessary.  