### PR TITLE
etcdserver: use pointer of sync.Once

### DIFF
--- a/etcdserver/snapshot_store.go
+++ b/etcdserver/snapshot_store.go
@@ -93,18 +93,19 @@ type snapshotStore struct {
 	// snap is nil iff there is no snapshot stored
 	snap       *snapshot
 	inUse      bool
-	createOnce sync.Once // ensure at most one snapshot is created when no snapshot stored
+	createOnce *sync.Once // ensure at most one snapshot is created when no snapshot stored
 
 	clock clockwork.Clock
 }
 
 func newSnapshotStore(dir string, kv dstorage.KV) *snapshotStore {
 	return &snapshotStore{
-		dir:       dir,
-		kv:        kv,
-		reqsnapc:  make(chan struct{}),
-		raftsnapc: make(chan raftpb.Snapshot),
-		clock:     clockwork.NewRealClock(),
+		dir:        dir,
+		kv:         kv,
+		reqsnapc:   make(chan struct{}),
+		raftsnapc:  make(chan raftpb.Snapshot),
+		createOnce: new(sync.Once),
+		clock:      clockwork.NewRealClock(),
 	}
 }
 
@@ -210,7 +211,7 @@ func (ss *snapshotStore) clear() {
 	}
 	ss.snap = nil
 	ss.inUse = false
-	ss.createOnce = sync.Once{}
+	ss.createOnce = &sync.Once{}
 }
 
 // SaveFrom saves snapshot at the given index from the given reader.

--- a/etcdserver/snapshot_store_test.go
+++ b/etcdserver/snapshot_store_test.go
@@ -102,7 +102,7 @@ func TestSnapshotStoreGetSnap(t *testing.T) {
 
 func TestSnapshotStoreClearUsedSnap(t *testing.T) {
 	s := &fakeSnapshot{}
-	var once sync.Once
+	var once *sync.Once
 	once.Do(func() {})
 	ss := &snapshotStore{
 		snap:       newSnapshot(raftpb.Snapshot{}, s),


### PR DESCRIPTION
This fixes govet error of
`gopath/src/github.com/coreos/etcd/etcdserver/snapshot_store.go:213: assignment
copies lock value to ss.createOnce: sync.Once contains sync.Mutex`.

Related to https://github.com/coreos/etcd/issues/3954