### PR TITLE
clientv3: fix shadowed variables in lease

### DIFF
--- a/clientv3/lease.go
+++ b/clientv3/lease.go
@@ -218,7 +218,7 @@ func (l *lessor) recvKeepAliveLoop() {
 
 		resp, err := stream.Recv()
 		if err != nil {
-			err := l.switchRemoteAndStream(err)
+			err = l.switchRemoteAndStream(err)
 			if err != nil {
 				l.Close()
 				return
@@ -278,14 +278,14 @@ func (l *lessor) sendKeepAliveLoop() {
 		var err error
 		for _, id := range tosend {
 			r := &pb.LeaseKeepAliveRequest{ID: int64(id)}
-			err := stream.Send(r)
+			err = stream.Send(r)
 			if err != nil {
 				break
 			}
 		}
 
 		if err != nil {
-			err := l.switchRemoteAndStream(err)
+			err = l.switchRemoteAndStream(err)
 			if err != nil {
 				l.Close()
 				return


### PR DESCRIPTION
/cc @xiang90 @heyitsanthony 

Reference: https://travis-ci.org/coreos/etcd/jobs/106344453

```
Checking govet -shadow...
clientv3/lease.go:221: declaration of err shadows declaration at clientv3/lease.go:219: 
clientv3/lease.go:288: declaration of err shadows declaration at clientv3/lease.go:278: 

```