### PR TITLE
etcdserver: add a new option for configuring per request timeout of c…

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -88,15 +88,16 @@ type config struct {
 	ElectionMs uint
 
 	// clustering
-	apurls, acurls      []url.URL
-	clusterState        *flags.StringsFlag
-	dnsCluster          string
-	dproxy              string
-	durl                string
-	fallback            *flags.StringsFlag
-	initialCluster      string
-	initialClusterToken string
-	strictReconfigCheck bool
+	apurls, acurls            []url.URL
+	clusterState              *flags.StringsFlag
+	dnsCluster                string
+	dproxy                    string
+	durl                      string
+	fallback                  *flags.StringsFlag
+	initialCluster            string
+	initialClusterToken       string
+	strictReconfigCheck       bool
+	discoveryRequestTimeoutMs uint
 
 	// proxy
 	proxy                  *flags.StringsFlag
@@ -181,6 +182,7 @@ func NewConfig() *config {
 		plog.Panicf("unexpected error setting up clusterStateFlag: %v", err)
 	}
 	fs.BoolVar(&cfg.strictReconfigCheck, "strict-reconfig-check", false, "Reject reconfiguration that might cause quorum loss")
+	fs.UintVar(&cfg.discoveryRequestTimeoutMs, "discovery-request-timeout", 1000, "Timeout (in milliseconds) of request in discovery process")
 
 	// proxy
 	fs.Var(cfg.proxy, "proxy", fmt.Sprintf("Valid values include %s", strings.Join(cfg.proxy.Values, ", ")))

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -265,25 +265,26 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 	}
 
 	srvcfg := &etcdserver.ServerConfig{
-		Name:                cfg.name,
-		ClientURLs:          cfg.acurls,
-		PeerURLs:            cfg.apurls,
-		DataDir:             cfg.dir,
-		DedicatedWALDir:     cfg.walDir,
-		SnapCount:           cfg.snapCount,
-		MaxSnapFiles:        cfg.maxSnapFiles,
-		MaxWALFiles:         cfg.maxWalFiles,
-		InitialPeerURLsMap:  urlsmap,
-		InitialClusterToken: token,
-		DiscoveryURL:        cfg.durl,
-		DiscoveryProxy:      cfg.dproxy,
-		NewCluster:          cfg.isNewCluster(),
-		ForceNewCluster:     cfg.forceNewCluster,
-		PeerTLSInfo:         cfg.peerTLSInfo,
-		TickMs:              cfg.TickMs,
-		ElectionTicks:       cfg.electionTicks(),
-		V3demo:              cfg.v3demo,
-		StrictReconfigCheck: cfg.strictReconfigCheck,
+		Name:                      cfg.name,
+		ClientURLs:                cfg.acurls,
+		PeerURLs:                  cfg.apurls,
+		DataDir:                   cfg.dir,
+		DedicatedWALDir:           cfg.walDir,
+		SnapCount:                 cfg.snapCount,
+		MaxSnapFiles:              cfg.maxSnapFiles,
+		MaxWALFiles:               cfg.maxWalFiles,
+		InitialPeerURLsMap:        urlsmap,
+		InitialClusterToken:       token,
+		DiscoveryURL:              cfg.durl,
+		DiscoveryProxy:            cfg.dproxy,
+		NewCluster:                cfg.isNewCluster(),
+		ForceNewCluster:           cfg.forceNewCluster,
+		PeerTLSInfo:               cfg.peerTLSInfo,
+		TickMs:                    cfg.TickMs,
+		ElectionTicks:             cfg.electionTicks(),
+		V3demo:                    cfg.v3demo,
+		StrictReconfigCheck:       cfg.strictReconfigCheck,
+		DiscoveryRequestTimeoutMs: cfg.discoveryRequestTimeoutMs,
 	}
 	var s *etcdserver.EtcdServer
 	s, err = etcdserver.NewServer(srvcfg)
@@ -368,7 +369,7 @@ func startProxy(cfg *config) error {
 		plog.Infof("proxy: using peer urls %v from cluster file %q", peerURLs, clusterfile)
 	case os.IsNotExist(err):
 		if cfg.durl != "" {
-			s, err := discovery.GetCluster(cfg.durl, cfg.dproxy)
+			s, err := discovery.GetCluster(cfg.durl, cfg.dproxy, cfg.discoveryRequestTimeoutMs)
 			if err != nil {
 				return err
 			}

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -51,7 +51,8 @@ type ServerConfig struct {
 
 	V3demo bool
 
-	StrictReconfigCheck bool
+	StrictReconfigCheck       bool
+	DiscoveryRequestTimeoutMs uint
 }
 
 // VerifyBootstrapConfig sanity-checks the initial config for bootstrap case

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -256,7 +256,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		if cfg.ShouldDiscover() {
 			var str string
 			var err error
-			str, err = discovery.JoinCluster(cfg.DiscoveryURL, cfg.DiscoveryProxy, m.ID, cfg.InitialPeerURLsMap.String())
+			str, err = discovery.JoinCluster(cfg.DiscoveryURL, cfg.DiscoveryProxy, m.ID, cfg.InitialPeerURLsMap.String(), cfg.DiscoveryRequestTimeoutMs)
 			if err != nil {
 				return nil, &discoveryError{op: "join", err: err}
 			}


### PR DESCRIPTION
…luster discovery process

Current etcd configures 1 second as a per request timeout in its
cluster discovery process and users don't have a way of changing the
timeout value. This commit adds a new option
-discovery-request-timeout to etcd. It can be used for changing the
timeout value with milliseconds unit.

Example usage (Procfile of goreman):
etcd1: bin/etcd -name infra1 -listen-client-urls http://127.0.0.1:12379 -advertise-client-urls http://127.0.0.1:12379 -listen-peer-urls http://127.0.0.1:12380 -initial-advertise-peer-urls http://127.0.0.1:12380 -discovery https://discovery.etcd.io/f0f0b626e76edc11b4aa011eda9a2d64 -discovery-request-timeout 2000