### PR TITLE
cover: checks for existence of ${COVERPKG}.out

### DIFF
--- a/cover
+++ b/cover
@@ -23,6 +23,10 @@ COVERPKG=${COVERPKG/#\//}
 COVERPKG=${COVERPKG/%\//}
 COVERPKG=${COVERPKG//\//_}
 
+if ! [ -f "${COVEROUT}/${COVERPKG}.out" ]; then
+	touch "${COVEROUT}/${COVERPKG}.out"
+fi
+
 # generate arg for "go test"
 export COVER="-coverprofile ${COVEROUT}/${COVERPKG}.out"
 


### PR DESCRIPTION
cover checks for the existence of COVEROUT, creating if not there, but doesn't check for ${COVEROUT}/${COVERPKG}.out. Added simple check for the latter.