### PR TITLE
contrib/recipes: fix revision race in double barrier

### DIFF
--- a/contrib/recipes/double_barrier.go
+++ b/contrib/recipes/double_barrier.go
@@ -60,7 +60,7 @@ func (b *DoubleBarrier) Enter() error {
 	_, err = WaitEvents(
 		b.client,
 		b.key+"/ready",
-		resp.Header.Revision,
+		ek.Revision(),
 		[]storagepb.Event_EventType{storagepb.PUT})
 	return err
 }
@@ -100,7 +100,7 @@ func (b *DoubleBarrier) Leave() error {
 		_, err = WaitEvents(
 			b.client,
 			string(highest.Key),
-			resp.Header.Revision,
+			highest.ModRevision,
 			[]storagepb.Event_EventType{storagepb.DELETE})
 		if err != nil {
 			return err
@@ -117,7 +117,7 @@ func (b *DoubleBarrier) Leave() error {
 	_, err = WaitEvents(
 		b.client,
 		key,
-		resp.Header.Revision,
+		lowest.ModRevision,
 		[]storagepb.Event_EventType{storagepb.DELETE})
 	if err != nil {
 		return err

--- a/integration/v3_double_barrier_test.go
+++ b/integration/v3_double_barrier_test.go
@@ -112,13 +112,21 @@ func TestDoubleBarrierFailover(t *testing.T) {
 
 	// wait for barrier enter to unblock
 	for i := 0; i < waiters; i++ {
-		<-donec
+		select {
+		case <-donec:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for enter, %d", i)
+		}
 	}
 	// kill lease, expect Leave unblock
 	recipe.RevokeSessionLease(clus.clients[0])
 	// join on rest of waiters
 	for i := 0; i < waiters-1; i++ {
-		<-donec
+		select {
+		case <-donec:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for leave, %d", i)
+		}
 	}
 }
 


### PR DESCRIPTION
current kv revision might be ahead of ready put event; watch using key's mod
revision instead.

Fixes #4425