### PR TITLE
etcdmain: Add max-snapshots and max-wals to help

### DIFF
--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -14,6 +14,8 @@
 
 package etcdmain
 
+import "strconv"
+
 var (
 	usageline = `usage: etcd [flags]
        start an etcd server
@@ -43,6 +45,10 @@ member flags:
 		list of URLs to listen on for peer traffic.
 	--listen-client-urls 'http://localhost:2379,http://localhost:4001'
 		list of URLs to listen on for client traffic.
+	--max-snapshots '` + strconv.Itoa(defaultMaxSnapshots) + `'
+		maximum number of snapshot files to retain (0 is unlimited).
+	--max-wals '` + strconv.Itoa(defaultMaxWALs) + `'
+		maximum number of wal files to retain (0 is unlimited).
 	-cors ''
 		comma-separated whitelist of origins for CORS (cross-origin resource sharing).
 


### PR DESCRIPTION
Based on the configuration doc, seems these two flags are missing
in the help. So add them and the descriptions are from config.go in
the same directory.
