### PR TITLE
pkg/fileutil: make TestLockAndUnlock less flaky on CI

### DIFF
--- a/pkg/fileutil/lock_test.go
+++ b/pkg/fileutil/lock_test.go
@@ -78,7 +78,7 @@ func TestLockAndUnlock(t *testing.T) {
 	select {
 	case <-locked:
 		t.Error("unexpected unblocking")
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	// unlock
@@ -90,7 +90,7 @@ func TestLockAndUnlock(t *testing.T) {
 	// the previously blocked routine should be unblocked
 	select {
 	case <-locked:
-	case <-time.After(20 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		t.Error("unexpected blocking")
 	}
 }


### PR DESCRIPTION
CI is slow sometime. To make the test less flaky, we increases the
timeout. This does not affect the correctness, but the test might
take longer to finish or to fail.

Fix #3990 

/cc @gyuho @heyitsanthony 