### PR TITLE
contrib/recipes: STM read atomicity

### DIFF
--- a/integration/v3_stm_test.go
+++ b/integration/v3_stm_test.go
@@ -75,7 +75,7 @@ func TestSTMConflict(t *testing.T) {
 	// ensure sum matches initial sum
 	sum := 0
 	for _, oldRK := range keys {
-		rk, err := recipe.GetRemoteKV(etcdc, oldRK.Key())
+		rk, err := recipe.GetRemoteKV(etcdc, oldRK.Key(), 0)
 		if err != nil {
 			t.Fatalf("couldn't fetch key %s (%v)", oldRK.Key(), err)
 		}
@@ -102,7 +102,7 @@ func TestSTMPutNewKey(t *testing.T) {
 		t.Fatalf("error on stm txn (%v)", err)
 	}
 
-	rk, err := recipe.GetRemoteKV(etcdc, "foo")
+	rk, err := recipe.GetRemoteKV(etcdc, "foo", 0)
 	if err != nil {
 		t.Fatalf("error fetching key (%v)", err)
 	}
@@ -128,7 +128,7 @@ func TestSTMAbort(t *testing.T) {
 		t.Fatalf("error on stm txn (%v)", err)
 	}
 
-	rk, err := recipe.GetRemoteKV(etcdc, "foo")
+	rk, err := recipe.GetRemoteKV(etcdc, "foo", 0)
 	if err != nil {
 		t.Fatalf("error fetching key (%v)", err)
 	}


### PR DESCRIPTION
A per-key read conflict model isn't very useful since two keys
may be inconsistent but per-key read conflict free.

Fixes #4420