### PR TITLE
etcdmain: more description for init cluster token

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Every change should be reflected on help.go as well.
+
 package etcdmain
 
 import (

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -57,6 +57,7 @@ clustering flags:
 		initial cluster state ('new' or 'existing').
 	--initial-cluster-token 'etcd-cluster'
 		initial cluster token for the etcd cluster during bootstrap.
+		Specifying this can protect you from unintended cross-cluster interaction when running multiple clusters.
 	--advertise-client-urls 'http://localhost:2379,http://localhost:4001'
 		list of this member's client URLs to advertise to the public.
 		The client URLs advertised should be accessible to machines that talk to etcd cluster. etcd client libraries parse these URLs to connect to the cluster.


### PR DESCRIPTION
This adds more description to initial-cluster-token from
coreos#3690 to help.go.