### PR TITLE
*: TestKVRange to clientv3/integration, fix rev

### DIFF
--- a/clientv3/integration/client_test.go
+++ b/clientv3/integration/client_test.go
@@ -16,12 +16,14 @@ package integration
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/integration"
 	"github.com/coreos/etcd/lease"
 	"github.com/coreos/etcd/pkg/testutil"
+	"github.com/coreos/etcd/storage/storagepb"
 )
 
 func TestKVPut(t *testing.T) {
@@ -58,6 +60,115 @@ func TestKVPut(t *testing.T) {
 		}
 		if tt.leaseID != lease.LeaseID(resp.Kvs[0].Lease) {
 			t.Errorf("#%d: val = %d, want %d", i, tt.leaseID, resp.Kvs[0].Lease)
+		}
+	}
+}
+
+func TestKVRange(t *testing.T) {
+	defer testutil.AfterTest(t)
+
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer clus.Terminate(t)
+
+	kv := clientv3.NewKV(clus.RandClient())
+
+	keySet := []string{"a", "b", "c", "c", "c", "foo", "foo/abc", "fop"}
+	for i, key := range keySet {
+		if _, err := kv.Put(key, "", lease.NoLease); err != nil {
+			t.Fatalf("#%d: couldn't put %q (%v)", i, key, err)
+		}
+	}
+	resp, err := kv.Get(keySet[0], 0)
+	if err != nil {
+		t.Fatalf("couldn't get key (%v)", err)
+	}
+	wheader := resp.Header
+
+	tests := []struct {
+		begin, end string
+		rev        int64
+		sortOption *clientv3.SortOption
+
+		wantSet []*storagepb.KeyValue
+	}{
+		// range first two
+		{
+			"a", "c",
+			0,
+			nil,
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+				{Key: []byte("b"), Value: nil, CreateRevision: 3, ModRevision: 3, Version: 1},
+			},
+		},
+		// range all with rev
+		{
+			"a", "x",
+			2,
+			nil,
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+			},
+		},
+		// range all with SortByKey, SortAscend
+		{
+			"a", "x",
+			0,
+			&clientv3.SortOption{Target: clientv3.SortByKey, Order: clientv3.SortAscend},
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+				{Key: []byte("b"), Value: nil, CreateRevision: 3, ModRevision: 3, Version: 1},
+				{Key: []byte("c"), Value: nil, CreateRevision: 4, ModRevision: 6, Version: 3},
+				{Key: []byte("foo"), Value: nil, CreateRevision: 7, ModRevision: 7, Version: 1},
+				{Key: []byte("foo/abc"), Value: nil, CreateRevision: 8, ModRevision: 8, Version: 1},
+				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},
+			},
+		},
+		// range all with SortByCreatedRev, SortDescend
+		{
+			"a", "x",
+			0,
+			&clientv3.SortOption{Target: clientv3.SortByCreatedRev, Order: clientv3.SortDescend},
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},
+				{Key: []byte("foo/abc"), Value: nil, CreateRevision: 8, ModRevision: 8, Version: 1},
+				{Key: []byte("foo"), Value: nil, CreateRevision: 7, ModRevision: 7, Version: 1},
+				{Key: []byte("c"), Value: nil, CreateRevision: 4, ModRevision: 6, Version: 3},
+				{Key: []byte("b"), Value: nil, CreateRevision: 3, ModRevision: 3, Version: 1},
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+			},
+		},
+		// range all with SortByModifiedRev, SortDescend
+		{
+			"a", "x",
+			0,
+			&clientv3.SortOption{Target: clientv3.SortByModifiedRev, Order: clientv3.SortDescend},
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},
+				{Key: []byte("foo/abc"), Value: nil, CreateRevision: 8, ModRevision: 8, Version: 1},
+				{Key: []byte("foo"), Value: nil, CreateRevision: 7, ModRevision: 7, Version: 1},
+				{Key: []byte("c"), Value: nil, CreateRevision: 4, ModRevision: 6, Version: 3},
+				{Key: []byte("b"), Value: nil, CreateRevision: 3, ModRevision: 3, Version: 1},
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		resp, err := kv.Range(tt.begin, tt.end, 0, tt.rev, tt.sortOption)
+		if err != nil {
+			t.Fatalf("#%d: couldn't range (%v)", i, err)
+		}
+		if !reflect.DeepEqual(wheader, resp.Header) {
+			t.Fatalf("#%d: wheader expected %+v, got %+v", i, wheader, resp.Header)
+		}
+		if !reflect.DeepEqual(tt.wantSet, resp.Kvs) {
+			t.Fatalf("#%d: resp.Kvs expected %+v, got %+v", i, tt.wantSet, resp.Kvs)
 		}
 	}
 }

--- a/etcdserver/v3demo_server.go
+++ b/etcdserver/v3demo_server.go
@@ -285,7 +285,6 @@ func applyRange(txnID int64, kv dstorage.KV, r *pb.RangeRequest) (*pb.RangeRespo
 
 	var (
 		kvs []storagepb.KeyValue
-		rev int64
 		err error
 	)
 
@@ -300,12 +299,12 @@ func applyRange(txnID int64, kv dstorage.KV, r *pb.RangeRequest) (*pb.RangeRespo
 	}
 
 	if txnID != noTxn {
-		kvs, rev, err = kv.TxnRange(txnID, r.Key, r.RangeEnd, limit, r.Revision)
+		kvs, _, err = kv.TxnRange(txnID, r.Key, r.RangeEnd, limit, r.Revision)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		kvs, rev, err = kv.Range(r.Key, r.RangeEnd, limit, r.Revision)
+		kvs, _, err = kv.Range(r.Key, r.RangeEnd, limit, r.Revision)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +337,7 @@ func applyRange(txnID int64, kv dstorage.KV, r *pb.RangeRequest) (*pb.RangeRespo
 		resp.More = true
 	}
 
-	resp.Header.Revision = rev
+	resp.Header.Revision = kv.Rev()
 	for i := range kvs {
 		resp.Kvs = append(resp.Kvs, &kvs[i])
 	}


### PR DESCRIPTION
For coreos#4338.
And resp.Header.Revision should be from the one in storage
when we just do range, because there is no storage data
change.