### PR TITLE
client: unmarshal user list in a correct manner

### DIFF
--- a/client/auth_user.go
+++ b/client/auth_user.go
@@ -188,12 +188,16 @@ func (u *httpAuthUserAPI) ListUsers(ctx context.Context) ([]string, error) {
 		return nil, sec
 	}
 	var userList struct {
-		Users []string `json:"users"`
+		Users []map[string]interface{} `json:"users"`
 	}
 	if err = json.Unmarshal(body, &userList); err != nil {
 		return nil, err
 	}
-	return userList.Users, nil
+	ret := make([]string, 0)
+	for _, u := range userList.Users {
+		ret = append(ret, u["user"].(string))
+	}
+	return ret, nil
 }
 
 func (u *httpAuthUserAPI) AddUser(ctx context.Context, username string, password string) error {


### PR DESCRIPTION
The master branch's `etcdctl user list` seems to be broken:
```
$ bin/etcdctl -u root:r user list
json: cannot unmarshal object into Go value of type string
```

This commit fixes the invalid unmarshaling.