### PR TITLE
rafthttp: describe raft MessageType when logging

### DIFF
--- a/rafthttp/peer_test.go
+++ b/rafthttp/peer_test.go
@@ -85,3 +85,25 @@ func TestPeerPick(t *testing.T) {
 		}
 	}
 }
+
+func TestDescribeMsgType(t *testing.T) {
+	ts := map[raftpb.MessageType]string{
+		raftpb.MsgHup:           "MsgHup(candidate requests to start a new election)",
+		raftpb.MsgBeat:          "MsgBeat(leader requests to send a heartbeat)",
+		raftpb.MsgProp:          "MsgProp(proposal to change configurations)",
+		raftpb.MsgApp:           "MsgApp(leader requests to replicate logs)",
+		raftpb.MsgAppResp:       "MsgAppResp(leader handles response to its log replication message)",
+		raftpb.MsgVote:          "MsgVote(follower votes for a new leader)",
+		raftpb.MsgVoteResp:      "MsgVoteResp(candidate receives votes from followers)",
+		raftpb.MsgSnap:          "MsgSnap(leader requests to install a snapshot message)",
+		raftpb.MsgHeartbeat:     "MsgHeartbeat(candidate/follower receives a heartbeat from a leader)",
+		raftpb.MsgHeartbeatResp: "MsgHeartbeatResp(leader handles response to its heartbeat message)",
+		raftpb.MsgUnreachable:   "MsgUnreachable(leader finds out that its request wasn't delivered)",
+		raftpb.MsgSnapStatus:    "MsgSnapStatus(leader handles response to its snapshot install request)",
+	}
+	for k, v := range ts {
+		if rs := describeMsgType(k); rs != v {
+			t.Errorf("expected %s for %s but got %s", v, k, rs)
+		}
+	}
+}

--- a/rafthttp/remote.go
+++ b/rafthttp/remote.go
@@ -42,9 +42,9 @@ func (g *remote) send(m raftpb.Message) {
 	case g.pipeline.msgc <- m:
 	default:
 		if g.status.isActive() {
-			plog.MergeWarningf("dropped %s to %s since sending buffer is full", m.Type, g.id)
+			plog.MergeWarningf("dropped %s to %s since sending buffer is full", describeMsgType(m.Type), g.id)
 		} else {
-			plog.Debugf("dropped %s to %s since sending buffer is full", m.Type, g.id)
+			plog.Debugf("dropped %s to %s since sending buffer is full", describeMsgType(m.Type), g.id)
 		}
 	}
 }

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -332,9 +332,9 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 		case recvc <- m:
 		default:
 			if cr.status.isActive() {
-				plog.MergeWarningf("dropped %s from %s since receiving buffer is full", m.Type, types.ID(m.From))
+				plog.MergeWarningf("dropped %s from %s since receiving buffer is full", describeMsgType(m.Type), types.ID(m.From))
 			} else {
-				plog.Debugf("dropped %s from %s since receiving buffer is full", m.Type, types.ID(m.From))
+				plog.Debugf("dropped %s from %s since receiving buffer is full", describeMsgType(m.Type), types.ID(m.From))
 			}
 		}
 	}


### PR DESCRIPTION
This is for https://github.com/coreos/etcd/issues/3806 to give more explicit
description of raft `MessageType`s.

Sample output:

```    
dropped MsgHup(candidate requests to start a new election)
dropped MsgBeat(leader requests to send a heartbeat)
dropped MsgProp(proposal to change configurations)
dropped MsgApp(leader requests to replicate logs)
dropped MsgAppResp(leader handles response to its log replication message)
dropped MsgVote(follower votes for a new leader)
dropped MsgVoteResp(candidate receives votes from followers)
dropped MsgSnap(leader requests to install a snapshot message)
dropped MsgHeartbeat(candidate/follower receives a heartbeat from a leader)
dropped MsgHeartbeatResp(leader handles response to its heartbeat message)
dropped MsgUnreachable(leader finds out that its request wasn't delivered)
dropped MsgSnapStatus(leader handles response to its snapshot install request)
```    

Please let me know if you have any feedback. Thanks,