### PR TITLE
rafthttp: use MergeLogger for rafthttp logging

### DIFF
--- a/pkg/logutil/merge_logger.go
+++ b/pkg/logutil/merge_logger.go
@@ -1,0 +1,192 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logutil includes utilities to faciliate logging.
+package logutil
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+)
+
+var (
+	defaultMergePeriod = time.Second
+
+	outputInterval = time.Second
+)
+
+// line represents a log line that can be printed out
+// through capnslog.PackageLogger.
+type line struct {
+	level capnslog.LogLevel
+	str   string
+}
+
+func (l line) append(s string) line {
+	return line{
+		level: l.level,
+		str:   l.str + " " + s,
+	}
+}
+
+// status represents the merge status of a line.
+type status struct {
+	period time.Duration
+
+	start time.Time // start time of latest merge period
+	count int       // number of merged lines from starting
+}
+
+func (s *status) isInMergePeriod(now time.Time) bool {
+	return s.period == 0 || s.start.Add(s.period).After(now)
+}
+
+func (s *status) isEmpty() bool { return s.count == 0 }
+
+func (s *status) summary(now time.Time) string {
+	return fmt.Sprintf("[merged %d repeated lines in %s]", s.count, now.Sub(s.start))
+}
+
+func (s *status) reset(now time.Time) {
+	s.start = now
+	s.count = 0
+}
+
+// MergeLogger supports merge logging, which merges repeated log lines
+// and prints summary log lines instead.
+//
+// For merge logging, MergeLogger prints out the line when the line appears
+// at the first time. MergeLogger holds the same log line printed within
+// defaultMergePeriod, and prints out summary log line at the end of defaultMergePeriod.
+// It stops merging when the line doesn't appear within the
+// defaultMergePeriod.
+type MergeLogger struct {
+	*capnslog.PackageLogger
+
+	mu      sync.Mutex // protect statusm
+	statusm map[line]*status
+}
+
+func NewMergeLogger(logger *capnslog.PackageLogger) *MergeLogger {
+	l := &MergeLogger{
+		PackageLogger: logger,
+		statusm:       make(map[line]*status),
+	}
+	go l.outputLoop()
+	return l
+}
+
+func (l *MergeLogger) MergeInfo(entries ...interface{}) {
+	l.merge(line{
+		level: capnslog.INFO,
+		str:   fmt.Sprint(entries...),
+	})
+}
+
+func (l *MergeLogger) MergeInfof(format string, args ...interface{}) {
+	l.merge(line{
+		level: capnslog.INFO,
+		str:   fmt.Sprintf(format, args...),
+	})
+}
+
+func (l *MergeLogger) MergeNotice(entries ...interface{}) {
+	l.merge(line{
+		level: capnslog.NOTICE,
+		str:   fmt.Sprint(entries...),
+	})
+}
+
+func (l *MergeLogger) MergeNoticef(format string, args ...interface{}) {
+	l.merge(line{
+		level: capnslog.NOTICE,
+		str:   fmt.Sprintf(format, args...),
+	})
+}
+
+func (l *MergeLogger) MergeWarning(entries ...interface{}) {
+	l.merge(line{
+		level: capnslog.WARNING,
+		str:   fmt.Sprint(entries...),
+	})
+}
+
+func (l *MergeLogger) MergeWarningf(format string, args ...interface{}) {
+	l.merge(line{
+		level: capnslog.WARNING,
+		str:   fmt.Sprintf(format, args...),
+	})
+}
+
+func (l *MergeLogger) MergeError(entries ...interface{}) {
+	l.merge(line{
+		level: capnslog.ERROR,
+		str:   fmt.Sprint(entries...),
+	})
+}
+
+func (l *MergeLogger) MergeErrorf(format string, args ...interface{}) {
+	l.merge(line{
+		level: capnslog.ERROR,
+		str:   fmt.Sprintf(format, args...),
+	})
+}
+
+func (l *MergeLogger) merge(ln line) {
+	l.mu.Lock()
+
+	// increase count if the logger is merging the line
+	if status, ok := l.statusm[ln]; ok {
+		status.count++
+		l.mu.Unlock()
+		return
+	}
+
+	// initialize status of the line
+	l.statusm[ln] = &status{
+		period: defaultMergePeriod,
+		start:  time.Now(),
+	}
+	// release the lock before IO operation
+	l.mu.Unlock()
+	// print out the line at its first time
+	l.PackageLogger.Logf(ln.level, ln.str)
+}
+
+func (l *MergeLogger) outputLoop() {
+	for now := range time.Tick(outputInterval) {
+		var outputs []line
+
+		l.mu.Lock()
+		for ln, status := range l.statusm {
+			if status.isInMergePeriod(now) {
+				continue
+			}
+			if status.isEmpty() {
+				delete(l.statusm, ln)
+				continue
+			}
+			outputs = append(outputs, ln.append(status.summary(now)))
+			status.reset(now)
+		}
+		l.mu.Unlock()
+
+		for _, o := range outputs {
+			l.PackageLogger.Logf(o.level, o.str)
+		}
+	}
+}

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -171,7 +171,7 @@ func startPeer(streamRt, pipelineRt http.RoundTripper, urls types.URLs, local, t
 						p.r.ReportSnapshot(m.To, raft.SnapshotFailure)
 					}
 					if status.isActive() {
-						plog.Warningf("dropped %s to %s since %s's sending buffer is full", m.Type, p.id, name)
+						plog.MergeWarningf("dropped %s to %s since %s's sending buffer is full", m.Type, p.id, name)
 					} else {
 						plog.Debugf("dropped %s to %s since %s's sending buffer is full", m.Type, p.id, name)
 					}

