### PR TITLE
travis: add Go tip for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 go:
   - 1.4
   - 1.5
+  - tip
 
 addons:
   apt:


### PR DESCRIPTION
It would be good to test etcd with the latest Go branch,
so that we can find bugs either in Go or etcd in advance.

Reference:
https://docs.travis-ci.com/user/languages/go