### PR TITLE
etcd-tester: add compactKV every case, clean up logs

### DIFF
--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -79,7 +79,6 @@ func (s *stresser) Stress() error {
 				})
 				putcancel()
 				if grpc.ErrorDesc(err) == context.Canceled.Error() {
-					log.Printf("etcd-tester: stresser#%d is cancelled", i)
 					return
 				}
 				s.mu.Lock()


### PR DESCRIPTION
It compacts the half of current revision for every failure case.
For https://github.com/coreos/etcd/issues/4380.