### PR TITLE
*: rename watcher to watchStream

### DIFF
--- a/storage/kv.go
+++ b/storage/kv.go
@@ -82,11 +82,11 @@ type WatchableKV interface {
 	Watchable
 }
 
-// Watchable is the interface that wraps the NewWatcher function.
+// Watchable is the interface that wraps the NewWatchStream function.
 type Watchable interface {
-	// NewWatcher returns a Watcher that can be used to
+	// NewWatchStream returns a WatchStream that can be used to
 	// watch events happened or happending on the KV.
-	NewWatcher() Watcher
+	NewWatchStream() WatchStream
 }
 
 // ConsistentWatchableKV is a WatchableKV that understands the consistency

--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -733,7 +733,7 @@ func TestWatchableKVWatch(t *testing.T) {
 	s := WatchableKV(newWatchableStore(tmpPath))
 	defer cleanup(s, tmpPath)
 
-	w := s.NewWatcher()
+	w := s.NewWatchStream()
 
 	wid, cancel := w.Watch([]byte("foo"), true, 0)
 	defer cancel()
@@ -784,7 +784,7 @@ func TestWatchableKVWatch(t *testing.T) {
 
 	w.Close()
 
-	w = s.NewWatcher()
+	w = s.NewWatchStream()
 	wid, cancel = w.Watch([]byte("foo1"), false, 1)
 	defer cancel()
 

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -59,12 +59,12 @@ var (
 			Help:      "Total number of keys.",
 		})
 
-	watcherGauge = prometheus.NewGauge(
+	watchStreamGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "etcd",
 			Subsystem: "storage",
-			Name:      "watcher_total",
-			Help:      "Total number of watchers.",
+			Name:      "watch_stream_total",
+			Help:      "Total number of watch streams.",
 		})
 
 	watchingGauge = prometheus.NewGauge(
@@ -143,7 +143,7 @@ func init() {
 	prometheus.MustRegister(deleteCounter)
 	prometheus.MustRegister(txnCounter)
 	prometheus.MustRegister(keysGauge)
-	prometheus.MustRegister(watcherGauge)
+	prometheus.MustRegister(watchStreamGauge)
 	prometheus.MustRegister(watchingGauge)
 	prometheus.MustRegister(slowWatchingGauge)
 	prometheus.MustRegister(totalEventsCounter)

--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -177,9 +177,9 @@ func (s *watchableStore) Close() error {
 	return s.store.Close()
 }
 
-func (s *watchableStore) NewWatcher() Watcher {
-	watcherGauge.Inc()
-	return &watcher{
+func (s *watchableStore) NewWatchStream() WatchStream {
+	watchStreamGauge.Inc()
+	return &watchStream{
 		watchable: s,
 		ch:        make(chan []storagepb.Event, chanBufLen),
 	}

--- a/storage/watchable_store_bench_test.go
+++ b/storage/watchable_store_bench_test.go
@@ -54,7 +54,7 @@ func BenchmarkWatchableStoreUnsyncedCancel(b *testing.B) {
 	testValue := []byte("bar")
 	s.Put(testKey, testValue)
 
-	w := s.NewWatcher()
+	w := s.NewWatchStream()
 
 	const k int = 2
 	benchSampleN := b.N
@@ -92,7 +92,7 @@ func BenchmarkWatchableStoreSyncedCancel(b *testing.B) {
 	testValue := []byte("bar")
 	s.Put(testKey, testValue)
 
-	w := s.NewWatcher()
+	w := s.NewWatchStream()
 
 	// put 1 million watchers on the same key
 	const watcherN = 1000000

--- a/storage/watchable_store_test.go
+++ b/storage/watchable_store_test.go
@@ -33,7 +33,7 @@ func TestWatch(t *testing.T) {
 	testValue := []byte("bar")
 	s.Put(testKey, testValue)
 
-	w := s.NewWatcher()
+	w := s.NewWatchStream()
 	w.Watch(testKey, true, 0)
 
 	if _, ok := s.synced[string(testKey)]; !ok {
@@ -52,7 +52,7 @@ func TestNewWatcherCancel(t *testing.T) {
 	testValue := []byte("bar")
 	s.Put(testKey, testValue)
 
-	w := s.NewWatcher()
+	w := s.NewWatchStream()
 	_, cancel := w.Watch(testKey, true, 0)
 
 	cancel()
@@ -91,7 +91,7 @@ func TestCancelUnsynced(t *testing.T) {
 	testValue := []byte("bar")
 	s.Put(testKey, testValue)
 
-	w := s.NewWatcher()
+	w := s.NewWatchStream()
 
 	// arbitrary number for watchers
 	watcherN := 100
@@ -138,7 +138,7 @@ func TestSyncWatchings(t *testing.T) {
 	testValue := []byte("bar")
 	s.Put(testKey, testValue)
 
-	w := s.NewWatcher()
+	w := s.NewWatchStream()
 
 	// arbitrary number for watchers
 	watcherN := 100
@@ -184,10 +184,10 @@ func TestSyncWatchings(t *testing.T) {
 	// All of the watchings actually share one channel
 	// so we only need to check one shared channel
 	// (See watcher.go for more detail).
-	if len(w.(*watcher).ch) != watcherN {
-		t.Errorf("watched event size = %d, want %d", len(w.(*watcher).ch), watcherN)
+	if len(w.(*watchStream).ch) != watcherN {
+		t.Errorf("watched event size = %d, want %d", len(w.(*watchStream).ch), watcherN)
 	}
-	evs := <-w.(*watcher).ch
+	evs := <-w.(*watchStream).ch
 	if len(evs) != 1 {
 		t.Errorf("len(evs) got = %d, want = 1", len(evs))
 	}

--- a/storage/watcher_bench_test.go
+++ b/storage/watcher_bench_test.go
@@ -23,7 +23,7 @@ func BenchmarkKVWatcherMemoryUsage(b *testing.B) {
 	watchable := newWatchableStore(tmpPath)
 	defer cleanup(watchable, tmpPath)
 
-	w := watchable.NewWatcher()
+	w := watchable.NewWatchStream()
 
 	b.ReportAllocs()
 	b.StartTimer()

--- a/storage/watcher_test.go
+++ b/storage/watcher_test.go
@@ -22,7 +22,7 @@ func TestWatcherWatchID(t *testing.T) {
 	s := WatchableKV(newWatchableStore(tmpPath))
 	defer cleanup(s, tmpPath)
 
-	w := s.NewWatcher()
+	w := s.NewWatchStream()
 	defer w.Close()
 
 	idm := make(map[int64]struct{})


### PR DESCRIPTION
Watcher vs Watching in storage pkg is confusing. Watcher should be named
as watchStream since it contains a channel as stream to send out events.
Then we can rename watching to watcher, which actually watches on a key
and send watched events through watchStream.

This commits renames watcher to watchStram.

/cc @jonboulle @gyuho @heyitsanthony 