### PR TITLE
test: print diff with gofmt

### DIFF
--- a/test
+++ b/test
@@ -61,7 +61,7 @@ if [ -n "$INTEGRATION" ]; then
 fi
 
 echo "Checking gofmt..."
-fmtRes=$(gofmt -l -s $FMT)
+fmtRes=$(gofmt -l -s -d $FMT)
 if [ -n "${fmtRes}" ]; then
 	echo -e "gofmt checking failed:\n${fmtRes}"
 	exit 255


### PR DESCRIPTION
Current test doesn't pass -d option to gofmt. Let's pass the option
for easy fix.

Example output:
Checking gofmt...
gofmt checking failed:
client/client.go
diff client/client.go gofmt/client/client.go
--- /tmp/gofmt741496847 2015-12-04 10:11:11.340651702 +0900
+++ /tmp/gofmt265273890 2015-12-04 10:11:11.340651702 +0900
@@ -41,7 +41,7 @@

 var DefaultTransport CancelableTransport = &http.Transport{
        Proxy: http.ProxyFromEnvironment,
-       Dial:(&net.Dialer{
+       Dial: (&net.Dialer{
                Timeout:   30 * time.Second,
                KeepAlive: 30 * time.Second,
        }).Dial,
@@ -265,7 +265,7 @@
                        return ErrNoEndpoints
                }

-               for i, _ := range c.endpoints {
+               for i := range c.endpoints {
                        if c.endpoints[i].String() == lu.String() {
                                c.pinned = i
                                break