### PR TITLE
hack/benchmark: set readall flag true to reuse TCP connections

### DIFF
--- a/hack/benchmark/README.md
+++ b/hack/benchmark/README.md
@@ -4,6 +4,12 @@ Benchmark 3-member etcd cluster to get its read and write performance.
 
 ## Instructions
 
+First install `boom` with:
+
+```
+go get -u github.com/rakyll/boom
+```
+
 1. Start 3-member etcd cluster on 3 machines
 2. Update `$leader` and `$servers` in the script
 3. Run the script in a separate machine

--- a/hack/benchmark/bench.sh
+++ b/hack/benchmark/bench.sh
@@ -9,17 +9,17 @@ keyarray=( 64 256 )
 for keysize in ${keyarray[@]}; do
 
   echo write, 1 client, $keysize key size, to leader
-  ./boom -m PUT -n 10 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 1 -T application/x-www-form-urlencoded $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
+  ./boom -readall=true -m PUT -n 10 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 1 -T application/x-www-form-urlencoded $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
 
   echo write, 64 client, $keysize key size, to leader
-  ./boom -m PUT -n 640 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 64 -T application/x-www-form-urlencoded $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
+  ./boom -readall=true -m PUT -n 640 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 64 -T application/x-www-form-urlencoded $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
 
   echo write, 256 client, $keysize key size, to leader
-  ./boom -m PUT -n 2560 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 256 -T application/x-www-form-urlencoded $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
+  ./boom -readall=true -m PUT -n 2560 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 256 -T application/x-www-form-urlencoded $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
 
   echo write, 64 client, $keysize key size, to all servers
   for i in ${servers[@]}; do
-    ./boom -m PUT -n 210 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 21 -T application/x-www-form-urlencoded $i/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo &
+    ./boom -readall=true -m PUT -n 210 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 21 -T application/x-www-form-urlencoded $i/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo &
   done
   # wait for all booms to start running
   sleep 3
@@ -32,7 +32,7 @@ for keysize in ${keyarray[@]}; do
 
   echo write, 256 client, $keysize key size, to all servers
   for i in ${servers[@]}; do
-    ./boom -m PUT -n 850 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 85 -T application/x-www-form-urlencoded $i/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo &
+    ./boom -readall=true -m PUT -n 850 -d value=`head -c $keysize < /dev/zero | tr '\0' '\141'` -c 85 -T application/x-www-form-urlencoded $i/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo &
   done
   sleep 3
   for pid in $(pgrep 'boom'); do
@@ -42,24 +42,24 @@ for keysize in ${keyarray[@]}; do
   done
 
   echo read, 1 client, $keysize key size, to leader
-  ./boom -n 100 -c 1 $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
+  ./boom -readall=true -n 100 -c 1 $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
 
   echo read, 64 client, $keysize key size, to leader
-  ./boom -n 6400 -c 64 $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
+  ./boom -readall=true -n 6400 -c 64 $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
 
   echo read, 256 client, $keysize key size, to leader
-  ./boom -n 25600 -c 256 $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
+  ./boom -readall=true -n 25600 -c 256 $leader/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
 
   echo read, 64 client, $keysize key size, to all servers
   # bench servers one by one, so it doesn't overload this benchmark machine
   # It doesn't impact correctness because read request doesn't involve peer interaction.
   for i in ${servers[@]}; do
-    ./boom -n 21000 -c 21 $i/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
+    ./boom -readall=true -n 21000 -c 21 $i/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
   done
 
   echo read, 256 client, $keysize key size, to all servers
   for i in ${servers[@]}; do
-    ./boom -n 85000 -c 85 $i/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
+    ./boom -readall=true -n 85000 -c 85 $i/v2/keys/foo | grep -e "Requests/sec" -e "Latency" -e "90%" | tr "\n" "\t" | xargs echo
   done
 
 done


### PR DESCRIPTION
readall flags ensures that client reads until response is complete.
This helps reuse the same TCP connections, therefore decreasing
TIME_WAIT states in benchmark.

Related to https://github.com/coreos/etcd/issues/4172.