### PR TITLE
client: Fix incorrect handling of context errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -276,8 +276,8 @@ func (c *httpClusterClient) Do(ctx context.Context, act httpAction) (*http.Respo
 		if err != nil {
 			cerr.Errors = append(cerr.Errors, err)
 			// mask previous errors with context error, which is controlled by user
-			if err == context.Canceled || err == context.DeadlineExceeded {
-				return nil, nil, err
+			if ctx.Err() != nil {
+				return nil, nil, ctx.Err()
 			}
 			continue
 		}


### PR DESCRIPTION
If a client request fails due to a context error (either a timeout or
cancellation), the client code is supposed to return that error
directly.  However, before this patch, Client was returning
ErrClusterUnavailable due to a big detecting context errors.  This
patch fixes the bug so that the appropriate context error is returned
instead.