### PR TITLE
etcdserver, auth: invalidate a cache of auth enabling flag when the f…

### DIFF
--- a/etcdserver/auth/auth_test.go
+++ b/etcdserver/auth/auth_test.go
@@ -183,6 +183,9 @@ func (td *testDoer) Do(_ context.Context, req etcdserverpb.Request) (etcdserver.
 	return etcdserver.Response{}, nil
 }
 
+func (td *testDoer) RegisterPathHookFunc(path string, r etcdserver.PathHookFunc, data interface{}) {
+}
+
 func TestAllUsers(t *testing.T) {
 	d := &testDoer{
 		get: []etcdserver.Response{

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -147,6 +147,12 @@ type Server interface {
 	ClusterVersion() *semver.Version
 }
 
+type PathHookFunc func(pb.Request, interface{})
+type PathHookFuncEntry struct {
+	f    PathHookFunc
+	data interface{}
+}
+
 // EtcdServer is the production implementation of the Server interface
 type EtcdServer struct {
 	// r must be the first element to keep 64-bit alignment for atomic
@@ -192,6 +198,8 @@ type EtcdServer struct {
 	// count the number of inflight snapshots.
 	// MUST use atomic operation to access this field.
 	inflightSnapshots int64
+
+	pathHookFuncEntries map[string]*PathHookFuncEntry
 }
 
 // NewServer creates a new EtcdServer from the supplied configuration. The
@@ -347,16 +355,17 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 			raftStorage: s,
 			storage:     NewStorage(w, ss),
 		},
-		id:            id,
-		attributes:    Attributes{Name: cfg.Name, ClientURLs: cfg.ClientURLs.StringSlice()},
-		cluster:       cl,
-		stats:         sstats,
-		lstats:        lstats,
-		SyncTicker:    time.Tick(500 * time.Millisecond),
-		versionRt:     prt,
-		reqIDGen:      idutil.NewGenerator(uint8(id), time.Now()),
-		forceVersionC: make(chan struct{}),
-		msgSnapC:      make(chan raftpb.Message, maxInFlightMsgSnap),
+		id:                  id,
+		attributes:          Attributes{Name: cfg.Name, ClientURLs: cfg.ClientURLs.StringSlice()},
+		cluster:             cl,
+		stats:               sstats,
+		lstats:              lstats,
+		SyncTicker:          time.Tick(500 * time.Millisecond),
+		versionRt:           prt,
+		reqIDGen:            idutil.NewGenerator(uint8(id), time.Now()),
+		forceVersionC:       make(chan struct{}),
+		msgSnapC:            make(chan raftpb.Message, maxInFlightMsgSnap),
+		pathHookFuncEntries: make(map[string]*PathHookFuncEntry),
 	}
 
 	if cfg.V3demo {
@@ -1036,6 +1045,11 @@ func (s *EtcdServer) applyRequest(r pb.Request) Response {
 		return Response{Event: ev, err: err}
 	}
 	expr := timeutil.UnixNanoToTime(r.Expiration)
+
+	if e, ok := s.pathHookFuncEntries[r.Path]; ok {
+		e.f(r, e.data)
+	}
+
 	switch r.Method {
 	case "POST":
 		return f(s.store.Create(r.Path, r.Dir, r.Val, true, expr))
@@ -1306,4 +1320,14 @@ func (s *EtcdServer) parseProposeCtxErr(err error, start time.Time) error {
 	}
 }
 
+
 func (s *EtcdServer) getKV() dstorage.ConsistentWatchableKV { return s.kv }
+
+func (s *EtcdServer) RegisterPathHookFunc(path string, f PathHookFunc, data interface{}) {
+	e := &PathHookFuncEntry{
+		f:    f,
+		data: data,
+	}
+
+	s.pathHookFuncEntries[path] = e
+}


### PR DESCRIPTION
…lag is updated

Current etcd doesn't invalidate a cache of auth enabling flag even if
the flag is updated via PUT request to /2/enabled. Therefore, even one
server enables or disables auth, other servers don't follow the
change.

This commit adds a mechanism for invalidating the flag. For
simplicity, the mechanism is based on a new hook functionality based
on path and request. It reduces an adhoc branch in the log update
path.

Fixes https://github.com/coreos/etcd/issues/3964