### PR TITLE
pkg/idutil: reduce conflict rate from 1% to 0.005%

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -358,7 +358,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 		lstats:        lstats,
 		SyncTicker:    time.Tick(500 * time.Millisecond),
 		peerRt:        prt,
-		reqIDGen:      idutil.NewGenerator(uint8(id), time.Now()),
+		reqIDGen:      idutil.NewGenerator(uint16(id), time.Now()),
 		forceVersionC: make(chan struct{}),
 		msgSnapC:      make(chan raftpb.Message, maxInFlightMsgSnap),
 	}

--- a/pkg/idutil/id_test.go
+++ b/pkg/idutil/id_test.go
@@ -22,7 +22,7 @@ import (
 func TestNewGenerator(t *testing.T) {
 	g := NewGenerator(0x12, time.Unix(0, 0).Add(0x3456*time.Millisecond))
 	id := g.Next()
-	wid := uint64(0x1200000034560001)
+	wid := uint64(0x12000000345601)
 	if id != wid {
 		t.Errorf("id = %x, want %x", id, wid)
 	}
@@ -45,7 +45,7 @@ func TestNewGeneratorUnique(t *testing.T) {
 
 func TestNext(t *testing.T) {
 	g := NewGenerator(0x12, time.Unix(0, 0).Add(0x3456*time.Millisecond))
-	wid := uint64(0x1200000034560001)
+	wid := uint64(0x12000000345601)
 	for i := 0; i < 1000; i++ {
 		id := g.Next()
 		if id != wid+uint64(i) {


### PR DESCRIPTION
Perviously, we only use 8bits from member identification
in id generation. The conflict rate is A(256,3)/256^3, which
is around 1%. Now we use 16bits to reduce the rate to 0.005%.

We can attach the full member id into id generation if needed...