### PR TITLE
raft: extend wait timeout in TestMultiNodeAdvance

### DIFF
--- a/raft/multinode_test.go
+++ b/raft/multinode_test.go
@@ -454,7 +454,7 @@ func TestMultiNodeAdvance(t *testing.T) {
 	mn.Advance(rd1)
 	select {
 	case <-mn.Ready():
-	case <-time.After(time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		t.Errorf("expect Ready after Advance, but there is no Ready available")
 	}
 }


### PR DESCRIPTION
This fixes the failure met in semaphore CI:

```
--- FAIL: TestMultiNodeAdvance-2 (0.01s)
		multinode_test.go:458: expect Ready after Advance, but there is
		no Ready available
```