### PR TITLE
raft: Always call bcastAppend after maybeCommit

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -360,6 +360,9 @@ func (r *raft) bcastHeartbeat() {
 	}
 }
 
+// maybeCommit attempts to advance the commit index. Returns true if
+// the commit index changed (in which case the caller should call
+// r.bcastAppend).
 func (r *raft) maybeCommit() bool {
 	// TODO(bmizerany): optimize.. Currently naive
 	mis := make(uint64Slice, 0, len(r.prs))
@@ -399,6 +402,7 @@ func (r *raft) appendEntry(es ...pb.Entry) {
 	}
 	r.raftLog.append(es...)
 	r.prs[r.id].maybeUpdate(r.raftLog.lastIndex())
+	// Regardless of maybeCommit's return, our caller will call bcastAppend.
 	r.maybeCommit()
 }
 
@@ -828,7 +832,9 @@ func (r *raft) removeNode(id uint64) {
 	r.pendingConf = false
 	// The quorum size is now smaller, so see if any pending entries can
 	// be committed.
-	r.maybeCommit()
+	if r.maybeCommit() {
+		r.bcastAppend()
+	}
 }
 
 func (r *raft) resetPendingConf() { r.pendingConf = false }


### PR DESCRIPTION
Mentioned in #4278, although not apparently linked to any test failure.

I tried moving most `bcastAppend` calls into `appendEntry` but that caused a bunch of tests to fail.