### PR TITLE
storage: extend wait timeout for execution

### DIFF
--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -665,7 +665,7 @@ func TestTxnBlockBackendForceCommit(t *testing.T) {
 	s.TxnEnd(id)
 	select {
 	case <-done:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatalf("failed to execute ForceCommit")
 	}
 


### PR DESCRIPTION
Extend timeout to pass always in traivs.

/cc @xiang90 The possible case that you mentioned happens now..