### PR TITLE
storage: add watch ID to identify watchings

### DIFF
--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -735,7 +735,7 @@ func TestWatchableKVWatch(t *testing.T) {
 
 	w := s.NewWatcher()
 
-	cancel := w.Watch([]byte("foo"), true, 0)
+	wid, cancel := w.Watch([]byte("foo"), true, 0)
 	defer cancel()
 
 	s.Put([]byte("foo"), []byte("bar"))
@@ -750,6 +750,7 @@ func TestWatchableKVWatch(t *testing.T) {
 				ModRevision:    1,
 				Version:        1,
 			},
+			WatchID: wid,
 		}
 		if !reflect.DeepEqual(ev, wev) {
 			t.Errorf("watched event = %+v, want %+v", ev, wev)
@@ -770,6 +771,7 @@ func TestWatchableKVWatch(t *testing.T) {
 				ModRevision:    2,
 				Version:        1,
 			},
+			WatchID: wid,
 		}
 		if !reflect.DeepEqual(ev, wev) {
 			t.Errorf("watched event = %+v, want %+v", ev, wev)
@@ -778,7 +780,10 @@ func TestWatchableKVWatch(t *testing.T) {
 		t.Fatalf("failed to watch the event")
 	}
 
-	cancel = w.Watch([]byte("foo1"), false, 1)
+	w.Close()
+
+	w = s.NewWatcher()
+	wid, cancel = w.Watch([]byte("foo1"), false, 1)
 	defer cancel()
 
 	select {
@@ -792,6 +797,7 @@ func TestWatchableKVWatch(t *testing.T) {
 				ModRevision:    2,
 				Version:        1,
 			},
+			WatchID: wid,
 		}
 		if !reflect.DeepEqual(ev, wev) {
 			t.Errorf("watched event = %+v, want %+v", ev, wev)
@@ -812,6 +818,7 @@ func TestWatchableKVWatch(t *testing.T) {
 				ModRevision:    3,
 				Version:        2,
 			},
+			WatchID: wid,
 		}
 		if !reflect.DeepEqual(ev, wev) {
 			t.Errorf("watched event = %+v, want %+v", ev, wev)

--- a/storage/storagepb/kv.proto
+++ b/storage/storagepb/kv.proto
@@ -32,5 +32,6 @@ message Event {
   // a delete/expire event contains the previous
   // key-value
   KeyValue kv = 2;
+  // watchID is the ID of watching this event is sent to.
+  int64 watchID = 3;
 }
-

--- a/storage/watchable_store_bench_test.go
+++ b/storage/watchable_store_bench_test.go
@@ -65,7 +65,7 @@ func BenchmarkWatchableStoreUnsyncedCancel(b *testing.B) {
 	cancels := make([]CancelFunc, watcherSize)
 	for i := 0; i < watcherSize; i++ {
 		// non-0 value to keep watchers in unsynced
-		cancel := w.Watch(testKey, true, 1)
+		_, cancel := w.Watch(testKey, true, 1)
 		cancels[i] = cancel
 	}
 
@@ -102,7 +102,7 @@ func BenchmarkWatchableStoreSyncedCancel(b *testing.B) {
 	cancels := make([]CancelFunc, watcherSize)
 	for i := 0; i < watcherSize; i++ {
 		// 0 for startRev to keep watchers in synced
-		cancel := w.Watch(testKey, true, 0)
+		_, cancel := w.Watch(testKey, true, 0)
 		cancels[i] = cancel
 	}
 

--- a/storage/watchable_store_test.go
+++ b/storage/watchable_store_test.go
@@ -49,7 +49,7 @@ func TestNewWatcherCancel(t *testing.T) {
 	s.Put(testKey, testValue)
 
 	w := s.NewWatcher()
-	cancel := w.Watch(testKey, true, 0)
+	_, cancel := w.Watch(testKey, true, 0)
 
 	cancel()
 

--- a/storage/watcher_test.go
+++ b/storage/watcher_test.go
@@ -1,0 +1,64 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import "testing"
+
+// TestWatcherWatchID tests that each watcher provides unique watch ID,
+// and the watched event attaches the correct watch ID.
+func TestWatcherWatchID(t *testing.T) {
+	s := WatchableKV(newWatchableStore(tmpPath))
+	defer cleanup(s, tmpPath)
+
+	w := s.NewWatcher()
+	defer w.Close()
+
+	idm := make(map[int64]struct{})
+
+	// synced watchings
+	for i := 0; i < 10; i++ {
+		id, cancel := w.Watch([]byte("foo"), false, 0)
+		if _, ok := idm[id]; ok {
+			t.Errorf("#%d: id %d exists", i, id)
+		}
+		idm[id] = struct{}{}
+
+		s.Put([]byte("foo"), []byte("bar"))
+
+		ev := <-w.Chan()
+		if ev.WatchID != id {
+			t.Errorf("#%d: watch id in event = %d, want %d", i, ev.WatchID, id)
+		}
+
+		cancel()
+	}
+
+	s.Put([]byte("foo2"), []byte("bar"))
+	// unsynced watchings
+	for i := 10; i < 20; i++ {
+		id, cancel := w.Watch([]byte("foo2"), false, 1)
+		if _, ok := idm[id]; ok {
+			t.Errorf("#%d: id %d exists", i, id)
+		}
+		idm[id] = struct{}{}
+
+		ev := <-w.Chan()
+		if ev.WatchID != id {
+			t.Errorf("#%d: watch id in event = %d, want %d", i, ev.WatchID, id)
+		}
+
+		cancel()
+	}
+}


### PR DESCRIPTION
One watcher includes multiple watchings, and their events are
sent out through one channel. For the received event, user would like to
know which watching it belongs to.

Introduce a watch ID. When watching on some key, user will get a watch
ID. The watch ID is attached to all events that is observed by this
watch.

for #3848 