### PR TITLE
fix watch issues in storage

### DIFF
--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -146,9 +146,10 @@ func (sws *serverWatchStream) sendLoop() {
 			}
 
 			err := sws.gRPCStream.Send(&pb.WatchResponse{
-				Header:  sws.newResponseHeader(wresp.Revision),
-				WatchId: int64(wresp.WatchID),
-				Events:  events,
+				Header:    sws.newResponseHeader(wresp.Revision),
+				WatchId:   int64(wresp.WatchID),
+				Events:    events,
+				Compacted: wresp.Compacted,
 			})
 			storage.ReportEventReceived()
 			if err != nil {

--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -324,7 +324,6 @@ func (s *watchableStore) syncWatchers() {
 	tx := s.store.b.BatchTx()
 	tx.Lock()
 	ks, vs := tx.UnsafeRange(keyBucketName, minBytes, maxBytes, 0)
-	tx.Unlock()
 
 	evs := []storagepb.Event{}
 
@@ -351,6 +350,7 @@ func (s *watchableStore) syncWatchers() {
 
 		evs = append(evs, ev)
 	}
+	tx.Unlock()
 
 	for w, es := range newWatcherToEventMap(s.unsynced, evs) {
 		select {

--- a/storage/watchable_store.go
+++ b/storage/watchable_store.go
@@ -131,7 +131,7 @@ func (s *watchableStore) Put(key, value []byte, lease lease.LeaseID) (rev int64)
 		Type: storagepb.PUT,
 		Kv:   &changes[0],
 	}
-	s.handle(rev, []storagepb.Event{ev})
+	s.notify(rev, []storagepb.Event{ev})
 	return rev
 }
 
@@ -156,7 +156,7 @@ func (s *watchableStore) DeleteRange(key, end []byte) (n, rev int64) {
 			Type: storagepb.DELETE,
 			Kv:   &change}
 	}
-	s.handle(rev, evs)
+	s.notify(rev, evs)
 	return n, rev
 }
 
@@ -191,7 +191,7 @@ func (s *watchableStore) TxnEnd(txnID int64) error {
 		}
 	}
 
-	s.handle(s.store.Rev(), evs)
+	s.notify(s.store.Rev(), evs)
 	s.mu.Unlock()
 
 	return nil
@@ -368,11 +368,6 @@ func (s *watchableStore) syncWatchers() {
 	}
 
 	slowWatcherGauge.Set(float64(len(s.unsynced)))
-}
-
-// handle handles the change of the happening event on all watchers.
-func (s *watchableStore) handle(rev int64, evs []storagepb.Event) {
-	s.notify(rev, evs)
 }
 
 // notify notifies the fact that given event at the given rev just happened to

--- a/storage/watcher.go
+++ b/storage/watcher.go
@@ -67,6 +67,9 @@ type WatchResponse struct {
 	// watcher, the revision is greater than the last modified revision
 	// inside Events.
 	Revision int64
+
+	// Compacted is set when the watcher is cancelled due to compaction.
+	Compacted bool
 }
 
 // watchStream contains a collection of watchers that share


### PR DESCRIPTION
1. fix a lock issue
2. remove unnecessary code
3. send compaction error when watched revision is compacted.