### PR TITLE
etcdserver: add waitTimeout parameter

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -158,7 +158,7 @@ func (h *keysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		reportRequestCompleted(rr, resp, startTime)
 	case resp.Watcher != nil:
-		ctx, cancel := context.WithTimeout(context.Background(), defaultWatchTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(rr.WaitTimeout))
 		defer cancel()
 		handleKeyWatch(ctx, w, resp.Watcher, rr.Stream, h.timer)
 	default:
@@ -444,7 +444,7 @@ func parseKeyRequest(r *http.Request, clock clockwork.Clock) (etcdserverpb.Reque
 	}
 	p := path.Join(etcdserver.StoreKeysPrefix, r.URL.Path[len(keysPrefix):])
 
-	var pIdx, wIdx uint64
+	var pIdx, wIdx, wTimeout uint64
 	if pIdx, err = getUint64(r.Form, "prevIndex"); err != nil {
 		return emptyReq, etcdErr.NewRequestError(
 			etcdErr.EcodeIndexNaN,
@@ -456,6 +456,15 @@ func parseKeyRequest(r *http.Request, clock clockwork.Clock) (etcdserverpb.Reque
 			etcdErr.EcodeIndexNaN,
 			`invalid value for "waitIndex"`,
 		)
+	}
+	if wTimeout, err = getUint64(r.Form, "waitTimeout"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeIndexNaN,
+			`invalid value for "waitTimeout"`,
+		)
+	}
+	if wTimeout == 0 {
+		wTimeout = uint64(defaultWatchTimeout)
 	}
 
 	var rec, sort, wait, dir, quorum, stream bool
@@ -540,19 +549,20 @@ func parseKeyRequest(r *http.Request, clock clockwork.Clock) (etcdserverpb.Reque
 	}
 
 	rr := etcdserverpb.Request{
-		Method:    r.Method,
-		Path:      p,
-		Val:       r.FormValue("value"),
-		Dir:       dir,
-		PrevValue: pV,
-		PrevIndex: pIdx,
-		PrevExist: pe,
-		Wait:      wait,
-		Since:     wIdx,
-		Recursive: rec,
-		Sorted:    sort,
-		Quorum:    quorum,
-		Stream:    stream,
+		Method:      r.Method,
+		Path:        p,
+		Val:         r.FormValue("value"),
+		Dir:         dir,
+		PrevValue:   pV,
+		PrevIndex:   pIdx,
+		PrevExist:   pe,
+		Wait:        wait,
+		WaitTimeout: wTimeout,
+		Since:       wIdx,
+		Recursive:   rec,
+		Sorted:      sort,
+		Quorum:      quorum,
+		Stream:      stream,
 	}
 
 	if pe != nil {

--- a/etcdserver/etcdserverpb/etcdserver.pb.go
+++ b/etcdserver/etcdserverpb/etcdserver.pb.go
@@ -45,6 +45,7 @@ type Request struct {
 	Quorum           bool   `protobuf:"varint,14,opt" json:"Quorum"`
 	Time             int64  `protobuf:"varint,15,opt" json:"Time"`
 	Stream           bool   `protobuf:"varint,16,opt" json:"Stream"`
+	WaitTimeout      uint64 `protobuf:"varint,17,opt" json:"WaitTimeout"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -168,6 +169,11 @@ func (m *Request) MarshalTo(data []byte) (int, error) {
 		data[i] = 0
 	}
 	i++
+	data[i] = 0x88
+	i++
+	data[i] = 0x1
+	i++
+	i = encodeVarintEtcdserver(data, i, uint64(m.WaitTimeout))
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -253,6 +259,7 @@ func (m *Request) Size() (n int) {
 	n += 2
 	n += 1 + sovEtcdserver(uint64(m.Time))
 	n += 3
+	n += 2 + sovEtcdserver(uint64(m.WaitTimeout))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -606,6 +613,22 @@ func (m *Request) Unmarshal(data []byte) error {
 				}
 			}
 			m.Stream = bool(v != 0)
+		case 17:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field WaitTimeout", wireType)
+			}
+			m.WaitTimeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.WaitTimeout |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			var sizeOfWire int
 			for {

--- a/etcdserver/etcdserverpb/etcdserver.proto
+++ b/etcdserver/etcdserverpb/etcdserver.proto
@@ -25,6 +25,7 @@ message Request {
 	optional bool   Quorum     = 14 [(gogoproto.nullable) = false];
 	optional int64  Time       = 15 [(gogoproto.nullable) = false];
 	optional bool   Stream     = 16 [(gogoproto.nullable) = false];
+	optional uint64 WaitTimeout = 17 [(gogoproto.nullable) = false];
 }
 
 message Metadata {


### PR DESCRIPTION
For clients that know the max amount of time they want to wait for a
watch response they can specify waitTimeout in nanoseconds.

```
$ time curl 'http://127.0.0.1:2379/v2/keys/foo?wait=true&waitTimeout=2000000000'

real    0m2.008s
user    0m0.003s
sys 0m0.004s
```

Potential fix to #2468
