### PR TITLE
travis: only run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ go:
   - 1.5
 
 script:
- - INTEGRATION=y ./test
+ - ./test


### PR DESCRIPTION
Travis has chronic problems successfully running the integration suite -
and we've successfully moved to Semaphore for that purpose - but can
still be useful as a fail-fast option for testing unit tests and formatting.

Alternative to #3717