### PR TITLE
etcdctl: add an option to ls for consistent result

### DIFF
--- a/etcdctl/command/ls_command.go
+++ b/etcdctl/command/ls_command.go
@@ -30,6 +30,7 @@ func NewLsCommand() cli.Command {
 			cli.BoolFlag{Name: "sort", Usage: "returns result in sorted order"},
 			cli.BoolFlag{Name: "recursive", Usage: "returns all key names recursively for the given path"},
 			cli.BoolFlag{Name: "p", Usage: "append slash (/) to directories"},
+			cli.BoolFlag{Name: "quorum", Usage: "require quorum for get request"},
 		},
 		Action: func(c *cli.Context) {
 			lsCommandFunc(c, mustNewKeyAPI(c))
@@ -46,9 +47,10 @@ func lsCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	sort := c.Bool("sort")
 	recursive := c.Bool("recursive")
+	quorum := c.Bool("quorum")
 
 	ctx, cancel := contextWithTotalTimeout(c)
-	resp, err := ki.Get(ctx, key, &client.GetOptions{Sort: sort, Recursive: recursive})
+	resp, err := ki.Get(ctx, key, &client.GetOptions{Sort: sort, Recursive: recursive, Quorum: quorum})
 	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)


### PR DESCRIPTION
Like the commit 11f49a09605b, this commit adds a new option "--quorum"
to etcdctl ls command. It is required for obtaining a consistent
result.