### PR TITLE
*: rename etcd service to kv service in gRPC

### DIFF
--- a/Documentation/rfc/v3api.proto
+++ b/Documentation/rfc/v3api.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
-// Interface exported by the server.
-service etcd {
+service KV {
   // Range gets the keys in the range from the store.
   rpc Range(RangeRequest) returns (RangeResponse) {}
 

--- a/etcdctlv3/command/compaction.go
+++ b/etcdctlv3/command/compaction.go
@@ -48,8 +48,8 @@ func compactionCommandFunc(c *cli.Context) {
 	if err != nil {
 		panic(err)
 	}
-	etcd := pb.NewEtcdClient(conn)
+	kv := pb.NewKVClient(conn)
 	req := &pb.CompactionRequest{Revision: rev}
 
-	etcd.Compact(context.Background(), req)
+	kv.Compact(context.Background(), req)
 }

--- a/etcdctlv3/command/delete_range_command.go
+++ b/etcdctlv3/command/delete_range_command.go
@@ -48,10 +48,10 @@ func deleteRangeCommandFunc(c *cli.Context) {
 	if err != nil {
 		panic(err)
 	}
-	etcd := pb.NewEtcdClient(conn)
+	kv := pb.NewKVClient(conn)
 	req := &pb.DeleteRangeRequest{Key: key, RangeEnd: rangeEnd}
 
-	etcd.DeleteRange(context.Background(), req)
+	kv.DeleteRange(context.Background(), req)
 
 	if rangeEnd != nil {
 		fmt.Printf("range [%s, %s) is deleted\n", string(key), string(rangeEnd))

--- a/etcdctlv3/command/put_command.go
+++ b/etcdctlv3/command/put_command.go
@@ -45,9 +45,9 @@ func putCommandFunc(c *cli.Context) {
 	if err != nil {
 		panic(err)
 	}
-	etcd := pb.NewEtcdClient(conn)
+	kv := pb.NewKVClient(conn)
 	req := &pb.PutRequest{Key: key, Value: value}
 
-	etcd.Put(context.Background(), req)
+	kv.Put(context.Background(), req)
 	fmt.Printf("%s %s\n", key, value)
 }

--- a/etcdctlv3/command/range_command.go
+++ b/etcdctlv3/command/range_command.go
@@ -48,10 +48,10 @@ func rangeCommandFunc(c *cli.Context) {
 	if err != nil {
 		panic(err)
 	}
-	etcd := pb.NewEtcdClient(conn)
+	kv := pb.NewKVClient(conn)
 	req := &pb.RangeRequest{Key: key, RangeEnd: rangeEnd}
 
-	resp, err := etcd.Range(context.Background(), req)
+	resp, err := kv.Range(context.Background(), req)
 	for _, kv := range resp.Kvs {
 		fmt.Printf("%s %s\n", string(kv.Key), string(kv.Value))
 	}

--- a/etcdctlv3/command/txn_command.go
+++ b/etcdctlv3/command/txn_command.go
@@ -55,9 +55,9 @@ func txnCommandFunc(c *cli.Context) {
 	if err != nil {
 		panic(err)
 	}
-	etcd := pb.NewEtcdClient(conn)
+	kv := pb.NewKVClient(conn)
 
-	resp, err := etcd.Txn(context.Background(), txn)
+	resp, err := kv.Txn(context.Background(), txn)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -321,7 +321,7 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 	if cfg.v3demo {
 		// set up v3 demo rpc
 		grpcServer := grpc.NewServer()
-		etcdserverpb.RegisterEtcdServer(grpcServer, v3rpc.New(s))
+		etcdserverpb.RegisterKVServer(grpcServer, v3rpc.New(s))
 		etcdserverpb.RegisterWatchServer(grpcServer, v3rpc.NewWatchServer(s.Watchable()))
 		go plog.Fatal(grpcServer.Serve(v3l))
 	}

--- a/etcdserver/api/v3rpc/key.go
+++ b/etcdserver/api/v3rpc/key.go
@@ -27,7 +27,7 @@ type handler struct {
 	server etcdserver.V3DemoServer
 }
 
-func New(s etcdserver.V3DemoServer) pb.EtcdServer {
+func New(s etcdserver.V3DemoServer) pb.KVServer {
 	return &handler{s}
 }
 

--- a/etcdserver/etcdserverpb/rpc.pb.go
+++ b/etcdserver/etcdserverpb/rpc.pb.go
@@ -399,9 +399,9 @@ func init() {
 var _ context.Context
 var _ grpc.ClientConn
 
-// Client API for Etcd service
+// Client API for KV service
 
-type EtcdClient interface {
+type KVClient interface {
 	// Range gets the keys in the range from the store.
 	Range(ctx context.Context, in *RangeRequest, opts ...grpc.CallOption) (*RangeResponse, error)
 	// Put puts the given key into the store.
@@ -421,62 +421,62 @@ type EtcdClient interface {
 	Compact(ctx context.Context, in *CompactionRequest, opts ...grpc.CallOption) (*CompactionResponse, error)
 }
 
-type etcdClient struct {
+type kVClient struct {
 	cc *grpc.ClientConn
 }
 
-func NewEtcdClient(cc *grpc.ClientConn) EtcdClient {
-	return &etcdClient{cc}
+func NewKVClient(cc *grpc.ClientConn) KVClient {
+	return &kVClient{cc}
 }
 
-func (c *etcdClient) Range(ctx context.Context, in *RangeRequest, opts ...grpc.CallOption) (*RangeResponse, error) {
+func (c *kVClient) Range(ctx context.Context, in *RangeRequest, opts ...grpc.CallOption) (*RangeResponse, error) {
 	out := new(RangeResponse)
-	err := grpc.Invoke(ctx, "/etcdserverpb.etcd/Range", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/etcdserverpb.KV/Range", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *etcdClient) Put(ctx context.Context, in *PutRequest, opts ...grpc.CallOption) (*PutResponse, error) {
+func (c *kVClient) Put(ctx context.Context, in *PutRequest, opts ...grpc.CallOption) (*PutResponse, error) {
 	out := new(PutResponse)
-	err := grpc.Invoke(ctx, "/etcdserverpb.etcd/Put", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/etcdserverpb.KV/Put", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *etcdClient) DeleteRange(ctx context.Context, in *DeleteRangeRequest, opts ...grpc.CallOption) (*DeleteRangeResponse, error) {
+func (c *kVClient) DeleteRange(ctx context.Context, in *DeleteRangeRequest, opts ...grpc.CallOption) (*DeleteRangeResponse, error) {
 	out := new(DeleteRangeResponse)
-	err := grpc.Invoke(ctx, "/etcdserverpb.etcd/DeleteRange", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/etcdserverpb.KV/DeleteRange", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *etcdClient) Txn(ctx context.Context, in *TxnRequest, opts ...grpc.CallOption) (*TxnResponse, error) {
+func (c *kVClient) Txn(ctx context.Context, in *TxnRequest, opts ...grpc.CallOption) (*TxnResponse, error) {
 	out := new(TxnResponse)
-	err := grpc.Invoke(ctx, "/etcdserverpb.etcd/Txn", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/etcdserverpb.KV/Txn", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *etcdClient) Compact(ctx context.Context, in *CompactionRequest, opts ...grpc.CallOption) (*CompactionResponse, error) {
+func (c *kVClient) Compact(ctx context.Context, in *CompactionRequest, opts ...grpc.CallOption) (*CompactionResponse, error) {
 	out := new(CompactionResponse)
-	err := grpc.Invoke(ctx, "/etcdserverpb.etcd/Compact", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/etcdserverpb.KV/Compact", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// Server API for Etcd service
+// Server API for KV service
 
-type EtcdServer interface {
+type KVServer interface {
 	// Range gets the keys in the range from the store.
 	Range(context.Context, *RangeRequest) (*RangeResponse, error)
 	// Put puts the given key into the store.
@@ -496,93 +496,93 @@ type EtcdServer interface {
 	Compact(context.Context, *CompactionRequest) (*CompactionResponse, error)
 }
 
-func RegisterEtcdServer(s *grpc.Server, srv EtcdServer) {
-	s.RegisterService(&_Etcd_serviceDesc, srv)
+func RegisterKVServer(s *grpc.Server, srv KVServer) {
+	s.RegisterService(&_KV_serviceDesc, srv)
 }
 
-func _Etcd_Range_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+func _KV_Range_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(RangeRequest)
 	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(EtcdServer).Range(ctx, in)
+	out, err := srv.(KVServer).Range(ctx, in)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func _Etcd_Put_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+func _KV_Put_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(PutRequest)
 	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(EtcdServer).Put(ctx, in)
+	out, err := srv.(KVServer).Put(ctx, in)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func _Etcd_DeleteRange_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+func _KV_DeleteRange_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(DeleteRangeRequest)
 	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(EtcdServer).DeleteRange(ctx, in)
+	out, err := srv.(KVServer).DeleteRange(ctx, in)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func _Etcd_Txn_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+func _KV_Txn_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(TxnRequest)
 	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(EtcdServer).Txn(ctx, in)
+	out, err := srv.(KVServer).Txn(ctx, in)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func _Etcd_Compact_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
+func _KV_Compact_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(CompactionRequest)
 	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(EtcdServer).Compact(ctx, in)
+	out, err := srv.(KVServer).Compact(ctx, in)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-var _Etcd_serviceDesc = grpc.ServiceDesc{
-	ServiceName: "etcdserverpb.etcd",
-	HandlerType: (*EtcdServer)(nil),
+var _KV_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "etcdserverpb.KV",
+	HandlerType: (*KVServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
 			MethodName: "Range",
-			Handler:    _Etcd_Range_Handler,
+			Handler:    _KV_Range_Handler,
 		},
 		{
 			MethodName: "Put",
-			Handler:    _Etcd_Put_Handler,
+			Handler:    _KV_Put_Handler,
 		},
 		{
 			MethodName: "DeleteRange",
-			Handler:    _Etcd_DeleteRange_Handler,
+			Handler:    _KV_DeleteRange_Handler,
 		},
 		{
 			MethodName: "Txn",
-			Handler:    _Etcd_Txn_Handler,
+			Handler:    _KV_Txn_Handler,
 		},
 		{
 			MethodName: "Compact",
-			Handler:    _Etcd_Compact_Handler,
+			Handler:    _KV_Compact_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{},

--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -7,8 +7,7 @@ import "etcd/storage/storagepb/kv.proto";
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.unmarshaler_all) = true;
 
-// Interface exported by the server.
-service etcd {
+service KV {
   // Range gets the keys in the range from the store.
   rpc Range(RangeRequest) returns (RangeResponse) {}
 

--- a/tools/v3benchmark/get.go
+++ b/tools/v3benchmark/get.go
@@ -27,7 +27,7 @@ func benchGet(conn *grpc.ClientConn, key, rangeEnd []byte, n, c int) {
 	requests := make(chan struct{}, n)
 
 	for i := 0; i < c; i++ {
-		go get(etcdserverpb.NewEtcdClient(conn), key, rangeEnd, requests)
+		go get(etcdserverpb.NewKVClient(conn), key, rangeEnd, requests)
 	}
 
 	for i := 0; i < n; i++ {
@@ -36,7 +36,7 @@ func benchGet(conn *grpc.ClientConn, key, rangeEnd []byte, n, c int) {
 	close(requests)
 }
 
-func get(client etcdserverpb.EtcdClient, key, end []byte, requests <-chan struct{}) {
+func get(client etcdserverpb.KVClient, key, end []byte, requests <-chan struct{}) {
 	defer wg.Done()
 	req := &etcdserverpb.RangeRequest{Key: key, RangeEnd: end}
 

--- a/tools/v3benchmark/put.go
+++ b/tools/v3benchmark/put.go
@@ -39,7 +39,7 @@ func benchPut(conn *grpc.ClientConn, key []byte, kc, n, c, size int) {
 	}
 
 	for i := 0; i < c; i++ {
-		go put(etcdserverpb.NewEtcdClient(conn), requests)
+		go put(etcdserverpb.NewKVClient(conn), requests)
 	}
 
 	suffixb := make([]byte, 8)
@@ -59,7 +59,7 @@ func benchPut(conn *grpc.ClientConn, key []byte, kc, n, c, size int) {
 	close(requests)
 }
 
-func put(client etcdserverpb.EtcdClient, requests <-chan *etcdserverpb.PutRequest) {
+func put(client etcdserverpb.KVClient, requests <-chan *etcdserverpb.PutRequest) {
 	defer wg.Done()
 
 	for r := range requests {


### PR DESCRIPTION
We are separating the giant services into multiple parts: kv, watch, lease, lock in the future.