### PR TITLE
*: support put with lease

### DIFF
--- a/etcdserver/v3demo_server.go
+++ b/etcdserver/v3demo_server.go
@@ -143,12 +143,12 @@ func applyPut(txnID int64, kv dstorage.KV, p *pb.PutRequest) (*pb.PutResponse, e
 		err error
 	)
 	if txnID != noTxn {
-		rev, err = kv.TxnPut(txnID, p.Key, p.Value)
+		rev, err = kv.TxnPut(txnID, p.Key, p.Value, dstorage.LeaseID(p.Lease))
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		rev = kv.Put(p.Key, p.Value)
+		rev = kv.Put(p.Key, p.Value, dstorage.LeaseID(p.Lease))
 	}
 	resp.Header.Revision = rev
 	return resp, nil

--- a/storage/consistent_watchable_store.go
+++ b/storage/consistent_watchable_store.go
@@ -59,9 +59,9 @@ func newConsistentWatchableStore(path string, ig ConsistentIndexGetter) *consist
 	}
 }
 
-func (s *consistentWatchableStore) Put(key, value []byte) (rev int64) {
+func (s *consistentWatchableStore) Put(key, value []byte, lease LeaseID) (rev int64) {
 	id := s.TxnBegin()
-	rev, err := s.TxnPut(id, key, value)
+	rev, err := s.TxnPut(id, key, value, lease)
 	if err != nil {
 		log.Panicf("unexpected TxnPut error (%v)", err)
 	}
@@ -109,11 +109,11 @@ func (s *consistentWatchableStore) TxnRange(txnID int64, key, end []byte, limit,
 	return s.watchableStore.TxnRange(txnID, key, end, limit, rangeRev)
 }
 
-func (s *consistentWatchableStore) TxnPut(txnID int64, key, value []byte) (rev int64, err error) {
+func (s *consistentWatchableStore) TxnPut(txnID int64, key, value []byte, lease LeaseID) (rev int64, err error) {
 	if s.skip {
 		return 0, nil
 	}
-	return s.watchableStore.TxnPut(txnID, key, value)
+	return s.watchableStore.TxnPut(txnID, key, value, lease)
 }
 
 func (s *consistentWatchableStore) TxnDeleteRange(txnID int64, key, end []byte) (n, rev int64, err error) {

--- a/storage/consistent_watchable_store_test.go
+++ b/storage/consistent_watchable_store_test.go
@@ -28,7 +28,7 @@ func TestConsistentWatchableStoreConsistentIndex(t *testing.T) {
 	tests := []uint64{1, 2, 3, 5, 10}
 	for i, tt := range tests {
 		idx = indexVal(tt)
-		s.Put([]byte("foo"), []byte("bar"))
+		s.Put([]byte("foo"), []byte("bar"), NoLease)
 
 		id := s.TxnBegin()
 		g := s.consistentIndex()
@@ -44,10 +44,10 @@ func TestConsistentWatchableStoreSkip(t *testing.T) {
 	s := newConsistentWatchableStore(tmpPath, &idx)
 	defer cleanup(s, tmpPath)
 
-	s.Put([]byte("foo"), []byte("bar"))
+	s.Put([]byte("foo"), []byte("bar"), NoLease)
 
 	// put is skipped
-	rev := s.Put([]byte("foo"), []byte("bar"))
+	rev := s.Put([]byte("foo"), []byte("bar"), NoLease)
 	if rev != 0 {
 		t.Errorf("rev = %d, want 0", rev)
 	}

--- a/storage/kv.go
+++ b/storage/kv.go
@@ -25,6 +25,8 @@ type CancelFunc func()
 
 type Snapshot backend.Snapshot
 
+type LeaseID int64
+
 type KV interface {
 	// Rev returns the current revision of the KV.
 	Rev() int64
@@ -37,9 +39,11 @@ type KV interface {
 	// If the required rev is compacted, ErrCompacted will be returned.
 	Range(key, end []byte, limit, rangeRev int64) (kvs []storagepb.KeyValue, rev int64, err error)
 
-	// Put puts the given key,value into the store.
+	// Put puts the given key, value into the store. Put also takes additional argument lease to
+	// attach a lease to a key-value pair as meta-data. KV implementation does not validate the lease
+	// id.
 	// A put also increases the rev of the store, and generates one event in the event history.
-	Put(key, value []byte) (rev int64)
+	Put(key, value []byte, lease LeaseID) (rev int64)
 
 	// DeleteRange deletes the given range from the store.
 	// A deleteRange increases the rev of the store if any key in the range exists.
@@ -57,7 +61,7 @@ type KV interface {
 	// TxnEnd ends the on-going txn with txn ID. If the on-going txn ID is not matched, error is returned.
 	TxnEnd(txnID int64) error
 	TxnRange(txnID int64, key, end []byte, limit, rangeRev int64) (kvs []storagepb.KeyValue, rev int64, err error)
-	TxnPut(txnID int64, key, value []byte) (rev int64, err error)
+	TxnPut(txnID int64, key, value []byte, lease LeaseID) (rev int64, err error)
 	TxnDeleteRange(txnID int64, key, end []byte) (n, rev int64, err error)
 
 	Compact(rev int64) error

--- a/storage/kvstore_bench_test.go
+++ b/storage/kvstore_bench_test.go
@@ -30,7 +30,7 @@ func BenchmarkStorePut(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.Put(keys[i], vals[i])
+		s.Put(keys[i], vals[i], NoLease)
 	}
 }
 
@@ -49,7 +49,7 @@ func BenchmarkStoreTxnPut(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		id := s.TxnBegin()
-		if _, err := s.TxnPut(id, keys[i], vals[i]); err != nil {
+		if _, err := s.TxnPut(id, keys[i], vals[i], NoLease); err != nil {
 			log.Fatalf("txn put error: %v", err)
 		}
 		s.TxnEnd(id)

--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -33,7 +33,7 @@ func TestStoreRev(t *testing.T) {
 	defer os.Remove(tmpPath)
 
 	for i := 0; i < 3; i++ {
-		s.Put([]byte("foo"), []byte("bar"))
+		s.Put([]byte("foo"), []byte("bar"), NoLease)
 		if r := s.Rev(); r != int64(i+1) {
 			t.Errorf("#%d: rev = %d, want %d", i, r, i+1)
 		}
@@ -61,6 +61,7 @@ func TestStorePut(t *testing.T) {
 				CreateRevision: 2,
 				ModRevision:    2,
 				Version:        1,
+				Lease:          1,
 			},
 			revision{2, 0},
 		},
@@ -75,6 +76,7 @@ func TestStorePut(t *testing.T) {
 				CreateRevision: 2,
 				ModRevision:    2,
 				Version:        2,
+				Lease:          2,
 			},
 			revision{2, 1},
 		},
@@ -89,6 +91,7 @@ func TestStorePut(t *testing.T) {
 				CreateRevision: 2,
 				ModRevision:    3,
 				Version:        3,
+				Lease:          3,
 			},
 			revision{3, 0},
 		},
@@ -102,7 +105,7 @@ func TestStorePut(t *testing.T) {
 		s.tx = b.BatchTx()
 		fi.indexGetRespc <- tt.r
 
-		s.put([]byte("foo"), []byte("bar"))
+		s.put([]byte("foo"), []byte("bar"), LeaseID(i+1))
 
 		data, err := tt.wkv.Marshal()
 		if err != nil {
@@ -357,9 +360,9 @@ func TestRestoreContinueUnfinishedCompaction(t *testing.T) {
 	s0 := newDefaultStore(tmpPath)
 	defer os.Remove(tmpPath)
 
-	s0.Put([]byte("foo"), []byte("bar"))
-	s0.Put([]byte("foo"), []byte("bar1"))
-	s0.Put([]byte("foo"), []byte("bar2"))
+	s0.Put([]byte("foo"), []byte("bar"), NoLease)
+	s0.Put([]byte("foo"), []byte("bar1"), NoLease)
+	s0.Put([]byte("foo"), []byte("bar2"), NoLease)
 
 	// write scheduled compaction, but not do compaction
 	rbytes := newRevBytes()
@@ -416,7 +419,7 @@ func TestTxnPut(t *testing.T) {
 		id := s.TxnBegin()
 		base := int64(i + 1)
 
-		rev, err := s.TxnPut(id, keys[i], vals[i])
+		rev, err := s.TxnPut(id, keys[i], vals[i], NoLease)
 		if err != nil {
 			t.Error("txn put error")
 		}

--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -65,11 +65,11 @@ func newWatchableStore(path string) *watchableStore {
 	return s
 }
 
-func (s *watchableStore) Put(key, value []byte) (rev int64) {
+func (s *watchableStore) Put(key, value []byte, lease LeaseID) (rev int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	rev = s.store.Put(key, value)
+	rev = s.store.Put(key, value, lease)
 	// TODO: avoid this range
 	kvs, _, err := s.store.Range(key, nil, 0, rev)
 	if err != nil {
@@ -111,8 +111,8 @@ func (s *watchableStore) TxnBegin() int64 {
 	return s.store.TxnBegin()
 }
 
-func (s *watchableStore) TxnPut(txnID int64, key, value []byte) (rev int64, err error) {
-	rev, err = s.store.TxnPut(txnID, key, value)
+func (s *watchableStore) TxnPut(txnID int64, key, value []byte, lease LeaseID) (rev int64, err error) {
+	rev, err = s.store.TxnPut(txnID, key, value, lease)
 	if err == nil {
 		s.tx.put(string(key))
 	}

--- a/storage/watchable_store_bench_test.go
+++ b/storage/watchable_store_bench_test.go
@@ -52,7 +52,7 @@ func BenchmarkWatchableStoreUnsyncedCancel(b *testing.B) {
 	// and force watchers to be in unsynced.
 	testKey := []byte("foo")
 	testValue := []byte("bar")
-	s.Put(testKey, testValue)
+	s.Put(testKey, testValue, NoLease)
 
 	w := s.NewWatchStream()
 
@@ -90,7 +90,7 @@ func BenchmarkWatchableStoreSyncedCancel(b *testing.B) {
 	// Put a key so that we can spawn watchers on that key
 	testKey := []byte("foo")
 	testValue := []byte("bar")
-	s.Put(testKey, testValue)
+	s.Put(testKey, testValue, NoLease)
 
 	w := s.NewWatchStream()
 

--- a/storage/watchable_store_test.go
+++ b/storage/watchable_store_test.go
@@ -31,7 +31,7 @@ func TestWatch(t *testing.T) {
 	}()
 	testKey := []byte("foo")
 	testValue := []byte("bar")
-	s.Put(testKey, testValue)
+	s.Put(testKey, testValue, NoLease)
 
 	w := s.NewWatchStream()
 	w.Watch(testKey, true, 0)
@@ -50,7 +50,7 @@ func TestNewWatcherCancel(t *testing.T) {
 	}()
 	testKey := []byte("foo")
 	testValue := []byte("bar")
-	s.Put(testKey, testValue)
+	s.Put(testKey, testValue, NoLease)
 
 	w := s.NewWatchStream()
 	_, cancel := w.Watch(testKey, true, 0)
@@ -89,7 +89,7 @@ func TestCancelUnsynced(t *testing.T) {
 	// and force watchers to be in unsynced.
 	testKey := []byte("foo")
 	testValue := []byte("bar")
-	s.Put(testKey, testValue)
+	s.Put(testKey, testValue, NoLease)
 
 	w := s.NewWatchStream()
 
@@ -135,7 +135,7 @@ func TestSyncWatchers(t *testing.T) {
 
 	testKey := []byte("foo")
 	testValue := []byte("bar")
-	s.Put(testKey, testValue)
+	s.Put(testKey, testValue, NoLease)
 
 	w := s.NewWatchStream()
 
@@ -210,7 +210,7 @@ func TestUnsafeAddWatcher(t *testing.T) {
 	}()
 	testKey := []byte("foo")
 	testValue := []byte("bar")
-	s.Put(testKey, testValue)
+	s.Put(testKey, testValue, NoLease)
 
 	size := 10
 	ws := make([]*watcher, size)

--- a/storage/watcher_test.go
+++ b/storage/watcher_test.go
@@ -34,7 +34,7 @@ func TestWatcherWatchID(t *testing.T) {
 		}
 		idm[id] = struct{}{}
 
-		s.Put([]byte("foo"), []byte("bar"))
+		s.Put([]byte("foo"), []byte("bar"), NoLease)
 
 		resp := <-w.Chan()
 		if resp.WatchID != id {
@@ -44,7 +44,7 @@ func TestWatcherWatchID(t *testing.T) {
 		cancel()
 	}
 
-	s.Put([]byte("foo2"), []byte("bar"))
+	s.Put([]byte("foo2"), []byte("bar"), NoLease)
 
 	// unsynced watchers
 	for i := 10; i < 20; i++ {

--- a/tools/benchmark/cmd/storage-put.go
+++ b/tools/benchmark/cmd/storage-put.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/etcd/storage"
 )
 
 // storagePutCmd represents a storage put performance benchmarking tool
@@ -72,13 +73,13 @@ func storagePutFunc(cmd *cobra.Command, args []string) {
 
 		if txn {
 			id := s.TxnBegin()
-			if _, err := s.TxnPut(id, keys[i], vals[i]); err != nil {
+			if _, err := s.TxnPut(id, keys[i], vals[i], storage.NoLease); err != nil {
 				fmt.Errorf("txn put error: %v", err)
 				os.Exit(1)
 			}
 			s.TxnEnd(id)
 		} else {
-			s.Put(keys[i], vals[i])
+			s.Put(keys[i], vals[i], storage.NoLease)
 		}
 
 		end := time.Now()


### PR DESCRIPTION
Now we persist the lease attached to each kv.