### PR TITLE
client: new envvar ETCDCLIENT_PEERS for supplying peer URLs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,8 +22,10 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -176,6 +178,14 @@ func New(cfg Config) (Client, error) {
 			password: cfg.Password,
 		}
 	}
+
+	if len(cfg.Endpoints) == 0 {
+		peerstr := os.Getenv("ETCDCLIENT_PEERS")
+		if peerstr != "" {
+			cfg.Endpoints = strings.Split(peerstr, ",")
+		}
+	}
+
 	if err := c.reset(cfg.Endpoints); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, programs using etcd client library need to supply peer
URLs via client.Config.Endpoints. It requires a mechanism for setting
the URLs to the variable via command line options, config files, or
environment variables in their own ways. It would be a little bit
confusing especially in a case that multiple client programs depend on
a single etcd cluster.

For avoiding the problem, this commit introduces a new environment
variable ETCDCLIENT_PEERS for a standard way of supplying the URLs.
