### PR TITLE
rafthttp: mark unreachable on unexpected response

### DIFF
--- a/rafthttp/pipeline.go
+++ b/rafthttp/pipeline.go
@@ -159,7 +159,6 @@ func (p *pipeline) post(data []byte) (err error) {
 		// always be stopped. So we use reportCriticalError to report it to errorc.
 		if err == errMemberRemoved {
 			reportCriticalError(err, p.errorc)
-			return nil
 		}
 		return err
 	}

--- a/rafthttp/pipeline.go
+++ b/rafthttp/pipeline.go
@@ -153,14 +153,18 @@ func (p *pipeline) post(data []byte) (err error) {
 	resp.Body.Close()
 
 	err = checkPostResponse(resp, b, req, p.to)
-	// errMemberRemoved is a critical error since a removed member should
-	// always be stopped. So we use reportCriticalError to report it to errorc.
-	if err == errMemberRemoved {
-		reportCriticalError(err, p.errorc)
-		return nil
+	if err != nil {
+		p.picker.unreachable(u)
+		// errMemberRemoved is a critical error since a removed member should
+		// always be stopped. So we use reportCriticalError to report it to errorc.
+		if err == errMemberRemoved {
+			reportCriticalError(err, p.errorc)
+			return nil
+		}
+		return err
 	}
 
-	return err
+	return nil
 }
 
 // waitSchedule waits other goroutines to be scheduled for a while

--- a/rafthttp/transport_test.go
+++ b/rafthttp/transport_test.go
@@ -128,6 +128,7 @@ func TestTransportUpdate(t *testing.T) {
 func TestTransportErrorc(t *testing.T) {
 	errorc := make(chan error, 1)
 	tr := &Transport{
+		Raft:        &fakeRaft{},
 		LeaderStats: stats.NewLeaderStats(""),
 		ErrorC:      errorc,
 		streamRt:    newRespRoundTripper(http.StatusForbidden, nil),


### PR DESCRIPTION
In rafthttp, when making request to some endpoint, it may receive
response with unexpected status code and header. This indicates the endpoint
doesn't function correctly. It should mark the endpoint unreachable.

Also make minimal changes to make code much readable.

fixes #3652 