### PR TITLE
Update clustering documentation for etcd2

### DIFF
--- a/Documentation/clustering.md
+++ b/Documentation/clustering.md
@@ -30,8 +30,8 @@ ETCD_INITIAL_CLUSTER_STATE=new
 ```
 
 ```
--initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
-  -initial-cluster-state new
+--initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
+--initial-cluster-state new
 ```
 
 Note that the URLs specified in `initial-cluster` are the _advertised peer URLs_, i.e. they should match the value of `initial-advertise-peer-urls` on the respective nodes.
@@ -43,46 +43,46 @@ etcd listens on [`listen-client-urls`](configuration.md#-listen-client-urls) to 
 On each machine you would start etcd with these flags:
 
 ```
-$ etcd -name infra0 -initial-advertise-peer-urls http://10.0.1.10:2380 \
-  -listen-peer-urls http://10.0.1.10:2380 \
-  -listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.10:2379 \
-  -initial-cluster-token etcd-cluster-1 \
-  -initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
-  -initial-cluster-state new
+$ etcd --name infra0 --initial-advertise-peer-urls http://10.0.1.10:2380 \
+  --listen-peer-urls http://10.0.1.10:2380 \
+  --listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.10:2379 \
+  --initial-cluster-token etcd-cluster-1 \
+  --initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
+  --initial-cluster-state new
 ```
 ```
-$ etcd -name infra1 -initial-advertise-peer-urls http://10.0.1.11:2380 \
-  -listen-peer-urls http://10.0.1.11:2380 \
-  -listen-client-urls http://10.0.1.11:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.11:2379 \
-  -initial-cluster-token etcd-cluster-1 \
-  -initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
-  -initial-cluster-state new
+$ etcd --name infra1 --initial-advertise-peer-urls http://10.0.1.11:2380 \
+  --listen-peer-urls http://10.0.1.11:2380 \
+  --listen-client-urls http://10.0.1.11:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.11:2379 \
+  --initial-cluster-token etcd-cluster-1 \
+  --initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
+  --initial-cluster-state new
 ```
 ```
-$ etcd -name infra2 -initial-advertise-peer-urls http://10.0.1.12:2380 \
-  -listen-peer-urls http://10.0.1.12:2380 \
-  -listen-client-urls http://10.0.1.12:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.12:2379 \
-  -initial-cluster-token etcd-cluster-1 \
-  -initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
-  -initial-cluster-state new
+$ etcd --name infra2 --initial-advertise-peer-urls http://10.0.1.12:2380 \
+  --listen-peer-urls http://10.0.1.12:2380 \
+  --listen-client-urls http://10.0.1.12:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.12:2379 \
+  --initial-cluster-token etcd-cluster-1 \
+  --initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
+  --initial-cluster-state new
 ```
 
-The command line parameters starting with `-initial-cluster` will be ignored on subsequent runs of etcd. You are free to remove the environment variables or command line flags after the initial bootstrap process. If you need to make changes to the configuration later (for example, adding or removing members to/from the cluster), see the [runtime configuration](runtime-configuration.md) guide.
+The command line parameters starting with `--initial-cluster` will be ignored on subsequent runs of etcd. You are free to remove the environment variables or command line flags after the initial bootstrap process. If you need to make changes to the configuration later (for example, adding or removing members to/from the cluster), see the [runtime configuration](runtime-configuration.md) guide.
 
 ### Error Cases
 
 In the following example, we have not included our new host in the list of enumerated nodes. If this is a new cluster, the node _must_ be added to the list of initial cluster members.
 
 ```
