### PR TITLE
raft: fix leaky goroutines in raft test

### DIFF
--- a/raft/example_test.go
+++ b/raft/example_test.go
@@ -26,6 +26,7 @@ func saveToDisk(ents []pb.Entry)      {}
 func ExampleNode() {
 	c := &Config{}
 	n := StartNode(c, nil)
+	defer n.Stop()
 
 	// stuff to n happens in other goroutines
 

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -330,6 +330,7 @@ func TestNodeStart(t *testing.T) {
 		MaxInflightMsgs: 256,
 	}
 	n := StartNode(c, []Peer{{ID: 1}})
+	defer n.Stop()
 	n.Campaign(ctx)
 	g := <-n.Ready()
 	if !reflect.DeepEqual(g, wants[0]) {
@@ -379,6 +380,7 @@ func TestNodeRestart(t *testing.T) {
 		MaxInflightMsgs: 256,
 	}
 	n := RestartNode(c)
+	defer n.Stop()
 	if g := <-n.Ready(); !reflect.DeepEqual(g, want) {
 		t.Errorf("g = %+v,\n             w   %+v", g, want)
 	}
@@ -423,6 +425,7 @@ func TestNodeRestartFromSnapshot(t *testing.T) {
 		MaxInflightMsgs: 256,
 	}
 	n := RestartNode(c)
+	defer n.Stop()
 	if g := <-n.Ready(); !reflect.DeepEqual(g, want) {
 		t.Errorf("g = %+v,\n             w   %+v", g, want)
 	} else {
@@ -450,6 +453,7 @@ func TestNodeAdvance(t *testing.T) {
 		MaxInflightMsgs: 256,
 	}
 	n := StartNode(c, []Peer{{ID: 1}})
+	defer n.Stop()
 	n.Campaign(ctx)
 	<-n.Ready()
 	n.Propose(ctx, []byte("foo"))


### PR DESCRIPTION
This doesn't add testutil dependency but checked with the testutil to
check leaky goroutines and these are the only ones found.