### PR TITLE
contrib: Give ownership on ETCD_DATA_DIR

### DIFF
--- a/contrib/systemd/etcd.service
+++ b/contrib/systemd/etcd.service
@@ -4,9 +4,11 @@ Documentation=https://github.com/coreos/etcd
 
 [Service]
 User=etcd
+PermissionsStartOnly=true
 Type=notify
 Environment=ETCD_DATA_DIR=/var/lib/etcd
 Environment=ETCD_NAME=%m
+ExecStartPre=/usr/bin/chown etcd:etcd ${ETCD_DATA_DIR}
 ExecStart=/usr/bin/etcd
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
This fix ownership problems when mount a new volume for etcd data