### PR TITLE
etcdserver: restructure auth.Store and auth.User

### DIFF
--- a/etcdserver/etcdhttp/client_auth.go
+++ b/etcdserver/etcdhttp/client_auth.go
@@ -53,7 +53,8 @@ func hasRootAccess(sec auth.Store, r *http.Request) bool {
 	if err != nil {
 		return false
 	}
-	ok = rootUser.CheckPassword(password)
+
+	ok = sec.CheckPassword(rootUser, password)
 	if !ok {
 		plog.Warningf("auth: wrong password for user %s", username)
 		return false
@@ -89,7 +90,7 @@ func hasKeyPrefixAccess(sec auth.Store, r *http.Request, key string, recursive b
 		plog.Warningf("auth: no such user: %s.", username)
 		return false
 	}
-	authAsUser := user.CheckPassword(password)
+	authAsUser := sec.CheckPassword(user, password)
 	if !authAsUser {
 		plog.Warningf("auth: incorrect password for user: %s.", username)
 		return false

--- a/etcdserver/etcdhttp/client_auth_test.go
+++ b/etcdserver/etcdhttp/client_auth_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/coreos/etcd/etcdserver/auth"
 )
 
-const goodPassword = "$2a$10$VYdJecHfm6WNodzv8XhmYeIG4n2SsQefdo5V2t6xIq/aWDHNqSUQW"
+const goodPassword = "good"
 
 func mustJSONRequest(t *testing.T, method string, p string, body string) *http.Request {
 	req, err := http.NewRequest(method, path.Join(authPrefix, p), strings.NewReader(body))
@@ -76,6 +76,14 @@ func (s *mockAuthStore) UpdateRole(role auth.Role) (auth.Role, error) {
 func (s *mockAuthStore) AuthEnabled() bool  { return s.enabled }
 func (s *mockAuthStore) EnableAuth() error  { return s.err }
 func (s *mockAuthStore) DisableAuth() error { return s.err }
+
+func (s *mockAuthStore) CheckPassword(user auth.User, password string) bool {
+	return user.Password == password
+}
+
+func (s *mockAuthStore) HashPassword(password string) (string, error) {
+	return password, nil
+}
 
 func TestAuthFlow(t *testing.T) {
 	enableMapMu.Lock()


### PR DESCRIPTION
This attempts to decouple password-related functions, which previously
existed both in the Store and User structs, by splitting them out into a
separate interface, PasswordStore.  This means that they can be more
easily swapped out during testing.

This also changes the relevant tests to use mock password functions
instead of the bcrypt-backed implementations; as a result, the tests are
much faster.

Before:
```
        github.com/coreos/etcd/etcdserver/auth          31.495s
        github.com/coreos/etcd/etcdserver/etcdhttp      91.205s
```

After:
```
        github.com/coreos/etcd/etcdserver/auth          1.207s
        github.com/coreos/etcd/etcdserver/etcdhttp      1.207s
```