### PR TITLE
MAINTAINERS: add Ben Darnell

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,3 @@
+Ben Darnell <ben@bendarnell.com>
 Brandon Philips <brandon.philips@coreos.com> (@philips)
 Xiang Li <xiang.li@coreos.com> (@xiang90)


### PR DESCRIPTION
Add Ben Darnell as a maintainer because of his ongoing and significant contributions to the raft package in this repo.