### PR TITLE
rafthttp: add peer id before starting servers in tests

### DIFF
--- a/clientv3/txn.go
+++ b/clientv3/txn.go
@@ -143,11 +143,12 @@ func (txn *txn) Commit() (*TxnResponse, error) {
 			return (*TxnResponse)(resp), nil
 		}
 
-		if txn.isWrite {
+		if isRPCError(err) {
 			return nil, err
 		}
 
-		if isRPCError(err) {
+		if txn.isWrite {
+			go kv.switchRemote(err)
 			return nil, err
 		}
 

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -374,6 +374,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		TLSInfo:     cfg.PeerTLSInfo,
 		DialTimeout: cfg.peerDialTimeout(),
 		ID:          id,
+		URLs:        cfg.PeerURLs,
 		ClusterID:   cl.ID(),
 		Raft:        srv,
 		Snapshotter: ss,

--- a/rafthttp/http_test.go
+++ b/rafthttp/http_test.go
@@ -151,7 +151,7 @@ func TestServeRaftPrefix(t *testing.T) {
 		req.Header.Set("X-Etcd-Cluster-ID", tt.clusterID)
 		req.Header.Set("X-Server-Version", version.Version)
 		rw := httptest.NewRecorder()
-		h := newPipelineHandler(tt.p, types.ID(0))
+		h := newPipelineHandler(NewNopTransporter(), tt.p, types.ID(0))
 		h.ServeHTTP(rw, req)
 		if rw.Code != tt.wcode {
 			t.Errorf("#%d: got code=%d, want %d", i, rw.Code, tt.wcode)
@@ -364,4 +364,3 @@ func (pr *fakePeer) update(urls types.URLs)                { pr.peerURLs = urls 
 func (pr *fakePeer) attachOutgoingConn(conn *outgoingConn) { pr.connc <- conn }
 func (pr *fakePeer) activeSince() time.Time                { return time.Time{} }
 func (pr *fakePeer) stop()                                 {}
-func (pr *fakePeer) urls() types.URLs                      { return pr.peerURLs }

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -65,9 +65,6 @@ type Peer interface {
 	// update updates the urls of remote peer.
 	update(urls types.URLs)
 
-	// urls  retrieves the urls of the remote peer
-	urls() types.URLs
-
 	// attachOutgoingConn attaches the outgoing connection to the peer for
 	// stream usage. After the call, the ownership of the outgoing
 	// connection hands over to the peer. The peer will close the connection
@@ -161,8 +158,8 @@ func startPeer(transport *Transport, urls types.URLs, local, to, cid types.ID, r
 		}
 	}()
 
-	p.msgAppV2Reader = startStreamReader(p, transport.streamRt, picker, streamTypeMsgAppV2, local, to, cid, status, p.recvc, p.propc, errorc)
-	reader := startStreamReader(p, transport.streamRt, picker, streamTypeMessage, local, to, cid, status, p.recvc, p.propc, errorc)
+	p.msgAppV2Reader = startStreamReader(transport, picker, streamTypeMsgAppV2, local, to, cid, status, p.recvc, p.propc, errorc)
+	reader := startStreamReader(transport, picker, streamTypeMessage, local, to, cid, status, p.recvc, p.propc, errorc)
 	go func() {
 		var paused bool
 		for {
@@ -227,10 +224,6 @@ func (p *peer) update(urls types.URLs) {
 	case p.newURLsC <- urls:
 	case <-p.done:
 	}
-}
-
-func (p *peer) urls() types.URLs {
-	return p.picker.urls
 }
 
 func (p *peer) attachOutgoingConn(conn *outgoingConn) {

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -226,8 +226,7 @@ func (cw *streamWriter) stop() {
 // streamReader is a long-running go-routine that dials to the remote stream
 // endpoint and reads messages from the response body returned.
 type streamReader struct {
-	localPeer     Peer
-	tr            http.RoundTripper
+	tr            *Transport
 	picker        *urlPicker
 	t             streamType
 	local, remote types.ID
@@ -244,21 +243,20 @@ type streamReader struct {
 	done   chan struct{}
 }
 
-func startStreamReader(p Peer, tr http.RoundTripper, picker *urlPicker, t streamType, local, remote, cid types.ID, status *peerStatus, recvc chan<- raftpb.Message, propc chan<- raftpb.Message, errorc chan<- error) *streamReader {
+func startStreamReader(tr *Transport, picker *urlPicker, t streamType, local, remote, cid types.ID, status *peerStatus, recvc chan<- raftpb.Message, propc chan<- raftpb.Message, errorc chan<- error) *streamReader {
 	r := &streamReader{
-		localPeer: p,
-		tr:        tr,
-		picker:    picker,
-		t:         t,
-		local:     local,
-		remote:    remote,
-		cid:       cid,
-		status:    status,
-		recvc:     recvc,
-		propc:     propc,
-		errorc:    errorc,
-		stopc:     make(chan struct{}),
-		done:      make(chan struct{}),
+		tr:     tr,
+		picker: picker,
+		t:      t,
+		local:  local,
+		remote: remote,
+		cid:    cid,
+		status: status,
+		recvc:  recvc,
+		propc:  propc,
+		errorc: errorc,
+		stopc:  make(chan struct{}),
+		done:   make(chan struct{}),
 	}
 	go r.run()
 	return r
@@ -374,11 +372,14 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 	req.Header.Set("X-Etcd-Cluster-ID", cr.cid.String())
 	req.Header.Set("X-Raft-To", cr.remote.String())
 
-	var peerURLs []string
-	for _, url := range cr.localPeer.urls() {
-		peerURLs = append(peerURLs, url.String())
+	// report local urls for peer discovery (sometimes not set in unit tests)
+	if cr.tr.URLs != nil {
+		var peerURLs []string
+		for _, url := range cr.tr.URLs {
+			peerURLs = append(peerURLs, url.String())
+		}
+		req.Header.Set("X-PeerURLs", strings.Join(peerURLs, ","))
 	}
-	req.Header.Set("X-Server-Peers", strings.Join(peerURLs, ","))
 
 	cr.mu.Lock()
 	select {
@@ -387,10 +388,10 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("stream reader is stopped")
 	default:
 	}
-	cr.cancel = httputil.RequestCanceler(cr.tr, req)
+	cr.cancel = httputil.RequestCanceler(cr.tr.streamRt, req)
 	cr.mu.Unlock()
 
-	resp, err := cr.tr.RoundTrip(req)
+	resp, err := cr.tr.streamRt.RoundTrip(req)
 	if err != nil {
 		cr.picker.unreachable(u)
 		return nil, err

--- a/rafthttp/stream_test.go
+++ b/rafthttp/stream_test.go
@@ -116,12 +116,11 @@ func TestStreamReaderDialRequest(t *testing.T) {
 	for i, tt := range []streamType{streamTypeMessage, streamTypeMsgAppV2} {
 		tr := &roundTripperRecorder{}
 		sr := &streamReader{
-			tr:        tr,
-			localPeer: newFakePeer(),
-			picker:    mustNewURLPicker(t, []string{"http://localhost:2380"}),
-			local:     types.ID(1),
-			remote:    types.ID(2),
-			cid:       types.ID(1),
+			tr:     &Transport{streamRt: tr},
+			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
+			local:  types.ID(1),
+			remote: types.ID(2),
+			cid:    types.ID(1),
 		}
 		sr.dial(tt)
 
@@ -167,13 +166,12 @@ func TestStreamReaderDialResult(t *testing.T) {
 			err:    tt.err,
 		}
 		sr := &streamReader{
-			tr:        tr,
-			localPeer: newFakePeer(),
-			picker:    mustNewURLPicker(t, []string{"http://localhost:2380"}),
-			local:     types.ID(1),
-			remote:    types.ID(2),
-			cid:       types.ID(1),
-			errorc:    make(chan error, 1),
+			tr:     &Transport{streamRt: tr},
+			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
+			local:  types.ID(1),
+			remote: types.ID(2),
+			cid:    types.ID(1),
+			errorc: make(chan error, 1),
 		}
 
 		_, err := sr.dial(streamTypeMessage)
@@ -196,12 +194,11 @@ func TestStreamReaderDialDetectUnsupport(t *testing.T) {
 			header: http.Header{},
 		}
 		sr := &streamReader{
-			tr:        tr,
-			localPeer: newFakePeer(),
-			picker:    mustNewURLPicker(t, []string{"http://localhost:2380"}),
-			local:     types.ID(1),
-			remote:    types.ID(2),
-			cid:       types.ID(1),
+			tr:     &Transport{streamRt: tr},
+			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
+			local:  types.ID(1),
+			remote: types.ID(2),
+			cid:    types.ID(1),
 		}
 
 		_, err := sr.dial(typ)
@@ -257,9 +254,8 @@ func TestStream(t *testing.T) {
 		h.sw = sw
 
 		picker := mustNewURLPicker(t, []string{srv.URL})
-		tr := &http.Transport{}
-		peer := newFakePeer()
-		sr := startStreamReader(peer, tr, picker, tt.t, types.ID(1), types.ID(2), types.ID(1), newPeerStatus(types.ID(1)), recvc, propc, nil)
+		tr := &Transport{streamRt: &http.Transport{}}
+		sr := startStreamReader(tr, picker, tt.t, types.ID(1), types.ID(2), types.ID(1), newPeerStatus(types.ID(1)), recvc, propc, nil)
 		defer sr.stop()
 		// wait for stream to work
 		var writec chan<- raftpb.Message

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -97,9 +97,10 @@ type Transport struct {
 	DialTimeout time.Duration     // maximum duration before timing out dial of the request
 	TLSInfo     transport.TLSInfo // TLS information used when creating connection
 
-	ID          types.ID // local member ID
-	ClusterID   types.ID // raft cluster ID for request validation
-	Raft        Raft     // raft state machine, to which the Transport forwards received messages and reports status
+	ID          types.ID   // local member ID
+	URLs        types.URLs // local peer URLs
+	ClusterID   types.ID   // raft cluster ID for request validation
+	Raft        Raft       // raft state machine, to which the Transport forwards received messages and reports status
 	Snapshotter *snap.Snapshotter
 	ServerStats *stats.ServerStats // used to record general transportation statistics
 	// used to record transportation statistics with followers when
@@ -139,9 +140,9 @@ func (t *Transport) Start() error {
 }
 
 func (t *Transport) Handler() http.Handler {
-	pipelineHandler := newPipelineHandler(t.Raft, t.ClusterID)
+	pipelineHandler := newPipelineHandler(t, t.Raft, t.ClusterID)
 	streamHandler := newStreamHandler(t, t, t.Raft, t.ID, t.ClusterID)
-	snapHandler := newSnapshotHandler(t.Raft, t.Snapshotter, t.ClusterID)
+	snapHandler := newSnapshotHandler(t, t.Raft, t.Snapshotter, t.ClusterID)
 	mux := http.NewServeMux()
 	mux.Handle(RaftPrefix, pipelineHandler)
 	mux.Handle(RaftStreamPrefix+"/", streamHandler)

--- a/rafthttp/transport_test.go
+++ b/rafthttp/transport_test.go
@@ -121,7 +121,7 @@ func TestTransportUpdate(t *testing.T) {
 	tr.UpdatePeer(types.ID(1), []string{u})
 	wurls := types.URLs(testutil.MustNewURLs(t, []string{"http://localhost:2380"}))
 	if !reflect.DeepEqual(peer.peerURLs, wurls) {
-		t.Errorf("urls = %+v, want %+v", peer.urls, wurls)
+		t.Errorf("urls = %+v, want %+v", peer.peerURLs, wurls)
 	}
 }
 


### PR DESCRIPTION
an unexpected peer could impersonate the expected peer

fixes  #4417