### PR TITLE
clientv3: copy correct pointers into txn comparisons

### DIFF
--- a/clientv3/txn.go
+++ b/clientv3/txn.go
@@ -85,8 +85,8 @@ func (txn *txn) If(cs ...Cmp) Txn {
 
 	txn.cif = true
 
-	for _, cmp := range cs {
-		txn.cmps = append(txn.cmps, (*pb.Compare)(&cmp))
+	for i := range cs {
+		txn.cmps = append(txn.cmps, (*pb.Compare)(&cs[i]))
 	}
 
 	return txn


### PR DESCRIPTION
Was copying the range variable's pointer; all elements of cmp were the same.