### PR TITLE
etcdctlv3: refactoring

### DIFF
--- a/etcdctlv3/command/compaction_command.go
+++ b/etcdctlv3/command/compaction_command.go
@@ -43,7 +43,7 @@ func compactionCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitError, err)
 	}
 
-	c := mustClient(cmd)
+	c := mustClientFromCmd(cmd)
 	if cerr := clientv3.NewKV(c).Compact(context.TODO(), rev); cerr != nil {
 		ExitWithError(ExitError, cerr)
 		return

--- a/etcdctlv3/command/delete_range_command.go
+++ b/etcdctlv3/command/delete_range_command.go
@@ -44,7 +44,7 @@ func deleteRangeCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	req := &pb.DeleteRangeRequest{Key: key, RangeEnd: rangeEnd}
-	mustClient(cmd).KV.DeleteRange(context.Background(), req)
+	mustClientFromCmd(cmd).KV.DeleteRange(context.Background(), req)
 
 	if rangeEnd != nil {
 		fmt.Printf("range [%s, %s) is deleted\n", string(key), string(rangeEnd))

--- a/etcdctlv3/command/lease_command.go
+++ b/etcdctlv3/command/lease_command.go
@@ -62,7 +62,7 @@ func leaseCreateCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("bad TTL (%v)", err))
 	}
 
-	c := mustClient(cmd)
+	c := mustClientFromCmd(cmd)
 	l := clientv3.NewLease(c)
 	resp, err := l.Create(context.TODO(), ttl)
 	if err != nil {
@@ -95,7 +95,7 @@ func leaseRevokeCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("bad lease ID arg (%v), expecting ID in Hex", err))
 	}
 
-	c := mustClient(cmd)
+	c := mustClientFromCmd(cmd)
 	l := clientv3.NewLease(c)
 	_, err = l.Revoke(context.TODO(), lease.LeaseID(id))
 	if err != nil {
@@ -128,7 +128,7 @@ func leaseKeepAliveCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("bad lease ID arg (%v), expecting ID in Hex", err))
 	}
 