-$ etcd -name infra1 -initial-advertise-peer-urls http://10.0.1.11:2380 \
-  -listen-peer-urls https://10.0.1.11:2380 \
-  -listen-client-urls http://10.0.1.11:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.11:2379 \
-  -initial-cluster infra0=http://10.0.1.10:2380 \
-  -initial-cluster-state new
+$ etcd --name infra1 --initial-advertise-peer-urls http://10.0.1.11:2380 \
+  --listen-peer-urls https://10.0.1.11:2380 \
+  --listen-client-urls http://10.0.1.11:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.11:2379 \
+  --initial-cluster infra0=http://10.0.1.10:2380 \
+  --initial-cluster-state new
 etcd: infra1 not listed in the initial cluster config
 exit 1
 ```
@@ -90,12 +90,12 @@ exit 1
 In this example, we are attempting to map a node (infra0) on a different address (127.0.0.1:2380) than its enumerated address in the cluster list (10.0.1.10:2380). If this node is to listen on multiple addresses, all addresses _must_ be reflected in the "initial-cluster" configuration directive.
 
 ```
-$ etcd -name infra0 -initial-advertise-peer-urls http://127.0.0.1:2380 \
-  -listen-peer-urls http://10.0.1.10:2380 \
-  -listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.10:2379 \
-  -initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
-  -initial-cluster-state=new
+$ etcd --name infra0 --initial-advertise-peer-urls http://127.0.0.1:2380 \
+  --listen-peer-urls http://10.0.1.10:2380 \
+  --listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.10:2379 \
+  --initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380 \
+  --initial-cluster-state=new
 etcd: error setting up initial cluster: infra0 has different advertised URLs in the cluster and advertised peer URLs list
 exit 1
 ```
@@ -103,12 +103,12 @@ exit 1
 If you configure a peer with a different set of configuration and attempt to join this cluster you will get a cluster ID mismatch and etcd will exit.
 
 ```
-$ etcd -name infra3 -initial-advertise-peer-urls http://10.0.1.13:2380 \
-  -listen-peer-urls http://10.0.1.13:2380 \
-  -listen-client-urls http://10.0.1.13:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.13:2379 \
-  -initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra3=http://10.0.1.13:2380 \
-  -initial-cluster-state=new
+$ etcd --name infra3 --initial-advertise-peer-urls http://10.0.1.13:2380 \
+  --listen-peer-urls http://10.0.1.13:2380 \
+  --listen-client-urls http://10.0.1.13:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.13:2379 \
+  --initial-cluster infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra3=http://10.0.1.13:2380 \
+  --initial-cluster-state=new
 etcd: conflicting cluster ID to the target cluster (c6ab534d07e8fcc4 != bc25ea2a74fb18b0). Exiting.
 exit 1
 ```
@@ -148,30 +148,30 @@ If you bootstrap an etcd cluster using discovery service with more than the expe
 
 The URL you will use in this case will be `https://myetcd.local/v2/keys/discovery/6c007a14875d53d9bf0ef5a6fc0257c817f0fb83` and the etcd members will use the `https://myetcd.local/v2/keys/discovery/6c007a14875d53d9bf0ef5a6fc0257c817f0fb83` directory for registration as they start.
 
