### PR TITLE
clean up usage for etcd flag

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -41,19 +41,19 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 + default: "1000"
 + env variable: ETCD_ELECTION_TIMEOUT
 
-### -listen-peer-urls
-+ List of URLs to listen on for peer traffic. This flag tells the etcd to accept incoming requests from its peers on the specified scheme://IP:port combinations. Scheme can be either http or https.If 0.0.0.0 is specified as the IP, etcd listens to the given port on all interfaces. If an IP address is given as well as a port, etcd will listen on the given port and interface. Multiple URLs may be used to specify a number of addresses and ports to listen on. The etcd will respond to requests from any of the listed addresses and ports.
-+ default: "http://localhost:2380,http://localhost:7001"
-+ env variable: ETCD_LISTEN_PEER_URLS
-+ example: "http://10.0.0.1:2380"
-+ invalid example: "http://example.com:2380" (domain name is invalid for binding)
-
 ### -listen-client-urls
 + List of URLs to listen on for client traffic. This flag tells the etcd to accept incoming requests from the clients on the specified scheme://IP:port combinations. Scheme can be either http or https. If 0.0.0.0 is specified as the IP, etcd listens to the given port on all interfaces. If an IP address is given as well as a port, etcd will listen on the given port and interface. Multiple URLs may be used to specify a number of addresses and ports to listen on. The etcd will respond to requests from any of the listed addresses and ports.
 + default: "http://localhost:2379,http://localhost:4001"
 + env variable: ETCD_LISTEN_CLIENT_URLS
 + example: "http://10.0.0.1:2379"
 + invalid example: "http://example.com:2379" (domain name is invalid for binding)
+
+### -advertise-client-urls
++ List of this member's client URLs to advertise to the rest of the cluster. These URLs can contain domain names.
++ default: "http://localhost:2379,http://localhost:4001"
++ env variable: ETCD_ADVERTISE_CLIENT_URLS
++ example: "http://example.com:2379, http://10.0.0.1:2379"
++ Be careful if you are advertising URLs such as http://localhost:2379 from a cluster member and are using the proxy feature of etcd. This will cause loops, because the proxy will be forwarding requests to itself until its resources (memory, file descriptors) are eventually depleted.
 
 ### -max-snapshots
 + Maximum number of snapshot files to retain (0 is unlimited)
@@ -79,7 +79,6 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 `-discovery` prefix flags need to be set when using [discovery service][discovery].
 
 ### -initial-advertise-peer-urls
-
 + List of this member's peer URLs to advertise to the rest of the cluster. These addresses are used for communicating etcd data around the cluster. At least one must be routable to all cluster members. These URLs can contain domain names.
 + default: "http://localhost:2380,http://localhost:7001"
 + env variable: ETCD_INITIAL_ADVERTISE_PEER_URLS
@@ -103,12 +102,12 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 + default: "etcd-cluster"
 + env variable: ETCD_INITIAL_CLUSTER_TOKEN
 
-### -advertise-client-urls
-+ List of this member's client URLs to advertise to the rest of the cluster. These URLs can contain domain names.
-+ default: "http://localhost:2379,http://localhost:4001"
-+ env variable: ETCD_ADVERTISE_CLIENT_URLS
-+ example: "http://example.com:2379, http://10.0.0.1:2379"
-+ Be careful if you are advertising URLs such as http://localhost:2379 from a cluster member and are using the proxy feature of etcd. This will cause loops, because the proxy will be forwarding requests to itself until its resources (memory, file descriptors) are eventually depleted.
+### -listen-peer-urls
++ List of URLs to listen on for peer traffic. This flag tells the etcd to accept incoming requests from its peers on the specified scheme://IP:port combinations. Scheme can be either http or https.If 0.0.0.0 is specified as the IP, etcd listens to the given port on all interfaces. If an IP address is given as well as a port, etcd will listen on the given port and interface. Multiple URLs may be used to specify a number of addresses and ports to listen on. The etcd will respond to requests from any of the listed addresses and ports.
++ default: "http://localhost:2380,http://localhost:7001"
++ env variable: ETCD_LISTEN_PEER_URLS
++ example: "http://10.0.0.1:2380"
++ invalid example: "http://example.com:2380" (domain name is invalid for binding)
 
 ### -discovery
 + Discovery URL used to bootstrap the cluster.

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -39,8 +39,9 @@ member flags:
 		time (in milliseconds) of a heartbeat interval.
 	--election-timeout '1000'
 		time (in milliseconds) for an election to timeout. See tuning documentation for details.
-	--listen-peer-urls 'http://localhost:2380,http://localhost:7001'
-		list of URLs to listen on for peer traffic.
+	--advertise-client-urls 'http://localhost:2379,http://localhost:4001'
+		list of this member's client URLs to advertise to the public.
+		The client URLs advertised should be accessible to machines that talk to etcd cluster. etcd client libraries parse these URLs to connect to the cluster.
 	--listen-client-urls 'http://localhost:2379,http://localhost:4001'
 		list of URLs to listen on for client traffic.
 	-cors ''
@@ -51,6 +52,8 @@ clustering flags:
 
 	--initial-advertise-peer-urls 'http://localhost:2380,http://localhost:7001'
 		list of this member's peer URLs to advertise to the rest of the cluster.
+	--listen-peer-urls 'http://localhost:2380,http://localhost:7001'
+		list of URLs to listen on for peer traffic.
 	--initial-cluster 'default=http://localhost:2380,default=http://localhost:7001'
 		initial cluster configuration for bootstrapping.
 	--initial-cluster-state 'new'
@@ -58,9 +61,6 @@ clustering flags:
 	--initial-cluster-token 'etcd-cluster'
 		initial cluster token for the etcd cluster during bootstrap.
 		Specifying this can protect you from unintended cross-cluster interaction when running multiple clusters.
-	--advertise-client-urls 'http://localhost:2379,http://localhost:4001'
-		list of this member's client URLs to advertise to the public.
-		The client URLs advertised should be accessible to machines that talk to etcd cluster. etcd client libraries parse these URLs to connect to the cluster.
 	--discovery ''
 		discovery URL used to bootstrap the cluster.
 	--discovery-fallback 'proxy'


### PR DESCRIPTION
IIUC, `-advertise-client-urls` should be a member flag while `-listen-peer-urls` a clustering one
Ref #3886