### PR TITLE
Documentation/security: Fix links about tls keygen.

### DIFF
--- a/Documentation/security.md
+++ b/Documentation/security.md
@@ -1,12 +1,10 @@
-# security model
+# Security Model
 
 etcd supports SSL/TLS as well as authentication through client certificates, both for clients to server as well as peer (server to server / cluster) communication.
 
 To get up and running you first need to have a CA certificate and a signed key pair for one member. It is recommended to create and sign a new key pair for every member in a cluster.
 
-For convenience the [cfssl](https://github.com/cloudflare/cfssl) tool provides an easy interface to certificate generation, and we provide a full example using the tool at [here](../hack/tls-setup). Alternatively this site provides a good reference on how to generate self-signed key pairs:
-
-http://www.g-loaded.eu/2005/11/10/be-your-own-ca/
+For convenience, the [cfssl](https://github.com/cloudflare/cfssl) tool provides an easy interface to certificate generation, and we provide an example using the tool [here](https://github.com/coreos/etcd/tree/master/hack/tls-setup). You can also examine this [alternative guide to generating self-signed key pairs](http://www.g-loaded.eu/2005/11/10/be-your-own-ca/).
 
 ## Basic setup
 


### PR DESCRIPTION
Edit to replace a relative link (won't work with that target) with
an absolute link.
Heading 1 Title Case.
Polish graf 3.

Fixes https://github.com/coreos/docs/issues/662