### PR TITLE
e2e: compare output in Go string literal

### DIFF
--- a/e2e/etcdctl_test.go
+++ b/e2e/etcdctl_test.go
@@ -212,9 +212,9 @@ func etcdctlSet(clus *etcdProcessCluster, key, value string, noSync bool) error 
 func etcdctlMk(clus *etcdProcessCluster, key, value string, first, noSync bool) error {
 	cmdArgs := append(etcdctlPrefixArgs(clus, noSync), "mk", key, value)
 	if first {
-		return spawnWithExpect(cmdArgs, value)
+		return spawnWithExpectedString(cmdArgs, value)
 	}
-	return spawnWithExpect(cmdArgs, "Error:  105: Key already exists")
+	return spawnWithExpectedString(cmdArgs, "Error:  105: Key already exists")
 }
 
 func etcdctlGet(clus *etcdProcessCluster, key, value string, noSync bool) error {


### PR DESCRIPTION
I manually print out the command outputs when the issue
was reproduced, and checked they are matching when compared as
Go string literals (UTF-8), but not when compared with regex.

Fixes https://github.com/coreos/etcd/issues/4480.