--- a/rafthttp/remote.go
+++ b/rafthttp/remote.go
@@ -42,7 +42,7 @@ func (g *remote) send(m raftpb.Message) {
 	case g.pipeline.msgc <- m:
 	default:
 		if g.status.isActive() {
-			plog.Warningf("dropped %s to %s since sending buffer is full", m.Type, g.id)
+			plog.MergeWarningf("dropped %s to %s since sending buffer is full", m.Type, g.id)
 		} else {
 			plog.Debugf("dropped %s to %s since sending buffer is full", m.Type, g.id)
 		}

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -331,7 +331,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 		case recvc <- m:
 		default:
 			if cr.status.isActive() {
-				plog.Warningf("dropped %s from %s since receiving buffer is full", m.Type, types.ID(m.From))
+				plog.MergeWarningf("dropped %s from %s since receiving buffer is full", m.Type, types.ID(m.From))
 			} else {
 				plog.Debugf("dropped %s from %s since receiving buffer is full", m.Type, types.ID(m.From))
 			}

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -24,13 +24,14 @@ import (
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/xiang90/probing"
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/etcdserver/stats"
+	"github.com/coreos/etcd/pkg/logutil"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
-var plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "rafthttp")
+var plog = logutil.NewMergeLogger(capnslog.NewPackageLogger("github.com/coreos/etcd", "rafthttp"))
 
 type Raft interface {
 	Process(ctx context.Context, m raftpb.Message) error


### PR DESCRIPTION
rafthttp logs repeated messages whenever the same connection error
happens, and it easily becomes log spamming.
Use MergeLogger as the default logger to merge repeated log lines.

This performs the same functionality as logging control in peerStatus.
So I remove the logging control in peerStatus and only use MergeLogger.

A leader logs of 3-member cluster like this:
```
[first follower is online]
2015-11-02 13:04:10.077340 E | rafthttp: failed to dial 91bc3c398fb3c146 on stream Message (dial tcp 127.0.0.1:22380: getsockopt: connection refused) [merged 319 repeated lines in 32.535044736s]
2015-11-02 13:04:10.077355 E | rafthttp: failed to dial 91bc3c398fb3c146 on stream MsgApp v2 (dial tcp 127.0.0.1:22380: getsockopt: connection refused) [merged 319 repeated lines in 32.53498537s]
2015-11-02 13:04:10.077363 E | rafthttp: failed to dial fd422379fda50e48 on stream Message (dial tcp 127.0.0.1:32380: getsockopt: connection refused) [merged 320 repeated lines in 32.531640475s]
2015-11-02 13:04:10.077369 E | rafthttp: failed to dial fd422379fda50e48 on stream MsgApp v2 (dial tcp 127.0.0.1:32380: getsockopt: connection refused) [merged 320 repeated lines in 32.531619957s]
2015-11-02 13:04:10.077372 E | rafthttp: failed to write fd422379fda50e48 on pipeline (dial tcp 127.0.0.1:32380: getsockopt: connection refused) [merged 24 repeated lines in 31.937195869s]
2015-11-02 13:04:10.077375 E | rafthttp: failed to write 91bc3c398fb3c146 on pipeline (dial tcp 127.0.0.1:22380: getsockopt: connection refused) [merged 24 repeated lines in 31.937131233s]
2015-11-02 13:04:10.077418 I | rafthttp: the connection with 91bc3c398fb3c146 became active
...
[second follower is online]
2015-11-02 13:04:17.002485 E | rafthttp: failed to dial fd422379fda50e48 on stream MsgApp v2 (dial tcp 127.0.0.1:32380: getsockopt: connection refused) [merged 67 repeated lines in 6.867907047s]
2015-11-02 13:04:17.002502 E | rafthttp: failed to dial fd422379fda50e48 on stream Message (dial tcp 127.0.0.1:32380: getsockopt: connection refused) [merged 67 repeated lines in 6.867877413s]
2015-11-02 13:04:17.002508 E | rafthttp: failed to write fd422379fda50e48 on pipeline (dial tcp 127.0.0.1:32380: getsockopt: connection refused) [merged 80 repeated lines in 6.163153163s]
2015-11-02 13:04:17.002516 I | rafthttp: the connection with fd422379fda50e48 became active
```

A slow-snapshot-recovery follower acts like this:
```
2015-11-02 13:04:27.066564 W | rafthttp: dropped MsgAppResp to 8211f1d0f64f3269 since pipeline's sending buffer is full
2015-11-02 13:04:27.066595 W | rafthttp: dropped MsgHeartbeatResp to 8211f1d0f64f3269 since pipeline's sending buffer is full
2015-11-02 13:04:27.066870 W | rafthttp: dropped MsgProp to 8211f1d0f64f3269 since pipeline's sending buffer is full
2015-11-02 13:04:28.956096 W | rafthttp: dropped MsgAppResp to 8211f1d0f64f3269 since pipeline's sending buffer is full [merged 20 repeated lines in 1.889445223s]
2015-11-02 13:04:28.956127 W | rafthttp: dropped MsgHeartbeatResp to 8211f1d0f64f3269 since pipeline's sending buffer is full [merged 46 repeated lines in 1.889413195s]
```

fixes #3462 in a general way