### PR TITLE
testutil: fix data race in RecorderBuffered

### DIFF
--- a/pkg/testutil/recorder.go
+++ b/pkg/testutil/recorder.go
@@ -61,7 +61,7 @@ func (r *RecorderBuffered) Wait(n int) (acts []Action, err error) {
 	WaitSchedule()
 	acts = r.Action()
 	if len(acts) < n {
-		err = newLenErr(n, len(r.actions))
+		err = newLenErr(n, len(acts))
 	}
 	return acts, err
 }


### PR DESCRIPTION
Was accessing a shared data structure instead of the private copy.

Fixes #4198