### PR TITLE
storage/backend: support MAP_POPULATE for unix

### DIFF
--- a/storage/backend/backend.go
+++ b/storage/backend/backend.go
@@ -61,7 +61,7 @@ func New(path string, d time.Duration, limit int) Backend {
 }
 
 func newBackend(path string, d time.Duration, limit int) *backend {
-	db, err := bolt.Open(path, 0600, nil)
+	db, err := bolt.Open(path, 0600, boltOpenOptions)
 	if err != nil {
 		log.Panicf("backend: cannot open database at %s (%v)", path, err)
 	}

--- a/storage/backend/boltoption_darwin.go
+++ b/storage/backend/boltoption_darwin.go
@@ -1,0 +1,19 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import "github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt"
+
+var boltOpenOptions *bolt.Options = nil

--- a/storage/backend/boltoption_freebsd.go
+++ b/storage/backend/boltoption_freebsd.go
@@ -1,0 +1,19 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import "github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt"
+
+var boltOpenOptions *bolt.Options = nil

--- a/storage/backend/boltoption_unix.go
+++ b/storage/backend/boltoption_unix.go
@@ -1,0 +1,31 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux solaris
+
+package backend
+
+import (
+	"syscall"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt"
+)
+
+// syscall.MAP_POPULATE on linux 2.6.23+ does sequential read-ahead
+// which can speed up entire-database read with boltdb. We want to
+// enable MAP_POPULATE for faster key-value store recovery in storage
+// package. If your kernel version is lower than 2.6.23
+// (https://github.com/torvalds/linux/releases/tag/v2.6.23), mmap might
+// silently ignore this flag. Please update your kernel to prevent this.
+var boltOpenOptions = &bolt.Options{MmapFlags: syscall.MAP_POPULATE}

--- a/storage/backend/boltoption_windows.go
+++ b/storage/backend/boltoption_windows.go
@@ -1,0 +1,21 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import "github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt"
+
+// TODO: support syscall.MAP_POPULATE in windows.
+// Need upstream patch from boltdb/bolt.
+var boltOpenOptions *bolt.Option = nil


### PR DESCRIPTION
/cc @xiang90 

This adds build constraints in order to pass memory-map flags to bolt.Option.
If backend package passes syscall.MAP_POPULATE flag, the boltdb does read-ahead
which speeds up entire-database read, which then leads to faster storage
Restore. Benchmark result shows for 4GB, it opens and loads 6x faster in SSD,
and 12x faster in HDD. For 2GB, 1.6x faster with MAP_POPULATE in SSD.


<br>
<hr>
##### Background

storage package should do read ahead to make kernal preload some pages into
page cache and speed up the recover reads in etcd.

Related issue:
- https://github.com/coreos/etcd/issues/3786

<br>
##### Test script

```
	start := time.Now()
	kv := storage.New("test.db", &fg{})
	kv.Restore()
	fmt.Println("kv.Restore took:", time.Since(start))
```


<br>
##### Results: SSD (local machine)

```
Ubuntu 15.10 with SSD
model name  : Intel(R) Core(TM) i7-4910MQ CPU @ 2.90GHz
go version go1.5.1 linux/amd64
linux kernel version: 4.2.0-18-generic

open + load(restore) 4GB data of 1 million random bytes keys:
WITHOUT MAP_POPULATE: 2 min 5 sec (open 3.706302ms, restore 1m58.015088268s)
WITH    MAP_POPULATE: 21 sec (open 7.771817481s, restore 13.6191382s)

open + load(restore) 2GB data of 1 million simple integer keys:
WITHOUT MAP_POPULATE: 18 sec (open 10.893178ms, restore 17.197815402s)
WITH    MAP_POPULATE: 11 sec (open 3.923564768s, restore 6.810750348s)
```


<br>
##### Results: HDD (GCE)

```
Debian GNU/Linux 7.9 (wheezy) with HDD
machine type: n1-highmem-2 (2 vCPUs, 13 GB memory) / Intel Haswell
model name      : Intel(R) Xeon(R) CPU @ 2.30GHz
go version go1.5.1 linux/amd64
linux kernel version: 3.16.0-0.bpo.4-amd64

open + load(restore) 4GB data of 1 million random bytes keys:
WITHOUT MAP_POPULATE: 9 min 10 sec (open 28.758918ms, restore 8m40.518096833s)
WITH    MAP_POPULATE: 46 sec (open 36.944924626s, restore 9.460929924s)
```
