### PR TITLE
v3rpc: do not send closing event

### DIFF
--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -61,7 +61,10 @@ func (ws *watchServer) Watch(stream pb.Watch_WatchServer) error {
 func sendLoop(stream pb.Watch_WatchServer, watcher storage.Watcher, closec chan struct{}) {
 	for {
 		select {
-		case e := <-watcher.Chan():
+		case e, ok := <-watcher.Chan():
+			if !ok {
+				return
+			}
 			err := stream.Send(&pb.WatchResponse{Event: &e})
 			if err != nil {
 				return


### PR DESCRIPTION
When a watch stream closes, both of the watcher.Chan and closec
will be closed. Which to trigger first is random.

If watcher.Chan is triggered first, we should not send out the empty event.
Sending the empty is wrong and waste a lot of CPU resources.
Instead we should just return.

Partially Fix https://github.com/coreos/etcd/issues/3859