-	c := mustClient(cmd)
+	c := mustClientFromCmd(cmd)
 	l := clientv3.NewLease(c)
 	respc, kerr := l.KeepAlive(context.TODO(), lease.LeaseID(id))
 	if kerr != nil {

--- a/etcdctlv3/command/member_command.go
+++ b/etcdctlv3/command/member_command.go
@@ -109,7 +109,7 @@ func memberAddCommandFunc(cmd *cobra.Command, args []string) {
 	urls := strings.Split(memberPeerURLs, ",")
 
 	req := &pb.MemberAddRequest{PeerURLs: urls}
-	resp, err := mustClient(cmd).Cluster.MemberAdd(context.TODO(), req)
+	resp, err := mustClientFromCmd(cmd).Cluster.MemberAdd(context.TODO(), req)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
@@ -129,7 +129,7 @@ func memberRemoveCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	req := &pb.MemberRemoveRequest{ID: uint64(id)}
-	resp, err := mustClient(cmd).Cluster.MemberRemove(context.TODO(), req)
+	resp, err := mustClientFromCmd(cmd).Cluster.MemberRemove(context.TODO(), req)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
@@ -155,7 +155,7 @@ func memberUpdateCommandFunc(cmd *cobra.Command, args []string) {
 	urls := strings.Split(memberPeerURLs, ",")
 
 	req := &pb.MemberUpdateRequest{ID: uint64(id), PeerURLs: urls}
-	resp, err := mustClient(cmd).Cluster.MemberUpdate(context.TODO(), req)
+	resp, err := mustClientFromCmd(cmd).Cluster.MemberUpdate(context.TODO(), req)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
@@ -165,7 +165,7 @@ func memberUpdateCommandFunc(cmd *cobra.Command, args []string) {
 
 // memberListCommandFunc executes the "member list" command.
 func memberListCommandFunc(cmd *cobra.Command, args []string) {
-	resp, err := mustClient(cmd).Cluster.MemberList(context.TODO(), &pb.MemberListRequest{})
+	resp, err := mustClientFromCmd(cmd).Cluster.MemberList(context.TODO(), &pb.MemberListRequest{})
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}

--- a/etcdctlv3/command/put_command.go
+++ b/etcdctlv3/command/put_command.go
@@ -71,7 +71,7 @@ func putCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	req := &pb.PutRequest{Key: key, Value: value, Lease: id}
-	_, err = mustClient(cmd).KV.Put(context.Background(), req)
+	_, err = mustClientFromCmd(cmd).KV.Put(context.Background(), req)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}

--- a/etcdctlv3/command/range_command.go
+++ b/etcdctlv3/command/range_command.go
@@ -93,7 +93,7 @@ func rangeCommandFunc(cmd *cobra.Command, args []string) {
 		SortTarget: sortByTarget,
 		Limit:      int64(rangeLimit),
 	}
-	resp, err := mustClient(cmd).KV.Range(context.Background(), req)
+	resp, err := mustClientFromCmd(cmd).KV.Range(context.Background(), req)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}

--- a/etcdctlv3/command/snapshot_command.go
+++ b/etcdctlv3/command/snapshot_command.go
@@ -40,9 +40,9 @@ func NewSnapshotCommand() *cobra.Command {
 func snapshotCommandFunc(cmd *cobra.Command, args []string) {
 	switch {
 	case len(args) == 0:
-		snapshotToStdout(mustClient(cmd))
+		snapshotToStdout(mustClientFromCmd(cmd))
 	case len(args) == 1:
-		snapshotToFile(mustClient(cmd), args[0])
+		snapshotToFile(mustClientFromCmd(cmd), args[0])
 	default:
 		err := fmt.Errorf("snapshot takes at most one argument")
 		ExitWithError(ExitBadArgs, err)

--- a/etcdctlv3/command/txn_command.go
+++ b/etcdctlv3/command/txn_command.go
@@ -49,7 +49,7 @@ func txnCommandFunc(cmd *cobra.Command, args []string) {
 		next = next(txn, reader)
 	}
 
-	resp, err := mustClient(cmd).KV.Txn(context.Background(), txn)
+	resp, err := mustClientFromCmd(cmd).KV.Txn(context.Background(), txn)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}

--- a/etcdctlv3/command/watch_command.go
+++ b/etcdctlv3/command/watch_command.go
@@ -38,7 +38,7 @@ func NewWatchCommand() *cobra.Command {
 
 // watchCommandFunc executes the "watch" command.
 func watchCommandFunc(cmd *cobra.Command, args []string) {
-	wStream, err := mustClient(cmd).Watch.Watch(context.TODO())
+	wStream, err := mustClientFromCmd(cmd).Watch.Watch(context.TODO())
 	if err != nil {
 		ExitWithError(ExitBadConnection, err)
 	}

--- a/etcdctlv3/main.go
+++ b/etcdctlv3/main.go
@@ -43,9 +43,9 @@ var (
 func init() {
 	rootCmd.PersistentFlags().StringVar(&globalFlags.Endpoints, "endpoint", "127.0.0.1:2378", "gRPC endpoint")
 
-	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.CertFile, "cert", "", "identify HTTPS client using this SSL certificate file")
-	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.KeyFile, "key", "", "identify HTTPS client using this SSL key file")
-	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.CAFile, "cacert", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.CertFile, "cert", "", "identify secure client using this TLS certificate file")
+	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.KeyFile, "key", "", "identify secure client using this TLS key file")
+	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.CAFile, "cacert", "", "verify certificates of TLS-enabled secure servers using this CA bundle")
 
 	rootCmd.AddCommand(
 		command.NewRangeCommand(),


### PR DESCRIPTION
1. Make the flag description more generic and prefer TLS over SSL.
2. Separate out cmd parsing logic for creating client.