### PR TITLE
client: an option for prioritizing a leader node as a request destina…

### DIFF
--- a/client/members.go
+++ b/client/members.go
@@ -105,6 +105,9 @@ type MembersAPI interface {
 
 	// Update instructs etcd to update an existing Member in the cluster.
 	Update(ctx context.Context, mID string, peerURLs []string) error
+
+	// Get leader of the current cluster
+	Leader(ctx context.Context) (*Member, error)
 }
 
 type httpMembersAPI struct {
@@ -199,6 +202,25 @@ func (m *httpMembersAPI) Remove(ctx context.Context, memberID string) error {
 	return assertStatusCode(resp.StatusCode, http.StatusNoContent, http.StatusGone)
 }
 
+func (m *httpMembersAPI) Leader(ctx context.Context) (*Member, error) {
+	req := &membersAPIActionLeader{}
+	resp, body, err := m.client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	var leader Member
+	if err := json.Unmarshal(body, &leader); err != nil {
+		return nil, err
+	}
+
+	return &leader, nil
+}
+
 type membersAPIActionList struct{}
 
 func (l *membersAPIActionList) HTTPRequest(ep url.URL) *http.Request {
@@ -253,6 +275,14 @@ func assertStatusCode(got int, want ...int) (err error) {
 		}
 	}
 	return fmt.Errorf("unexpected status code %d", got)
+}
+
+type membersAPIActionLeader struct{}
+
+func (l *membersAPIActionLeader) HTTPRequest(ep url.URL) *http.Request {
+	u := v2MembersURL(ep)
+	req, _ := http.NewRequest("GET", u.String()+"/leader", nil)
+	return req
 }
 
 // v2MembersURL add the necessary path to the provided endpoint


### PR DESCRIPTION
…tion

Current etcd client library chooses a default destination node from
every member of a cluster in a random manner. However, requests of
write and read (for consistent results) need to be forwarded to the
leader node as the nature of Raft algorithm. If the chosen node is a
follower, additional network traffic will be caused by the forwarding
from follower to leader.

For reducing the forward traffic, this commit adds a new option
PrioritizeLeader to client.Config. If this variable is true, the
library chooses the leader node as a default destination of request.

I evaluated the effectiveness of this commit with 4 t1.micro
instances of AWS (3 nodes for etcd cluster and 1 node for etcd
client). Client executes this simple benchmark
(https://github.com/mitake/etcd-things/tree/master/prioritize-leader-bench),
just writes 10000 keys. When PrioritizeLeader is false, the benchmark
needed 1 min and 32.102 sec to finish. When it is true, the benchmark
needed 1 min 4.760 sec.

Major ToDos:
- more benchmarks
- refreshing an index of leader node in a case of leader failure
