### PR TITLE
Only send snapshot when member is online

### DIFF
--- a/raft/progress.go
+++ b/raft/progress.go
@@ -59,7 +59,7 @@ type Progress struct {
 	// recentActive is true if the progress is recently active. Receiving any messages
 	// from the corresponding follower indicates the progress is active.
 	// recentActive can be reset to false after an election timeout.
-	recentActive bool
+	RecentActive bool
 
 	// inflights is a sliding window for the inflight messages.
 	// When inflights is full, no more message should be sent.
@@ -73,7 +73,7 @@ type Progress struct {
 
 func (pr *Progress) resetState(state ProgressStateType) {
 	pr.Paused = false
-	pr.recentActive = false
+	pr.RecentActive = false
 	pr.PendingSnapshot = 0
 	pr.State = state
 	pr.ins.reset()

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -275,6 +275,11 @@ func (r *raft) sendAppend(to uint64) {
 	ents, erre := r.raftLog.entries(pr.Next, r.maxMsgSize)
 
 	if errt != nil || erre != nil { // send snapshot if we failed to get term or entries
+		if !pr.RecentActive {
+			r.logger.Debugf("ignore sending snapshot to %x since it is not recently active", to)
+			return
+		}
+
 		m.Type = pb.MsgSnap
 		snapshot, err := r.raftLog.snapshot()
 		if err != nil {

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -600,7 +600,7 @@ func stepLeader(r *raft, m pb.Message) {
 	}
 	switch m.Type {
 	case pb.MsgAppResp:
-		pr.recentActive = true
+		pr.RecentActive = true
 
 		if m.Reject {
 			r.logger.Debugf("%x received msgApp rejection(lastindex: %d) from %x for index %d",
@@ -635,7 +635,7 @@ func stepLeader(r *raft, m pb.Message) {
 			}
 		}
 	case pb.MsgHeartbeatResp:
-		pr.recentActive = true
+		pr.RecentActive = true
 
 		// free one slot for the full inflights window to allow progress.
 		if pr.State == ProgressStateReplicate && pr.ins.full() {
@@ -867,11 +867,11 @@ func (r *raft) checkQuorumActive() bool {
 			continue
 		}
 
-		if r.prs[id].recentActive {
+		if r.prs[id].RecentActive {
 			act += 1
 		}
 
-		r.prs[id].recentActive = false
+		r.prs[id].RecentActive = false
 	}
 
 	return act >= r.q()


### PR DESCRIPTION
In v3, we do not always have snapshot ready. When sending snapshot, etcdserver needs to generate snapshot in real-time. It requires some resources. We should only send snapshot when we know the node is online.

@bdarnell I only made minimum change to raft pkg (I want to keep raft as simple as possible). But it seems easier to move the whole logic into raft if every raft application wants this behavior. What do you think? 