### PR TITLE
store: fix data race when modify event in watchHub.

### DIFF
--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -78,8 +78,9 @@ func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeInde
 	defer wh.mutex.Unlock()
 	// If the event exists in the known history, append the EtcdIndex and return immediately
 	if event != nil {
-		event.EtcdIndex = storeIndex
-		w.eventChan <- event
+		ne := event.Clone()
+		ne.EtcdIndex = storeIndex
+		w.eventChan <- ne
 		return w, nil
 	}
 


### PR DESCRIPTION
The event got from watchHub should be considered as readonly.
To modify it, we first need to get a clone of it or there might
be a data race.

Fix https://github.com/kubernetes/kubernetes/issues/18437

/cc @gyuho @wojtek-t @timothysc 