### PR TITLE
pkg/transport: extend wait timeout for write

### DIFF
--- a/pkg/transport/timeout_dialer_test.go
+++ b/pkg/transport/timeout_dialer_test.go
@@ -50,7 +50,8 @@ func TestReadWriteTimeoutDialer(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(d.wtimeoutd * 10):
+	// It waits 1s more to avoid delay in low-end system.
+	case <-time.After(d.wtimeoutd*10 + time.Second):
 		t.Fatal("wait timeout")
 	}
 

--- a/pkg/transport/timeout_listener_test.go
+++ b/pkg/transport/timeout_listener_test.go
@@ -76,7 +76,8 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(wln.wtimeoutd * 10):
+	// It waits 1s more to avoid delay in low-end system.
+	case <-time.After(wln.wtimeoutd*10 + time.Second):
 		t.Fatal("wait timeout")
 	}
 


### PR DESCRIPTION
This helps the test to pass safely in semaphore CI.

Based on my manual testing of several tens of rounds, it may take at most 500ms to return
error in semaphore CI, so I set 1s as a safe value.

I failed to find the root cause. I find out that running tests in parallel has effect on it, but it is not the root cause because travis CI can run this test well.

I didn't dig it more because the wanted error is still returned, and the case is related to the test environment in semaphore CI a lot.