### PR TITLE
etcdctlv3: support reading value from stdin

### DIFF
--- a/etcdctlv3/command/global.go
+++ b/etcdctlv3/command/global.go
@@ -16,6 +16,8 @@ package command
 
 import (
 	"errors"
+	"io"
+	"io/ioutil"
 	"time"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
@@ -72,4 +74,15 @@ func mustClient(cmd *cobra.Command) *clientv3.Client {
 		ExitWithError(ExitBadConnection, err)
 	}
 	return client
+}
+
+func argOrStdin(args []string, stdin io.Reader, i int) ([]byte, error) {
+	if i < len(args) {
+		return []byte(args[i]), nil
+	}
+	bytes, err := ioutil.ReadAll(stdin)
+	if string(bytes) == "" || err != nil {
+		return nil, errors.New("no available argument and stdin")
+	}
+	return bytes, nil
 }

--- a/etcdctlv3/command/put_command.go
+++ b/etcdctlv3/command/put_command.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
@@ -30,7 +31,7 @@ var (
 // NewPutCommand returns the cobra command for "put".
 func NewPutCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "put [options] <key> <value>",
+		Use:   "put [options] <key> <value> (<value> can also be given from stdin)",
 		Short: "Put puts the given key into the store.",
 		Long: `
 Put puts the given key into the store.
@@ -40,6 +41,11 @@ Insert '--' for workaround:
 
 $ put <key> -- <value>
 $ put -- <key> <value>
+
+If <value> isn't given, this command tries to read the value from standard input.
+For example,
+$ cat file | put <key>
+will store the content of the file to <key>.
 `,
 		Run: putCommandFunc,
 	}
@@ -49,17 +55,16 @@ $ put -- <key> <value>
 
 // putCommandFunc executes the "put" command.
 func putCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) != 2 {
-		ExitWithError(ExitBadArgs, fmt.Errorf("put command needs 2 arguments."))
+	key := []byte(args[0])
+	value, err := argOrStdin(args, os.Stdin, 1)
+	if err != nil {
+		ExitWithError(ExitBadArgs, fmt.Errorf("put command needs 1 argument and input from stdin or 2 arguments."))
 	}
 
 	id, err := strconv.ParseInt(leaseStr, 16, 64)
 	if err != nil {
 		ExitWithError(ExitBadArgs, fmt.Errorf("bad lease ID arg (%v), expecting ID in Hex", err))
 	}
-
-	key := []byte(args[0])
-	value := []byte(args[1])
 
 	req := &pb.PutRequest{Key: key, Value: value, Lease: id}
 	mustClient(cmd).KV.Put(context.Background(), req)


### PR DESCRIPTION
This commit lets etcdctlv3 support reading value from stdin like
`etcdctl set`. It is convenient for storing complex, long value.