### PR TITLE
etcdserver: always check if the data dir is writable before starting

### DIFF
--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -26,6 +26,8 @@ import (
 
 const (
 	privateFileMode = 0600
+	// owner can make/remove files inside the directory
+	privateDirMode = 0700
 )
 
 var (
@@ -55,6 +57,16 @@ func ReadDir(dirpath string) ([]string, error) {
 	}
 	sort.Strings(names)
 	return names, nil
+}
+
+// TouchDirAll is simliar to os.MkdirAll. It creates directories with 0700 permission if any directory
+// does not exists. TouchDirAll also ensures the given directory is writable.
+func TouchDirAll(dir string) error {
+	err := os.MkdirAll(dir, privateDirMode)
+	if err != nil && err != os.ErrExist {
+		return err
+	}
+	return IsDirWriteable(dir)
 }
 
 func Exist(name string) bool {


### PR DESCRIPTION
Fix #3713

#3713 also mentions another issue that etcd should not auto create data-dir if not exist. I do not think that is a good suggestion. I feel it is just OK to create a non-existing data dir for user.

/cc @heyitsanthony 