### PR TITLE
etcdmain: fix unstoppable startEtcd function

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -323,7 +323,7 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 		grpcServer := grpc.NewServer()
 		etcdserverpb.RegisterKVServer(grpcServer, v3rpc.NewKVServer(s))
 		etcdserverpb.RegisterWatchServer(grpcServer, v3rpc.NewWatchServer(s.Watchable()))
-		go plog.Fatal(grpcServer.Serve(v3l))
+		go func() { plog.Fatal(grpcServer.Serve(v3l)) }()
 	}
 
 	return s.StopNotify(), nil


### PR DESCRIPTION
We should wrap the blocking function with a closure. And first
creates a go routine to execute the function with the closure. Or 
the inner function blocks before creating the go routine.

Fix #3787 

/cc @eyakubovich @gyuho 