### PR TITLE
etcdserver: abstract kv struct out

### DIFF
--- a/etcdserver/kv.go
+++ b/etcdserver/kv.go
@@ -1,0 +1,116 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	dstorage "github.com/coreos/etcd/storage"
+)
+
+const databaseFilename = "db"
+
+type kv struct {
+	// dir to host KV file and incoming snapshot file
+	dir string
+	ig  dstorage.ConsistentIndexGetter
+
+	dstorage.ConsistentWatchableKV
+}
+
+func newKV(dir string, ig dstorage.ConsistentIndexGetter) (*kv, error) {
+	kv := &kv{
+		dir: dir,
+		ig:  ig,
+		ConsistentWatchableKV: dstorage.New(path.Join(dir, databaseFilename), ig),
+	}
+	if err := kv.ConsistentWatchableKV.Restore(); err != nil {
+		kv.ConsistentWatchableKV.Close()
+		return nil, fmt.Errorf("failed to restore KV (%v)", err)
+	}
+	return kv, nil
+}
+
+// SaveFrom saves snapshot at the given index from the given reader.
+// If the snapshot with the given index has been saved successfully, it keeps
+// the original saved snapshot and returns error.
+// The function guarantees that SaveFrom always saves either complete
+// snapshot or no snapshot, even if the call is aborted because program
+// is hard killed.
+func (kv *kv) SaveFrom(r io.Reader, index uint64) error {
+	f, err := ioutil.TempFile(kv.dir, "tmp")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(f, r)
+	f.Close()
+	if err != nil {
+		os.Remove(f.Name())
+		return err
+	}
+	fn := path.Join(kv.dir, fmt.Sprintf("%016x.db", index))
+	if fileutil.Exist(fn) {
+		os.Remove(f.Name())
+		return fmt.Errorf("snapshot to save has existed")
+	}
+	err = os.Rename(f.Name(), fn)
+	if err != nil {
+		os.Remove(f.Name())
+		return err
+	}
+	return nil
+}
+
+// restore sets the saved snapshot file at the given index
+// as the underlying database, and restores KV from the snapshot.
+func (kv *kv) restore(index uint64) error {
+	if err := kv.ConsistentWatchableKV.Close(); err != nil {
+		return fmt.Errorf("faile to close KV (%v)", err)
+	}
+	snapfn, err := kv.getSnapFilePath(index)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot file path (%v)", err)
+	}
+	fn := path.Join(kv.dir, databaseFilename)
+	if err := os.Rename(snapfn, fn); err != nil {
+		return fmt.Errorf("failed to rename snapshot file (%v)", err)
+	}
+	kv.ConsistentWatchableKV = dstorage.New(fn, kv.ig)
+	if err := kv.ConsistentWatchableKV.Restore(); err != nil {
+		return fmt.Errorf("failed to restore KV (%v)", err)
+	}
+	return nil
+}
+
+// getSnapFilePath returns the file path for the snapshot with given index.
+// If the snapshot does not exist, it returns error.
+func (kv *kv) getSnapFilePath(index uint64) (string, error) {
+	fns, err := fileutil.ReadDir(kv.dir)
+	if err != nil {
+		return "", err
+	}
+	wfn := fmt.Sprintf("%016x.db", index)
+	for _, fn := range fns {
+		if fn == wfn {
+			return path.Join(kv.dir, fn), nil
+		}
+	}
+	return "", fmt.Errorf("snapshot file doesn't exist")
+}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -189,7 +189,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 	var id types.ID
 	var cl *cluster
 
