### PR TITLE
*: get snapshot from backend

### DIFF
--- a/etcdserver/snapshot_merge.go
+++ b/etcdserver/snapshot_merge.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/coreos/etcd/snap"
-	dstorage "github.com/coreos/etcd/storage"
+	"github.com/coreos/etcd/storage/backend"
 )
 
 // createMergedSnapshotMessage creates a snapshot message that contains: raft status (term, conf),
@@ -40,7 +40,7 @@ func (s *EtcdServer) createMergedSnapshotMessage(m raftpb.Message, snapi uint64,
 	}
 
 	// get a snapshot of v3 KV as readCloser
-	rc := newSnapshotReaderCloser(s.kv.Snapshot())
+	rc := newSnapshotReaderCloser(s.be.Snapshot())
 
 	// put the []byte snapshot of store into raft snapshot and return the merged snapshot with
 	// KV readCloser snapshot.
@@ -57,7 +57,7 @@ func (s *EtcdServer) createMergedSnapshotMessage(m raftpb.Message, snapi uint64,
 	return *snap.NewMessage(m, rc)
 }
 
-func newSnapshotReaderCloser(snapshot dstorage.Snapshot) io.ReadCloser {
+func newSnapshotReaderCloser(snapshot backend.Snapshot) io.ReadCloser {
 	pr, pw := io.Pipe()
 	go func() {
 		_, err := snapshot.WriteTo(pw)

--- a/storage/backend/backend.go
+++ b/storage/backend/backend.go
@@ -105,6 +105,7 @@ func (b *backend) ForceCommit() {
 }
 
 func (b *backend) Snapshot() Snapshot {
+	b.batchTx.Commit()
 	tx, err := b.db.Begin(false)
 	if err != nil {
 		log.Fatalf("storage: cannot begin tx (%s)", err)

--- a/storage/kv.go
+++ b/storage/kv.go
@@ -20,8 +20,6 @@ import (
 	"github.com/coreos/etcd/storage/storagepb"
 )
 
-type Snapshot backend.Snapshot
-
 type KV interface {
 	// Rev returns the current revision of the KV.
 	Rev() int64
@@ -64,9 +62,6 @@ type KV interface {
 	// Get the hash of KV state.
 	// This method is designed for consistency checking purpose.
 	Hash() (uint32, error)
-
-	// Snapshot snapshots the full KV store.
-	Snapshot() Snapshot
 
 	// Commit commits txns into the underlying backend.
 	Commit()

--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -714,7 +714,7 @@ func TestKVSnapshot(t *testing.T) {
 	}
 	defer os.Remove(newPath)
 
-	snap := s.Snapshot()
+	snap := s.b.Snapshot()
 	defer snap.Close()
 	_, err = snap.WriteTo(f)
 	if err != nil {

--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -235,11 +235,6 @@ func (s *store) Hash() (uint32, error) {
 	return s.b.Hash()
 }
 
-func (s *store) Snapshot() Snapshot {
-	s.b.ForceCommit()
-	return s.b.Snapshot()
-}
-
 func (s *store) Commit() { s.b.ForceCommit() }
 
 func (s *store) Restore(b backend.Backend) error {


### PR DESCRIPTION
We should get snapshot from backend, not just KV.
We plan to store the lease data into backend too.