### PR TITLE
Added examples folder in /client with two examples

### DIFF
--- a/client/examples/directory/directory.go
+++ b/client/examples/directory/directory.go
@@ -26,7 +26,8 @@ func main() {
 	cfg := client.Config{
 		Endpoints: []string{"http://127.0.0.1:2379"},
 		Transport: client.DefaultTransport,
-		// set timeout per request to fail fast when the target endpoint is unavailable
+		// set timeout per request to fail fast when the target endpoint
+		// is unavailable
 		HeaderTimeoutPerRequest: time.Second,
 	}
 
@@ -36,47 +37,37 @@ func main() {
 	}
 	kapi := client.NewKeysAPI(c)
 
-	// create a directory myNodes that will hold many keys
-	log.Print("Setting '/myNodes' to create a directory")
+	log.Print("Setting '/myNodes' to create a directory that will hold some keys")
 	o := client.SetOptions{Dir: true}
 	resp, err := kapi.Set(context.Background(), "/myNodes", "", &o)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// print common key info
-		log.Printf("Set is done. Metadata is %q\n", resp)
 	}
+	log.Printf("Set is done. Metadata is %q\n", resp)
 
-	//Setting a coupe of values in previous directory
 	log.Print("Setting '/myNodes/key1' with value 'value1'")
 	resp, err = kapi.Set(context.Background(), "/myNodes/key1", "value1", nil)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// print common key info
-		log.Printf("Set is done. Metadata is %q\n", resp)
 	}
+	log.Printf("Set is done. Metadata is %q\n", resp)
 
 	log.Print("Setting '/myNodes/key2' with value 'value2'")
 	resp, err = kapi.Set(context.Background(), "/myNodes/key2", "value2", nil)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// print common key info
-		log.Printf("Set is done. Metadata is %q\n", resp)
 	}
+	log.Printf("Set is done. Metadata is %q\n", resp)
 
-	// Getting directory contents for '/myNodes' (key1, key2)
 	log.Print("Getting directory contents for '/myNodes' (key1, key2)")
 	resp, err = kapi.Get(context.Background(), "/myNodes", nil)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// print common key info
-		log.Printf("Set is done. Metadata is %q\n", resp)
-		// print directory keys
-		for _, n := range resp.Node.Nodes {
-			log.Printf("Key: %q, Value: %q", n.Key, n.Value)
-		}
 	}
+	log.Printf("Set is done. Metadata is %q\n", resp)
+	// print directory keys
+	for _, n := range resp.Node.Nodes {
+		log.Printf("Key: %q, Value: %q", n.Key, n.Value)
+	}
+
 }

--- a/client/examples/directory/directory.go
+++ b/client/examples/directory/directory.go
@@ -1,0 +1,82 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/client"
+)
+
+func main() {
+	cfg := client.Config{
+		Endpoints: []string{"http://127.0.0.1:2379"},
+		Transport: client.DefaultTransport,
+		// set timeout per request to fail fast when the target endpoint is unavailable
+		HeaderTimeoutPerRequest: time.Second,
+	}
+
+	c, err := client.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	kapi := client.NewKeysAPI(c)
+
+	// create a directory myNodes that will hold many keys
+	log.Print("Setting '/myNodes' to create a directory")
+	o := client.SetOptions{Dir: true}
+	resp, err := kapi.Set(context.Background(), "/myNodes", "", &o)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		// print common key info
+		log.Printf("Set is done. Metadata is %q\n", resp)
+	}
+
+	//Setting a coupe of values in previous directory
+	log.Print("Setting '/myNodes/key1' with value 'value1'")
+	resp, err = kapi.Set(context.Background(), "/myNodes/key1", "value1", nil)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		// print common key info
+		log.Printf("Set is done. Metadata is %q\n", resp)
+	}
+
+	log.Print("Setting '/myNodes/key2' with value 'value2'")
+	resp, err = kapi.Set(context.Background(), "/myNodes/key2", "value2", nil)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		// print common key info
+		log.Printf("Set is done. Metadata is %q\n", resp)
+	}
+
+	// Getting directory contents for '/myNodes' (key1, key2)
+	log.Print("Getting directory contents for '/myNodes' (key1, key2)")
+	resp, err = kapi.Get(context.Background(), "/myNodes", nil)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		// print common key info
+		log.Printf("Set is done. Metadata is %q\n", resp)
+		// print directory keys
+		for _, n := range resp.Node.Nodes {
+			log.Printf("Key: %q, Value: %q", n.Key, n.Value)
+		}
+	}
+}

--- a/client/examples/directory/directory_test.go
+++ b/client/examples/directory/directory_test.go
@@ -1,0 +1,67 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/client"
+)
+
+func TestMain(m *testing.M) {
+	main()
+	code := m.Run()
+
+	//Clean
+	log.Println("Cleaning test...")
+
+	//Clean nodes within "myNodes
+	cfg := client.Config{
+		Endpoints: []string{"http://127.0.0.1:2379"},
+		Transport: client.DefaultTransport,
+		// set timeout per request to fail fast when the target endpoint is unavailable
+		HeaderTimeoutPerRequest: time.Second,
+	}
+
+	c, err := client.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	kapi := client.NewKeysAPI(c)
+
+	//Delete created directory
+	log.Print("Deleting '/myNodes and all it's subchildren'")
+	o := client.DeleteOptions{Recursive: true}
+	resp, err := kapi.Delete(context.Background(), "/myNodes", &o)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		// print common key info
+		log.Printf("Delete is done. Metadata is %q\n", resp)
+	}
+
+	//Assert directory is deleted
+	log.Println("Checking /myNodes is deleted")
+	resp, err = kapi.Get(context.Background(), "/myNodes", nil)
+	if resp != nil {
+		log.Fatal("/myNodes was not deleted\n")
+	}
+
+	os.Exit(code)
+}

