### PR TITLE
storage: remove unnecessary math/rand seed

### DIFF
--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -18,7 +18,6 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"math"
-	mrand "math/rand"
 	"os"
 	"reflect"
 	"testing"
@@ -845,7 +844,6 @@ func (i *fakeIndex) Equal(b index) bool { return false }
 func createBytesSlice(bytesN, sliceN int) [][]byte {
 	rs := [][]byte{}
 	for len(rs) != sliceN {
-		mrand.Seed(time.Now().UnixNano())
 		v := make([]byte, bytesN)
 		if _, err := rand.Read(v); err != nil {
 			panic(err)


### PR DESCRIPTION
As @jonboulle pointed out at
https://github.com/coreos/etcd/pull/4070/files#r48441847:

> math/rand is unrelated to crypto/rand; the latter reads from /dev/urandom and
> is relying on the kernel's PRNG. Just remove the seed entirely.