### PR TITLE
etcdserver/test: synchronously wait on TestApplySnapshotAndCommittedE…

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1019,7 +1019,7 @@ func TestRecvSnapshot(t *testing.T) {
 // first and then committed entries.
 func TestApplySnapshotAndCommittedEntries(t *testing.T) {
 	n := newNopReadyNode()
-	st := store.NewRecorder()
+	st := store.NewRecorderStream()
 	cl := newCluster("abc")
 	cl.SetStore(store.New())
 	storage := raft.NewMemoryStorage()

--- a/store/store.go
+++ b/store/store.go
@@ -756,13 +756,17 @@ type StoreRecorder struct {
 // It always returns invalid empty response and no error.
 type storeRecorder struct {
 	Store
-	testutil.RecorderBuffered
+	testutil.Recorder
 }
 
-func NewNop() Store { return &storeRecorder{} }
+func NewNop() Store { return &storeRecorder{Recorder: &testutil.RecorderBuffered{}} }
 func NewRecorder() *StoreRecorder {
-	sr := &storeRecorder{}
-	return &StoreRecorder{Store: sr, Recorder: sr}
+	sr := &storeRecorder{Recorder: &testutil.RecorderBuffered{}}
+	return &StoreRecorder{Store: sr, Recorder: sr.Recorder}
+}
+func NewRecorderStream() *StoreRecorder {
+	sr := &storeRecorder{Recorder: testutil.NewRecorderStream()}
+	return &StoreRecorder{Store: sr, Recorder: sr.Recorder}
 }
 
 func (s *storeRecorder) Version() int  { return 0 }
@@ -856,7 +860,8 @@ type errStoreRecorder struct {
 
 func NewErrRecorder(err error) *StoreRecorder {
 	sr := &errStoreRecorder{err: err}
-	return &StoreRecorder{Store: sr, Recorder: sr}
+	sr.Recorder = &testutil.RecorderBuffered{}
+	return &StoreRecorder{Store: sr, Recorder: sr.Recorder}
 }
 
 func (s *errStoreRecorder) Get(path string, recursive, sorted bool) (*Event, error) {


### PR DESCRIPTION
…ntries

Replaces the RecorderBuffered with a RecorderStream so Wait will block
waiting for updates to the etcdserver store.

Fixes #4296