### PR TITLE
etcdserver: delete member directory when NewServer errors

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -222,6 +222,16 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		return nil, err
 	}
 
+	isSuccess := false
+	defer func() {
+		if !isSuccess {
+			// It removes member directory when NewServer returns error.
+			// This prevents conflicts with 'proxy' directory when
+			// the node falls back to proxy.
+			os.RemoveAll(cfg.MemberDir())
+		}
+	}()
+
 	haveWAL := wal.Exist(cfg.WALDir())
 	ss := snap.New(cfg.SnapDir())
 
@@ -394,6 +404,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 	}
 	srv.r.transport = tr
 
+	isSuccess = true
 	return srv, nil
 }
 


### PR DESCRIPTION
This is for https://github.com/coreos/etcd/issues/3827.
This removes member directory with defer statement. And it removes only when
etcdserver.NewServer returns error.

/cc @xiang90 @heyitsanthony 