### PR TITLE
etcdserver: fix creating member dir

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -217,11 +217,6 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		return nil, err
 	}
 
-	err = os.MkdirAll(cfg.MemberDir(), privateDirMode)
-	if err != nil && err != os.ErrExist {
-		return nil, err
-	}
-
 	haveWAL := wal.Exist(cfg.WALDir())
 	ss := snap.New(cfg.SnapDir())
 
@@ -326,6 +321,11 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		cl.Recover()
 	default:
 		return nil, fmt.Errorf("unsupported bootstrap config")
+	}
+
+	err = os.MkdirAll(cfg.MemberDir(), privateDirMode)
+	if err != nil && err != os.ErrExist {
+		return nil, err
 	}
 
 	sstats := &stats.ServerStats{


### PR DESCRIPTION
@gyuho I reverted your previous fix since that is a partial fix, which does not cover the discovery case.

I feel this is a easier way to fix the root problem. We should not create member dir before validation. 