-**Each member must have a different name flag specified. `Hostname` or `machine-id` can be a good choice. Or discovery will fail due to duplicated name.** 
+**Each member must have a different name flag specified. `Hostname` or `machine-id` can be a good choice. Or discovery will fail due to duplicated name.**
 
 Now we start etcd with those relevant flags for each member:
 
 ```
-$ etcd -name infra0 -initial-advertise-peer-urls http://10.0.1.10:2380 \
-  -listen-peer-urls http://10.0.1.10:2380 \
-  -listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.10:2379 \
-  -discovery https://myetcd.local/v2/keys/discovery/6c007a14875d53d9bf0ef5a6fc0257c817f0fb83
+$ etcd --name infra0 --initial-advertise-peer-urls http://10.0.1.10:2380 \
+  --listen-peer-urls http://10.0.1.10:2380 \
+  --listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.10:2379 \
+  --discovery https://myetcd.local/v2/keys/discovery/6c007a14875d53d9bf0ef5a6fc0257c817f0fb83
 ```
 ```
-$ etcd -name infra1 -initial-advertise-peer-urls http://10.0.1.11:2380 \
-  -listen-peer-urls http://10.0.1.11:2380 \
-  -listen-client-urls http://10.0.1.11:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.11:2379 \
-  -discovery https://myetcd.local/v2/keys/discovery/6c007a14875d53d9bf0ef5a6fc0257c817f0fb83
+$ etcd --name infra1 --initial-advertise-peer-urls http://10.0.1.11:2380 \
+  --listen-peer-urls http://10.0.1.11:2380 \
+  --listen-client-urls http://10.0.1.11:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.11:2379 \
+  --discovery https://myetcd.local/v2/keys/discovery/6c007a14875d53d9bf0ef5a6fc0257c817f0fb83
 ```
 ```
-$ etcd -name infra2 -initial-advertise-peer-urls http://10.0.1.12:2380 \
-  -listen-peer-urls http://10.0.1.12:2380 \
-  -listen-client-urls http://10.0.1.12:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.12:2379 \
-  -discovery https://myetcd.local/v2/keys/discovery/6c007a14875d53d9bf0ef5a6fc0257c817f0fb83
+$ etcd --name infra2 --initial-advertise-peer-urls http://10.0.1.12:2380 \
+  --listen-peer-urls http://10.0.1.12:2380 \
+  --listen-client-urls http://10.0.1.12:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.12:2379 \
+  --discovery https://myetcd.local/v2/keys/discovery/6c007a14875d53d9bf0ef5a6fc0257c817f0fb83
 ```
 
 This will cause each member to register itself with the custom etcd discovery service and begin the cluster once all machines have been registered.
@@ -200,30 +200,30 @@ ETCD_DISCOVERY=https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573d
 -discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 ```
 
-**Each member must have a different name flag specified. `Hostname` or `machine-id` can be a good choice. Or discovery will fail due to duplicated name.** 
+**Each member must have a different name flag specified. `Hostname` or `machine-id` can be a good choice. Or discovery will fail due to duplicated name.**
 
 Now we start etcd with those relevant flags for each member:
 
 ```
-$ etcd -name infra0 -initial-advertise-peer-urls http://10.0.1.10:2380 \
-  -listen-peer-urls http://10.0.1.10:2380 \
-  -listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.10:2379 \
-  -discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
+$ etcd --name infra0 --initial-advertise-peer-urls http://10.0.1.10:2380 \
+  --listen-peer-urls http://10.0.1.10:2380 \
+  --listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.10:2379 \
+  --discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 ```
 ```
-$ etcd -name infra1 -initial-advertise-peer-urls http://10.0.1.11:2380 \
-  -listen-peer-urls http://10.0.1.11:2380 \
-  -listen-client-urls http://10.0.1.11:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.11:2379 \
-  -discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
+$ etcd --name infra1 --initial-advertise-peer-urls http://10.0.1.11:2380 \
+  --listen-peer-urls http://10.0.1.11:2380 \
+  --listen-client-urls http://10.0.1.11:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.11:2379 \
+  --discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 ```
 ```
-$ etcd -name infra2 -initial-advertise-peer-urls http://10.0.1.12:2380 \
-  -listen-peer-urls http://10.0.1.12:2380 \
-  -listen-client-urls http://10.0.1.12:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.12:2379 \
-  -discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
+$ etcd --name infra2 --initial-advertise-peer-urls http://10.0.1.12:2380 \
+  --listen-peer-urls http://10.0.1.12:2380 \
+  --listen-client-urls http://10.0.1.12:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.12:2379 \
+  --discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 ```
 
 This will cause each member to register itself with the discovery service and begin the cluster once all members have been registered.
@@ -236,11 +236,11 @@ You can use the environment variable `ETCD_DISCOVERY_PROXY` to cause etcd to use
 
 
 ```
-$ etcd -name infra0 -initial-advertise-peer-urls http://10.0.1.10:2380 \
-  -listen-peer-urls http://10.0.1.10:2380 \
-  -listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.10:2379 \
-  -discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
+$ etcd --name infra0 --initial-advertise-peer-urls http://10.0.1.10:2380 \
+  --listen-peer-urls http://10.0.1.10:2380 \
+  --listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.10:2379 \
+  --discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 etcd: error: the cluster doesn’t have a size configuration value in https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de/_config
 exit 1
 ```
@@ -250,12 +250,12 @@ exit 1
 This error will occur if the discovery cluster already has the configured number of members, and `discovery-fallback` is explicitly disabled
 
 ```
