### PR TITLE
storage: use only one mutex for store struct

### DIFF
--- a/storage/kvstore_bench_test.go
+++ b/storage/kvstore_bench_test.go
@@ -1,0 +1,57 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package storage
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+func BenchmarkStorePut(b *testing.B) {
+	s := newStore(tmpPath)
+	defer os.Remove(tmpPath)
+
+	// arbitrary number of bytes
+	bytesN := 64
+	keys := createBytesSlice(bytesN, b.N)
+	vals := createBytesSlice(bytesN, b.N)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Put(keys[i], vals[i])
+	}
+}
+
+// BenchmarkStoreTxnPut benchmarks the Put operation
+// with transaction begin and end, where transaction involves
+// some synchronization operations, such as mutex locking.
+func BenchmarkStoreTxnPut(b *testing.B) {
+	s := newStore(tmpPath)
+	defer cleanup(s, tmpPath)
+
+	// arbitrary number of bytes
+	bytesN := 64
+	keys := createBytesSlice(bytesN, b.N)
+	vals := createBytesSlice(bytesN, b.N)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		id := s.TxnBegin()
+		if _, err := s.TxnPut(id, keys[i], vals[i]); err != nil {
+			log.Fatalf("txn put error: %v", err)
+		}
+		s.TxnEnd(id)
+	}
+}


### PR DESCRIPTION
Follow up from https://github.com/coreos/etcd/pull/4029.

[**`sync.Mutex` is a variable**](https://golang.org/pkg/sync/#Mutex), which means there needs to be only one mutex
value per scope. We don't need a separate mutex inside store struct,
**if we assume that `TxnPut` and `TxnRange` are called ONLY ONCE
per transaction (between `TxnBegin` and `TxnEnd`)**, as [documented](https://github.com/coreos/etcd/blob/master/storage/kv.go#L52-L61):

```go
	// TxnBegin begins a txn. Only Txn prefixed operation can be executed, others will be blocked
	// until txn ends. Only one on-going txn is allowed.
	// TxnBegin returns an int64 txn ID.
	// All txn prefixed operations with same txn ID will be done with the same rev.
	TxnBegin() int64
	// TxnEnd ends the on-going txn with txn ID. If the on-going txn ID is not matched, error is returned.
	TxnEnd(txnID int64) error
	TxnRange(txnID int64, key, end []byte, limit, rangeRev int64) (kvs []storagepb.KeyValue, rev int64, err error)
	TxnPut(txnID int64, key, value []byte) (rev int64, err error)
	TxnDeleteRange(txnID int64, key, end []byte) (n, rev int64, err error)
```

Below are benchmarks before and after (if the delta is negative, it means
performance increase with this patch):

```
BenchmarkStorePut:
[1]:
benchmark               old ns/op     new ns/op     delta
BenchmarkStorePut       51365         55579         +8.20%
BenchmarkStorePut-4     66769         77290         +15.76%

benchmark               old allocs     new allocs     delta
BenchmarkStorePut       26             17             -34.62%
BenchmarkStorePut-4     18             17             -5.56%

benchmark               old bytes     new bytes     delta
BenchmarkStorePut       2000          1523          -23.85%
BenchmarkStorePut-4     1586          1530          -3.53%


[2]:
benchmark               old ns/op     new ns/op     delta
BenchmarkStorePut       53975         40284         -25.37%
BenchmarkStorePut-4     67024         79245         +18.23%

benchmark               old allocs     new allocs     delta
BenchmarkStorePut       26             21             -19.23%
BenchmarkStorePut-4     26             26             +0.00%

benchmark               old bytes     new bytes     delta
BenchmarkStorePut       2001          1725          -13.79%
BenchmarkStorePut-4     2017          2028          +0.55%


[3]:
benchmark               old ns/op     new ns/op     delta
BenchmarkStorePut       49534         33685         -32.00%
BenchmarkStorePut-4     75679         79654         +5.25%

benchmark               old allocs     new allocs     delta
BenchmarkStorePut       20             18             -10.00%
BenchmarkStorePut-4     26             26             +0.00%

benchmark               old bytes     new bytes     delta
BenchmarkStorePut       1666          1571          -5.70%
BenchmarkStorePut-4     2023          2020          -0.15%

---

BenchmarkStoreTxnPut:
[1]:
benchmark                  old ns/op     new ns/op     delta
BenchmarkStoreTxnPut       35277         31067         -11.93%
BenchmarkStoreTxnPut-4     38128         38189         +0.16%

benchmark                  old allocs     new allocs     delta
BenchmarkStoreTxnPut       21             18             -14.29%
BenchmarkStoreTxnPut-4     21             21             +0.00%

benchmark                  old bytes     new bytes     delta
BenchmarkStoreTxnPut       2386          2048          -14.17%
BenchmarkStoreTxnPut-4     2389          2356          -1.38%


[2]:
benchmark                  old ns/op     new ns/op     delta
BenchmarkStoreTxnPut       34149         29346         -14.06%
BenchmarkStoreTxnPut-4     54279         33869         -37.60%

benchmark                  old allocs     new allocs     delta
BenchmarkStoreTxnPut       21             18             -14.29%
BenchmarkStoreTxnPut-4     21             21             +0.00%

benchmark                  old bytes     new bytes     delta
BenchmarkStoreTxnPut       2385          2049          -14.09%
BenchmarkStoreTxnPut-4     2371          2374          +0.13%


[3]:
benchmark                  old ns/op     new ns/op     delta
BenchmarkStoreTxnPut       33314         26506         -20.44%
BenchmarkStoreTxnPut-4     36791         29421         -20.03%

benchmark                  old allocs     new allocs     delta
BenchmarkStoreTxnPut       17             18             +5.88%
BenchmarkStoreTxnPut-4     21             18             -14.29%

benchmark                  old bytes     new bytes     delta
BenchmarkStoreTxnPut       2027          2049          +1.09%
BenchmarkStoreTxnPut-4     2345          2045          -12.79%

```

/cc @xiang90 