### PR TITLE
rafthttp: fix data races detected by go race detector

### DIFF
--- a/rafthttp/pipeline_test.go
+++ b/rafthttp/pipeline_test.go
@@ -246,9 +246,11 @@ func newRoundTripperBlocker() *roundTripperBlocker {
 		cancel:   make(map[*http.Request]chan struct{}),
 	}
 }
+
 func (t *roundTripperBlocker) unblock() {
 	close(t.unblockc)
 }
+
 func (t *roundTripperBlocker) CancelRequest(req *http.Request) {
 	t.mu.Lock()
 	defer t.mu.Unlock()


### PR DESCRIPTION
1. fix the race in the test. fakeWriteFlushCloser is used by multiple routines without locking.

2. stopped variable has data race. Removing it since the stop logic is actually unnecessary. 