-$ etcd -name infra0 -initial-advertise-peer-urls http://10.0.1.10:2380 \
-  -listen-peer-urls http://10.0.1.10:2380 \
-  -listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.10:2379 \
-  -discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de \
-  -discovery-fallback exit
+$ etcd --name infra0 --initial-advertise-peer-urls http://10.0.1.10:2380 \
+  --listen-peer-urls http://10.0.1.10:2380 \
+  --listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.10:2379 \
+  --discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de \
+  --discovery-fallback exit
 etcd: discovery: cluster is full
 exit 1
 ```
@@ -266,11 +266,11 @@ This is a harmless warning notifying you that the discovery URL will be
 ignored on this machine.
 
 ```
-$ etcd -name infra0 -initial-advertise-peer-urls http://10.0.1.10:2380 \
-  -listen-peer-urls http://10.0.1.10:2380 \
-  -listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
-  -advertise-client-urls http://10.0.1.10:2379 \
-  -discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
+$ etcd --name infra0 --initial-advertise-peer-urls http://10.0.1.10:2380 \
+  --listen-peer-urls http://10.0.1.10:2380 \
+  --listen-client-urls http://10.0.1.10:2379,http://127.0.0.1:2379 \
+  --advertise-client-urls http://10.0.1.10:2379 \
+  --discovery https://discovery.etcd.io/3e86b59982e49066c5d813af1c2e2579cbf573de
 etcdserver: discovery token ignored since a cluster has already been initialized. Valid log found at /var/lib/etcd
 ```
 
@@ -296,9 +296,9 @@ If `_etcd-client-ssl._tcp.example.com` is found, clients will attempt to communi
 
 ```
 $ dig +noall +answer SRV _etcd-server._tcp.example.com
-_etcd-server._tcp.example.com. 300 IN	SRV	0 0 2380 infra0.example.com.
-_etcd-server._tcp.example.com. 300 IN	SRV	0 0 2380 infra1.example.com.
-_etcd-server._tcp.example.com. 300 IN	SRV	0 0 2380 infra2.example.com.
+_etcd-server._tcp.example.com. 300 IN  SRV  0 0 2380 infra0.example.com.
+_etcd-server._tcp.example.com. 300 IN  SRV  0 0 2380 infra1.example.com.
+_etcd-server._tcp.example.com. 300 IN  SRV  0 0 2380 infra2.example.com.
 ```
 
 ```
@@ -310,82 +310,82 @@ _etcd-client._tcp.example.com. 300 IN SRV 0 0 2379 infra2.example.com.
 
 ```
 $ dig +noall +answer infra0.example.com infra1.example.com infra2.example.com
-infra0.example.com.	300	IN	A	10.0.1.10
-infra1.example.com.	300	IN	A	10.0.1.11
-infra2.example.com.	300	IN	A	10.0.1.12
+infra0.example.com.  300  IN  A  10.0.1.10
+infra1.example.com.  300  IN  A  10.0.1.11
+infra2.example.com.  300  IN  A  10.0.1.12
 ```
 #### Bootstrap the etcd cluster using DNS
 
 etcd cluster members can listen on domain names or IP address, the bootstrap process will resolve DNS A records.
 
