### PR TITLE
build, test: don't pass -a flag for go build during ordinal building

### DIFF
--- a/build
+++ b/build
@@ -29,5 +29,5 @@ else
 fi
 
 # Static compilation is useful when etcd is run in a container
-CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-s -X ${REPO_PATH}/version.GitSHA${LINK_OPERATOR}${GIT_SHA}" -o bin/etcd ${REPO_PATH}
-CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-s" -o bin/etcdctl ${REPO_PATH}/etcdctl
+CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "-s -X ${REPO_PATH}/version.GitSHA${LINK_OPERATOR}${GIT_SHA}" -o bin/etcd ${REPO_PATH}
+CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "-s" -o bin/etcdctl ${REPO_PATH}/etcdctl

--- a/test
+++ b/test
@@ -13,6 +13,7 @@ set -e
 # Invoke ./cover for HTML output
 COVER=${COVER:-"-cover"}
 
+GO_BUILD_FLAGS=-a
 source ./build
 
 # Hack: gofmt ./ will recursively check the .git directory. So use *.go for gofmt.


### PR DESCRIPTION
./build takes long time. On my Core i5 box, it requires almost 25
seconds. Without -a flag, it takes almost 15 seconds. Therefore this
commit reduces the flag in default. ./test activates -a via a new env
var GO_BUILD_FLAGS.