### PR TITLE
store: fix to 'go vet' errors

### DIFF
--- a/store/event_test.go
+++ b/store/event_test.go
@@ -60,24 +60,24 @@ func TestScanHistory(t *testing.T) {
 
 	e, err := eh.scan("/foo", false, 1)
 	if err != nil || e.Index() != 1 {
-		t.Fatalf("scan error [/foo] [1] %v", e.Index)
+		t.Fatalf("scan error [/foo] [1] %d (%v)", e.Index(), err)
 	}
 
 	e, err = eh.scan("/foo/bar", false, 1)
 
 	if err != nil || e.Index() != 2 {
-		t.Fatalf("scan error [/foo/bar] [2] %v", e.Index)
+		t.Fatalf("scan error [/foo/bar] [2] %d (%v)", e.Index(), err)
 	}
 
 	e, err = eh.scan("/foo/bar", true, 3)
 
 	if err != nil || e.Index() != 4 {
-		t.Fatalf("scan error [/foo/bar/bar] [4] %v", e.Index)
+		t.Fatalf("scan error [/foo/bar/bar] [4] %d (%v)", e.Index(), err)
 	}
 
 	e, err = eh.scan("/foo/foo/foo", false, 6)
 	if err != nil || e.Index() != 6 {
-		t.Fatalf("scan error [/foo/foo/foo] [6] %v", e.Index)
+		t.Fatalf("scan error [/foo/foo/foo] [6] %d (%v)", e.Index(), err)
 	}
 
 	e, err = eh.scan("/foo/bar", true, 7)


### PR DESCRIPTION
This check has been introduced to go tip [1]. Just fixes by calling
the Index method.

1: https://github.com/golang/go/commit/0f89efa255a46eb6528d27c920030721ae68b507
