### PR TITLE
Godep: temporary fix for arm64 build

### DIFF
--- a/Godeps/_workspace/src/github.com/boltdb/bolt/bolt_arm64.go
+++ b/Godeps/_workspace/src/github.com/boltdb/bolt/bolt_arm64.go
@@ -1,5 +1,3 @@
-// +build arm64
-
 package bolt
 
 // maxMapSize represents the largest mmap size supported by Bolt.


### PR DESCRIPTION
Addressing https://github.com/boltdb/bolt/pull/491.

We have a pending issue before we introduce other changes in boltdb.
This is temporary fix. Will be overwritten later by `godep update`.

I will write boltdb related issues.