### PR TITLE
MAINTAINERS: add Ben Darnell

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,4 @@
-Brandon Philips <brandon.philips@coreos.com> (@philips)
-Xiang Li <xiang.li@coreos.com> (@xiang90)
+Brandon Philips <brandon.philips@coreos.com> (@philips) pkg:*
+Xiang Li <xiang.li@coreos.com> (@xiang90) pkg:*
+
+Ben Darnell <ben@cockroachlabs.com> (@bdarnell) pkg:github.com/coreos/etcd/raft


### PR DESCRIPTION
Add Ben Darnell as a maintainer because of his ongoing and significant contributions to the raft package in this repo.

cc @xiang90 @bdarnell 