### PR TITLE
fix integration_test compile error

### DIFF
--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -417,7 +417,7 @@ func (c *cluster) Launch(t *testing.T) {
 			errc <- m.Launch()
 		}(m)
 	}
-	for range c.Members {
+	for _ := range c.Members {
 		if err := <-errc; err != nil {
 			t.Fatalf("error setting up member: %v", err)
 		}


### PR DESCRIPTION
fix test error
```
Checking gofmt...
integration/cluster_test.go:420:6: expected operand, found 'range'
integration/cluster_test.go:421:3: expected '{', found 'if'
integration/cluster_test.go:422:48: missing ',' before newline in composite literal
'}'     
```