### PR TITLE
storage: extend timeout for slow CI

### DIFF
--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -455,7 +456,11 @@ func TestTxnBlockBackendForceCommit(t *testing.T) {
 	s.TxnEnd(id)
 	select {
 	case <-done:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second): // wait 5 seconds for CI with slow IO
+		// print out stack traces of all routines if there is a failure
+		stackTrace := make([]byte, 8*1024)
+		n := runtime.Stack(stackTrace, true)
+		t.Error(string(stackTrace[:n]))
 		t.Fatalf("failed to execute ForceCommit")
 	}
 }


### PR DESCRIPTION
1. extend timeout

2. print out stacktrace. When it fails again, we can get more confidence that the
failure is caused by slow IO.

Fix https://github.com/coreos/etcd/issues/4057

/cc @gyuho @heyitsanthony 