### PR TITLE
docs: remove old client-matrix link

### DIFF
--- a/Documentation/libraries-and-tools.md
+++ b/Documentation/libraries-and-tools.md
@@ -87,10 +87,6 @@
 
 - [efrecon/etcd-tcl](https://github.com/efrecon/etcd-tcl) - Supports v2, except wait.
 
-A detailed recap of client functionalities can be found in the [clients compatibility matrix][clients-matrix.md].
-
-[clients-matrix.md]: https://github.com/coreos/etcd/blob/master/Documentation/clients-matrix.md
-
 **Chef Integration**
 
 - [coderanger/etcd-chef](https://github.com/coderanger/etcd-chef)


### PR DESCRIPTION
This document was removed in 23406dc2ee261dcdcfd35b2dbad29a55e09bc9fc
but still linked to here.