### PR TITLE
etcdctl: cluster health exit with non-zero when cluster is unhealthy

### DIFF
--- a/etcdctl/command/cluster_health.go
+++ b/etcdctl/command/cluster_health.go
@@ -122,8 +122,13 @@ func handleClusterHealth(c *cli.Context) {
 		}
 
 		if !forever {
-			break
+			if health {
+				os.Exit(ExitSuccess)
+			} else {
+				os.Exit(ExitClusterNotHealthy)
+			}
 		}
+
 		fmt.Printf("\nnext check after 10 second...\n\n")
 		time.Sleep(10 * time.Second)
 	}

--- a/etcdctl/command/error.go
+++ b/etcdctl/command/error.go
@@ -27,6 +27,7 @@ const (
 	ExitBadConnection
 	ExitBadAuth
 	ExitServerError
+	ExitClusterNotHealthy
 )
 
 func handleError(code int, err error) {


### PR DESCRIPTION
Fix #3624

We cannot really know if the cluster is degraded or not since https://github.com/coreos/etcd/issues/3852#issuecomment-155624157

