### PR TITLE
raft: no-op instead of panic for Campaigning while leader

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -485,9 +485,13 @@ func (r *raft) poll(id uint64, v bool) (granted int) {
 
 func (r *raft) Step(m pb.Message) error {
 	if m.Type == pb.MsgHup {
-		r.logger.Infof("%x is starting a new election at term %d", r.id, r.Term)
-		r.campaign()
-		r.Commit = r.raftLog.committed
+		if r.state != StateLeader {
+			r.logger.Infof("%x is starting a new election at term %d", r.id, r.Term)
+			r.campaign()
+			r.Commit = r.raftLog.committed
+		} else {
+			r.logger.Debugf("%x ignoring MsgHup because already leader", r.id)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
We need to be able to force an election (on one node) after creating a
new group (cockroachdb/cockroach#1384), but it is difficult to ensure
that our call to Campaign does not race with an election that may be
started by raft itself. A redundant call to Campaign should be a no-op
instead of a panic. (But the panic in becomeCandidate remains, because
we don't want to update the term or change the committed index in this
case)

@xiang90 @yichengq 