### PR TITLE
Reconfiguration for raftexample (#4018)

### DIFF
--- a/contrib/raftexample/README.md
+++ b/contrib/raftexample/README.md
@@ -65,6 +65,36 @@ goreman run start raftexample2
 curl -L http://127.0.0.1:22380/my-key
 ```
 
+### Dynamic cluster reconfiguration
+
+Nodes can be added to or removed from a running cluster using requests to the REST API.
+
+For example, suppose we have a 3-node cluster that was started with the commands:
+```sh
+raftexample --id 1 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 --port 12380
+raftexample --id 2 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 --port 22380
+raftexample --id 3 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 --port 32380
+```
+
+A fourth node with ID 4 can be added by issuing a POST:
+```sh
+curl -L http://127.0.0.1:12380/4 -XPOST -d http://127.0.0.1:42379
+```
+
+Then the new node can be started as the others were, using the --join option:
+```sh
+raftexample --id 4 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379,http://127.0.0.1:42379 --port 42380 --join
+```
+
+The new node should join the cluster and be able to service key/value requests.
+
+We can remove a node using a DELETE request:
+```sh
+curl -L http://127.0.0.1:12380/3 -XDELETE
+```
+
+Node 3 should shut itself down once the cluster has processed this request.
+
 ## Design
 
 The raftexample consists of three components: a raft-backed key-value store, a REST API server, and a raft consensus server based on etcd's raft implementation.
@@ -87,4 +117,3 @@ For raftexample, this commit channel is consumed by the key-value store.
 
 ### TODO
 - Snapshot support
-- Dynamic reconfiguration

--- a/contrib/raftexample/httpapi.go
+++ b/contrib/raftexample/httpapi.go
@@ -19,11 +19,14 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/coreos/etcd/raft/raftpb"
 )
 
 // Handler for a http based key-value store backed by raft
 type httpKVAPI struct {
-	store *kvstore
+	store       *kvstore
+	confChangeC chan<- raftpb.ConfChange
 }
 
 func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -48,18 +51,48 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			http.Error(w, "Failed to GET", http.StatusNotFound)
 		}
+	case r.Method == "POST":
+		url, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("Failed to read on POST (%v)\n", err)
+			http.Error(w, "Failed on POST", http.StatusBadRequest)
+			return
+		}
+
+		nodeId, err := strconv.ParseUint(key[1:], 0, 64)
+		if err != nil {
+			log.Printf("Failed to convert ID for conf change (%v)\n", err)
+			http.Error(w, "Failed on POST", http.StatusBadRequest)
+			return
+		}
+
+		cc := raftpb.ConfChange{
+			Type:    raftpb.ConfChangeAddNode,
+			NodeID:  nodeId,
+			Context: url,
+		}
+		h.confChangeC <- cc
+
+		// As above, optimistic that raft will apply the conf change
+		w.WriteHeader(http.StatusNoContent)
 	default:
 		w.Header().Set("Allow", "PUT")
 		w.Header().Add("Allow", "GET")
+		w.Header().Add("Allow", "POST")
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 
 // serveHttpKVAPI starts a key-value server with a GET/PUT API and listens.
-func serveHttpKVAPI(port int, proposeC chan<- string, commitC <-chan *string, errorC <-chan error) {
+func serveHttpKVAPI(port int, proposeC chan<- string, confChangeC chan<- raftpb.ConfChange,
+	commitC <-chan *string, errorC <-chan error) {
+
 	srv := http.Server{
-		Addr:    ":" + strconv.Itoa(port),
-		Handler: &httpKVAPI{newKVStore(proposeC, commitC, errorC)},
+		Addr: ":" + strconv.Itoa(port),
+		Handler: &httpKVAPI{
+			store:       newKVStore(proposeC, commitC, errorC),
+			confChangeC: confChangeC,
+		},
 	}
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"flag"
 	"strings"
+
+	"github.com/coreos/etcd/raft/raftpb"
 )
 
 func main() {
@@ -27,9 +29,11 @@ func main() {
 
 	proposeC := make(chan string)
 	defer close(proposeC)
+	confChangeC := make(chan raftpb.ConfChange)
+	defer close(confChangeC)
 
 	// raft provides a commit stream for the proposals from the http api
-	commitC, errorC := newRaftNode(*id, strings.Split(*cluster, ","), proposeC)
+	commitC, errorC := newRaftNode(*id, strings.Split(*cluster, ","), proposeC, confChangeC)
 
 	// the key-value http handler will propose updates to raft
 	serveHttpKVAPI(*kvport, proposeC, commitC, errorC)

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -25,6 +25,7 @@ func main() {
 	cluster := flag.String("cluster", "http://127.0.0.1:9021", "comma separated cluster peers")
 	id := flag.Int("id", 1, "node ID")
 	kvport := flag.Int("port", 9121, "key-value server port")
+	join := flag.Bool("join", false, "join an existing cluster")
 	flag.Parse()
 
 	proposeC := make(chan string)
@@ -33,8 +34,8 @@ func main() {
 	defer close(confChangeC)
 
 	// raft provides a commit stream for the proposals from the http api
-	commitC, errorC := newRaftNode(*id, strings.Split(*cluster, ","), proposeC, confChangeC)
+	commitC, errorC := newRaftNode(*id, strings.Split(*cluster, ","), *join, proposeC, confChangeC)
 
 	// the key-value http handler will propose updates to raft
-	serveHttpKVAPI(*kvport, proposeC, commitC, errorC)
+	serveHttpKVAPI(*kvport, proposeC, confChangeC, commitC, errorC)
 }

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -228,7 +228,7 @@ func (rc *raftNode) serveChannels() {
 			rc.wal.Save(rd.HardState, rd.Entries)
 			rc.raftStorage.Append(rd.Entries)
 			rc.transport.Send(rd.Messages)
-			if ok := rc.publishEntries(rd.Entries); !ok {
+			if ok := rc.publishEntries(rd.CommittedEntries); !ok {
 				rc.stop()
 				return
 			}

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -18,13 +18,16 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/coreos/etcd/raft/raftpb"
 )
 
 type cluster struct {
-	peers    []string
-	commitC  []<-chan *string
-	errorC   []<-chan error
-	proposeC []chan string
+	peers       []string
+	commitC     []<-chan *string
+	errorC      []<-chan error
+	proposeC    []chan string
+	confChangeC []chan raftpb.ConfChange
 }
 
 // newCluster creates a cluster of n nodes
@@ -35,15 +38,18 @@ func newCluster(n int) *cluster {
 	}
 
 	clus := &cluster{
-		peers:    peers,
-		commitC:  make([]<-chan *string, len(peers)),
-		errorC:   make([]<-chan error, len(peers)),
-		proposeC: make([]chan string, len(peers))}
+		peers:       peers,
+		commitC:     make([]<-chan *string, len(peers)),
+		errorC:      make([]<-chan error, len(peers)),
+		proposeC:    make([]chan string, len(peers)),
+		confChangeC: make([]chan raftpb.ConfChange, len(peers)),
+	}
 
 	for i := range clus.peers {
 		os.RemoveAll(fmt.Sprintf("raftexample-%d", i+1))
 		clus.proposeC[i] = make(chan string, 1)
-		clus.commitC[i], clus.errorC[i] = newRaftNode(i+1, clus.peers, clus.proposeC[i])
+		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
+		clus.commitC[i], clus.errorC[i] = newRaftNode(i+1, clus.peers, clus.proposeC[i], clus.confChangeC[i])
 	}
 
 	return clus

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -49,7 +49,7 @@ func newCluster(n int) *cluster {
 		os.RemoveAll(fmt.Sprintf("raftexample-%d", i+1))
 		clus.proposeC[i] = make(chan string, 1)
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
-		clus.commitC[i], clus.errorC[i] = newRaftNode(i+1, clus.peers, clus.proposeC[i], clus.confChangeC[i])
+		clus.commitC[i], clus.errorC[i] = newRaftNode(i+1, clus.peers, false, clus.proposeC[i], clus.confChangeC[i])
 	}
 
 	return clus


### PR DESCRIPTION
I'm doing a project using etcd/raft and have been trying to get configuration changes working. Since I was having trouble with it in my own project, I figured I'd try it in raftexample as a simplification (with the added bonus of potentially fulfilling the request in issue #4018), but I'm hitting the same problem. Posting this PR in hopes of getting some guidance on what I'm doing wrong.

With the current code I'm able to start two nodes, make an HTTP request to add a third node, and have the third node join the cluster. However, when the leader tries to catch up the new node's log, the new node continuously rejects the AppendEntries RPC, and they go back and forth forever, so the new node never gets caught up and becomes fully functional.

With debugging on, I see the following on the leader:
```
2016-02-05 13:50:53.331050 I | rafthttp: the connection with 3 became active
raft2016/02/05 13:50:53 DEBUG: 1 received msgApp rejection(lastindex: 3) from 3 for index 4
raft2016/02/05 13:50:53 DEBUG: 1 decreased progress of 3 to [next = 4, match = 0, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
raft2016/02/05 13:50:53 DEBUG: 1 received msgApp rejection(lastindex: 3) from 3 for index 3
raft2016/02/05 13:50:53 DEBUG: 1 decreased progress of 3 to [next = 3, match = 0, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
raft2016/02/05 13:50:53 DEBUG: 1 received msgApp rejection(lastindex: 3) from 3 for index 3
raft2016/02/05 13:50:53 DEBUG: 1 received msgApp rejection(lastindex: 3) from 3 for index 4
raft2016/02/05 13:50:53 DEBUG: 1 decreased progress of 3 to [next = 4, match = 3, state = ProgressStateReplicate, waiting = false, pendingSnapshot = 0]
raft2016/02/05 13:50:53 DEBUG: 1 received msgApp rejection(lastindex: 3) from 3 for index 3
raft2016/02/05 13:50:53 DEBUG: 1 decreased progress of 3 to [next = 3, match = 3, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
raft2016/02/05 13:50:53 DEBUG: 1 received msgApp rejection(lastindex: 3) from 3 for index 3
raft2016/02/05 13:50:53 DEBUG: 1 decreased progress of 3 to [next = 3, match = 3, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
raft2016/02/05 13:50:53 DEBUG: 1 received msgApp rejection(lastindex: 3) from 3 for index 3
raft2016/02/05 13:50:53 DEBUG: 1 decreased progress of 3 to [next = 3, match = 3, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
```

And this on the new node:
```
raft2016/02/05 13:50:53 INFO: 3 became follower at term 0
raft2016/02/05 13:50:53 INFO: newRaft 3 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
raft2016/02/05 13:50:53 INFO: 3 became follower at term 1
2016-02-05 13:50:53.331061 I | rafthttp: the connection with 1 became active
2016-02-05 13:50:53.335394 I | rafthttp: the connection with 2 became active
raft2016/02/05 13:50:53 INFO: 3 [term: 1] received a MsgHeartbeat message with higher term from 1 [term: 4]
raft2016/02/05 13:50:53 INFO: 3 became follower at term 4
raft2016/02/05 13:50:53 INFO: raft.node: 3 elected leader 1 at term 4
raft2016/02/05 13:50:53 DEBUG: 3 [logterm: 0, index: 4] rejected msgApp [logterm: 4, index: 4] from 1
raft2016/02/05 13:50:53 DEBUG: 3 [logterm: 1, index: 3] rejected msgApp [logterm: 4, index: 3] from 1
raft2016/02/05 13:50:53 DEBUG: 3 [logterm: 1, index: 3] rejected msgApp [logterm: 4, index: 3] from 1
raft2016/02/05 13:50:53 DEBUG: 3 [logterm: 0, index: 4] rejected msgApp [logterm: 4, index: 4] from 1
raft2016/02/05 13:50:53 DEBUG: 3 [logterm: 1, index: 3] rejected msgApp [logterm: 4, index: 3] from 1
raft2016/02/05 13:50:53 DEBUG: 3 [logterm: 1, index: 3] rejected msgApp [logterm: 4, index: 3] from 1
raft2016/02/05 13:50:53 DEBUG: 3 [logterm: 1, index: 3] rejected msgApp [logterm: 4, index: 3] from 1
```

Can anyone spot what I'm missing here?

Thanks!