### PR TITLE
docs/libraries-and-tools: update the link of etcdctl

### DIFF
--- a/Documentation/libraries-and-tools.md
+++ b/Documentation/libraries-and-tools.md
@@ -2,7 +2,7 @@
 
 **Tools**
 
-- [etcdctl](https://github.com/coreos/etcdctl) - A command line client for etcd
+- [etcdctl](https://github.com/coreos/etcd/tree/master/etcdctl) - A command line client for etcd
 - [etcd-backup](https://github.com/fanhattan/etcd-backup) - A powerful command line utility for dumping/restoring etcd - Supports v2
 - [etcd-dump](https://npmjs.org/package/etcd-dump) - Command line utility for dumping/restoring etcd.
 - [etcd-fs](https://github.com/xetorthio/etcd-fs) - FUSE filesystem for etcd


### PR DESCRIPTION
The old repo is deprecated, and we develop etcdctl in etcd repo now.