### PR TITLE
etcdmain: fix package description compatible with godoc.org

### DIFF
--- a/etcdmain/doc.go
+++ b/etcdmain/doc.go
@@ -12,6 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* Package etcd contains the main entry point for the etcd binary. */
-
+// Package etcdmain contains the main entry point for the etcd binary.
 package etcdmain


### PR DESCRIPTION
This fixes some typos in doc.go. Current comment cannot be parsed as you see
at https://godoc.org/github.com/coreos/etcd/etcdmain.

Thanks,