### PR TITLE
storage: delete key instead of setting it to false

### DIFF
--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -317,12 +317,16 @@ func newOngoingTx() *ongoingTx {
 
 func (tx *ongoingTx) put(k string) {
 	tx.putm[k] = true
-	tx.delm[k] = false
+	if _, ok := tx.delm[k]; ok {
+		delete(tx.delm, k)
+	}
 }
 
 func (tx *ongoingTx) del(k string) {
 	tx.delm[k] = true
-	tx.putm[k] = false
+	if _, ok := tx.putm[k]; ok {
+		delete(tx.putm, k)
+	}
 }
 
 type watching struct {

--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -304,26 +304,26 @@ func (s *watchableStore) notify(rev int64, ev storagepb.Event) {
 
 type ongoingTx struct {
 	// keys put/deleted in the ongoing txn
-	putm map[string]bool
-	delm map[string]bool
+	putm map[string]struct{}
+	delm map[string]struct{}
 }
 
 func newOngoingTx() *ongoingTx {
 	return &ongoingTx{
-		putm: make(map[string]bool),
-		delm: make(map[string]bool),
+		putm: make(map[string]struct{}),
+		delm: make(map[string]struct{}),
 	}
 }
 
 func (tx *ongoingTx) put(k string) {
-	tx.putm[k] = true
+	tx.putm[k] = struct{}{}
 	if _, ok := tx.delm[k]; ok {
 		delete(tx.delm, k)
 	}
 }
 
 func (tx *ongoingTx) del(k string) {
-	tx.delm[k] = true
+	tx.delm[k] = struct{}{}
 	if _, ok := tx.putm[k]; ok {
 		delete(tx.putm, k)
 	}


### PR DESCRIPTION
When getting the watched events, it iterate all keys in putm and delm
to generate the events. If we don't delete the key from putm/delm,
it would range on the key that is not actually put or deleted. This is
incorrect.

Fix the panic that happens when single put/delete is watched.