### PR TITLE
etcdserver, auth: turn Quorum on in requests of auth checking

### DIFF
--- a/etcdserver/auth/auth_requests.go
+++ b/etcdserver/auth/auth_requests.go
@@ -119,6 +119,7 @@ func (s *store) requestResource(res string, dir bool) (etcdserver.Response, erro
 		Method: "GET",
 		Path:   p,
 		Dir:    dir,
+		Quorum: true,
 	}
 	return s.server.Do(ctx, rr)
 }


### PR DESCRIPTION
The auth information shouldn't be stale. Turning on the Quorum flag
for the request would be required for consistent auth.