### PR TITLE
backend: do not commit unless there is a pending change

### DIFF
--- a/storage/backend/batch_tx.go
+++ b/storage/backend/batch_tx.go
@@ -132,7 +132,11 @@ func (t *batchTx) commit(stop bool) {
 	var err error
 	// commit the last tx
 	if t.tx != nil {
+		if t.pending == 0 && !stop {
+			return
+		}
 		err = t.tx.Commit()
+		t.pending = 0
 		if err != nil {
 			log.Fatalf("storage: cannot commit tx (%s)", err)
 		}


### PR DESCRIPTION
Reduce the number of fsync etcd issues when the cluster is
idle.

Now the number of iops of idle etcd3 and etcd2 clusters are the same.

Fix #4058 