### PR TITLE
client: add a new endpoint selection mode for prioritizing follower

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -71,6 +71,12 @@ const (
 	//
 	// This mode should be used with Client.AutoSync().
 	EndpointSelectionPrioritizeLeader
+
+	// CAUTION: EndpointSelectionPrioritizeFollower is for benchmarking purpose.
+	// If 'SelectionMode' is set to 'EndpointSelectionPrioritizeFollower',
+	// requests are sent to followers in the cluster. The purpose of this mode
+	// is just for stabilizing benchmarking results.
+	EndpointSelectionPrioritizeFollower
 )
 
 type Config struct {
@@ -300,6 +306,20 @@ func (c *httpClusterClient) SetEndpoints(eps []string) error {
 		}
 		// If endpoints doesn't have the lu, just keep c.pinned = 0.
 		// Forwarding between follower and leader would be required but it works.
+	case EndpointSelectionPrioritizeFollower:
+		c.endpoints = neps
+		lep, err := c.getLeaderEndpoint()
+		if err != nil {
+			// maybe election is ongoing
+			c.pinned = 0
+		}
+
+		for i := range c.endpoints {
+			if c.endpoints[i].String() != lep {
+				c.pinned = i
+				break
+			}
+		}
 	default:
 		return errors.New(fmt.Sprintf("invalid endpoint selection mode: %d", c.selectionMode))
 	}


### PR DESCRIPTION
This commit adds a new endpoint selection mode for prioritizing
follower, EndpointSelectionPrioritizeFollower. If this mode is used,
followers are prioritized as request destination.

This is just for benchmarking purpose. Choosing a leader or a follower
as a request destination produces very different scores in typical
benchmark. For measuring worse score for certain, the new mode is
useful.
