### PR TITLE
contrib/raftexample: fix restart

### DIFF
--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -35,8 +35,6 @@ type kv struct {
 
 func newKVStore(proposeC chan<- string, commitC <-chan *string, errorC <-chan error) *kvstore {
 	s := &kvstore{proposeC: proposeC, kvStore: make(map[string]string)}
-	// replay log into key-value map
-	s.readCommits(commitC, errorC)
 	// read commits from raft into kvStore map until error
 	go s.readCommits(commitC, errorC)
 	return s

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -148,15 +148,13 @@ func (rc *raftNode) openWAL() *wal.WAL {
 // channel and returns an appendable WAL.
 func (rc *raftNode) replayWAL() *wal.WAL {
 	w := rc.openWAL()
-	_, _, ents, err := w.ReadAll()
+	_, st, ents, err := w.ReadAll()
 	if err != nil {
 		log.Fatalf("raftexample: failed to read WAL (%v)", err)
 	}
 	// append to storage so raft starts at the right place in log
 	rc.raftStorage.Append(ents)
-	rc.publishEntries(ents)
-	// send nil value so client knows commit channel is current
-	rc.commitC <- nil
+	rc.raftStorage.SetHardState(st)
 	return w
 }
 


### PR DESCRIPTION
1. Restarting raft should set hardState correctly.
2. We do not have to apply log entries before starting/restarting raft.

Fix #4474, #4476