### PR TITLE
etcdserver: reject v3 txns with duplicate put keys

### DIFF
--- a/etcdserver/api/v3rpc/error.go
+++ b/etcdserver/api/v3rpc/error.go
@@ -23,6 +23,7 @@ import (
 var (
 	ErrEmptyKey      = grpc.Errorf(codes.InvalidArgument, "key is not provided")
 	ErrTooManyOps    = grpc.Errorf(codes.InvalidArgument, "too many operations in txn request")
+	ErrDuplicateKey  = grpc.Errorf(codes.InvalidArgument, "duplicate key given in txn request")
 	ErrCompacted     = grpc.Errorf(codes.OutOfRange, storage.ErrCompacted.Error())
 	ErrFutureRev     = grpc.Errorf(codes.OutOfRange, storage.ErrFutureRev.Error())
 	ErrLeaseNotFound = grpc.Errorf(codes.NotFound, "requested lease not found")


### PR DESCRIPTION
An API check to support PR #4363; bad requests didn't return an error.