### PR TITLE
clientv3: ErrClientConnClosing is not a rpc error from server

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -200,5 +200,5 @@ func dialEndpointList(c *Client) (*grpc.ClientConn, error) {
 }
 
 func isRPCError(err error) bool {
-	return grpc.Code(err) != codes.Unknown
+	return grpc.Code(err) != codes.Unknown && err != grpc.ErrClientConnClosing
 }


### PR DESCRIPTION
The code of ErrClientConnClosing is Internal not Unknown. But
it is also not a rpc error from server and worth retrying.

/cc @heyitsanthony 