### PR TITLE
storage: change the format of key and value stored in backend

### DIFF
--- a/storage/backend_key.go
+++ b/storage/backend_key.go
@@ -1,0 +1,63 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/binary"
+
+	"github.com/coreos/etcd/storage/storagepb"
+)
+
+// backendKeyBytesLen is the length of backendKey bytes.
+// First a few bytes stores the revision of backendKey. The following byte
+// is a ' ' as delimiter. The last 4 bytes is the event type in big-endian
+// format.
+const backendKeyBytesLen = revBytesLen + 1 + 4
+
+type backendKey struct {
+	rev revision
+	t   storagepb.Event_EventType
+}
+
+func newBackendKeyBytes() []byte {
+	return make([]byte, backendKeyBytesLen)
+}
+
+// backendKeyToBytes converts backendKey to bytes.
+// The lexicograph order of backendKey's byte slice representation
+// is the same as the order of its revision.
+func backendKeyToBytes(key backendKey, bytes []byte) {
+	revToBytes(key.rev, bytes[:revBytesLen])
+	bytes[revBytesLen] = ' '
+	binary.BigEndian.PutUint32(bytes[revBytesLen+1:], uint32(key.t))
+}
+
+func bytesToBackendKey(bytes []byte) backendKey {
+	return backendKey{
+		rev: bytesToRev(bytes[:revBytesLen]),
+		t:   storagepb.Event_EventType(binary.BigEndian.Uint32(bytes[revBytesLen+1:])),
+	}
+}
+
+func backendKeyBytesRange(rev revision) (start, end []byte) {
+	start = newRevBytes()
+	revToBytes(rev, start)
+
+	end = newBackendKeyBytes()
+	endRev := revision{main: rev.main, sub: rev.sub + 1}
+	revToBytes(endRev, end)
+
+	return start, end
+}

--- a/storage/revision.go
+++ b/storage/revision.go
@@ -16,6 +16,11 @@ package storage
 
 import "encoding/binary"
 
+// revBytesLen is the length of revision bytes.
+// First 8 bytes is the revision.main in big-endian format. The 9th byte
+// is a '_'. The last 8 bytes is the revision.sub in big-endian format.
+const revBytesLen = 8 + 1 + 8
+
 type revision struct {
 	main int64
 	sub  int64
@@ -32,7 +37,7 @@ func (a revision) GreaterThan(b revision) bool {
 }
 
 func newRevBytes() []byte {
-	return make([]byte, 8+1+8)
+	return make([]byte, revBytesLen)
 }
 
 func revToBytes(rev revision, bytes []byte) {


### PR DESCRIPTION
Store KeyValue struct instead of Event struct in backend value for
better abstraction as xiang suggests. The event type in Event struct is
stored into backend key now.

The `backendKey` naming is just so so IMO. If you guys have better naming, I could update it.