### PR TITLE
[Documentation] move /version to other_apis and add /health

### DIFF
--- a/Documentation/other_apis.md
+++ b/Documentation/other_apis.md
@@ -1,3 +1,7 @@
+[Members API](#members-api)
+
+[Miscellaneous APIs](#miscellaneous-apis)
+
 # Members API
 
 * [List members](#list-members)
@@ -50,7 +54,7 @@ curl http://10.0.0.10:2379/v2/members
 
 ## Add a member
 
-Returns an HTTP 201 response code and the representation of added member with a newly generated a memberID when successful. Returns a string describing the failure condition when unsuccessful. 
+Returns an HTTP 201 response code and the representation of added member with a newly generated a memberID when successful. Returns a string describing the failure condition when unsuccessful.
 
 If the POST body is malformed an HTTP 400 will be returned. If the member exists in the cluster or existed in the cluster at some point in the past an HTTP 409 will be returned. If any of the given peerURLs exists in the cluster an HTTP 409 will be returned. If the cluster fails to process the request within timeout an HTTP 500 will be returned, though the request may be processed later.
 
@@ -81,7 +85,7 @@ curl http://10.0.0.10:2379/v2/members -XPOST \
 ## Delete a member
 
 Remove a member from the cluster. The member ID must be a hex-encoded uint64.
-Returns 204 with empty content when successful. Returns a string describing the failure condition when unsuccessful. 
+Returns 204 with empty content when successful. Returns a string describing the failure condition when unsuccessful.
 
 If the member does not exist in the cluster an HTTP 500(TODO: fix this) will be returned. If the cluster fails to process the request within timeout an HTTP 500 will be returned, though the request may be processed later.
 
@@ -116,4 +120,33 @@ PUT /v2/members/<id> HTTP/1.1
 ```sh
 curl http://10.0.0.10:2379/v2/members/272e204152 -XPUT \
 -H "Content-Type: application/json" -d '{"peerURLs":["http://10.0.0.10:2380"]}'
+```
+
+# Miscellaneous APIs
+
+* [Getting the etcd version](#getting-the-etcd-version)
+* [Checking health of an etcd member node](#checking-health-of-an-etcd-member-node)
+
+## Getting the etcd version
+
+The etcd version of a specific instance can be obtained from the `/version` endpoint.
+
+```sh
+curl -L http://127.0.0.1:2379/version
+```
+
+```
+etcd 2.0.12
+```
+
+## Checking health of an etcd member node
+
+Etcd provides a `/health` endpoint to verify the health of a particular member.
+
+```sh
+curl http://10.0.0.10:2379/health
+```
+
+```json
+{"health": "true"}
 ```


### PR DESCRIPTION
moved /version http endpoint to other_api document and added health with
an example

unfortunately the editor seemed to do whitespace changes to lines I didn't touch...