### PR TITLE
etcdserver: fix snapshot index in creation log line

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -560,7 +560,7 @@ func (s *EtcdServer) run() {
 			}
 		case <-s.r.raftStorage.reqsnap():
 			s.r.raftStorage.raftsnap() <- s.createRaftSnapshot(appliedi, confState)
-			plog.Infof("requested snapshot created at %d", snapi)
+			plog.Infof("requested snapshot created at %d", appliedi)
 		case err := <-s.errorc:
 			plog.Errorf("%s", err)
 			plog.Infof("the data-dir used by this member must be removed.")


### PR DESCRIPTION
The snapshot is created at appliedi instead of snapi.