### PR TITLE
etcdserver: get rid of unreliable WaitSchedule

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -849,8 +849,15 @@ func TestRecvSnapshot(t *testing.T) {
 
 	s.start()
 	n.readyc <- raft.Ready{Snapshot: raftpb.Snapshot{Metadata: raftpb.SnapshotMetadata{Index: 1}}}
-	// make goroutines move forward to receive snapshot
-	testutil.WaitSchedule()
+
+	// wait for actions happened on the storage
+	for {
+		if len(p.Action()) != 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
 	s.Stop()
 
 	wactions := []testutil.Action{{Name: "Recovery"}}


### PR DESCRIPTION
In this case, we know we are waiting for an action happened on
storage. We can do a busy wait instead of calling waitSchedule.

The test previously failed on CI with no observed actions.

Fix #3793.