### PR TITLE
storage, test: unlock transaction in the retry loop

### DIFF
--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -654,11 +654,11 @@ func TestRestoreContinueUnfinishedCompaction(t *testing.T) {
 		tx = s1.b.BatchTx()
 		tx.Lock()
 		ks, _ := tx.UnsafeRange(keyBucketName, revbytes, nil, 0)
+		tx.Unlock()
 		if len(ks) != 0 {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		tx.Unlock()
 		return
 	}
 


### PR DESCRIPTION
Reported by @AkihiroSuda . Could you share how to reproduce the problem, @AkihiroSuda ?