### PR TITLE
travis, test: allow failures with gotip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: go
 sudo: false
+
 go:
   - 1.4
   - 1.5
   - tip
+
+matrix:
+  allow_failures:
+    - go: tip
 
 addons:
   apt:

--- a/test
+++ b/test
@@ -52,12 +52,12 @@ if [ $MACHINE_TYPE != "armv7l" ]; then
   RACE="--race"
 fi
 
-go test -timeout 3m ${COVER} $@ ${TEST} ${RACE} -cpu 1,2,4
-go test -timeout 3m ${COVER} $@ ${NO_RACE_TEST} -cpu 1,2,4
+go test -timeout 3m ${COVER} ${RACE} -cpu 1,2,4 $@ ${TEST}
+go test -timeout 3m ${COVER} -cpu 1,2,4 $@ ${NO_RACE_TEST}
 
 if [ -n "$INTEGRATION" ]; then
 	echo "Running integration tests..."
-	go test -timeout 10m $@ ${REPO_PATH}/integration -v -cpu 1,2,4
+	go test -timeout 10m -v -cpu 1,2,4 $@ ${REPO_PATH}/integration
 fi
 
 echo "Checking gofmt..."


### PR DESCRIPTION
This allows tests to fail with Go tip, because go tip branch might not be
stable. This replaces https://github.com/coreos/etcd/pull/3953.