### PR TITLE
v3api: add support for sending watcher control response

### DIFF
--- a/etcdctlv3/command/watch_command.go
+++ b/etcdctlv3/command/watch_command.go
@@ -98,9 +98,15 @@ func recvLoop(wStream pb.Watch_WatchClient) {
 		if err != nil {
 			ExitWithError(ExitError, err)
 		}
-		evs := resp.Events
-		for _, ev := range evs {
-			fmt.Printf("%s: %s %s\n", ev.Type, string(ev.Kv.Key), string(ev.Kv.Value))
+
+		switch {
+		// TODO: handle canceled/compacted and other control response types
+		case resp.Created:
+			fmt.Printf("watcher created: id %08x\n", resp.WatchId)
+		default:
+			for _, ev := range resp.Events {
+				fmt.Printf("%s: %s %s\n", ev.Type, string(ev.Kv.Key), string(ev.Kv.Value))
+			}
 		}
 	}
 }


### PR DESCRIPTION
Client can create multiple watchers over one stream. We attach watchID on each response we sent to client, so that client can know the receiver of a response. 

Client also needs to know the mapping from watchID and a watcher created since ID is assigned by server.

We use a simple way to assign watchID inside one stream. We assign ID from 0. Also the watcher is created in sequential in side one stream. Client needs to record the create request it sent and when it receives a created response, it can easily map an id to a watcher.