### PR TITLE
etcdserver: move the auth mechanism to etcdserver

### DIFF
--- a/etcdserver/auth_request.go
+++ b/etcdserver/auth_request.go
@@ -84,10 +84,17 @@ func (s *authStore) detectAuth() bool {
 	if s.server == nil {
 		return false
 	}
+
+	if s.enabled != nil {
+		return *s.enabled
+	}
+
 	value, err := s.requestResource("/enabled", false)
 	if err != nil {
 		if e, ok := err.(*etcderr.Error); ok {
 			if e.ErrorCode == etcderr.EcodeKeyNotFound {
+				b := false
+				s.enabled = &b
 				return false
 			}
 		}
@@ -101,6 +108,7 @@ func (s *authStore) detectAuth() bool {
 		plog.Errorf("internal bookkeeping value for enabled isn't valid JSON (%v)", err)
 		return false
 	}
+	s.enabled = &u
 	return u
 }
 
@@ -112,6 +120,7 @@ func (s *authStore) requestResource(res string, dir bool) (Response, error) {
 		Method: "GET",
 		Path:   p,
 		Dir:    dir,
+		Quorum: true,
 	}
 	return s.server.Do(ctx, rr)
 }

--- a/etcdserver/auth_request.go
+++ b/etcdserver/auth_request.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package auth
+package etcdserver
 
 import (
 	"encoding/json"
@@ -20,11 +20,10 @@ import (
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	etcderr "github.com/coreos/etcd/error"
-	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 )
 
-func (s *store) ensureAuthDirectories() error {
+func (s *authStore) ensureAuthDirectories() error {
 	if s.ensuredOnce {
 		return nil
 	}
@@ -72,16 +71,16 @@ func (s *store) ensureAuthDirectories() error {
 	return nil
 }
 
-func (s *store) enableAuth() error {
+func (s *authStore) enableAuth() error {
 	_, err := s.updateResource("/enabled", true)
 	return err
 }
-func (s *store) disableAuth() error {
+func (s *authStore) disableAuth() error {
 	_, err := s.updateResource("/enabled", false)
 	return err
 }
 
-func (s *store) detectAuth() bool {
+func (s *authStore) detectAuth() bool {
 	if s.server == nil {
 		return false
 	}
@@ -105,7 +104,7 @@ func (s *store) detectAuth() bool {
 	return u
 }
 
-func (s *store) requestResource(res string, dir bool) (etcdserver.Response, error) {
+func (s *authStore) requestResource(res string, dir bool) (Response, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
 	defer cancel()
 	p := path.Join(StorePermsPrefix, res)
@@ -117,22 +116,22 @@ func (s *store) requestResource(res string, dir bool) (etcdserver.Response, erro
 	return s.server.Do(ctx, rr)
 }
 
-func (s *store) updateResource(res string, value interface{}) (etcdserver.Response, error) {
+func (s *authStore) updateResource(res string, value interface{}) (Response, error) {
 	return s.setResource(res, value, true)
 }
-func (s *store) createResource(res string, value interface{}) (etcdserver.Response, error) {
+func (s *authStore) createResource(res string, value interface{}) (Response, error) {
 	return s.setResource(res, value, false)
 }
-func (s *store) setResource(res string, value interface{}, prevexist bool) (etcdserver.Response, error) {
+func (s *authStore) setResource(res string, value interface{}, prevexist bool) (Response, error) {
 	err := s.ensureAuthDirectories()
 	if err != nil {
-		return etcdserver.Response{}, err
+		return Response{}, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
 	defer cancel()
 	data, err := json.Marshal(value)
 	if err != nil {
-		return etcdserver.Response{}, err
+		return Response{}, err
 	}
 	p := path.Join(StorePermsPrefix, res)
 	rr := etcdserverpb.Request{
@@ -144,10 +143,10 @@ func (s *store) setResource(res string, value interface{}, prevexist bool) (etcd
 	return s.server.Do(ctx, rr)
 }
 
-func (s *store) deleteResource(res string) (etcdserver.Response, error) {
+func (s *authStore) deleteResource(res string) (Response, error) {
 	err := s.ensureAuthDirectories()
 	if err != nil {
-		return etcdserver.Response{}, err
+		return Response{}, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
 	defer cancel()

--- a/etcdserver/auth_test.go
+++ b/etcdserver/auth_test.go
@@ -614,6 +614,8 @@ func TestDisableAuth(t *testing.T) {
 		t.Error("Expected error; already disabled")
 	}
 
+	// clear cache
+	s.enabled = nil
 	err = s.DisableAuth()
 	if err != nil {
 		t.Error("Unexpected error", err)

--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -62,6 +62,7 @@ func NewClientHandler(server *etcdserver.EtcdServer, timeout time.Duration) http
 	go capabilityLoop(server)
 
 	sec := etcdserver.NewAuthStore(server, timeout)
+	sec.InitPointerOfServer(server)
 
 	kh := &keysHandler{
 		sec:     sec,

--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -34,7 +34,6 @@ import (
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	etcdErr "github.com/coreos/etcd/error"
 	"github.com/coreos/etcd/etcdserver"
-	"github.com/coreos/etcd/etcdserver/auth"
 	"github.com/coreos/etcd/etcdserver/etcdhttp/httptypes"
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/etcdserver/stats"
@@ -62,7 +61,7 @@ const (
 func NewClientHandler(server *etcdserver.EtcdServer, timeout time.Duration) http.Handler {
 	go capabilityLoop(server)
 
-	sec := auth.NewStore(server, timeout)
+	sec := etcdserver.NewAuthStore(server, timeout)
 
 	kh := &keysHandler{
 		sec:     sec,
@@ -131,7 +130,7 @@ func NewClientHandler(server *etcdserver.EtcdServer, timeout time.Duration) http
 }
 
 type keysHandler struct {
-	sec     auth.Store
+	sec     etcdserver.AuthStore
 	server  etcdserver.Server
 	cluster etcdserver.Cluster
 	timer   etcdserver.RaftTimer
@@ -198,7 +197,7 @@ func (h *deprecatedMachinesHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 }
 
 type membersHandler struct {
-	sec     auth.Store
+	sec     etcdserver.AuthStore
 	server  etcdserver.Server
 	cluster etcdserver.Cluster
 	timeout time.Duration

--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -24,7 +24,6 @@ import (
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	etcdErr "github.com/coreos/etcd/error"
 	"github.com/coreos/etcd/etcdserver"
-	"github.com/coreos/etcd/etcdserver/auth"
 	"github.com/coreos/etcd/etcdserver/etcdhttp/httptypes"
 	"github.com/coreos/etcd/pkg/logutil"
 )
@@ -54,7 +53,7 @@ func writeError(w http.ResponseWriter, r *http.Request, err error) {
 		if et := e.WriteTo(w); et != nil {
 			plog.Debugf("error writing HTTPError (%v) to %s", et, r.RemoteAddr)
 		}
-	case auth.Error:
+	case etcdserver.AuthError:
 		herr := httptypes.NewHTTPError(e.HTTPStatus(), e.Error())
 		if et := herr.WriteTo(w); et != nil {
 			plog.Debugf("error writing HTTPError (%v) to %s", et, r.RemoteAddr)

--- a/test
+++ b/test
@@ -16,7 +16,7 @@ COVER=${COVER:-"-cover"}
 source ./build
 
 # Hack: gofmt ./ will recursively check the .git directory. So use *.go for gofmt.
-TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/auth etcdserver/etcdhttp etcdserver/etcdhttp/httptypes pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/osutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft snap storage storage/backend store version wal"
+TESTABLE_AND_FORMATTABLE="client discovery error etcdctl/command etcdmain etcdserver etcdserver/etcdhttp etcdserver/etcdhttp/httptypes pkg/fileutil pkg/flags pkg/idutil pkg/ioutil pkg/netutil pkg/osutil pkg/pbutil pkg/types pkg/transport pkg/wait proxy raft snap storage storage/backend store version wal"
 # TODO: add it to race testing when the issue is resolved
 # https://github.com/golang/go/issues/9946
 NO_RACE_TESTABLE="rafthttp"


### PR DESCRIPTION
It is required for tight integration between the auth and the server
that enables efficient caching of the auth flag.