### PR TITLE
etcdserver: extend wait timeout in TestPublishRetry

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1099,7 +1099,8 @@ func TestPublishRetry(t *testing.T) {
 		done:     make(chan struct{}),
 		reqIDGen: idutil.NewGenerator(0, time.Time{}),
 	}
-	time.AfterFunc(500*time.Microsecond, func() { close(srv.done) })
+	// TODO: use fakeClockwork
+	time.AfterFunc(10*time.Millisecond, func() { close(srv.done) })
 	srv.publish(10 * time.Nanosecond)
 
 	action := n.Action()


### PR DESCRIPTION
It fixes the failure in semaphore CI:
```
--- FAIL: TestPublishRetry (0.00s)
		server_test.go:1108: len(action) = 1, want >= 2
```

A better way is to use fakeClockwork for it. I have added a TODO for it.