### PR TITLE
integration: decrease timeout for isMemberBootstrapped

### DIFF
--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -29,8 +29,8 @@ import (
 
 // isMemberBootstrapped tries to check if the given member has been bootstrapped
 // in the given cluster.
-func isMemberBootstrapped(cl *cluster, member string, rt http.RoundTripper) bool {
-	rcl, err := getClusterFromRemotePeers(getRemotePeerURLs(cl, member), time.Second, false, rt)
+func isMemberBootstrapped(cl *cluster, member string, rt http.RoundTripper, timeout time.Duration) bool {
+	rcl, err := getClusterFromRemotePeers(getRemotePeerURLs(cl, member), timeout, false, rt)
 	if err != nil {
 		return false
 	}

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -46,8 +46,9 @@ type ServerConfig struct {
 	ForceNewCluster     bool
 	PeerTLSInfo         transport.TLSInfo
 
-	TickMs        uint
-	ElectionTicks int
+	TickMs           uint
+	ElectionTicks    int
+	BootstrapTimeout time.Duration
 
 	V3demo bool
 
@@ -180,4 +181,11 @@ func checkDuplicateURL(urlsmap types.URLsMap) bool {
 		}
 	}
 	return false
+}
+
+func (c *ServerConfig) bootstrapTimeout() time.Duration {
+	if c.BootstrapTimeout != 0 {
+		return c.BootstrapTimeout
+	}
+	return time.Second
 }

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -269,7 +269,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 			return nil, err
 		}
 		m := cl.MemberByName(cfg.Name)
-		if isMemberBootstrapped(cl, cfg.Name, prt) {
+		if isMemberBootstrapped(cl, cfg.Name, prt, cfg.bootstrapTimeout()) {
 			return nil, fmt.Errorf("member %s has already been bootstrapped", m.ID)
 		}
 		if cfg.ShouldDiscover() {

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -422,6 +422,7 @@ func mustNewMember(t *testing.T, name string, peerTLS *transport.TLSInfo, client
 	}
 	m.InitialClusterToken = clusterName
 	m.NewCluster = true
+	m.BootstrapTimeout = 10 * time.Millisecond
 	if m.PeerTLSInfo != nil {
 		m.ServerConfig.PeerTLSInfo = *m.PeerTLSInfo
 	}


### PR DESCRIPTION
Spending seconds(!) when it would fail anyway.

integration/TestV3 (before): 100.670
integration/TestV3 (after): 29.571