### PR TITLE
store: handle watch dir removal correctly

### DIFF
--- a/store/event_history.go
+++ b/store/event_history.go
@@ -90,6 +90,10 @@ func (eh *EventHistory) scan(key string, recursive bool, index uint64) (*Event, 
 			ok = ok || strings.HasPrefix(e.Node.Key, key)
 		}
 
+		if (e.Action == Delete || e.Action == Expire) && e.PrevNode != nil && e.PrevNode.Dir {
+			ok = ok || strings.HasPrefix(key, e.PrevNode.Key)
+		}
+
 		if ok {
 			return e, nil
 		}

--- a/store/event_test.go
+++ b/store/event_test.go
@@ -14,9 +14,7 @@
 
 package store
 
-import (
-	"testing"
-)
+import "testing"
 
 // TestEventQueue tests a queue with capacity = 100
 // Add 200 events into that queue, and test if the
@@ -55,6 +53,11 @@ func TestScanHistory(t *testing.T) {
 	eh.addEvent(newEvent(Create, "/foo/bar/bar", 4, 4))
 	eh.addEvent(newEvent(Create, "/foo/foo/foo", 5, 5))
 
+	// Delete a dir
+	de := newEvent(Delete, "/foo", 6, 6)
+	de.PrevNode = newDir(nil, "/foo", 1, nil, Permanent).Repr(false, false, nil)
+	eh.addEvent(de)
+
 	e, err := eh.scan("/foo", false, 1)
 	if err != nil || e.Index() != 1 {
 		t.Fatalf("scan error [/foo] [1] %v", e.Index)
@@ -72,8 +75,12 @@ func TestScanHistory(t *testing.T) {
 		t.Fatalf("scan error [/foo/bar/bar] [4] %v", e.Index)
 	}
 
-	e, err = eh.scan("/foo/bar", true, 6)
+	e, err = eh.scan("/foo/foo/foo", false, 6)
+	if err != nil || e.Index() != 6 {
+		t.Fatalf("scan error [/foo/foo/foo] [6] %v", e.Index)
+	}
 
+	e, err = eh.scan("/foo/bar", true, 7)
 	if e != nil {
 		t.Fatalf("bad index shoud reuturn nil")
 	}


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/1160.

The deleting dir event should match the watch if the watched key is inside the deleted dir.