### PR TITLE
raft: extend wait timeout in TestNodeAdvance

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -463,7 +463,7 @@ func TestNodeAdvance(t *testing.T) {
 	n.Advance()
 	select {
 	case <-n.Ready():
-	case <-time.After(time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		t.Errorf("expect Ready after Advance, but there is no Ready available")
 	}
 }


### PR DESCRIPTION
This fixes the failure met in semaphore CI.

I have gone through all time.After in raft package tests, and this is the only place left that only waits 1ms.

/cc @bdarnell 