### PR TITLE
etcdserver: not reuse connections for peer transport

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -208,7 +208,7 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 			plog.Warningf("The scheme of peer url %s is http while peer key/cert files are presented. Ignored peer key/cert files.", u.String())
 		}
 		var l net.Listener
-		l, err = transport.NewTimeoutListener(u.Host, u.Scheme, cfg.peerTLSInfo, rafthttp.ConnReadTimeout, rafthttp.ConnWriteTimeout)
+		l, err = rafthttp.NewListener(u, cfg.peerTLSInfo)
 		if err != nil {
 			return nil, err
 		}

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -29,8 +29,8 @@ import (
 
 // isMemberBootstrapped tries to check if the given member has been bootstrapped
 // in the given cluster.
-func isMemberBootstrapped(cl *cluster, member string, tr *http.Transport) bool {
-	rcl, err := getClusterFromRemotePeers(getRemotePeerURLs(cl, member), time.Second, false, tr)
+func isMemberBootstrapped(cl *cluster, member string, rt http.RoundTripper) bool {
+	rcl, err := getClusterFromRemotePeers(getRemotePeerURLs(cl, member), time.Second, false, rt)
 	if err != nil {
 		return false
 	}
@@ -52,14 +52,14 @@ func isMemberBootstrapped(cl *cluster, member string, tr *http.Transport) bool {
 // response, an error is returned.
 // Each request has a 10-second timeout. Because the upper limit of TTL is 5s,
 // 10 second is enough for building connection and finishing request.
-func GetClusterFromRemotePeers(urls []string, tr *http.Transport) (*cluster, error) {
-	return getClusterFromRemotePeers(urls, 10*time.Second, true, tr)
+func GetClusterFromRemotePeers(urls []string, rt http.RoundTripper) (*cluster, error) {
+	return getClusterFromRemotePeers(urls, 10*time.Second, true, rt)
 }
 
 // If logerr is true, it prints out more error messages.
-func getClusterFromRemotePeers(urls []string, timeout time.Duration, logerr bool, tr *http.Transport) (*cluster, error) {
+func getClusterFromRemotePeers(urls []string, timeout time.Duration, logerr bool, rt http.RoundTripper) (*cluster, error) {
 	cc := &http.Client{
-		Transport: tr,
+		Transport: rt,
 		Timeout:   timeout,
 	}
 	for _, u := range urls {
@@ -114,7 +114,7 @@ func getRemotePeerURLs(cl Cluster, local string) []string {
 // The key of the returned map is the member's ID. The value of the returned map
 // is the semver versions string, including server and cluster.
 // If it fails to get the version of a member, the key will be nil.
-func getVersions(cl Cluster, local types.ID, tr *http.Transport) map[string]*version.Versions {
+func getVersions(cl Cluster, local types.ID, rt http.RoundTripper) map[string]*version.Versions {
 	members := cl.Members()
 	vers := make(map[string]*version.Versions)
 	for _, m := range members {
@@ -126,7 +126,7 @@ func getVersions(cl Cluster, local types.ID, tr *http.Transport) map[string]*ver
 			vers[m.ID.String()] = &version.Versions{Server: version.Version, Cluster: cv}
 			continue
 		}
-		ver, err := getVersion(m, tr)
+		ver, err := getVersion(m, rt)
 		if err != nil {
 			plog.Warningf("cannot get the version of member %s (%v)", m.ID, err)
 			vers[m.ID.String()] = nil
@@ -172,8 +172,8 @@ func decideClusterVersion(vers map[string]*version.Versions) *semver.Version {
 // cluster version in the range of [MinClusterVersion, Version] and no known members has a cluster version
 // out of the range.
 // We set this rule since when the local member joins, another member might be offline.
-func isCompatibleWithCluster(cl Cluster, local types.ID, tr *http.Transport) bool {
-	vers := getVersions(cl, local, tr)
+func isCompatibleWithCluster(cl Cluster, local types.ID, rt http.RoundTripper) bool {
+	vers := getVersions(cl, local, rt)
 	minV := semver.Must(semver.NewVersion(version.MinClusterVersion))
 	maxV := semver.Must(semver.NewVersion(version.Version))
 	maxV = &semver.Version{
@@ -214,9 +214,9 @@ func isCompatibleWithVers(vers map[string]*version.Versions, local types.ID, min
 
 // getVersion returns the Versions of the given member via its
 // peerURLs. Returns the last error if it fails to get the version.
-func getVersion(m *Member, tr *http.Transport) (*version.Versions, error) {
+func getVersion(m *Member, rt http.RoundTripper) (*version.Versions, error) {
 	cc := &http.Client{
-		Transport: tr,
+		Transport: rt,
 	}
 	var (
 		err  error

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -40,7 +40,6 @@ import (
 	"github.com/coreos/etcd/pkg/pbutil"
 	"github.com/coreos/etcd/pkg/runtime"
 	"github.com/coreos/etcd/pkg/timeutil"
-	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/pkg/wait"
 	"github.com/coreos/etcd/raft"
@@ -211,12 +210,10 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 	haveWAL := wal.Exist(cfg.WALDir())
 	ss := snap.New(cfg.SnapDir())
 
-	// use timeout transport to pair with remote timeout listeners
-	pt, err := transport.NewTimeoutTransport(cfg.PeerTLSInfo, cfg.peerDialTimeout(), 0, 0)
+	prt, err := rafthttp.NewRoundTripper(cfg.PeerTLSInfo, cfg.peerDialTimeout())
 	if err != nil {
 		return nil, err
 	}
-	prt := http.RoundTripper(pt)
 	var remotes []*Member
 	switch {
 	case !haveWAL && !cfg.NewCluster:

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -211,7 +211,8 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 	haveWAL := wal.Exist(cfg.WALDir())
 	ss := snap.New(cfg.SnapDir())
 
-	pt, err := transport.NewTransport(cfg.PeerTLSInfo, cfg.peerDialTimeout())
+	// use timeout transport to pair with remote timeout listeners
+	pt, err := transport.NewTimeoutTransport(cfg.PeerTLSInfo, cfg.peerDialTimeout(), 0, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -136,15 +136,11 @@ type Transport struct {
 
 func (t *Transport) Start() error {
 	var err error
-	// Read/write timeout is set for stream roundTripper to promptly
-	// find out broken status, which minimizes the number of messages
-	// sent on broken connection.
-	t.streamRt, err = transport.NewTimeoutTransport(t.TLSInfo, t.DialTimeout, ConnReadTimeout, ConnWriteTimeout)
+	t.streamRt, err = newStreamRoundTripper(t.TLSInfo, t.DialTimeout)
 	if err != nil {
 		return err
 	}
-	// use timeout transport to pair with remote timeout listeners
-	t.pipelineRt, err = transport.NewTimeoutTransport(t.TLSInfo, t.DialTimeout, 0, 0)
+	t.pipelineRt, err = NewRoundTripper(t.TLSInfo, t.DialTimeout)
 	if err != nil {
 		return err
 	}

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -143,7 +143,8 @@ func (t *Transport) Start() error {
 	if err != nil {
 		return err
 	}
-	t.pipelineRt, err = transport.NewTransport(t.TLSInfo, t.DialTimeout)
+	// use timeout transport to pair with remote timeout listeners
+	t.pipelineRt, err = transport.NewTimeoutTransport(t.TLSInfo, t.DialTimeout, 0, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
etcd uses timeout listener, and times out the accepted connections
if there is no activity. If we use idle connections in
transport, the connection may have timed out, and return error when
doing any request. So we do not reuse connections.

This fixes the problem that etcd fail to get version of peers.

fixes #3723 