### PR TITLE
etcdserver, auth: not cache a flag of auth status

### DIFF
--- a/etcdserver/auth/auth.go
+++ b/etcdserver/auth/auth.go
@@ -102,8 +102,7 @@ type store struct {
 	timeout     time.Duration
 	ensuredOnce bool
 
-	mu      sync.Mutex // protect enabled
-	enabled *bool
+	mu sync.Mutex // protect enabled
 
 	PasswordStore
 }
@@ -440,8 +439,6 @@ func (s *store) EnableAuth() error {
 		return err
 	}
 
-	b := true
-	s.enabled = &b
 	plog.Noticef("auth: enabled auth")
 	return nil
 }
@@ -456,8 +453,6 @@ func (s *store) DisableAuth() error {
 
 	err := s.disableAuth()
 	if err == nil {
-		b := false
-		s.enabled = &b
 		plog.Noticef("auth: disabled auth")
 	} else {
 		plog.Errorf("error disabling auth (%v)", err)

--- a/etcdserver/auth/auth_requests.go
+++ b/etcdserver/auth/auth_requests.go
@@ -85,15 +85,10 @@ func (s *store) detectAuth() bool {
 	if s.server == nil {
 		return false
 	}
-	if s.enabled != nil {
-		return *s.enabled
-	}
 	value, err := s.requestResource("/enabled", false)
 	if err != nil {
 		if e, ok := err.(*etcderr.Error); ok {
 			if e.ErrorCode == etcderr.EcodeKeyNotFound {
-				b := false
-				s.enabled = &b
 				return false
 			}
 		}
@@ -107,7 +102,6 @@ func (s *store) detectAuth() bool {
 		plog.Errorf("internal bookkeeping value for enabled isn't valid JSON (%v)", err)
 		return false
 	}
-	s.enabled = &u
 	return u
 }
 

--- a/etcdserver/auth/auth_test.go
+++ b/etcdserver/auth/auth_test.go
@@ -615,8 +615,6 @@ func TestDisableAuth(t *testing.T) {
 		t.Error("Expected error; already disabled")
 	}
 
-	// clear cache
-	s.enabled = nil
 	err = s.DisableAuth()
 	if err != nil {
 		t.Error("Unexpected error", err)


### PR DESCRIPTION
This commit removes a flag that indicates auth is enabled or disabled
because it doesn't have an invalidation mechanism.

Fixes https://github.com/coreos/etcd/issues/3601 and https://github.com/coreos/etcd/issues/3964