### PR TITLE
pkg/testutil: fix unreachable govet complain

### DIFF
--- a/pkg/testutil/recorder.go
+++ b/pkg/testutil/recorder.go
@@ -100,7 +100,6 @@ func (r *recorderStream) Action() (acts []Action) {
 			return acts
 		}
 	}
-	return acts
 }
 
 func (r *recorderStream) Chan() <-chan Action {


### PR DESCRIPTION
go tool vet *.go complains the return statement
at the end is unreachable.