### PR TITLE
RFC: etcdserver: not count unreachable nodes as a started node during reco…

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -387,6 +387,8 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		s.snapStore.tr = tr
 	}
 
+	cl.SetTransport(tr)
+
 	return srv, nil
 }
 


### PR DESCRIPTION
…nfig

-strict-reconfig-check option ensures a quorum cannot be losed by
membership reconfiguration even if unstarted nodes are misconfigured
(e.g. typos in peerURLs). As suggested in [1], this commit lets
isReadyToAddMember() not to count unreachable nodes as started nodes.

This PR isn't ready to merge. I'd like to hear the maintainers' opinion especially in the below points:
1. Is it correct to use EtcdServer.ReportUnreachable() for detecting unreachable nodes?
2. This PR doesn't have a mechanism of detecting revival of unreachable nodes. What mechanism can I use for the detection?
I'm really glad if I can hear your comments.

[1] https://github.com/coreos/etcd/pull/3543#issuecomment-141509597