### PR TITLE
*: fix shadowed variables

### DIFF
--- a/client/auth_role.go
+++ b/client/auth_role.go
@@ -115,14 +115,13 @@ func (r *httpAuthRoleAPI) ListRoles(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+	if err = assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
 		return nil, err
 	}
 	var userList struct {
 		Roles []string `json:"roles"`
 	}
-	err = json.Unmarshal(body, &userList)
-	if err != nil {
+	if err = json.Unmarshal(body, &userList); err != nil {
 		return nil, err
 	}
 	return userList.Roles, nil
@@ -218,17 +217,16 @@ func (r *httpAuthRoleAPI) modRole(ctx context.Context, req *authRoleAPIAction) (
 	if err != nil {
 		return nil, err
 	}
-	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+	if err = assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
 		var sec authError
-		err := json.Unmarshal(body, &sec)
+		err = json.Unmarshal(body, &sec)
 		if err != nil {
 			return nil, err
 		}
 		return nil, sec
 	}
 	var role Role
-	err = json.Unmarshal(body, &role)
-	if err != nil {
+	if err = json.Unmarshal(body, &role); err != nil {
 		return nil, err
 	}
 	return &role, nil

--- a/client/auth_user.go
+++ b/client/auth_user.go
@@ -78,9 +78,9 @@ func (s *httpAuthAPI) enableDisable(ctx context.Context, req httpAction) error {
 	if err != nil {
 		return err
 	}
-	if err := assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
+	if err = assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
 		var sec authError
-		err := json.Unmarshal(body, &sec)
+		err = json.Unmarshal(body, &sec)
 		if err != nil {
 			return err
 		}
@@ -179,9 +179,9 @@ func (u *httpAuthUserAPI) ListUsers(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+	if err = assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
 		var sec authError
-		err := json.Unmarshal(body, &sec)
+		err = json.Unmarshal(body, &sec)
 		if err != nil {
 			return nil, err
 		}
@@ -190,8 +190,7 @@ func (u *httpAuthUserAPI) ListUsers(ctx context.Context) ([]string, error) {
 	var userList struct {
 		Users []string `json:"users"`
 	}
-	err = json.Unmarshal(body, &userList)
-	if err != nil {
+	if err = json.Unmarshal(body, &userList); err != nil {
 		return nil, err
 	}
 	return userList.Users, nil
@@ -221,9 +220,9 @@ func (u *httpAuthUserAPI) addRemoveUser(ctx context.Context, req *authUserAPIAct
 	if err != nil {
 		return err
 	}
-	if err := assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
+	if err = assertStatusCode(resp.StatusCode, http.StatusOK, http.StatusCreated); err != nil {
 		var sec authError
-		err := json.Unmarshal(body, &sec)
+		err = json.Unmarshal(body, &sec)
 		if err != nil {
 			return err
 		}
@@ -280,17 +279,16 @@ func (u *httpAuthUserAPI) modUser(ctx context.Context, req *authUserAPIAction) (
 	if err != nil {
 		return nil, err
 	}
-	if err := assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
+	if err = assertStatusCode(resp.StatusCode, http.StatusOK); err != nil {
 		var sec authError
-		err := json.Unmarshal(body, &sec)
+		err = json.Unmarshal(body, &sec)
 		if err != nil {
 			return nil, err
 		}
 		return nil, sec
 	}
 	var user User
-	err = json.Unmarshal(body, &user)
-	if err != nil {
+	if err = json.Unmarshal(body, &user); err != nil {
 		return nil, err
 	}
 	return &user, nil

--- a/etcdctl/command/backup_command.go
+++ b/etcdctl/command/backup_command.go
@@ -61,7 +61,7 @@ func handleBackup(c *cli.Context) {
 	if snapshot != nil {
 		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
 		newss := snap.New(destSnap)
-		if err := newss.SaveSnap(*snapshot); err != nil {
+		if err = newss.SaveSnap(*snapshot); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -363,7 +363,7 @@ func startProxy(cfg *config) error {
 			plog.Warningf("discovery token ignored since the proxy has already been initialized. Valid cluster file found at %q", clusterfile)
 		}
 		urls := struct{ PeerURLs []string }{}
-		err := json.Unmarshal(b, &urls)
+		err = json.Unmarshal(b, &urls)
 		if err != nil {
 			return err
 		}

--- a/etcdserver/auth/auth.go
+++ b/etcdserver/auth/auth.go
@@ -424,28 +424,26 @@ func (s *store) EnableAuth() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	_, err := s.GetUser("root")
-	if err != nil {
+	if _, err := s.GetUser("root"); err != nil {
 		return authErr(http.StatusConflict, "No root user available, please create one")
 	}
-	_, err = s.GetRole(GuestRoleName)
-	if err != nil {
+	if _, err := s.GetRole(GuestRoleName); err != nil {
 		plog.Printf("no guest role access found, creating default")
-		err := s.CreateRole(guestRole)
-		if err != nil {
+		if err := s.CreateRole(guestRole); err != nil {
 			plog.Errorf("error creating guest role. aborting auth enable.")
 			return err
 		}
 	}
-	err = s.enableAuth()
-	if err == nil {
-		b := true
-		s.enabled = &b
-		plog.Noticef("auth: enabled auth")
-	} else {
+
+	if err := s.enableAuth(); err != nil {
 		plog.Errorf("error enabling auth (%v)", err)
+		return err
 	}
-	return err
+
+	b := true
+	s.enabled = &b
+	plog.Noticef("auth: enabled auth")
+	return nil
 }
 
 func (s *store) DisableAuth() error {

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -78,7 +78,7 @@ func getClusterFromRemotePeers(urls []string, timeout time.Duration, logerr bool
 			continue
 		}
 		var membs []*Member
-		if err := json.Unmarshal(b, &membs); err != nil {
+		if err = json.Unmarshal(b, &membs); err != nil {
 			if logerr {
 				plog.Warningf("could not unmarshal cluster response: %v", err)
 			}
@@ -246,7 +246,7 @@ func getVersion(m *Member, rt http.RoundTripper) (*version.Versions, error) {
 			continue
 		}
 		var vers version.Versions
-		if err := json.Unmarshal(b, &vers); err != nil {
+		if err = json.Unmarshal(b, &vers); err != nil {
 			plog.Warningf("failed to unmarshal the response body got from the peerURL(%s) of member %s (%v)", u, m.ID, err)
 			continue
 		}

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -158,14 +158,14 @@ func (r *raftNode) start(s *EtcdServer) {
 					}
 				}
 
-				apply := apply{
+				ap := apply{
 					entries:  rd.CommittedEntries,
 					snapshot: rd.Snapshot,
 					done:     make(chan struct{}),
 				}
 
 				select {
-				case r.applyc <- apply:
+				case r.applyc <- ap:
 				case <-r.stopped:
 					return
 				}
@@ -185,7 +185,7 @@ func (r *raftNode) start(s *EtcdServer) {
 				r.s.send(rd.Messages)
 
 				select {
-				case <-apply.done:
+				case <-ap.done:
 				case <-r.stopped:
 					return
 				}
@@ -253,7 +253,7 @@ func startNode(cfg *ServerConfig, cl *cluster, ids []types.ID) (id types.ID, n r
 			ClusterID: uint64(cl.ID()),
 		},
 	)
-	if err := os.MkdirAll(cfg.SnapDir(), privateDirMode); err != nil {
+	if err = os.MkdirAll(cfg.SnapDir(), privateDirMode); err != nil {
 		plog.Fatalf("create snapshot directory error: %v", err)
 	}
 	if w, err = wal.Create(cfg.WALDir(), metadata); err != nil {

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1037,7 +1037,7 @@ func (s *EtcdServer) snapshot(snapi uint64, confState raftpb.ConfState) {
 		}
 		// SaveSnap saves the snapshot and releases the locked wal files
 		// to the snapshot index.
-		if err := s.r.storage.SaveSnap(snap); err != nil {
+		if err = s.r.storage.SaveSnap(snap); err != nil {
 			plog.Fatalf("save snapshot error: %v", err)
 		}
 		plog.Infof("saved snapshot at index %d", snap.Metadata.Index)

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -52,7 +52,7 @@ func TestReadDir(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error creating file: %v", err)
 		}
-		if err := fh.Close(); err != nil {
+		if err = fh.Close(); err != nil {
 			t.Fatalf("error closing file: %v", err)
 		}
 	}

--- a/pkg/fileutil/lock_test.go
+++ b/pkg/fileutil/lock_test.go
@@ -28,7 +28,7 @@ func TestLockAndUnlock(t *testing.T) {
 	}
 	f.Close()
 	defer func() {
-		err := os.Remove(f.Name())
+		err = os.Remove(f.Name())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/fileutil/purge_test.go
+++ b/pkg/fileutil/purge_test.go
@@ -121,7 +121,7 @@ func TestPurgeFileHoldingLock(t *testing.T) {
 	}
 
 	select {
-	case err := <-errch:
+	case err = <-errch:
 		t.Errorf("unexpected purge error %v", err)
 	case <-time.After(time.Millisecond):
 	}

--- a/raft/rafttest/network.go
+++ b/raft/rafttest/network.go
@@ -85,7 +85,7 @@ func (rn *raftNetwork) send(m raftpb.Message) {
 		to = nil
 	}
 	drop := rn.dropmap[conn{m.From, m.To}]
-	delay := rn.delaymap[conn{m.From, m.To}]
+	dl := rn.delaymap[conn{m.From, m.To}]
 	rn.mu.Unlock()
 
 	if to == nil {
@@ -94,9 +94,9 @@ func (rn *raftNetwork) send(m raftpb.Message) {
 	if drop != 0 && rand.Float64() < drop {
 		return
 	}
-	// TODO: shall we delay without blocking the send call?
-	if delay.d != 0 && rand.Float64() < delay.rate {
-		rd := rand.Int63n(int64(delay.d))
+	// TODO: shall we dl without blocking the send call?
+	if dl.d != 0 && rand.Float64() < dl.rate {
+		rd := rand.Int63n(int64(dl.d))
 		time.Sleep(time.Duration(rd))
 	}
 

--- a/storage/index_test.go
+++ b/storage/index_test.go
@@ -225,17 +225,17 @@ func TestIndexCompact(t *testing.T) {
 	for i := int64(1); i < maxRev; i++ {
 		am := ti.Compact(i)
 
-		windex := newTreeIndex()
+		wti := newTreeIndex()
 		for _, tt := range tests {
 			if _, ok := am[tt.rev]; ok || tt.rev.GreaterThan(revision{main: i}) {
 				if tt.remove {
-					windex.Tombstone(tt.key, tt.rev)
+					wti.Tombstone(tt.key, tt.rev)
 				} else {
-					windex.Restore(tt.key, tt.created, tt.rev, tt.ver)
+					wti.Restore(tt.key, tt.created, tt.rev, tt.ver)
 				}
 			}
 		}
-		if !ti.Equal(windex) {
+		if !ti.Equal(wti) {
 			t.Errorf("#%d: not equal ti", i)
 		}
 	}
@@ -252,17 +252,17 @@ func TestIndexCompact(t *testing.T) {
 		}
 		am := ti.Compact(i)
 
-		windex := newTreeIndex()
+		wti := newTreeIndex()
 		for _, tt := range tests {
 			if _, ok := am[tt.rev]; ok || tt.rev.GreaterThan(revision{main: i}) {
 				if tt.remove {
-					windex.Tombstone(tt.key, tt.rev)
+					wti.Tombstone(tt.key, tt.rev)
 				} else {
-					windex.Restore(tt.key, tt.created, tt.rev, tt.ver)
+					wti.Restore(tt.key, tt.created, tt.rev, tt.ver)
 				}
 			}
 		}
-		if !ti.Equal(windex) {
+		if !ti.Equal(wti) {
 			t.Errorf("#%d: not equal ti", i)
 		}
 	}

--- a/storage/index_test.go
+++ b/storage/index_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func TestIndexGet(t *testing.T) {
-	index := newTreeIndex()
-	index.Put([]byte("foo"), revision{main: 2})
-	index.Put([]byte("foo"), revision{main: 4})
-	index.Tombstone([]byte("foo"), revision{main: 6})
+	ti := newTreeIndex()
+	ti.Put([]byte("foo"), revision{main: 2})
+	ti.Put([]byte("foo"), revision{main: 4})
+	ti.Tombstone([]byte("foo"), revision{main: 6})
 
 	tests := []struct {
 		rev int64
@@ -42,7 +42,7 @@ func TestIndexGet(t *testing.T) {
 		{6, revision{}, revision{}, 0, ErrRevisionNotFound},
 	}
 	for i, tt := range tests {
-		rev, created, ver, err := index.Get([]byte("foo"), tt.rev)
+		rev, created, ver, err := ti.Get([]byte("foo"), tt.rev)
 		if err != tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
 		}
@@ -62,9 +62,9 @@ func TestIndexRange(t *testing.T) {
 	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2")}
 	allRevs := []revision{{main: 1}, {main: 2}, {main: 3}}
 
-	index := newTreeIndex()
+	ti := newTreeIndex()
 	for i := range allKeys {
-		index.Put(allKeys[i], allRevs[i])
+		ti.Put(allKeys[i], allRevs[i])
 	}
 
 	atRev := int64(3)
@@ -107,7 +107,7 @@ func TestIndexRange(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		keys, revs := index.Range(tt.key, tt.end, atRev)
+		keys, revs := ti.Range(tt.key, tt.end, atRev)
 		if !reflect.DeepEqual(keys, tt.wkeys) {
 			t.Errorf("#%d: keys = %+v, want %+v", i, keys, tt.wkeys)
 		}
@@ -118,19 +118,19 @@ func TestIndexRange(t *testing.T) {
 }
 
 func TestIndexTombstone(t *testing.T) {
-	index := newTreeIndex()
-	index.Put([]byte("foo"), revision{main: 1})
+	ti := newTreeIndex()
+	ti.Put([]byte("foo"), revision{main: 1})
 
-	err := index.Tombstone([]byte("foo"), revision{main: 2})
+	err := ti.Tombstone([]byte("foo"), revision{main: 2})
 	if err != nil {
 		t.Errorf("tombstone error = %v, want nil", err)
 	}
 
-	_, _, _, err = index.Get([]byte("foo"), 2)
+	_, _, _, err = ti.Get([]byte("foo"), 2)
 	if err != ErrRevisionNotFound {
 		t.Errorf("get error = %v, want nil", err)
 	}
-	err = index.Tombstone([]byte("foo"), revision{main: 3})
+	err = ti.Tombstone([]byte("foo"), revision{main: 3})
 	if err != ErrRevisionNotFound {
 		t.Errorf("tombstone error = %v, want %v", err, ErrRevisionNotFound)
 	}
@@ -140,9 +140,9 @@ func TestIndexRangeSince(t *testing.T) {
 	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2"), []byte("foo2"), []byte("foo1"), []byte("foo")}
 	allRevs := []revision{{main: 1}, {main: 2}, {main: 3}, {main: 4}, {main: 5}, {main: 6}}
 
-	index := newTreeIndex()
+	ti := newTreeIndex()
 	for i := range allKeys {
-		index.Put(allKeys[i], allRevs[i])
+		ti.Put(allKeys[i], allRevs[i])
 	}
 
 	atRev := int64(1)
@@ -184,7 +184,7 @@ func TestIndexRangeSince(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		revs := index.RangeSince(tt.key, tt.end, atRev)
+		revs := ti.RangeSince(tt.key, tt.end, atRev)
 		if !reflect.DeepEqual(revs, tt.wrevs) {
 			t.Errorf("#%d: revs = %+v, want %+v", i, revs, tt.wrevs)
 		}
@@ -214,16 +214,16 @@ func TestIndexCompact(t *testing.T) {
 	}
 
 	// Continuous Compact
-	index := newTreeIndex()
+	ti := newTreeIndex()
 	for _, tt := range tests {
 		if tt.remove {
-			index.Tombstone(tt.key, tt.rev)
+			ti.Tombstone(tt.key, tt.rev)
 		} else {
-			index.Put(tt.key, tt.rev)
+			ti.Put(tt.key, tt.rev)
 		}
 	}
 	for i := int64(1); i < maxRev; i++ {
-		am := index.Compact(i)
+		am := ti.Compact(i)
 
 		windex := newTreeIndex()
 		for _, tt := range tests {
@@ -235,22 +235,22 @@ func TestIndexCompact(t *testing.T) {
 				}
 			}
 		}
-		if !index.Equal(windex) {
-			t.Errorf("#%d: not equal index", i)
+		if !ti.Equal(windex) {
+			t.Errorf("#%d: not equal ti", i)
 		}
 	}
 
 	// Once Compact
 	for i := int64(1); i < maxRev; i++ {
-		index := newTreeIndex()
+		ti := newTreeIndex()
 		for _, tt := range tests {
 			if tt.remove {
-				index.Tombstone(tt.key, tt.rev)
+				ti.Tombstone(tt.key, tt.rev)
 			} else {
-				index.Put(tt.key, tt.rev)
+				ti.Put(tt.key, tt.rev)
 			}
 		}
-		am := index.Compact(i)
+		am := ti.Compact(i)
 
 		windex := newTreeIndex()
 		for _, tt := range tests {
@@ -262,8 +262,8 @@ func TestIndexCompact(t *testing.T) {
 				}
 			}
 		}
-		if !index.Equal(windex) {
-			t.Errorf("#%d: not equal index", i)
+		if !ti.Equal(windex) {
+			t.Errorf("#%d: not equal ti", i)
 		}
 	}
 }
@@ -282,11 +282,11 @@ func TestIndexRestore(t *testing.T) {
 	}
 
 	// Continuous Restore
-	index := newTreeIndex()
+	ti := newTreeIndex()
 	for i, tt := range tests {
-		index.Restore(key, tt.created, tt.modified, tt.ver)
+		ti.Restore(key, tt.created, tt.modified, tt.ver)
 
-		modified, created, ver, err := index.Get(key, tt.modified.main)
+		modified, created, ver, err := ti.Get(key, tt.modified.main)
 		if modified != tt.modified {
 			t.Errorf("#%d: modified = %v, want %v", i, modified, tt.modified)
 		}
@@ -303,10 +303,10 @@ func TestIndexRestore(t *testing.T) {
 
 	// Once Restore
 	for i, tt := range tests {
-		index := newTreeIndex()
-		index.Restore(key, tt.created, tt.modified, tt.ver)
+		ti := newTreeIndex()
+		ti.Restore(key, tt.created, tt.modified, tt.ver)
 
-		modified, created, ver, err := index.Get(key, tt.modified.main)
+		modified, created, ver, err := ti.Get(key, tt.modified.main)
 		if modified != tt.modified {
 			t.Errorf("#%d: modified = %v, want %v", i, modified, tt.modified)
 		}

--- a/store/event_history.go
+++ b/store/event_history.go
@@ -82,7 +82,7 @@ func (eh *EventHistory) scan(key string, recursive bool, index uint64) (*Event, 
 
 		if recursive {
 			// add tailing slash
-			key := path.Clean(key)
+			key = path.Clean(key)
 			if key[len(key)-1] != '/' {
 				key = key + "/"
 			}

--- a/tools/functional-tester/etcd-agent/agent.go
+++ b/tools/functional-tester/etcd-agent/agent.go
@@ -106,8 +106,7 @@ func (a *Agent) restart() error {
 }
 
 func (a *Agent) cleanup() error {
-	err := a.stop()
-	if err != nil {
+	if err := a.stop(); err != nil {
 		return err
 	}
 	a.state = stateUninitialized

--- a/wal/encoder.go
+++ b/wal/encoder.go
@@ -68,7 +68,7 @@ func (e *encoder) encode(rec *walpb.Record) error {
 		}
 		data = e.buf[:n]
 	}
-	if err := writeInt64(e.bw, int64(len(data)), e.uint64buf); err != nil {
+	if err = writeInt64(e.bw, int64(len(data)), e.uint64buf); err != nil {
 		return err
 	}
 	_, err = e.bw.Write(data)

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -102,8 +102,7 @@ func Create(dirpath string, metadata []byte) (*WAL, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = l.Lock()
-	if err != nil {
+	if err = l.Lock(); err != nil {
 		return nil, err
 	}
 
@@ -121,7 +120,7 @@ func Create(dirpath string, metadata []byte) (*WAL, error) {
 	if err := w.encoder.encode(&walpb.Record{Type: metadataType, Data: metadata}); err != nil {
 		return nil, err
 	}
-	if err = w.SaveSnapshot(walpb.Snapshot{}); err != nil {
+	if err := w.SaveSnapshot(walpb.Snapshot{}); err != nil {
 		return nil, err
 	}
 	return w, nil
@@ -339,25 +338,25 @@ func (w *WAL) cut() error {
 	w.f = ft
 	prevCrc := w.encoder.crc.Sum32()
 	w.encoder = newEncoder(w.f, prevCrc)
-	if err := w.saveCrc(prevCrc); err != nil {
+	if err = w.saveCrc(prevCrc); err != nil {
 		return err
 	}
-	if err := w.encoder.encode(&walpb.Record{Type: metadataType, Data: w.metadata}); err != nil {
+	if err = w.encoder.encode(&walpb.Record{Type: metadataType, Data: w.metadata}); err != nil {
 		return err
 	}
-	if err := w.saveState(&w.state); err != nil {
+	if err = w.saveState(&w.state); err != nil {
 		return err
 	}
 	// close temp wal file
-	if err := w.sync(); err != nil {
+	if err = w.sync(); err != nil {
 		return err
 	}
-	if err := w.f.Close(); err != nil {
+	if err = w.f.Close(); err != nil {
 		return err
 	}
 
 	// atomically move temp wal file to wal file
-	if err := os.Rename(ftpath, fpath); err != nil {
+	if err = os.Rename(ftpath, fpath); err != nil {
 		return err
 	}
 
@@ -366,8 +365,7 @@ func (w *WAL) cut() error {
 	if err != nil {
 		return err
 	}
-	err = fileutil.Preallocate(f, segmentSizeBytes)
-	if err != nil {
+	if err = fileutil.Preallocate(f, segmentSizeBytes); err != nil {
 		plog.Errorf("failed to allocate space when creating new wal file (%v)", err)
 		return err
 	}
@@ -382,8 +380,7 @@ func (w *WAL) cut() error {
 		return err
 	}
 
-	err = l.Lock()
-	if err != nil {
+	if err := l.Lock(); err != nil {
 		return err
 	}
 	w.locks = append(w.locks, l)

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -153,10 +153,10 @@ func TestCut(t *testing.T) {
 
 	state := raftpb.HardState{Term: 1}
 	// TODO(unihorn): remove this when cut can operate on an empty file
-	if err := w.Save(state, []raftpb.Entry{{}}); err != nil {
+	if err = w.Save(state, []raftpb.Entry{{}}); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.cut(); err != nil {
+	if err = w.cut(); err != nil {
 		t.Fatal(err)
 	}
 	wname := walName(1, 1)
@@ -165,10 +165,10 @@ func TestCut(t *testing.T) {
 	}
 
 	es := []raftpb.Entry{{Index: 1, Term: 1, Data: []byte{1}}}
-	if err := w.Save(raftpb.HardState{}, es); err != nil {
+	if err = w.Save(raftpb.HardState{}, es); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.cut(); err != nil {
+	if err = w.cut(); err != nil {
 		t.Fatal(err)
 	}
 	snap := walpb.Snapshot{Index: 2, Term: 1}
@@ -212,7 +212,7 @@ func TestRecover(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := w.SaveSnapshot(walpb.Snapshot{}); err != nil {
+	if err = w.SaveSnapshot(walpb.Snapshot{}); err != nil {
 		t.Fatal(err)
 	}
 	ents := []raftpb.Entry{{Index: 1, Term: 1, Data: []byte{1}}, {Index: 2, Term: 2, Data: []byte{2}}}
@@ -385,10 +385,10 @@ func TestOpenAtUncommittedIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := w.SaveSnapshot(walpb.Snapshot{}); err != nil {
+	if err = w.SaveSnapshot(walpb.Snapshot{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.Save(raftpb.HardState{}, []raftpb.Entry{{Index: 0}}); err != nil {
+	if err = w.Save(raftpb.HardState{}, []raftpb.Entry{{Index: 0}}); err != nil {
 		t.Fatal(err)
 	}
 	w.Close()
@@ -398,7 +398,7 @@ func TestOpenAtUncommittedIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	// commit up to index 0, try to read index 1
-	if _, _, _, err := w.ReadAll(); err != nil {
+	if _, _, _, err = w.ReadAll(); err != nil {
 		t.Errorf("err = %v, want nil", err)
 	}
 	w.Close()


### PR DESCRIPTION
This fixes for shadowed error variables found by go tip go tool vet.
Fixes for https://github.com/coreos/etcd/issues/3954.