### PR TITLE
functional-tester/etcd-agent: configurable agent port

### DIFF
--- a/tools/functional-tester/etcd-agent/main.go
+++ b/tools/functional-tester/etcd-agent/main.go
@@ -17,17 +17,20 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
+	"path/filepath"
 )
 
 func main() {
-	etcdPath := flag.String("etcd-path", "/opt/etcd/bin/etcd", "the path to etcd binary")
+	etcdPath := flag.String("etcd-path", filepath.Join(os.Getenv("GOPATH"), "bin/etcd"), "the path to etcd binary")
+	port := flag.String("port", ":9027", "port to serve agent server")
 	flag.Parse()
 
 	a, err := newAgent(*etcdPath)
 	if err != nil {
 		log.Fatal(err)
 	}
-	a.serveRPC()
+	a.serveRPC(*port)
 
 	var done chan struct{}
 	<-done

--- a/tools/functional-tester/etcd-agent/rpc.go
+++ b/tools/functional-tester/etcd-agent/rpc.go
@@ -23,14 +23,14 @@ import (
 	"github.com/coreos/etcd/tools/functional-tester/etcd-agent/client"
 )
 
-func (a *Agent) serveRPC() {
+func (a *Agent) serveRPC(port string) {
 	rpc.Register(a)
 	rpc.HandleHTTP()
-	l, e := net.Listen("tcp", ":9027")
+	l, e := net.Listen("tcp", port)
 	if e != nil {
 		log.Fatal("agent:", e)
 	}
-	log.Println("agent listening on :9027")
+	log.Println("agent listening on", port)
 	go http.Serve(l, nil)
 }
 


### PR DESCRIPTION
To make local testing easier.