### PR TITLE
etcd-agent: ignore error when no file to rename

### DIFF
--- a/tools/functional-tester/etcd-agent/agent.go
+++ b/tools/functional-tester/etcd-agent/agent.go
@@ -194,7 +194,14 @@ func archiveLogAndDataDir(log string, datadir string) error {
 		return err
 	}
 	if err := os.Rename(log, path.Join(dir, log)); err != nil {
-		return err
+		if !os.IsNotExist(err) {
+			return err
+		}
 	}
-	return os.Rename(datadir, path.Join(dir, datadir))
+	if err := os.Rename(datadir, path.Join(dir, datadir)); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/coreos/etcd/issues/4512.
When cluster fails before creation of log or data directory
the file does not exist and cannot be renamed. This skips such
error because there's no need to store empty logs in failure_archive.