### PR TITLE
raft: update RecentActive name in comments

### DIFF
--- a/raft/progress.go
+++ b/raft/progress.go
@@ -56,9 +56,9 @@ type Progress struct {
 	// is reported to be failed.
 	PendingSnapshot uint64
 
-	// recentActive is true if the progress is recently active. Receiving any messages
+	// RecentActive is true if the progress is recently active. Receiving any messages
 	// from the corresponding follower indicates the progress is active.
-	// recentActive can be reset to false after an election timeout.
+	// RecentActive can be reset to false after an election timeout.
 	RecentActive bool
 
 	// inflights is a sliding window for the inflight messages.

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -862,7 +862,7 @@ func (r *raft) isElectionTimeout() bool {
 // checkQuorumActive returns true if the quorum is active from
 // the view of the local raft state machine. Otherwise, it returns
 // false.
-// checkQuorumActive also reset all recentActive to false.
+// checkQuorumActive also resets all RecentActive to false.
 func (r *raft) checkQuorumActive() bool {
 	var act int
 


### PR DESCRIPTION
Noticed when retrospectively reviewing #3976 that a couple of places
were missed when the variable was renamed.