### PR TITLE
storage: remove unnecessary todo

### DIFF
--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -299,7 +299,6 @@ func (s *store) restore() error {
 		log.Printf("storage: restore compact to %d", s.compactMainRev)
 	}
 
-	// TODO: limit N to reduce max memory usage
 	keys, vals := tx.UnsafeRange(keyBucketName, min, max, 0)
 	for i, key := range keys {
 		var kv storagepb.KeyValue


### PR DESCRIPTION
boltdb supports zero-copy get.

https://godoc.org/github.com/boltdb/bolt#Bucket.Get

The returned key,value will not copy into memory again.
So there is nothing we need to do here.