--- a/client/examples/setGetKey/setGetKey.go
+++ b/client/examples/setGetKey/setGetKey.go
@@ -26,7 +26,8 @@ func main() {
 	cfg := client.Config{
 		Endpoints: []string{"http://127.0.0.1:2379"},
 		Transport: client.DefaultTransport,
-		// set timeout per request to fail fast when the target endpoint is unavailable
+		// set timeout per request to fail fast when the target endpoint
+		// is unavailable
 		HeaderTimeoutPerRequest: time.Second,
 	}
 	c, err := client.New(cfg)
@@ -34,24 +35,20 @@ func main() {
 		log.Fatal(err)
 	}
 	kapi := client.NewKeysAPI(c)
-	// set "/foo" key with "bar" value
+
 	log.Print("Setting '/foo' key with 'bar' value")
 	resp, err := kapi.Set(context.Background(), "/foo", "bar", nil)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// print common key info
-		log.Printf("Set is done. Metadata is %q\n", resp)
 	}
-	// get "/foo" key's value
+	log.Printf("Set is done. Metadata is %q\n", resp)
+
 	log.Print("Getting '/foo' key value")
 	resp, err = kapi.Get(context.Background(), "/foo", nil)
 	if err != nil {
 		log.Fatal(err)
-	} else {
-		// print common key info
-		log.Printf("Get is done. Metadata is %q\n", resp)
-		// print value
-		log.Printf("%q key has %q value\n", resp.Node.Key, resp.Node.Value)
 	}
+
+	log.Printf("Get is done. Metadata is %q\n", resp)
+	log.Printf("%q key has %q value\n", resp.Node.Key, resp.Node.Value)
 }

--- a/client/examples/setGetKey/setGetKey.go
+++ b/client/examples/setGetKey/setGetKey.go
@@ -1,0 +1,57 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/client"
+)
+
+func main() {
+	cfg := client.Config{
+		Endpoints: []string{"http://127.0.0.1:2379"},
+		Transport: client.DefaultTransport,
+		// set timeout per request to fail fast when the target endpoint is unavailable
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	c, err := client.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	kapi := client.NewKeysAPI(c)
+	// set "/foo" key with "bar" value
+	log.Print("Setting '/foo' key with 'bar' value")
+	resp, err := kapi.Set(context.Background(), "/foo", "bar", nil)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		// print common key info
+		log.Printf("Set is done. Metadata is %q\n", resp)
+	}
+	// get "/foo" key's value
+	log.Print("Getting '/foo' key value")
+	resp, err = kapi.Get(context.Background(), "/foo", nil)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		// print common key info
+		log.Printf("Get is done. Metadata is %q\n", resp)
+		// print value
+		log.Printf("%q key has %q value\n", resp.Node.Key, resp.Node.Value)
+	}
+}

--- a/client/examples/setGetKey/setGetKey_test.go
+++ b/client/examples/setGetKey/setGetKey_test.go
@@ -1,0 +1,62 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/client"
+)
+
+func TestMain(m *testing.M) {
+	main()
+	code := m.Run()
+
+	//Clean
+	cfg := client.Config{
+		Endpoints: []string{"http://127.0.0.1:2379"},
+		Transport: client.DefaultTransport,
+		// set timeout per request to fail fast when the target endpoint is unavailable
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	c, err := client.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	kapi := client.NewKeysAPI(c)
+
+	// Delete "/foo" key
+	log.Print("Deleting '/foo' key with 'bar' value")
+	resp, err := kapi.Delete(context.Background(), "/foo", nil)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		// print common key info
+		log.Printf("Delete is done. Metadata is %q\n", resp)
+	}
+
+	//Assert key has been deleted
+	log.Println("Checking /foo key is deleted")
+	resp, err = kapi.Get(context.Background(), "/foo", nil)
+	if resp != nil {
+		log.Fatal("/foo was not deleted\n")
+	}
+
+	os.Exit(code)
+}

--- a/test
+++ b/test
@@ -16,7 +16,7 @@ COVER=${COVER:-"-cover"}
 source ./build
 
 # Hack: gofmt ./ will recursively check the .git directory. So use *.go for gofmt.
-TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/auth etcdserver/etcdhttp etcdserver/etcdhttp/httptypes pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/osutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft snap storage storage/backend store version wal"
+TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/auth etcdserver/etcdhttp etcdserver/etcdhttp/httptypes pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/osutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft snap storage storage/backend store version wal client/examples/directory client/examples/setGetKey"
 # TODO: add it to race testing when the issue is resolved
 # https://github.com/golang/go/issues/9946
 NO_RACE_TESTABLE="rafthttp"
@@ -88,7 +88,7 @@ echo "Checking for license header..."
 licRes=$(for file in $(find . -type f -iname '*.go' ! -path './Godeps/*'); do
 		head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo -e "  ${file}"
 	done;)
-if [ -n "${licRes}" ]; then 
+if [ -n "${licRes}" ]; then
 	echo -e "license header checking failed:\n${licRes}"
 	exit 255
 fi


### PR DESCRIPTION
Continuing https://github.com/coreos/etcd/pull/3985

I have added two examples directory of client usage.
- "setGetKey" folder is the same example found in README.md with integration testing (and post cleaning) in "./test"
- "directory" folder is an example using directory listing and key retrieval with integration test (and post cleaning). Also integrated in global test "./test". Creates a "/myNodes" folder and added "key1" -> "value1" and "key2" -> "value2" to them.

Also, I have added in "./test" script the two folders with the examples so that they can be tested globally in integration. Everything written by the examples is later deleted and checked in the test.

I haven't touched the README.md as I wasn't sure what was the best way to update it with this information.

I hope this is the way you prefer.
