### PR TITLE
etcdctl, etcdctlv3: add help message for non-valid value arg

### DIFF
--- a/etcdctl/command/set_command.go
+++ b/etcdctl/command/set_command.go
@@ -29,6 +29,12 @@ func NewSetCommand() cli.Command {
 		Name:      "set",
 		Usage:     "set the value of a key",
 		ArgsUsage: "<key> <value>",
+		Description: `Set sets the value of a key.
+
+   When <value> begins with '-', <value> is interpreted as a flag.
+   Insert '--' for workaround:
+
+   $ set -- <key> <value>`,
 		Flags: []cli.Flag{
 			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live"},
 			cli.StringFlag{Name: "swap-with-value", Value: "", Usage: "previous value"},

--- a/etcdctlv3/command/put_command.go
+++ b/etcdctlv3/command/put_command.go
@@ -31,9 +31,18 @@ var (
 // NewPutCommand returns the cobra command for "put".
 func NewPutCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "put",
+		Use:   "put [options] <key> <value>",
 		Short: "Put puts the given key into the store.",
-		Run:   putCommandFunc,
+		Long: `
+Put puts the given key into the store.
+
+When <value> begins with '-', <value> is interpreted as a flag.
+Insert '--' for workaround:
+
+$ put <key> -- <value>
+$ put -- <key> <value>
+`,
+		Run: putCommandFunc,
 	}
 	cmd.Flags().StringVar(&leaseStr, "lease", "0", "lease ID attached to the put key")
 	return cmd


### PR DESCRIPTION
Unix commands interpret argument value of first character '-'
as a flag. And this won't be fixed in our upstream CLI libraries.
This adds help message to show users workarounds.

Addressing https://github.com/coreos/etcd/issues/2020.