### PR TITLE
etcdctl: a new option for quorum get

### DIFF
--- a/etcdctl/command/get_command.go
+++ b/etcdctl/command/get_command.go
@@ -30,6 +30,7 @@ func NewGetCommand() cli.Command {
 		Usage: "retrieve the value of a key",
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "sort", Usage: "returns result in sorted order"},
+			cli.BoolFlag{Name: "quorum", Usage: "require quorum for get request"},
 		},
 		Action: func(c *cli.Context) {
 			getCommandFunc(c, mustNewKeyAPI(c))
@@ -45,9 +46,10 @@ func getCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	key := c.Args()[0]
 	sorted := c.Bool("sort")
+	quorum := c.Bool("quorum")
 
 	ctx, cancel := contextWithTotalTimeout(c)
-	resp, err := ki.Get(ctx, key, &client.GetOptions{Sort: sorted})
+	resp, err := ki.Get(ctx, key, &client.GetOptions{Sort: sorted, Quorum: quorum})
 	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)


### PR DESCRIPTION
Current etcdctl seems to lack an option for specifying quorum flag for
GET. This commit adds the option.