### PR TITLE
raft: fix print format for term in one log line

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -627,7 +627,7 @@ func stepCandidate(r *raft, m pb.Message) {
 		r.becomeFollower(m.Term, m.From)
 		r.handleSnapshot(m)
 	case pb.MsgVote:
-		r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] rejected vote from %x [logterm: %d, index: %d] at term %x",
+		r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] rejected vote from %x [logterm: %d, index: %d] at term %d",
 			r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.From, m.LogTerm, m.Index, r.Term)
 		r.send(pb.Message{To: m.From, Type: pb.MsgVoteResp, Reject: true})
 	case pb.MsgVoteResp:


### PR DESCRIPTION
`term` should be printed in decimal representation instead of
hexadecimal one.

I have manually checked all '%x' in raft package, and they are only used for printing out member ID now.