### PR TITLE
*: update clusterMinVersion and feature maps for incoming v2.3

### DIFF
--- a/etcdserver/etcdhttp/capability.go
+++ b/etcdserver/etcdhttp/capability.go
@@ -37,6 +37,7 @@ var (
 	capabilityMaps = map[string]map[capability]bool{
 		"2.1.0": {authCapability: true},
 		"2.2.0": {authCapability: true},
+		"2.3.0": {authCapability: true},
 	}
 
 	enableMapMu sync.Mutex

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -48,6 +48,7 @@ var (
 		"2.0.0": {},
 		"2.1.0": {streamTypeMsgAppV2, streamTypeMessage},
 		"2.2.0": {streamTypeMsgAppV2, streamTypeMessage},
+		"2.3.0": {streamTypeMsgAppV2, streamTypeMessage},
 	}
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
-	MinClusterVersion = "2.1.0"
+	MinClusterVersion = "2.2.0"
 	Version           = "2.2.0+git"
 
 	// Git SHA Value will be set during build


### PR DESCRIPTION
This is the preparation for bumping to v2.3.0-alpha.0

I have manually changed its version to v2.3.0, and tests the upgrade process with it. It upgrades smoothly, and the cluster could always make progress. The log reads reasonable too.