### PR TITLE
raft: remove go vet compliants

### DIFF
--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -460,7 +460,7 @@ func TestLeaderCommitEntry(t *testing.T) {
 			t.Errorf("to = %x, want %x", m.To, w)
 		}
 		if m.Type != pb.MsgApp {
-			t.Errorf("type = %s, want %s", m.Type, pb.MsgApp)
+			t.Errorf("type = %v, want %v", m.Type, pb.MsgApp)
 		}
 		if m.Commit != li+1 {
 			t.Errorf("commit = %d, want %d", m.Commit, li+1)

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -977,7 +977,7 @@ func TestMsgAppRespWaitReset(t *testing.T) {
 		t.Fatalf("expected 1 message, got %d: %+v", len(msgs), msgs)
 	}
 	if msgs[0].Type != pb.MsgApp || msgs[0].To != 2 {
-		t.Errorf("expected MsgApp to node 2, got %s to %d", msgs[0].Type, msgs[0].To)
+		t.Errorf("expected MsgApp to node 2, got %v to %d", msgs[0].Type, msgs[0].To)
 	}
 	if len(msgs[0].Entries) != 1 || msgs[0].Entries[0].Index != 2 {
 		t.Errorf("expected to send entry 2, but got %v", msgs[0].Entries)
@@ -994,7 +994,7 @@ func TestMsgAppRespWaitReset(t *testing.T) {
 		t.Fatalf("expected 1 message, got %d: %+v", len(msgs), msgs)
 	}
 	if msgs[0].Type != pb.MsgApp || msgs[0].To != 3 {
-		t.Errorf("expected MsgApp to node 3, got %s to %d", msgs[0].Type, msgs[0].To)
+		t.Errorf("expected MsgApp to node 3, got %v to %d", msgs[0].Type, msgs[0].To)
 	}
 	if len(msgs[0].Entries) != 1 || msgs[0].Entries[0].Index != 2 {
 		t.Errorf("expected to send entry 2, but got %v", msgs[0].Entries)
@@ -1435,7 +1435,7 @@ func TestSendAppendForProgressProbe(t *testing.T) {
 			t.Errorf("len(msg) = %d, want %d", len(msg), 1)
 		}
 		if msg[0].Type != pb.MsgHeartbeat {
-			t.Errorf("type = %s, want %s", msg[0].Type, pb.MsgHeartbeat)
+			t.Errorf("type = %v, want %v", msg[0].Type, pb.MsgHeartbeat)
 		}
 	}
 }

--- a/raft/util.go
+++ b/raft/util.go
@@ -62,7 +62,7 @@ type EntryFormatter func([]byte) string
 // Message for debugging.
 func DescribeMessage(m pb.Message, f EntryFormatter) string {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%x->%x %s Term:%d Log:%d/%d", m.From, m.To, m.Type, m.Term, m.LogTerm, m.Index)
+	fmt.Fprintf(&buf, "%x->%x %v Term:%d Log:%d/%d", m.From, m.To, m.Type, m.Term, m.LogTerm, m.Index)
 	if m.Reject {
 		fmt.Fprintf(&buf, " Rejected")
 	}


### PR DESCRIPTION
The values should be string for printf format.