### PR TITLE
*: range with current revision for response header

### DIFF
--- a/clientv3/integration/client_test.go
+++ b/clientv3/integration/client_test.go
@@ -16,12 +16,14 @@ package integration
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/integration"
 	"github.com/coreos/etcd/lease"
 	"github.com/coreos/etcd/pkg/testutil"
+	"github.com/coreos/etcd/storage/storagepb"
 )
 
 func TestKVPut(t *testing.T) {
@@ -58,6 +60,115 @@ func TestKVPut(t *testing.T) {
 		}
 		if tt.leaseID != lease.LeaseID(resp.Kvs[0].Lease) {
 			t.Errorf("#%d: val = %d, want %d", i, tt.leaseID, resp.Kvs[0].Lease)
+		}
+	}
+}
+
+func TestKVRange(t *testing.T) {
+	defer testutil.AfterTest(t)
+
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer clus.Terminate(t)
+
+	kv := clientv3.NewKV(clus.RandClient())
+
+	keySet := []string{"a", "b", "c", "c", "c", "foo", "foo/abc", "fop"}
+	for i, key := range keySet {
+		if _, err := kv.Put(key, "", lease.NoLease); err != nil {
+			t.Fatalf("#%d: couldn't put %q (%v)", i, key, err)
+		}
+	}
+	resp, err := kv.Get(keySet[0], 0)
+	if err != nil {
+		t.Fatalf("couldn't get key (%v)", err)
+	}
+	wheader := resp.Header
+
+	tests := []struct {
+		begin, end string
+		rev        int64
+		sortOption *clientv3.SortOption
+
+		wantSet []*storagepb.KeyValue
+	}{
+		// range first two
+		{
+			"a", "c",
+			0,
+			nil,
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+				{Key: []byte("b"), Value: nil, CreateRevision: 3, ModRevision: 3, Version: 1},
+			},
+		},
+		// range all with rev
+		{
+			"a", "x",
+			2,
+			nil,
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+			},
+		},
+		// range all with SortByKey, SortAscend
+		{
+			"a", "x",
+			0,
+			&clientv3.SortOption{Target: clientv3.SortByKey, Order: clientv3.SortAscend},
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+				{Key: []byte("b"), Value: nil, CreateRevision: 3, ModRevision: 3, Version: 1},
+				{Key: []byte("c"), Value: nil, CreateRevision: 4, ModRevision: 6, Version: 3},
+				{Key: []byte("foo"), Value: nil, CreateRevision: 7, ModRevision: 7, Version: 1},
+				{Key: []byte("foo/abc"), Value: nil, CreateRevision: 8, ModRevision: 8, Version: 1},
+				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},
+			},
+		},
+		// range all with SortByCreatedRev, SortDescend
+		{
+			"a", "x",
+			0,
+			&clientv3.SortOption{Target: clientv3.SortByCreatedRev, Order: clientv3.SortDescend},
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},
+				{Key: []byte("foo/abc"), Value: nil, CreateRevision: 8, ModRevision: 8, Version: 1},
+				{Key: []byte("foo"), Value: nil, CreateRevision: 7, ModRevision: 7, Version: 1},
+				{Key: []byte("c"), Value: nil, CreateRevision: 4, ModRevision: 6, Version: 3},
+				{Key: []byte("b"), Value: nil, CreateRevision: 3, ModRevision: 3, Version: 1},
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+			},
+		},
+		// range all with SortByModifiedRev, SortDescend
+		{
+			"a", "x",
+			0,
+			&clientv3.SortOption{Target: clientv3.SortByModifiedRev, Order: clientv3.SortDescend},
+
+			[]*storagepb.KeyValue{
+				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},
+				{Key: []byte("foo/abc"), Value: nil, CreateRevision: 8, ModRevision: 8, Version: 1},
+				{Key: []byte("foo"), Value: nil, CreateRevision: 7, ModRevision: 7, Version: 1},
+				{Key: []byte("c"), Value: nil, CreateRevision: 4, ModRevision: 6, Version: 3},
+				{Key: []byte("b"), Value: nil, CreateRevision: 3, ModRevision: 3, Version: 1},
+				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		resp, err := kv.Range(tt.begin, tt.end, 0, tt.rev, tt.sortOption)
+		if err != nil {
+			t.Fatalf("#%d: couldn't range (%v)", i, err)
+		}
+		if !reflect.DeepEqual(wheader, resp.Header) {
+			t.Fatalf("#%d: wheader expected %+v, got %+v", i, wheader, resp.Header)
+		}
+		if !reflect.DeepEqual(tt.wantSet, resp.Kvs) {
+			t.Fatalf("#%d: resp.Kvs expected %+v, got %+v", i, tt.wantSet, resp.Kvs)
 		}
 	}
 }


### PR DESCRIPTION
This uses the main current revision for range response header.
It adds curRev argument in order to precalculate it before
holding the transaction mutex therefore avoiding the deadlocks.
And this adds clientv3/integration tests for Range operations.