-	if !cfg.V3demo && fileutil.Exist(path.Join(cfg.StorageDir(), databaseFilename)) {
+	if !cfg.V3demo && fileutil.Exist(cfg.StorageDir()) {
 		return nil, errors.New("experimental-v3demo cannot be disabled once it is enabled")
 	}
 

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -46,7 +46,6 @@ import (
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/coreos/etcd/rafthttp"
 	"github.com/coreos/etcd/snap"
-	dstorage "github.com/coreos/etcd/storage"
 	"github.com/coreos/etcd/store"
 	"github.com/coreos/etcd/version"
 	"github.com/coreos/etcd/wal"
@@ -63,8 +62,6 @@ const (
 
 	purgeFileInterval      = 30 * time.Second
 	monitorVersionInterval = 5 * time.Second
-
-	databaseFilename = "db"
 )
 
 var (
@@ -160,7 +157,7 @@ type EtcdServer struct {
 	cluster *cluster
 
 	store store.Store
-	kv    dstorage.ConsistentWatchableKV
+	kv    *kv
 
 	stats  *stats.ServerStats
 	lstats *stats.LeaderStats
@@ -347,11 +344,11 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		if err != nil && err != os.ErrExist {
 			return nil, err
 		}
-		srv.kv = dstorage.New(path.Join(cfg.StorageDir(), databaseFilename), &srv.consistIndex)
-		if err := srv.kv.Restore(); err != nil {
-			plog.Fatalf("v3 storage restore error: %v", err)
+		srv.kv, err = newKV(cfg.StorageDir(), &srv.consistIndex)
+		if err != nil {
+			return nil, err
 		}
-		s.snapStore = newSnapshotStore(cfg.StorageDir(), srv.kv)
+		s.snapStore = newSnapshotStore(srv.kv)
 	}
 
 	// TODO: move transport initialization near the definition of remote
@@ -361,7 +358,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		ID:          id,
 		ClusterID:   cl.ID(),
 		Raft:        srv,
-		SnapSaver:   s.snapStore,
+		SnapSaver:   srv.kv,
 		ServerStats: sstats,
 		LeaderStats: lstats,
 		ErrorC:      srv.errorc,
@@ -496,20 +493,8 @@ func (s *EtcdServer) run() {
 				}
 
 				if s.cfg.V3demo {
-					if err := s.kv.Close(); err != nil {
-						plog.Panicf("close KV error: %v", err)
-					}
-					snapfn, err := s.r.raftStorage.snapStore.getSnapFilePath(apply.snapshot.Metadata.Index)
-					if err != nil {
-						plog.Panicf("get snapshot file path error: %v", err)
-					}
-					fn := path.Join(s.cfg.StorageDir(), databaseFilename)
-					if err := os.Rename(snapfn, fn); err != nil {
-						plog.Panicf("rename snapshot file error: %v", err)
-					}
-					s.kv = dstorage.New(fn, &s.consistIndex)
-					if err := s.kv.Restore(); err != nil {
-						plog.Panicf("restore KV error: %v", err)
+					if err := s.kv.restore(apply.snapshot.Metadata.Index); err != nil {
+						plog.Panicf("restore storage error: %v", err)
 					}
 				}
 				if err := s.store.Recovery(apply.snapshot.Data); err != nil {

--- a/etcdserver/snapshot_store_test.go
+++ b/etcdserver/snapshot_store_test.go
@@ -32,7 +32,7 @@ func TestSnapshotStoreCreateSnap(t *testing.T) {
 	snap := raftpb.Snapshot{
 		Metadata: raftpb.SnapshotMetadata{Index: 1},
 	}
-	ss := newSnapshotStore("", &nopKV{})
+	ss := newSnapshotStore(&nopKV{})
 	fakeClock := clockwork.NewFakeClock()
 	ss.clock = fakeClock
 	go func() {
@@ -61,7 +61,7 @@ func TestSnapshotStoreGetSnap(t *testing.T) {
 	snap := raftpb.Snapshot{
 		Metadata: raftpb.SnapshotMetadata{Index: 1},
 	}
-	ss := newSnapshotStore("", &nopKV{})
+	ss := newSnapshotStore(&nopKV{})
 	fakeClock := clockwork.NewFakeClock()
 	ss.clock = fakeClock
 	ss.tr = &nopTransporter{}


### PR DESCRIPTION
kv struct is the wrapper around storage.KV, and it handles save and
restore snapshot logic. This is changed to make code more readable.

This helps to kill TODO.

This also adjust code block to help to fix https://github.com/coreos/etcd/issues/3773#issuecomment-156903933