-The resolved address in `-initial-advertise-peer-urls` *must match* one of the resolved addresses in the SRV targets. The etcd member reads the resolved address to find out if it belongs to the cluster defined in the SRV records.
+The resolved address in `--initial-advertise-peer-urls` *must match* one of the resolved addresses in the SRV targets. The etcd member reads the resolved address to find out if it belongs to the cluster defined in the SRV records.
 
 ```
-$ etcd -name infra0 \
--discovery-srv example.com \
--initial-advertise-peer-urls http://infra0.example.com:2380 \
--initial-cluster-token etcd-cluster-1 \
--initial-cluster-state new \
--advertise-client-urls http://infra0.example.com:2379 \
--listen-client-urls http://infra0.example.com:2379 \
--listen-peer-urls http://infra0.example.com:2380
-```
-
-```
-$ etcd -name infra1 \
--discovery-srv example.com \
--initial-advertise-peer-urls http://infra1.example.com:2380 \
--initial-cluster-token etcd-cluster-1 \
--initial-cluster-state new \
--advertise-client-urls http://infra1.example.com:2379 \
--listen-client-urls http://infra1.example.com:2379 \
--listen-peer-urls http://infra1.example.com:2380
+$ etcd --name infra0 \
+--discovery-srv example.com \
+--initial-advertise-peer-urls http://infra0.example.com:2380 \
+--initial-cluster-token etcd-cluster-1 \
+--initial-cluster-state new \
+--advertise-client-urls http://infra0.example.com:2379 \
+--listen-client-urls http://infra0.example.com:2379 \
+--listen-peer-urls http://infra0.example.com:2380
 ```
 
 ```
-$ etcd -name infra2 \
--discovery-srv example.com \
--initial-advertise-peer-urls http://infra2.example.com:2380 \
--initial-cluster-token etcd-cluster-1 \
--initial-cluster-state new \
--advertise-client-urls http://infra2.example.com:2379 \
--listen-client-urls http://infra2.example.com:2379 \
--listen-peer-urls http://infra2.example.com:2380
+$ etcd --name infra1 \
+--discovery-srv example.com \
+--initial-advertise-peer-urls http://infra1.example.com:2380 \
+--initial-cluster-token etcd-cluster-1 \
+--initial-cluster-state new \
+--advertise-client-urls http://infra1.example.com:2379 \
+--listen-client-urls http://infra1.example.com:2379 \
+--listen-peer-urls http://infra1.example.com:2380
+```
+
+```
+$ etcd --name infra2 \
+--discovery-srv example.com \
+--initial-advertise-peer-urls http://infra2.example.com:2380 \
+--initial-cluster-token etcd-cluster-1 \
+--initial-cluster-state new \
+--advertise-client-urls http://infra2.example.com:2379 \
+--listen-client-urls http://infra2.example.com:2379 \
+--listen-peer-urls http://infra2.example.com:2380
 ```
 
 You can also bootstrap the cluster using IP addresses instead of domain names:
 
 ```
-$ etcd -name infra0 \
--discovery-srv example.com \
--initial-advertise-peer-urls http://10.0.1.10:2380 \
--initial-cluster-token etcd-cluster-1 \
--initial-cluster-state new \
--advertise-client-urls http://10.0.1.10:2379 \
--listen-client-urls http://10.0.1.10:2379 \
--listen-peer-urls http://10.0.1.10:2380
+$ etcd --name infra0 \
+--discovery-srv example.com \
+--initial-advertise-peer-urls http://10.0.1.10:2380 \
+--initial-cluster-token etcd-cluster-1 \
+--initial-cluster-state new \
+--advertise-client-urls http://10.0.1.10:2379 \
+--listen-client-urls http://10.0.1.10:2379 \
+--listen-peer-urls http://10.0.1.10:2380
 ```
 
 ```
-$ etcd -name infra1 \
--discovery-srv example.com \
--initial-advertise-peer-urls http://10.0.1.11:2380 \
--initial-cluster-token etcd-cluster-1 \
--initial-cluster-state new \
--advertise-client-urls http://10.0.1.11:2379 \
--listen-client-urls http://10.0.1.11:2379 \
--listen-peer-urls http://10.0.1.11:2380
+$ etcd --name infra1 \
+--discovery-srv example.com \
+--initial-advertise-peer-urls http://10.0.1.11:2380 \
+--initial-cluster-token etcd-cluster-1 \
+--initial-cluster-state new \
+--advertise-client-urls http://10.0.1.11:2379 \
+--listen-client-urls http://10.0.1.11:2379 \
+--listen-peer-urls http://10.0.1.11:2380
 ```
 
 ```
-$ etcd -name infra2 \
--discovery-srv example.com \
--initial-advertise-peer-urls http://10.0.1.12:2380 \
--initial-cluster-token etcd-cluster-1 \
--initial-cluster-state new \
--advertise-client-urls http://10.0.1.12:2379 \
--listen-client-urls http://10.0.1.12:2379 \
--listen-peer-urls http://10.0.1.12:2380
+$ etcd --name infra2 \
+--discovery-srv example.com \
+--initial-advertise-peer-urls http://10.0.1.12:2380 \
+--initial-cluster-token etcd-cluster-1 \
+--initial-cluster-state new \
+--advertise-client-urls http://10.0.1.12:2379 \
+--listen-client-urls http://10.0.1.12:2379 \
+--listen-peer-urls http://10.0.1.12:2380
 ```
 
 #### etcd proxy configuration
