### PR TITLE
pkg/fileutil: skip TestIsDirWriteable when running as root

### DIFF
--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -17,6 +17,7 @@ package fileutil
 import (
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -33,6 +34,17 @@ func TestIsDirWriteable(t *testing.T) {
 	}
 	if err := os.Chmod(tmpdir, 0444); err != nil {
 		t.Fatalf("unexpected os.Chmod error: %v", err)
+	}
+	me, err := user.Current()
+	if err != nil {
+		// err can be non-nil when cross compiled
+		// http://stackoverflow.com/questions/20609415/cross-compiling-user-current-not-implemented-on-linux-amd64
+		t.Skipf("failed to get current user: %v", err)
+	}
+	if me.Name == "root" || me.Name == "Administrator" {
+		// ideally we should check CAP_DAC_OVERRIDE.
+		// but it does not matter for tests.
+		t.Skipf("running as a superuser")
 	}
 	if err := IsDirWriteable(tmpdir); err == nil {
 		t.Fatalf("expected IsDirWriteable to error")


### PR DESCRIPTION
Closes #4007 