### PR TITLE
storage: add metrics to watcher

### DIFF
--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -59,6 +59,14 @@ var (
 			Help:      "Total number of keys.",
 		})
 
+	watcherGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "etcd",
+			Subsystem: "storage",
+			Name:      "watcher_total",
+			Help:      "Total number of watchers.",
+		})
+
 	watchingGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "etcd",
@@ -135,9 +143,10 @@ func init() {
 	prometheus.MustRegister(deleteCounter)
 	prometheus.MustRegister(txnCounter)
 	prometheus.MustRegister(keysGauge)
+	prometheus.MustRegister(watcherGauge)
 	prometheus.MustRegister(watchingGauge)
-	prometheus.MustRegister(totalEventsCounter)
 	prometheus.MustRegister(slowWatchingGauge)
+	prometheus.MustRegister(totalEventsCounter)
 	prometheus.MustRegister(pendingEventsGauge)
 	prometheus.MustRegister(indexCompactionPauseDurations)
 	prometheus.MustRegister(dbCompactionPauseDurations)

--- a/storage/watcher.go
+++ b/storage/watcher.go
@@ -56,6 +56,7 @@ func (ws *watcher) Watch(key []byte, prefix bool, startRev int64) CancelFunc {
 	}
 	// TODO: cancelFunc needs to be removed from the cancels when it is called.
 	ws.cancels = append(ws.cancels, c)
+	watcherGauge.Inc()
 	return c
 }
 
@@ -72,4 +73,5 @@ func (ws *watcher) Close() {
 	}
 	ws.closed = true
 	close(ws.ch)
+	watcherGauge.Dec()
 }


### PR DESCRIPTION
This adds metrics to watcher, and changes some order in MustRegister function
calls in init (same order that we define the gauges).