### PR TITLE
storage: fix watchable_store notify to hash-lookup once

### DIFF
--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -375,10 +375,10 @@ func (s *watchableStore) notify(rev int64, evs []storagepb.Event) {
 	we := newWatcherToEventMap(s.synced, evs)
 	for _, wm := range s.synced {
 		for w := range wm {
-			if _, ok := we[w]; !ok {
+			es, ok := we[w]
+			if !ok {
 				continue
 			}
-			es := we[w]
 			wr := WatchResponse{WatchID: w.id, Events: es}
 			select {
 			case w.ch <- wr:


### PR DESCRIPTION
We should just assign events and `ok` at first, and check the
boolean value, instead of looking up the map twice.

/cc @xiang90 @heyitsanthony 

Thanks,