### PR TITLE
tools/etcd-tester: extend timeout for stresser

### DIFF
--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -75,7 +75,7 @@ func (s *stresser) Stress() error {
 	for i := 0; i < s.N; i++ {
 		go func() {
 			for {
-				setctx, setcancel := context.WithTimeout(ctx, time.Second)
+				setctx, setcancel := context.WithTimeout(ctx, client.DefaultRequestTimeout)
 				key := fmt.Sprintf("foo%d", rand.Intn(s.KeySuffixRange))
 				_, err := kv.Set(setctx, key, randStr(s.KeySize), nil)
 				setcancel()


### PR DESCRIPTION
Extend the timeout from 1s to defaultRequestTimeout 5s.

The 1s may bring unwanted burden to the target member. If the member is
busy at recovering, it has limited bandwidth for client requests. A
short timeout at client side will retry quickly while keeping the
on-going connections. Thus, etcd will queue lots of requests and
connections and takes long time to clear them. This finally causes the
timeout of member health check.

This problem is a general one that how etcd handles amounts of requests
at the same time in a good way. We don't plan to address it at current
stage.