### PR TITLE
storage: add watchChan

### DIFF
--- a/storage/kv.go
+++ b/storage/kv.go
@@ -80,15 +80,9 @@ type KV interface {
 type WatchableKV interface {
 	KV
 
-	// Watcher watches the events happening or happened on the given key
-	// or key prefix from the given startRev.
-	// The whole event history can be watched unless compacted.
-	// If `prefix` is true, watch observes all events whose key prefix could be the given `key`.
-	// If `startRev` <=0, watch observes events after currentRev.
-	//
-	// Canceling the watcher releases resources associated with it, so code
-	// should always call cancel as soon as watch is done.
-	Watcher(key []byte, prefix bool, startRev int64) (Watcher, CancelFunc)
+	// NewWatcher returns a Watcher that can be used to
+	// watch events happened or happending on the KV.
+	NewWatcher() Watcher
 }
 
 // ConsistentWatchableKV is a WatchableKV that understands the consistency

--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -733,12 +733,14 @@ func TestWatchableKVWatch(t *testing.T) {
 	s := WatchableKV(newWatchableStore(tmpPath))
 	defer cleanup(s, tmpPath)
 
-	wa, cancel := s.Watcher([]byte("foo"), true, 0)
+	w := s.NewWatcher()
+
+	cancel := w.Watch([]byte("foo"), true, 0)
 	defer cancel()
 
 	s.Put([]byte("foo"), []byte("bar"))
 	select {
-	case ev := <-wa.Event():
+	case ev := <-w.Chan():
 		wev := storagepb.Event{
 			Type: storagepb.PUT,
 			Kv: &storagepb.KeyValue{
@@ -758,7 +760,7 @@ func TestWatchableKVWatch(t *testing.T) {
 
 	s.Put([]byte("foo1"), []byte("bar1"))
 	select {
-	case ev := <-wa.Event():
+	case ev := <-w.Chan():
 		wev := storagepb.Event{
 			Type: storagepb.PUT,
 			Kv: &storagepb.KeyValue{
@@ -776,11 +778,11 @@ func TestWatchableKVWatch(t *testing.T) {
 		t.Fatalf("failed to watch the event")
 	}
 
-	wa, cancel = s.Watcher([]byte("foo1"), false, 1)
+	cancel = w.Watch([]byte("foo1"), false, 1)
 	defer cancel()
 
 	select {
-	case ev := <-wa.Event():
+	case ev := <-w.Chan():
 		wev := storagepb.Event{
 			Type: storagepb.PUT,
 			Kv: &storagepb.KeyValue{
@@ -800,7 +802,7 @@ func TestWatchableKVWatch(t *testing.T) {
 
 	s.Put([]byte("foo1"), []byte("bar11"))
 	select {
-	case ev := <-wa.Event():
+	case ev := <-w.Chan():
 		wev := storagepb.Event{
 			Type: storagepb.PUT,
 			Kv: &storagepb.KeyValue{

--- a/storage/watchable_store_bench_test.go
+++ b/storage/watchable_store_bench_test.go
@@ -37,14 +37,14 @@ func BenchmarkWatchableStoreUnsyncedCancel(b *testing.B) {
 	// in unsynced for this benchmark.
 	s := &watchableStore{
 		store:    newStore(tmpPath),
-		unsynced: make(map[*watcher]struct{}),
+		unsynced: make(map[*watching]struct{}),
 
 		// For previous implementation, use:
-		// unsynced: make([]*watcher, 0),
+		// unsynced: make([]*watching, 0),
 
 		// to make the test not crash from assigning to nil map.
 		// 'synced' doesn't get populated in this test.
-		synced: make(map[string][]*watcher),
+		synced: make(map[string][]*watching),
 	}
 
 	defer func() {
@@ -60,10 +60,12 @@ func BenchmarkWatchableStoreUnsyncedCancel(b *testing.B) {
 	testValue := []byte("bar")
 	s.Put(testKey, testValue)
 
+	w := s.NewWatcher()
+
 	cancels := make([]CancelFunc, watcherSize)
 	for i := 0; i < watcherSize; i++ {
 		// non-0 value to keep watchers in unsynced
-		_, cancel := s.Watcher(testKey, true, 1)
+		cancel := w.Watch(testKey, true, 1)
 		cancels[i] = cancel
 	}
 

--- a/storage/watcher_bench_test.go
+++ b/storage/watcher_bench_test.go
@@ -20,12 +20,14 @@ import (
 )
 
 func BenchmarkKVWatcherMemoryUsage(b *testing.B) {
-	s := newWatchableStore(tmpPath)
-	defer cleanup(s, tmpPath)
+	watchable := newWatchableStore(tmpPath)
+	defer cleanup(watchable, tmpPath)
+
+	w := watchable.NewWatcher()
 
 	b.ReportAllocs()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		s.Watcher([]byte(fmt.Sprint("foo", i)), false, 0)
+		w.Watch([]byte(fmt.Sprint("foo", i)), false, 0)
 	}
 }


### PR DESCRIPTION
We want to support multiple watchers per one channel. Then
we can have one single go routine to watch multiple keys/prefixs.

This is the initial implementation. I do not plan to write test in this
pull request. The goal here is to agree on the API and functionality.
