### PR TITLE
refine error logs and messages, mainly for error cases of -strict-reconfig-check

### DIFF
--- a/client/cluster_error.go
+++ b/client/cluster_error.go
@@ -21,7 +21,11 @@ type ClusterError struct {
 }
 
 func (ce *ClusterError) Error() string {
-	return ErrClusterUnavailable.Error()
+	if len(ce.Errors) == 0 {
+		return ErrClusterUnavailable.Error()
+	}
+
+	return ce.Detail()
 }
 
 func (ce *ClusterError) Detail() string {

--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -59,7 +59,7 @@ func writeError(w http.ResponseWriter, r *http.Request, err error) {
 		}
 	default:
 		switch err {
-		case etcdserver.ErrTimeoutDueToLeaderFail, etcdserver.ErrTimeoutDueToConnectionLost:
+		case etcdserver.ErrTimeoutDueToLeaderFail, etcdserver.ErrTimeoutDueToConnectionLost, etcdserver.ErrNotEnoughStartedMembers:
 			plog.Error(err)
 		default:
 			plog.Errorf("got unexpected response error (%v)", err)

--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -64,7 +64,7 @@ func writeError(w http.ResponseWriter, r *http.Request, err error) {
 		default:
 			plog.Errorf("got unexpected response error (%v)", err)
 		}
-		herr := httptypes.NewHTTPError(http.StatusInternalServerError, "Internal Server Error")
+		herr := httptypes.NewHTTPError(http.StatusInternalServerError, err.Error())
 		if et := herr.WriteTo(w); et != nil {
 			plog.Debugf("error writing HTTPError (%v) to %s", et, r.RemoteAddr)
 		}


### PR DESCRIPTION
Current error logs and messages, mainly for error cases of membership changes with -strict-reconfig-check, are not correct. This PR refines it. It would also improve other error cases.

I made this PR with 3 commits for easy review because they have relatively independent topics. If maintainers like squashed one, I'll update this PR.