### PR TITLE
etcdmain: fix parsing discovery error

### DIFF
--- a/etcdserver/errors.go
+++ b/etcdserver/errors.go
@@ -40,16 +40,11 @@ func isKeyNotFound(err error) bool {
 	return ok && e.ErrorCode == etcdErr.EcodeKeyNotFound
 }
 
-type discoveryError struct {
-	op  string
-	err error
+type DiscoveryError struct {
+	Op  string
+	Err error
 }
 
-func (e discoveryError) Error() string {
-	return fmt.Sprintf("failed to %s discovery cluster (%v)", e.op, e.err)
-}
-
-func IsDiscoveryError(err error) bool {
-	_, ok := err.(*discoveryError)
-	return ok
+func (e DiscoveryError) Error() string {
+	return fmt.Sprintf("failed to %s discovery cluster (%v)", e.Op, e.Err)
 }

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -258,7 +258,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 			var err error
 			str, err = discovery.JoinCluster(cfg.DiscoveryURL, cfg.DiscoveryProxy, m.ID, cfg.InitialPeerURLsMap.String())
 			if err != nil {
-				return nil, &discoveryError{op: "join", err: err}
+				return nil, &DiscoveryError{Op: "join", Err: err}
 			}
 			urlsmap, err := types.NewURLsMap(str)
 			if err != nil {


### PR DESCRIPTION
The discovery error is wrapped into a struct now, and cannot be compared
to predefined errors. Correct the comparison behavior to fix the
problem.

fixes #3684 