### PR TITLE
storage: clean up test variable names, minor typos in comments

### DIFF
--- a/storage/watchable_store_test.go
+++ b/storage/watchable_store_test.go
@@ -89,7 +89,7 @@ func TestCancelUnsynced(t *testing.T) {
 
 	w := s.NewWatcher()
 
-	// arbitrary number for watcher
+	// arbitrary number for watchers
 	watcherN := 100
 
 	// create watcherN of CancelFunc of
@@ -136,7 +136,7 @@ func TestSyncWatchings(t *testing.T) {
 
 	w := s.NewWatcher()
 
-	// arbitrary number for watcher
+	// arbitrary number for watchers
 	watcherN := 100
 
 	for i := 0; i < watcherN; i++ {


### PR DESCRIPTION
This just changes variable name to be more consistent: `N` rather than `Size`.
And fix some minor grammatical errors.