### PR TITLE
storage: move watcherGauge to watchable_store

### DIFF
--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -165,6 +165,7 @@ func (s *watchableStore) Close() error {
 }
 
 func (s *watchableStore) NewWatcher() Watcher {
+	watcherGauge.Inc()
 	return &watcher{
 		watchable: s,
 		ch:        make(chan storagepb.Event, chanBufLen),

--- a/storage/watcher.go
+++ b/storage/watcher.go
@@ -56,7 +56,6 @@ func (ws *watcher) Watch(key []byte, prefix bool, startRev int64) CancelFunc {
 	}
 	// TODO: cancelFunc needs to be removed from the cancels when it is called.
 	ws.cancels = append(ws.cancels, c)
-	watcherGauge.Inc()
 	return c
 }
 


### PR DESCRIPTION
watcherGauge should be increased everytime we creates Watcher, not per watch
method call.

@xiang90 Sorry, I was confused as you pointed out.