### PR TITLE
travis.yml: switch back to VM-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
-sudo: false
 go:
   - 1.4
   - 1.5


### PR DESCRIPTION
container-based infrastructure does not work well to match our
expectation, so let us switch back to VM one to give it another try.

/cc @xiang90 