### PR TITLE
auth: use canonical path for pre-defined guest role

### DIFF
--- a/etcdserver/auth/auth.go
+++ b/etcdserver/auth/auth.go
@@ -53,8 +53,8 @@ var rootRole = Role{
 	Role: RootRoleName,
 	Permissions: Permissions{
 		KV: RWPermission{
-			Read:  []string{"*"},
-			Write: []string{"*"},
+			Read:  []string{"/*"},
+			Write: []string{"/*"},
 		},
 	},
 }
@@ -63,8 +63,8 @@ var guestRole = Role{
 	Role: GuestRoleName,
 	Permissions: Permissions{
 		KV: RWPermission{
-			Read:  []string{"*"},
-			Write: []string{"*"},
+			Read:  []string{"/*"},
+			Write: []string{"/*"},
 		},
 	},
 }


### PR DESCRIPTION
Fix #3784.

Manually tested.