### PR TITLE
pkg/transport: support listeners on unix sockets

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -26,7 +26,13 @@ import (
 )
 
 func NewListener(addr string, scheme string, info TLSInfo) (net.Listener, error) {
-	l, err := net.Listen("tcp", addr)
+	nettype := "tcp"
+	if scheme == "unix" {
+		// unix sockets via unix://laddr
+		nettype = scheme
+	}
+
+	l, err := net.Listen(nettype, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/transport/listener_test.go
+++ b/pkg/transport/listener_test.go
@@ -241,3 +241,11 @@ func TestTLSInfoConfigFuncs(t *testing.T) {
 		}
 	}
 }
+
+func TestNewListenerUnixSocket(t *testing.T) {
+	l, err := NewListener("testsocket", "unix", TLSInfo{})
+	if err != nil {
+		t.Errorf("error listening on unix socket (%v)", err)
+	}
+	l.Close()
+}


### PR DESCRIPTION
Given unix://socketname, NewListener will listen on unix socket "socketname".
This is useful when binding to tcp ports is undesirable (e.g., testing).