### PR TITLE
raft: fix malformed example name

### DIFF
--- a/raft/example_test.go
+++ b/raft/example_test.go
@@ -23,7 +23,7 @@ func sendMessages(msgs []pb.Message)  {}
 func saveStateToDisk(st pb.HardState) {}
 func saveToDisk(ents []pb.Entry)      {}
 
-func Example_Node() {
+func ExampleNode() {
 	c := &Config{}
 	n := StartNode(c, nil)
 


### PR DESCRIPTION
It is reported by latest govet:
```
gopath/src/github.com/coreos/etcd/raft/example_test.go:26: Example_Node
has malformed example suffix: Node
```