### PR TITLE
pkg/cors: add authorization into Access-Control-Allow-Headers

### DIFF
--- a/pkg/cors/cors.go
+++ b/pkg/cors/cors.go
@@ -65,7 +65,7 @@ type CORSHandler struct {
 func (h *CORSHandler) addHeader(w http.ResponseWriter, origin string) {
 	w.Header().Add("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 	w.Header().Add("Access-Control-Allow-Origin", origin)
-	w.Header().Add("Access-Control-Allow-Headers", "accept, content-type")
+	w.Header().Add("Access-Control-Allow-Headers", "accept, content-type, authorization")
 }
 
 // ServeHTTP adds the correct CORS headers based on the origin and returns immediately


### PR DESCRIPTION
This helps browser to send auth-related request to etcd server when
cors flag is set.

fixes #3766 

@robszumski @sym3tri Could you help to review this one?