### PR TITLE
readme: link to raft.github.io instead of raftconsensus.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ etcd is used [in production by many companies](./Documentation/production-users.
 See [etcdctl][etcdctl] for a simple command line client.
 Or feel free to just use `curl`, as in the examples below.
 
-[raft]: http://raftconsensus.github.io/
+[raft]: https://raft.github.io/
 [k8s]: http://kubernetes.io/
 [fleet]: https://github.com/coreos/fleet
 [locksmith]: https://github.com/coreos/locksmith


### PR DESCRIPTION
When browsing to raftconsensus.github.io, it shows a banner and says "This website has moved to https://raft.github.io/" (and redirects to it).

Also, TLS :)