### PR TITLE
integration: fix race in WatchFromCurrentRevision

### DIFF
--- a/integration/v3_grpc_test.go
+++ b/integration/v3_grpc_test.go
@@ -369,6 +369,10 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			t.Fatalf("#%d: wAPI.Watch error: %v", i, err)
 		}
 
+		if err := wStream.Send(tt.watchRequest); err != nil {
+			t.Fatalf("#%d: wStream.Send error: %v", i, err)
+		}
+
 		go func() {
 			for _, k := range tt.putKeys {
 				kvc := pb.NewKVClient(clus.RandConn())
@@ -378,10 +382,6 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 				}
 			}
 		}()
-
-		if err := wStream.Send(tt.watchRequest); err != nil {
-			t.Fatalf("#%d: wStream.Send error: %v", i, err)
-		}
 
 		var createdWatchId int64
 		for j, wresp := range tt.wresps {


### PR DESCRIPTION
Since watching from current revision, keys should be put after the
watcher is registered or the test may time out. Shows up in CI.