### PR TITLE
etcdserver: don't allow methods other than GET in /debug/vars

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -324,6 +324,10 @@ func (h *statsHandler) serveLeader(w http.ResponseWriter, r *http.Request) {
 }
 
 func serveVars(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r.Method, "GET") {
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	fmt.Fprintf(w, "{\n")
 	first := true


### PR DESCRIPTION
Currently, /debug/vars seems to allow all types of methods e.g. PUT,
POST, etc. However, this path is a readonly stuff so it should allow
GET only.