### PR TITLE
etcd-agent: cleans page cache when cleaning up

### DIFF
--- a/tools/functional-tester/etcd-agent/agent.go
+++ b/tools/functional-tester/etcd-agent/agent.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"os/exec"
@@ -119,7 +120,17 @@ func (a *Agent) cleanup() error {
 	}
 	f, err := os.Create(a.etcdLogPath)
 	a.logfile = f
-	return err
+	if err != nil {
+		return err
+	}
+
+	// https://www.kernel.org/doc/Documentation/sysctl/vm.txt
+	// https://github.com/torvalds/linux/blob/master/fs/drop_caches.c
+	cmd := exec.Command("/bin/sh", "-c", `echo "echo 1 > /proc/sys/vm/drop_caches" | sudo sh`)
+	if err := cmd.Run(); err != nil {
+		log.Printf("error when cleaning page cache (%v)", err)
+	}
+	return nil
 }
 
 // terminate stops the exiting etcd process the agent started


### PR DESCRIPTION
https://www.kernel.org/doc/Documentation/sysctl/vm.txt
https://github.com/torvalds/linux/blob/master/fs/drop_caches.c


I cannot directly write to `/proc/sys/vm/drop_caches` using Go (without `sudo`).

http://unix.stackexchange.com/questions/17936/setting-proc-sys-vm-drop-caches-to-clear-cache

>  the value you can read is whatever you put last, but it's not used anywhere,
