### PR TITLE
scripts: cd into correct directory in genproto.sh

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -26,13 +26,16 @@ pushd ${GOPATH}/src/github.com/gogo/protobuf/
 popd
 
 export PATH="${GOBIN}:${PATH}"
+export CURRENT_DIRECTORY=${PWD}
 
 # copy all proto dependencies inside etcd to gopath
 for dir in ${DIRS}; do
 	mkdir -p ${GOPATH}/src/github.com/coreos/etcd/${dir}
+	cd ..
 	pushd ${dir}
 		cp *.proto ${GOPATH}/src/github.com/coreos/etcd/${dir}
 	popd
+	cd ${CURRENT_DIRECTORY}
 done
 
 COREOS_ROOT="${GOPATH}/src/github.com/coreos"
@@ -42,10 +45,12 @@ GOGOPROTO_PATH="${GOGOPROTO_ROOT}:${GOGOPROTO_ROOT}/protobuf"
 ESCAPED_PREFIX=$(echo $PREFIX | sed -e 's/[\/&]/\\&/g')
 
 for dir in ${DIRS}; do
+	cd ..
 	pushd ${dir}
 		protoc --gogofast_out=plugins=grpc,import_prefix=github.com/coreos/:. -I=.:"${GOGOPROTO_PATH}":"${COREOS_ROOT}" *.proto
 		sed -i.bak -E "s/github\.com\/coreos\/(gogoproto|github\.com|golang\.org|google\.golang\.org)/${ESCAPED_PREFIX}\/\1/g" *.pb.go
 		sed -i.bak -E 's/github\.com\/coreos\/(errors|fmt|io)/\1/g' *.pb.go
 		rm -f *.bak
 	popd
+	cd ${CURRENT_DIRECTORY}
 done


### PR DESCRIPTION
This is a workaround for https://github.com/coreos/etcd/issues/3815.
genproto.sh script is not working when run in scripts directory because it
executes the command pushd assuming that the working directory is the project
root directory (github.com/coreos/etcd). This fix assumes that the script would
be run IN the scripts directory and cds into the parent directory when it needs
to run pushd.

As Brandon says, we need a better way to do this.