### PR TITLE
clientv3: fix current watcher reconnection

### DIFF
--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -198,6 +198,12 @@ func (w *watcher) addStream(resp *pb.WatchResponse, pendingReq *watchRequest) {
 		resumec: make(chan int64),
 	}
 
+	if pendingReq.rev == 0 {
+		// note the header revision so that a put following a current watcher
+		// disconnect will arrive on the watcher channel after reconnect
+		ws.initReq.rev = resp.Header.Revision
+	}
+
 	w.mu.Lock()
 	w.streams[ws.id] = ws
 	w.mu.Unlock()


### PR DESCRIPTION
If a current watcher didn't receive any events, a reconnect cycle would
advance its revision to the store's current revision. Instead, reconnect
using the watcher's creation header revision if the watcher hasn't received
any events.

Fixes #4502