### PR TITLE
etcdserver: update comments in a generated file

### DIFF
--- a/etcdserver/etcdserverpb/etcdserver.pb.go
+++ b/etcdserver/etcdserverpb/etcdserver.pb.go
@@ -40,14 +40,14 @@
 		LeaseKeepAliveRequest
 		LeaseKeepAliveResponse
 		Member
-		AddMemberRequest
-		AddMemberResponse
-		RemoveMemberRequest
-		RemoveMemberResponse
-		UpdateMemberRequest
-		UpdateMemberResponse
-		ListMemberRequest
-		ListMemberResponse
+		MemberAddRequest
+		MemberAddResponse
+		MemberRemoveRequest
+		MemberRemoveResponse
+		MemberUpdateRequest
+		MemberUpdateResponse
+		MemberListRequest
+		MemberListResponse
 */
 package etcdserverpb
 


### PR DESCRIPTION
On the latest master branch, etcdserver/etcdserverpb/etcdserver.pb.go
is changed when scripts/genproto.sh is executed. The content only has
changes for comment. Therefore it is not important but the change is
annoying when we update the proto file.