### PR TITLE
expose error details for normal stringify

### DIFF
--- a/client/cluster_error.go
+++ b/client/cluster_error.go
@@ -21,7 +21,11 @@ type ClusterError struct {
 }
 
 func (ce *ClusterError) Error() string {
-	return ErrClusterUnavailable.Error()
+	s := ce.Detail()
+	if len(s) > 0 {
+		return s
+	}
+	return "ClusterError without any details"
 }
 
 func (ce *ClusterError) Detail() string {


### PR DESCRIPTION
If I just do a normal `Error` against a `ClusterError`, I never get any details from it.  I'd like the details by default.