### PR TITLE
storage: remove unnecessary test variable assignment

### DIFF
--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -281,7 +281,7 @@ func testKVPutMultipleTimes(t *testing.T, f putFunc) {
 		base := int64(i + 1)
 
 		rev := f(s, []byte("foo"), []byte("bar"))
-		if wrev := base; rev != wrev {
+		if rev != base {
 			t.Errorf("#%d: rev = %d, want %d", i, rev, base)
 		}
 


### PR DESCRIPTION
There is no need to assign a separate variable since 'base' is already defined
as a local variable within the loop.