### PR TITLE
storage: fix WatchableKV interface and refine comment

### DIFF
--- a/storage/kv.go
+++ b/storage/kv.go
@@ -97,9 +97,8 @@ type WatchableKV interface {
 	// event history can be watched unless compacted.
 	// If `prefix` is true, watch observes all events whose key prefix could be the given `key`.
 	// If `startRev` <=0, watch observes events after currentRev.
-	// If `endRev` <=0, watch observes events until watch is cancelled.
 	//
 	// Canceling the watcher releases resources associated with it, so code
 	// should always call cancel as soon as watch is done.
-	Watcher(key []byte, prefix bool, startRev, endRev int64) (Watcher, CancelFunc)
+	Watcher(key []byte, prefix bool, startRev int64) (Watcher, CancelFunc)
 }

--- a/storage/kv.go
+++ b/storage/kv.go
@@ -93,8 +93,9 @@ type Watcher interface {
 type WatchableKV interface {
 	KV
 
-	// Watcher watches the events happening or happened in etcd. The whole
-	// event history can be watched unless compacted.
+	// Watcher watches the events happening or happened on the given key
+	// or key prefix from the given startRev.
+	// The whole event history can be watched unless compacted.
 	// If `prefix` is true, watch observes all events whose key prefix could be the given `key`.
 	// If `startRev` <=0, watch observes events after currentRev.
 	//

--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -730,7 +730,7 @@ func TestKVSnapshot(t *testing.T) {
 }
 
 func TestWatchableKVWatch(t *testing.T) {
-	s := newWatchableStore(tmpPath)
+	s := WatchableKV(newWatchableStore(tmpPath))
 	defer cleanup(s, tmpPath)
 
 	wa, cancel := s.Watcher([]byte("foo"), true, 0)


### PR DESCRIPTION
We delete endRev from the watch functionality, so the interface needs
to be fixed.