### PR TITLE
raft: Call maybeCommit after removing a node

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -826,6 +826,9 @@ func (r *raft) addNode(id uint64) {
 func (r *raft) removeNode(id uint64) {
 	r.delProgress(id)
 	r.pendingConf = false
+	// The quorum size is now smaller, so see if any pending entries can
+	// be committed.
+	r.maybeCommit()
 }
 
 func (r *raft) resetPendingConf() { r.pendingConf = false }

--- a/raft/util.go
+++ b/raft/util.go
@@ -65,13 +65,19 @@ func DescribeMessage(m pb.Message, f EntryFormatter) string {
 	fmt.Fprintf(&buf, "%x->%x %v Term:%d Log:%d/%d", m.From, m.To, m.Type, m.Term, m.LogTerm, m.Index)
 	if m.Reject {
 		fmt.Fprintf(&buf, " Rejected")
+		if m.RejectHint != 0 {
+			fmt.Fprintf(&buf, "(Hint:%d)", m.RejectHint)
+		}
 	}
 	if m.Commit != 0 {
 		fmt.Fprintf(&buf, " Commit:%d", m.Commit)
 	}
 	if len(m.Entries) > 0 {
 		fmt.Fprintf(&buf, " Entries:[")
-		for _, e := range m.Entries {
+		for i, e := range m.Entries {
+			if i != 0 {
+				buf.WriteString(", ")
+			}
 			buf.WriteString(DescribeEntry(e, f))
 		}
 		fmt.Fprintf(&buf, "]")


### PR DESCRIPTION
removeNode reduces the required quorum size, so some pending entries may
be able to commit after it is applied.

Discovered in cockroachdb/cockroach#3642