### PR TITLE
pkg/wait: extend wait timeout in TestWaitTime

### DIFF
--- a/pkg/wait/wait_time_test.go
+++ b/pkg/wait/wait_time_test.go
@@ -42,7 +42,7 @@ func TestWaitTime(t *testing.T) {
 	wt.Trigger(t1)
 	select {
 	case <-ch1:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("cannot receive from ch as expected")
 	}
 


### PR DESCRIPTION
Fix this error happening on travis:
```
--- FAIL: TestWaitTime-2 (0.01s)
		wait_time_test.go:46: cannot receive from ch as expected
```