@@ -393,7 +393,7 @@ $ etcd -name infra2 \
 DNS SRV records can also be used to configure the list of peers for an etcd server running in proxy mode:
 
 ```
-$ etcd --proxy on -discovery-srv example.com
+$ etcd --proxy on --discovery-srv example.com
 ```
 
 #### etcd client configuration
@@ -410,7 +410,7 @@ $ etcdctl --discovery-srv example.com set foo bar
 
 #### Error Cases
 
-You might see an error like `cannot find local etcd $name from SRV records.`. That means the etcd member fails to find itself from the cluster defined in SRV records. The resolved address in `-initial-advertise-peer-urls` *must match* one of the resolved addresses in the SRV targets.
+You might see an error like `cannot find local etcd $name from SRV records.`. That means the etcd member fails to find itself from the cluster defined in SRV records. The resolved address in `--initial-advertise-peer-urls` *must match* one of the resolved addresses in the SRV targets.
 
 # 0.4 to 2.0+ Migration Guide
 
@@ -418,11 +418,11 @@ In etcd 2.0 we introduced the ability to listen on more than one address and to 
 
 To make understanding this feature easier, we changed the naming of some flags, but we support the old flags to make the migration from the old to new version easier.
 
-|Old Flag		|New Flag		|Migration Behavior									|
+|Old Flag    |New Flag    |Migration Behavior                  |
 |-----------------------|-----------------------|---------------------------------------------------------------------------------------|
-|-peer-addr		|-initial-advertise-peer-urls 	|If specified, peer-addr will be used as the only peer URL. Error if both flags specified.|
-|-addr			|-advertise-client-urls	|If specified, addr will be used as the only client URL. Error if both flags specified.|
-|-peer-bind-addr	|-listen-peer-urls	|If specified, peer-bind-addr will be used as the only peer bind URL. Error if both flags specified.|
-|-bind-addr		|-listen-client-urls	|If specified, bind-addr will be used as the only client bind URL. Error if both flags specified.|
-|-peers			|none			|Deprecated. The -initial-cluster flag provides a similar concept with different semantics. Please read this guide on cluster startup.|
-|-peers-file		|none			|Deprecated. The -initial-cluster flag provides a similar concept with different semantics. Please read this guide on cluster startup.|
+|-peer-addr    |--initial-advertise-peer-urls   |If specified, peer-addr will be used as the only peer URL. Error if both flags specified.|
+|-addr      |--advertise-client-urls  |If specified, addr will be used as the only client URL. Error if both flags specified.|
+|-peer-bind-addr  |--listen-peer-urls  |If specified, peer-bind-addr will be used as the only peer bind URL. Error if both flags specified.|
+|-bind-addr    |--listen-client-urls  |If specified, bind-addr will be used as the only client bind URL. Error if both flags specified.|
+|-peers      |none      |Deprecated. The --initial-cluster flag provides a similar concept with different semantics. Please read this guide on cluster startup.|
+|-peers-file    |none      |Deprecated. The --initial-cluster flag provides a similar concept with different semantics. Please read this guide on cluster startup.|


### PR DESCRIPTION
Make clustering documentation use double-dash flags. Also replace tabs with spaces.

See https://github.com/coreos/bugs/issues/1128.