### PR TITLE
etcdctlv3: Compatibility Support

### DIFF
--- a/etcdctlv3/README.md
+++ b/etcdctlv3/README.md
@@ -323,3 +323,19 @@ Simple reply
 
 [etcdrpc]: ../etcdserver/etcdserverpb/rpc.proto
 [storagerpc]: ../storage/storagepb/kv.proto
+
+## Compatibility Support
+
+etcdctl is still in its early stage. We try out best to ensure fully compatible releases, however we might break compatibility to fix bugs or improve commands. If we intend to release a version of etcdctl with backward incompatibilities, we will provide notice prior to release and have instructions on how to upgrade.
+
+### Input Compatibility
+
+Input includes the command name, its flags, and its arguments. We ensure backward compatibility of the input of normal commands in non-interactive mode.
+
+### Output Compatibility
+
+Output includes output from etcdctl and its exit code. etcdctl provides `simple` output format by default.
+We ensure compatibility for the `simple` output format of normal commands in non-interactive mode. Currently, we do not ensure
+backward compatibility for `JSON` format and the format in non-interactive mode. Currently, we do not ensure backward compatibility of utility commands.
+
+### TODO: compatibility with etcd server


### PR DESCRIPTION
We'd better start worrying output compatibility from day one and set up correct expectation.

We will start with a simple rule for **output** compatibility (we will start worry about other kinds of compatibility later)

1. output compatibility for all simple reply format and other backwards-compatibility friendly format like protobuf
2. no output compatibility support for interactive mode command, like interactive watch, txn.
3. no output compatibility for utilities like mirror-maker or snapshot.
4. adding output compatibility support for other backwards-compatibilit unfriendly format (like JSON) when we feel they are stable.

/cc @philips @heyitsanthony @gyuho 