### PR TITLE
Doc: fix typos for v3benchmark

### DIFF
--- a/Documentation/benchmarks/etcd-3-demo-benchmarks.md
+++ b/Documentation/benchmarks/etcd-3-demo-benchmarks.md
@@ -14,7 +14,7 @@ GCE n1-highcpu-2 machine type
 
 ## Testing
 
-Use [etcd v3 benchmark tool](../../hack/v3benchmark/).
+Use [etcd v3 benchmark tool](../../tools/v3benchmark/).
 
 ## Performance
 


### PR DESCRIPTION
The official benchmakr code seems to be in `tools` directory (not in `hack`).