### PR TITLE
etcdserver: log snapshot request correctly at debug level

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -561,7 +561,7 @@ func (s *EtcdServer) run() {
 			}
 		case <-s.r.raftStorage.reqsnap():
 			s.r.raftStorage.raftsnap() <- s.createRaftSnapshot(appliedi, confState)
-			plog.Infof("requested snapshot created at %d", snapi)
+			plog.Debugf("requested snapshot created at %d", appliedi)
 		case err := <-s.errorc:
 			plog.Errorf("%s", err)
 			plog.Infof("the data-dir used by this member must be removed.")


### PR DESCRIPTION
    This happens repeatedly when one follower is dead, and brings limited
    information. Mask it to avoid spamming like this:

```
2015-10-28 22:07:53.154154 I | etcdserver: requested snapshot created at
1776711
2015-10-28 22:07:53.654527 I | etcdserver: requested snapshot created at
1776711
2015-10-28 22:07:54.154223 I | etcdserver: requested snapshot created at
1776711
```

for #2370 