### PR TITLE
etcdmain: add debug flag to enable logging

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -304,7 +304,7 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 	// Start the peer server in a goroutine
 	for _, l := range plns {
 		go func(l net.Listener) {
-			plog.Fatal(serveHTTP(l, ph, 5*time.Minute))
+			plog.Fatal(serveHTTP(l, ph, 5*time.Minute, cfg.debug))
 		}(l)
 	}
 	// Start a client server goroutine for each listen address
@@ -312,7 +312,7 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 		go func(l net.Listener) {
 			// read timeout does not work with http close notify
 			// TODO: https://github.com/golang/go/issues/9524
-			plog.Fatal(serveHTTP(l, ch, 0))
+			plog.Fatal(serveHTTP(l, ch, 0, cfg.debug))
 		}(l)
 	}
 


### PR DESCRIPTION
This is for `TODO: add debug flag; enable logging when debug flag is set`.
This adds an argument to `serveHTTP` function to make it configurable to set
`ErrorLog` or not.

Do I understand the `TODO` correctly? What do we mean by `enable logging`?
Do we want to use `capnslog`?

Thanks!