### PR TITLE
storage: save the KeyValue instead of Event in backend 

### DIFF
--- a/storage/index.go
+++ b/storage/index.go
@@ -28,7 +28,7 @@ type index interface {
 	Put(key []byte, rev revision)
 	Restore(key []byte, created, modified revision, ver int64)
 	Tombstone(key []byte, rev revision) error
-	RangeEvents(key, end []byte, rev int64) []revision
+	RangeSince(key, end []byte, rev int64) []revision
 	Compact(rev int64) map[revision]struct{}
 	Equal(b index) bool
 }
@@ -134,10 +134,10 @@ func (ti *treeIndex) Tombstone(key []byte, rev revision) error {
 	return ki.tombstone(rev.main, rev.sub)
 }
 
-// RangeEvents returns all revisions from key(including) to end(excluding)
+// RangeSince returns all revisions from key(including) to end(excluding)
 // at or after the given rev. The returned slice is sorted in the order
 // of revision.
-func (ti *treeIndex) RangeEvents(key, end []byte, rev int64) []revision {
+func (ti *treeIndex) RangeSince(key, end []byte, rev int64) []revision {
 	ti.RLock()
 	defer ti.RUnlock()
 

--- a/storage/index_test.go
+++ b/storage/index_test.go
@@ -136,7 +136,7 @@ func TestIndexTombstone(t *testing.T) {
 	}
 }
 
-func TestIndexRangeEvents(t *testing.T) {
+func TestIndexRangeSince(t *testing.T) {
 	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2"), []byte("foo2"), []byte("foo1"), []byte("foo")}
 	allRevs := []revision{{main: 1}, {main: 2}, {main: 3}, {main: 4}, {main: 5}, {main: 6}}
 
@@ -184,7 +184,7 @@ func TestIndexRangeEvents(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		revs := index.RangeEvents(tt.key, tt.end, atRev)
+		revs := index.RangeSince(tt.key, tt.end, atRev)
 		if !reflect.DeepEqual(revs, tt.wrevs) {
 			t.Errorf("#%d: revs = %+v, want %+v", i, revs, tt.wrevs)
 		}

--- a/storage/revision.go
+++ b/storage/revision.go
@@ -16,6 +16,11 @@ package storage
 
 import "encoding/binary"
 
+// revBytesLen is the byte length of a normal revision.
+// First 8 bytes is the revision.main in big-endian format. The 9th byte
+// is a '_'. The last 8 bytes is the revision.sub in big-endian format.
+const revBytesLen = 8 + 1 + 8
+
 type revision struct {
 	main int64
 	sub  int64
@@ -32,7 +37,7 @@ func (a revision) GreaterThan(b revision) bool {
 }
 
 func newRevBytes() []byte {
-	return make([]byte, 8+1+8)
+	return make([]byte, revBytesLen)
 }
 
 func revToBytes(rev revision, bytes []byte) {

--- a/storage/revision.go
+++ b/storage/revision.go
@@ -37,7 +37,7 @@ func (a revision) GreaterThan(b revision) bool {
 }
 
 func newRevBytes() []byte {
-	return make([]byte, revBytesLen)
+	return make([]byte, revBytesLen, markedRevBytesLen)
 }
 
 func revToBytes(rev revision, bytes []byte) {


### PR DESCRIPTION
Store KeyValue struct instead of Event struct in backend for
better abstraction as xiang suggests.

The point is to decouple the key-value storage layer and the
event notification layer clearly. It gives the watchableKV the flexibility
to define whatever event structure it wants without breaking
the ondisk format at key-value storage layer.

Do it as the way described here: https://github.com/coreos/etcd/pull/3842#discussion_r44368066