### PR TITLE
clientv3: compose API interfaces into client struct

### DIFF
--- a/clientv3/concurrency/key.go
+++ b/clientv3/concurrency/key.go
@@ -40,9 +40,7 @@ func NewUniqueKey(ctx context.Context, kv v3.KV, pfx string, opts ...v3.OpOption
 }
 
 func waitUpdate(ctx context.Context, client *v3.Client, key string, opts ...v3.OpOption) error {
-	w := v3.NewWatcher(client)
-	defer w.Close()
-	wc := w.Watch(ctx, key, opts...)
+	wc := client.Watch(ctx, key, opts...)
 	if wc == nil {
 		return ctx.Err()
 	}

--- a/clientv3/example_cluster_test.go
+++ b/clientv3/example_cluster_test.go
@@ -32,9 +32,7 @@ func ExampleCluster_memberList() {
 	}
 	defer cli.Close()
 
-	capi := clientv3.NewCluster(cli)
-
-	resp, err := capi.MemberList(context.Background())
+	resp, err := cli.MemberList(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -52,9 +50,7 @@ func ExampleCluster_memberLeader() {
 	}
 	defer cli.Close()
 
-	capi := clientv3.NewCluster(cli)
-
-	resp, err := capi.MemberLeader(context.Background())
+	resp, err := cli.MemberLeader(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -72,10 +68,8 @@ func ExampleCluster_memberAdd() {
 	}
 	defer cli.Close()
 
-	capi := clientv3.NewCluster(cli)
-
 	peerURLs := endpoints[2:]
-	mresp, err := capi.MemberAdd(context.Background(), peerURLs)
+	mresp, err := cli.MemberAdd(context.Background(), peerURLs)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -93,14 +87,12 @@ func ExampleCluster_memberRemove() {
 	}
 	defer cli.Close()
 
-	capi := clientv3.NewCluster(cli)
-
-	resp, err := capi.MemberList(context.Background())
+	resp, err := cli.MemberList(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	_, err = capi.MemberRemove(context.Background(), resp.Members[0].ID)
+	_, err = cli.MemberRemove(context.Background(), resp.Members[0].ID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -116,15 +108,13 @@ func ExampleCluster_memberUpdate() {
 	}
 	defer cli.Close()
 
-	capi := clientv3.NewCluster(cli)
-
-	resp, err := capi.MemberList(context.Background())
+	resp, err := cli.MemberList(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	peerURLs := []string{"http://localhost:12378"}
-	_, err = capi.MemberUpdate(context.Background(), resp.Members[0].ID, peerURLs)
+	_, err = cli.MemberUpdate(context.Background(), resp.Members[0].ID, peerURLs)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/clientv3/example_kv_test.go
+++ b/clientv3/example_kv_test.go
@@ -32,10 +32,8 @@ func ExampleKV_put() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
-
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	resp, err := kvc.Put(ctx, "sample_key", "sample_value")
+	resp, err := cli.Put(ctx, "sample_key", "sample_value")
 	cancel()
 	if err != nil {
 		log.Fatal(err)
@@ -54,15 +52,13 @@ func ExampleKV_get() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
-
-	_, err = kvc.Put(context.TODO(), "foo", "bar")
+	_, err = cli.Put(context.TODO(), "foo", "bar")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	resp, err := kvc.Get(ctx, "foo")
+	resp, err := cli.Get(ctx, "foo")
 	cancel()
 	if err != nil {
 		log.Fatal(err)
@@ -83,11 +79,9 @@ func ExampleKV_getSortedPrefix() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
-
 	for i := range make([]int, 3) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-		_, err = kvc.Put(ctx, fmt.Sprintf("key_%d", i), "value")
+		_, err = cli.Put(ctx, fmt.Sprintf("key_%d", i), "value")
 		cancel()
 		if err != nil {
 			log.Fatal(err)
@@ -95,7 +89,7 @@ func ExampleKV_getSortedPrefix() {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	resp, err := kvc.Get(ctx, "key", clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
+	resp, err := cli.Get(ctx, "key", clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortDescend))
 	cancel()
 	if err != nil {
 		log.Fatal(err)
@@ -118,10 +112,8 @@ func ExampleKV_delete() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
-
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	resp, err := kvc.Delete(ctx, "key", clientv3.WithPrefix())
+	resp, err := cli.Delete(ctx, "key", clientv3.WithPrefix())
 	cancel()
 	if err != nil {
 		log.Fatal(err)
@@ -140,10 +132,8 @@ func ExampleKV_compact() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
-
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	resp, err := kvc.Get(ctx, "foo")
+	resp, err := cli.Get(ctx, "foo")
 	cancel()
 	if err != nil {
 		log.Fatal(err)
@@ -151,7 +141,7 @@ func ExampleKV_compact() {
 	compRev := resp.Header.Revision // specify compact revision of your choice
 
 	ctx, cancel = context.WithTimeout(context.Background(), requestTimeout)
-	err = kvc.Compact(ctx, compRev)
+	err = cli.Compact(ctx, compRev)
 	cancel()
 	if err != nil {
 		log.Fatal(err)
@@ -207,15 +197,13 @@ func ExampleKV_do() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
-
 	ops := []clientv3.Op{
 		clientv3.OpPut("put-key", "123"),
 		clientv3.OpGet("put-key"),
 		clientv3.OpPut("put-key", "456")}
 
 	for _, op := range ops {
-		if _, err := kvc.Do(context.TODO(), op); err != nil {
+		if _, err := cli.Do(context.TODO(), op); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/clientv3/example_lease_test.go
+++ b/clientv3/example_lease_test.go
@@ -33,11 +33,8 @@ func ExampleLease_create() {
 	}
 	defer cli.Close()
 
-	lapi := clientv3.NewLease(cli)
-	defer lapi.Close()
-
 	// minimum lease TTL is 5-second
-	resp, err := lapi.Create(context.TODO(), 5)
+	resp, err := cli.Create(context.TODO(), 5)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -59,10 +56,7 @@ func ExampleLease_revoke() {
 	}
 	defer cli.Close()
 
-	lapi := clientv3.NewLease(cli)
-	defer lapi.Close()
-
-	resp, err := lapi.Create(context.TODO(), 5)
+	resp, err := cli.Create(context.TODO(), 5)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -73,7 +67,7 @@ func ExampleLease_revoke() {
 	}
 
 	// revoking lease expires the key attached to its lease ID
-	_, err = lapi.Revoke(context.TODO(), lease.LeaseID(resp.ID))
+	_, err = cli.Revoke(context.TODO(), lease.LeaseID(resp.ID))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -96,10 +90,7 @@ func ExampleLease_keepAlive() {
 	}
 	defer cli.Close()
 
-	lapi := clientv3.NewLease(cli)
-	defer lapi.Close()
-
-	resp, err := lapi.Create(context.TODO(), 5)
+	resp, err := cli.Create(context.TODO(), 5)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -110,7 +101,7 @@ func ExampleLease_keepAlive() {
 	}
 
 	// the key 'foo' will be kept forever
-	_, err = lapi.KeepAlive(context.TODO(), lease.LeaseID(resp.ID))
+	_, err = cli.KeepAlive(context.TODO(), lease.LeaseID(resp.ID))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -126,10 +117,7 @@ func ExampleLease_keepAliveOnce() {
 	}
 	defer cli.Close()
 
-	lapi := clientv3.NewLease(cli)
-	defer lapi.Close()
-
-	resp, err := lapi.Create(context.TODO(), 5)
+	resp, err := cli.Create(context.TODO(), 5)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -140,7 +128,7 @@ func ExampleLease_keepAliveOnce() {
 	}
 
 	// to renew the lease only once
-	_, err = lapi.KeepAliveOnce(context.TODO(), lease.LeaseID(resp.ID))
+	_, err = cli.KeepAliveOnce(context.TODO(), lease.LeaseID(resp.ID))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/clientv3/example_lease_test.go
+++ b/clientv3/example_lease_test.go
@@ -33,7 +33,6 @@ func ExampleLease_create() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
 	lapi := clientv3.NewLease(cli)
 	defer lapi.Close()
 
@@ -44,7 +43,7 @@ func ExampleLease_create() {
 	}
 
 	// after 5 seconds, the key 'foo' will be removed
-	_, err = kvc.Put(context.TODO(), "foo", "bar", clientv3.WithLease(lease.LeaseID(resp.ID)))
+	_, err = cli.Put(context.TODO(), "foo", "bar", clientv3.WithLease(lease.LeaseID(resp.ID)))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -60,7 +59,6 @@ func ExampleLease_revoke() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
 	lapi := clientv3.NewLease(cli)
 	defer lapi.Close()
 
@@ -69,7 +67,7 @@ func ExampleLease_revoke() {
 		log.Fatal(err)
 	}
 
-	_, err = kvc.Put(context.TODO(), "foo", "bar", clientv3.WithLease(lease.LeaseID(resp.ID)))
+	_, err = cli.Put(context.TODO(), "foo", "bar", clientv3.WithLease(lease.LeaseID(resp.ID)))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -80,7 +78,7 @@ func ExampleLease_revoke() {
 		log.Fatal(err)
 	}
 
-	gresp, err := kvc.Get(context.TODO(), "foo")
+	gresp, err := cli.Get(context.TODO(), "foo")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,7 +96,6 @@ func ExampleLease_keepAlive() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
 	lapi := clientv3.NewLease(cli)
 	defer lapi.Close()
 
@@ -107,7 +104,7 @@ func ExampleLease_keepAlive() {
 		log.Fatal(err)
 	}
 
-	_, err = kvc.Put(context.TODO(), "foo", "bar", clientv3.WithLease(lease.LeaseID(resp.ID)))
+	_, err = cli.Put(context.TODO(), "foo", "bar", clientv3.WithLease(lease.LeaseID(resp.ID)))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -129,7 +126,6 @@ func ExampleLease_keepAliveOnce() {
 	}
 	defer cli.Close()
 
-	kvc := clientv3.NewKV(cli)
 	lapi := clientv3.NewLease(cli)
 	defer lapi.Close()
 
@@ -138,7 +134,7 @@ func ExampleLease_keepAliveOnce() {
 		log.Fatal(err)
 	}
 
-	_, err = kvc.Put(context.TODO(), "foo", "bar", clientv3.WithLease(lease.LeaseID(resp.ID)))
+	_, err = cli.Put(context.TODO(), "foo", "bar", clientv3.WithLease(lease.LeaseID(resp.ID)))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/clientv3/example_test.go
+++ b/clientv3/example_test.go
@@ -38,9 +38,7 @@ func Example() {
 	}
 	defer cli.Close() // make sure to close the client
 
-	kvc := clientv3.NewKV(cli)
-
-	_, err = kvc.Put(context.TODO(), "foo", "bar")
+	_, err = cli.Put(context.TODO(), "foo", "bar")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/clientv3/example_watch_test.go
+++ b/clientv3/example_watch_test.go
@@ -32,10 +32,7 @@ func ExampleWatcher_watch() {
 	}
 	defer cli.Close()
 
-	wc := clientv3.NewWatcher(cli)
-	defer wc.Close()
-
-	rch := wc.Watch(context.Background(), "foo")
+	rch := cli.Watch(context.Background(), "foo")
 	for wresp := range rch {
 		for _, ev := range wresp.Events {
 			fmt.Printf("%s %q : %q\n", ev.Type, ev.Kv.Key, ev.Kv.Value)
@@ -54,10 +51,7 @@ func ExampleWatcher_watchPrefix() {
 	}
 	defer cli.Close()
 
-	wc := clientv3.NewWatcher(cli)
-	defer wc.Close()
-
-	rch := wc.Watch(context.Background(), "foo", clientv3.WithPrefix())
+	rch := cli.Watch(context.Background(), "foo", clientv3.WithPrefix())
 	for wresp := range rch {
 		for _, ev := range wresp.Events {
 			fmt.Printf("%s %q : %q\n", ev.Type, ev.Kv.Key, ev.Kv.Value)

--- a/clientv3/mirror/syncer.go
+++ b/clientv3/mirror/syncer.go
@@ -106,21 +106,5 @@ func (s *syncer) SyncUpdates(ctx context.Context) clientv3.WatchChan {
 	if s.rev == 0 {
 		panic("unexpected revision = 0. Calling SyncUpdates before SyncBase finishes?")
 	}
-
-	respchan := make(chan clientv3.WatchResponse, 1024)
-
-	go func() {
-		wapi := clientv3.NewWatcher(s.c)
-		defer wapi.Close()
-		defer close(respchan)
-
-		// get all events since revision (or get non-compacted revision, if
-		// rev is too far behind)
-		wch := wapi.Watch(ctx, s.prefix, clientv3.WithPrefix(), clientv3.WithRev(s.rev))
-		for wr := range wch {
-			respchan <- wr
-		}
-	}()
-
-	return respchan
+	return s.c.Watch(ctx, s.prefix, clientv3.WithPrefix(), clientv3.WithRev(s.rev))
 }

--- a/clientv3/mirror/syncer.go
+++ b/clientv3/mirror/syncer.go
@@ -48,10 +48,9 @@ func (s *syncer) SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, cha
 	respchan := make(chan clientv3.GetResponse, 1024)
 	errchan := make(chan error, 1)
 
-	kapi := clientv3.NewKV(s.c)
 	// if rev is not specified, we will choose the most recent revision.
 	if s.rev == 0 {
-		resp, err := kapi.Get(ctx, "foo")
+		resp, err := s.c.Get(ctx, "foo")
 		if err != nil {
 			errchan <- err
 			close(respchan)
@@ -83,7 +82,7 @@ func (s *syncer) SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, cha
 		}
 
 		for {
-			resp, err := kapi.Get(ctx, key, opts...)
+			resp, err := s.c.Get(ctx, key, opts...)
 			if err != nil {
 				errchan <- err
 				return

--- a/contrib/recipes/barrier.go
+++ b/contrib/recipes/barrier.go
@@ -24,32 +24,31 @@ import (
 // release all blocked processes.
 type Barrier struct {
 	client *v3.Client
-	kv     v3.KV
 	ctx    context.Context
 
 	key string
 }
 
 func NewBarrier(client *v3.Client, key string) *Barrier {
-	return &Barrier{client, v3.NewKV(client), context.TODO(), key}
+	return &Barrier{client, context.TODO(), key}
 }
 
 // Hold creates the barrier key causing processes to block on Wait.
 func (b *Barrier) Hold() error {
-	_, err := NewKey(b.kv, b.key, 0)
+	_, err := NewKey(b.client, b.key, 0)
 	return err
 }
 
 // Release deletes the barrier key to unblock all waiting processes.
 func (b *Barrier) Release() error {
-	_, err := b.kv.Delete(b.ctx, b.key)
+	_, err := b.client.Delete(b.ctx, b.key)
 	return err
 }
 
 // Wait blocks on the barrier key until it is deleted. If there is no key, Wait
 // assumes Release has already been called and returns immediately.
 func (b *Barrier) Wait() error {
-	resp, err := b.kv.Get(b.ctx, b.key, v3.WithFirstKey()...)
+	resp, err := b.client.Get(b.ctx, b.key, v3.WithFirstKey()...)
 	if err != nil {
 		return err
 	}

--- a/contrib/recipes/key.go
+++ b/contrib/recipes/key.go
@@ -166,7 +166,7 @@ func NewEphemeralKV(client *v3.Client, key, val string) (*EphemeralKV, error) {
 	if err != nil {
 		return nil, err
 	}
-	k, err := NewKV(v3.NewKV(client), key, val, s.Lease())
+	k, err := NewKV(client, key, val, s.Lease())
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/recipes/watch.go
+++ b/contrib/recipes/watch.go
@@ -22,23 +22,19 @@ import (
 
 // WaitEvents waits on a key until it observes the given events and returns the final one.
 func WaitEvents(c *clientv3.Client, key string, rev int64, evs []storagepb.Event_EventType) (*storagepb.Event, error) {
-	w := clientv3.NewWatcher(c)
-	wc := w.Watch(context.Background(), key, clientv3.WithRev(rev))
+	wc := c.Watch(context.Background(), key, clientv3.WithRev(rev))
 	if wc == nil {
-		w.Close()
 		return nil, ErrNoWatcher
 	}
-	return waitEvents(wc, evs), w.Close()
+	return waitEvents(wc, evs), nil
 }
 
 func WaitPrefixEvents(c *clientv3.Client, prefix string, rev int64, evs []storagepb.Event_EventType) (*storagepb.Event, error) {
-	w := clientv3.NewWatcher(c)
-	wc := w.Watch(context.Background(), prefix, clientv3.WithPrefix(), clientv3.WithRev(rev))
+	wc := c.Watch(context.Background(), prefix, clientv3.WithPrefix(), clientv3.WithRev(rev))
 	if wc == nil {
-		w.Close()
 		return nil, ErrNoWatcher
 	}
-	return waitEvents(wc, evs), w.Close()
+	return waitEvents(wc, evs), nil
 }
 
 func waitEvents(wc clientv3.WatchChan, evs []storagepb.Event_EventType) *storagepb.Event {

--- a/etcdctlv3/command/compaction_command.go
+++ b/etcdctlv3/command/compaction_command.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
-	"github.com/coreos/etcd/clientv3"
 )
 
 // NewCompactionCommand returns the cobra command for "compaction".
@@ -44,7 +43,7 @@ func compactionCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	c := mustClientFromCmd(cmd)
-	if cerr := clientv3.NewKV(c).Compact(context.TODO(), rev); cerr != nil {
+	if cerr := c.Compact(context.TODO(), rev); cerr != nil {
 		ExitWithError(ExitError, cerr)
 		return
 	}

--- a/etcdctlv3/command/del_command.go
+++ b/etcdctlv3/command/del_command.go
@@ -34,9 +34,7 @@ func NewDelCommand() *cobra.Command {
 // delCommandFunc executes the "del" command.
 func delCommandFunc(cmd *cobra.Command, args []string) {
 	key, opts := getDelOp(cmd, args)
-	c := mustClientFromCmd(cmd)
-	kvapi := clientv3.NewKV(c)
-	resp, err := kvapi.Delete(context.TODO(), key, opts...)
+	resp, err := mustClientFromCmd(cmd).Delete(context.TODO(), key, opts...)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}

--- a/etcdctlv3/command/get_command.go
+++ b/etcdctlv3/command/get_command.go
@@ -49,9 +49,7 @@ func NewGetCommand() *cobra.Command {
 // getCommandFunc executes the "get" command.
 func getCommandFunc(cmd *cobra.Command, args []string) {
 	key, opts := getGetOp(cmd, args)
-	c := mustClientFromCmd(cmd)
-	kvapi := clientv3.NewKV(c)
-	resp, err := kvapi.Get(context.TODO(), key, opts...)
+	resp, err := mustClientFromCmd(cmd).Get(context.TODO(), key, opts...)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}

--- a/etcdctlv3/command/lease_command.go
+++ b/etcdctlv3/command/lease_command.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
-	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/lease"
 )
 
@@ -62,9 +61,7 @@ func leaseCreateCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("bad TTL (%v)", err))
 	}
 
-	c := mustClientFromCmd(cmd)
-	l := clientv3.NewLease(c)
-	resp, err := l.Create(context.TODO(), ttl)
+	resp, err := mustClientFromCmd(cmd).Create(context.TODO(), ttl)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create lease (%v)\n", err)
 		return
@@ -95,9 +92,7 @@ func leaseRevokeCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("bad lease ID arg (%v), expecting ID in Hex", err))
 	}
 
-	c := mustClientFromCmd(cmd)
-	l := clientv3.NewLease(c)
-	_, err = l.Revoke(context.TODO(), lease.LeaseID(id))
+	_, err = mustClientFromCmd(cmd).Revoke(context.TODO(), lease.LeaseID(id))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to revoke lease (%v)\n", err)
 		return
@@ -128,9 +123,7 @@ func leaseKeepAliveCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("bad lease ID arg (%v), expecting ID in Hex", err))
 	}
 
-	c := mustClientFromCmd(cmd)
-	l := clientv3.NewLease(c)
-	respc, kerr := l.KeepAlive(context.TODO(), lease.LeaseID(id))
+	respc, kerr := mustClientFromCmd(cmd).KeepAlive(context.TODO(), lease.LeaseID(id))
 	if kerr != nil {
 		ExitWithError(ExitBadConnection, kerr)
 	}

--- a/etcdctlv3/command/lock_command.go
+++ b/etcdctlv3/command/lock_command.go
@@ -68,7 +68,7 @@ func lockUntilSignal(c *clientv3.Client, lockname string) error {
 		return err
 	}
 
-	k, kerr := clientv3.NewKV(c).Get(ctx, m.Key())
+	k, kerr := c.Get(ctx, m.Key())
 	if kerr != nil {
 		return kerr
 	}

--- a/etcdctlv3/command/member_command.go
+++ b/etcdctlv3/command/member_command.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
-	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 )
 
 var (
@@ -108,8 +107,7 @@ func memberAddCommandFunc(cmd *cobra.Command, args []string) {
 
 	urls := strings.Split(memberPeerURLs, ",")
 
-	req := &pb.MemberAddRequest{PeerURLs: urls}
-	resp, err := mustClientFromCmd(cmd).Cluster.MemberAdd(context.TODO(), req)
+	resp, err := mustClientFromCmd(cmd).MemberAdd(context.TODO(), urls)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
@@ -128,8 +126,7 @@ func memberRemoveCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("bad member ID arg (%v), expecting ID in Hex", err))
 	}
 
-	req := &pb.MemberRemoveRequest{ID: uint64(id)}
-	resp, err := mustClientFromCmd(cmd).Cluster.MemberRemove(context.TODO(), req)
+	resp, err := mustClientFromCmd(cmd).MemberRemove(context.TODO(), id)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
@@ -154,8 +151,7 @@ func memberUpdateCommandFunc(cmd *cobra.Command, args []string) {
 
 	urls := strings.Split(memberPeerURLs, ",")
 
-	req := &pb.MemberUpdateRequest{ID: uint64(id), PeerURLs: urls}
-	resp, err := mustClientFromCmd(cmd).Cluster.MemberUpdate(context.TODO(), req)
+	resp, err := mustClientFromCmd(cmd).MemberUpdate(context.TODO(), id, urls)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
@@ -165,7 +161,7 @@ func memberUpdateCommandFunc(cmd *cobra.Command, args []string) {
 
 // memberListCommandFunc executes the "member list" command.
 func memberListCommandFunc(cmd *cobra.Command, args []string) {
-	resp, err := mustClientFromCmd(cmd).Cluster.MemberList(context.TODO(), &pb.MemberListRequest{})
+	resp, err := mustClientFromCmd(cmd).MemberList(context.TODO())
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}

--- a/etcdctlv3/command/put_command.go
+++ b/etcdctlv3/command/put_command.go
@@ -58,9 +58,7 @@ will store the content of the file to <key>.
 func putCommandFunc(cmd *cobra.Command, args []string) {
 	key, value, opts := getPutOp(cmd, args)
 
-	c := mustClientFromCmd(cmd)
-	kvapi := clientv3.NewKV(c)
-	resp, err := kvapi.Put(context.TODO(), key, value, opts...)
+	resp, err := mustClientFromCmd(cmd).Put(context.TODO(), key, value, opts...)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}

--- a/etcdctlv3/command/snapshot_command.go
+++ b/etcdctlv3/command/snapshot_command.go
@@ -52,9 +52,7 @@ func snapshotCommandFunc(cmd *cobra.Command, args []string) {
 // snapshotToStdout streams a snapshot over stdout
 func snapshotToStdout(c *clientv3.Client) {
 	// must explicitly fetch first revision since no retry on stdout
-	wapi := clientv3.NewWatcher(c)
-	defer wapi.Close()
-	wr := <-wapi.Watch(context.TODO(), "", clientv3.WithPrefix(), clientv3.WithRev(1))
+	wr := <-c.Watch(context.TODO(), "", clientv3.WithPrefix(), clientv3.WithRev(1))
 	if len(wr.Events) > 0 {
 		wr.CompactRevision = 1
 	}

--- a/etcdctlv3/command/txn_command.go
+++ b/etcdctlv3/command/txn_command.go
@@ -53,7 +53,7 @@ func txnCommandFunc(cmd *cobra.Command, args []string) {
 
 	reader := bufio.NewReader(os.Stdin)
 
-	txn := clientv3.NewKV(mustClientFromCmd(cmd)).Txn(context.Background())
+	txn := mustClientFromCmd(cmd).Txn(context.Background())
 	fmt.Println("compares:")
 	txn.If(readCompares(reader)...)
 	fmt.Println("success requests (get, put, delete):")

--- a/etcdctlv3/command/watch_command.go
+++ b/etcdctlv3/command/watch_command.go
@@ -57,16 +57,14 @@ func watchCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("watch in non-interactive mode requires an argument as key or prefix"))
 	}
 
-	c := mustClientFromCmd(cmd)
-	w := clientv3.NewWatcher(c)
-
 	opts := []clientv3.OpOption{clientv3.WithRev(watchRev)}
 	if watchPrefix {
 		opts = append(opts, clientv3.WithPrefix())
 	}
-	wc := w.Watch(context.TODO(), args[0], opts...)
+	c := mustClientFromCmd(cmd)
+	wc := c.Watch(context.TODO(), args[0], opts...)
 	printWatchCh(wc)
-	err := w.Close()
+	err := c.Close()
 	if err == nil {
 		ExitWithError(ExitInterrupted, fmt.Errorf("watch is canceled by the server"))
 	}
@@ -75,7 +73,6 @@ func watchCommandFunc(cmd *cobra.Command, args []string) {
 
 func watchInteractiveFunc(cmd *cobra.Command, args []string) {
 	c := mustClientFromCmd(cmd)
-	w := clientv3.NewWatcher(c)
 
 	reader := bufio.NewReader(os.Stdin)
 
@@ -117,7 +114,7 @@ func watchInteractiveFunc(cmd *cobra.Command, args []string) {
 		if watchPrefix {
 			opts = append(opts, clientv3.WithPrefix())
 		}
-		ch := w.Watch(context.TODO(), key, opts...)
+		ch := c.Watch(context.TODO(), key, opts...)
 		go printWatchCh(ch)
 	}
 }

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -37,6 +37,7 @@ import (
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc"
 	"github.com/coreos/etcd/etcdserver/etcdhttp"
+	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/pkg/testutil"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/pkg/types"
@@ -732,4 +733,24 @@ func (c *ClusterV3) RandClient() *clientv3.Client {
 
 func (c *ClusterV3) Client(i int) *clientv3.Client {
 	return c.clients[i]
+}
+
+type grpcAPI struct {
+	// Cluster is the cluster API for the client's connection.
+	Cluster pb.ClusterClient
+	// KV is the keyvalue API for the client's connection.
+	KV pb.KVClient
+	// Lease is the lease API for the client's connection.
+	Lease pb.LeaseClient
+	// Watch is the watch API for the client's connection.
+	Watch pb.WatchClient
+}
+
+func toGRPC(c *clientv3.Client) grpcAPI {
+	return grpcAPI{
+		pb.NewClusterClient(c.ActiveConnection()),
+		pb.NewKVClient(c.ActiveConnection()),
+		pb.NewLeaseClient(c.ActiveConnection()),
+		pb.NewWatchClient(c.ActiveConnection()),
+	}
 }

--- a/integration/v3_grpc_test.go
+++ b/integration/v3_grpc_test.go
@@ -33,7 +33,7 @@ func TestV3PutOverwrite(t *testing.T) {
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	kvc := clus.RandClient().KV
+	kvc := toGRPC(clus.RandClient()).KV
 	key := []byte("foo")
 	reqput := &pb.PutRequest{Key: key, Value: []byte("bar")}
 
@@ -77,7 +77,7 @@ func TestV3TxnTooManyOps(t *testing.T) {
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	kvc := clus.RandClient().KV
+	kvc := toGRPC(clus.RandClient()).KV
 
 	// unique keys
 	i := new(int)
@@ -161,7 +161,7 @@ func TestV3TxnDuplicateKeys(t *testing.T) {
 	},
 	}
 
-	kvc := clus.RandClient().KV
+	kvc := toGRPC(clus.RandClient()).KV
 	tests := []struct {
 		txnSuccess []*pb.RequestUnion
 
@@ -208,7 +208,7 @@ func TestV3PutMissingLease(t *testing.T) {
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	kvc := clus.RandClient().KV
+	kvc := toGRPC(clus.RandClient()).KV
 	key := []byte("foo")
 	preq := &pb.PutRequest{Key: key, Lease: 123456}
 	tests := []func(){
@@ -324,7 +324,7 @@ func TestV3DeleteRange(t *testing.T) {
 
 	for i, tt := range tests {
 		clus := NewClusterV3(t, &ClusterConfig{Size: 3})
-		kvc := clus.RandClient().KV
+		kvc := toGRPC(clus.RandClient()).KV
 
 		ks := tt.keySet
 		for j := range ks {
@@ -375,7 +375,7 @@ func TestV3TxnInvaildRange(t *testing.T) {
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	kvc := clus.RandClient().KV
+	kvc := toGRPC(clus.RandClient()).KV
 	preq := &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}
 
 	for i := 0; i < 3; i++ {
@@ -419,7 +419,7 @@ func TestV3TooLargeRequest(t *testing.T) {
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	kvc := clus.RandClient().KV
+	kvc := toGRPC(clus.RandClient()).KV
 
 	// 2MB request value
 	largeV := make([]byte, 2*1024*1024)
@@ -437,7 +437,7 @@ func TestV3Hash(t *testing.T) {
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	kvc := clus.RandClient().KV
+	kvc := toGRPC(clus.RandClient()).KV
 	preq := &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}
 
 	for i := 0; i < 3; i++ {
@@ -590,7 +590,7 @@ func TestV3RangeRequest(t *testing.T) {
 	for i, tt := range tests {
 		clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 		for _, k := range tt.putKeys {
-			kvc := clus.RandClient().KV
+			kvc := toGRPC(clus.RandClient()).KV
 			req := &pb.PutRequest{Key: []byte(k), Value: []byte("bar")}
 			if _, err := kvc.Put(context.TODO(), req); err != nil {
 				t.Fatalf("#%d: couldn't put key (%v)", i, err)
@@ -598,7 +598,7 @@ func TestV3RangeRequest(t *testing.T) {
 		}
 
 		for j, req := range tt.reqs {
-			kvc := clus.RandClient().KV
+			kvc := toGRPC(clus.RandClient()).KV
 			resp, err := kvc.Range(context.TODO(), &req)
 			if err != nil {
 				t.Errorf("#%d.%d: Range error: %v", i, j, err)
@@ -668,7 +668,7 @@ func TestTLSGRPCRejectInsecureClient(t *testing.T) {
 	donec := make(chan error, 1)
 	go func() {
 		reqput := &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}
-		_, perr := client.KV.Put(ctx, reqput)
+		_, perr := toGRPC(client).KV.Put(ctx, reqput)
 		donec <- perr
 	}()
 
@@ -717,7 +717,7 @@ func TestTLSGRPCAcceptSecureAll(t *testing.T) {
 	defer client.Close()
 
 	reqput := &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}
-	if _, err := client.KV.Put(context.TODO(), reqput); err != nil {
+	if _, err := toGRPC(client).KV.Put(context.TODO(), reqput); err != nil {
 		t.Fatalf("unexpected error on put over tls (%v)", err)
 	}
 }

--- a/integration/v3_stm_test.go
+++ b/integration/v3_stm_test.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"testing"
 
-	v3 "github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/contrib/recipes"
 )
 
@@ -31,7 +30,7 @@ func TestSTMConflict(t *testing.T) {
 	etcdc := clus.RandClient()
 	keys := make([]*recipe.RemoteKV, 5)
 	for i := 0; i < len(keys); i++ {
-		rk, err := recipe.NewKV(v3.NewKV(etcdc), fmt.Sprintf("foo-%d", i), "100", 0)
+		rk, err := recipe.NewKV(etcdc, fmt.Sprintf("foo-%d", i), "100", 0)
 		if err != nil {
 			t.Fatalf("could not make key (%v)", err)
 		}
@@ -76,7 +75,7 @@ func TestSTMConflict(t *testing.T) {
 	// ensure sum matches initial sum
 	sum := 0
 	for _, oldRK := range keys {
-		rk, err := recipe.GetRemoteKV(v3.NewKV(etcdc), oldRK.Key())
+		rk, err := recipe.GetRemoteKV(etcdc, oldRK.Key())
 		if err != nil {
 			t.Fatalf("couldn't fetch key %s (%v)", oldRK.Key(), err)
 		}
@@ -103,7 +102,7 @@ func TestSTMPutNewKey(t *testing.T) {
 		t.Fatalf("error on stm txn (%v)", err)
 	}
 
-	rk, err := recipe.GetRemoteKV(v3.NewKV(etcdc), "foo")
+	rk, err := recipe.GetRemoteKV(etcdc, "foo")
 	if err != nil {
 		t.Fatalf("error fetching key (%v)", err)
 	}
@@ -129,7 +128,7 @@ func TestSTMAbort(t *testing.T) {
 		t.Fatalf("error on stm txn (%v)", err)
 	}
 
-	rk, err := recipe.GetRemoteKV(v3.NewKV(etcdc), "foo")
+	rk, err := recipe.GetRemoteKV(etcdc, "foo")
 	if err != nil {
 		t.Fatalf("error fetching key (%v)", err)
 	}

--- a/tools/benchmark/cmd/watch.go
+++ b/tools/benchmark/cmd/watch.go
@@ -20,7 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/coreos/etcd/etcdserver/etcdserverpb"
+	v3 "github.com/coreos/etcd/clientv3"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/cheggaaa/pb"
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
@@ -73,23 +73,18 @@ func init() {
 }
 
 func watchFunc(cmd *cobra.Command, args []string) {
-	watched := make([][]byte, watchedKeyTotal)
+	watched := make([]string, watchedKeyTotal)
 	for i := range watched {
-		watched[i] = mustRandBytes(32)
+		watched[i] = string(mustRandBytes(32))
 	}
 
-	requests := make(chan etcdserverpb.WatchRequest, totalClients)
+	requests := make(chan string, totalClients)
 
 	clients := mustCreateClients(totalClients, totalConns)
 
-	streams := make([]etcdserverpb.Watch_WatchClient, watchTotalStreams)
-	var err error
+	streams := make([]v3.Watcher, watchTotalStreams)
 	for i := range streams {
-		streams[i], err = clients[i%len(clients)].Watch.Watch(context.TODO())
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Failed to create watch stream:", err)
-			os.Exit(1)
-		}
+		streams[i] = v3.NewWatcher(clients[i%len(clients)])
 	}
 
 	putStartNotifier = make(chan struct{})
@@ -111,10 +106,7 @@ func watchFunc(cmd *cobra.Command, args []string) {
 
 	go func() {
 		for i := 0; i < watchTotal; i++ {
-			requests <- etcdserverpb.WatchRequest{
-				RequestUnion: &etcdserverpb.WatchRequest_CreateRequest{
-					CreateRequest: &etcdserverpb.WatchCreateRequest{
-						Key: watched[i%(len(watched))]}}}
+			requests <- watched[i%len(watched)]
 		}
 		close(requests)
 	}()
@@ -139,7 +131,7 @@ func watchFunc(cmd *cobra.Command, args []string) {
 	recvCompletedNotifier = make(chan struct{})
 	close(putStartNotifier)
 
-	putreqc := make(chan etcdserverpb.PutRequest)
+	putreqc := make(chan v3.Op)
 
 	for i := 0; i < watchPutTotal; i++ {
 		go doPutForWatch(context.TODO(), clients[i%len(clients)].KV, putreqc)
@@ -149,10 +141,7 @@ func watchFunc(cmd *cobra.Command, args []string) {
 
 	go func() {
 		for i := 0; i < eventsTotal; i++ {
-			putreqc <- etcdserverpb.PutRequest{
-				Key:   watched[i%(len(watched))],
-				Value: []byte("data"),
-			}
+			putreqc <- v3.OpPut(watched[i%(len(watched))], "data")
 			// TODO: use a real rate-limiter instead of sleep.
 			time.Sleep(time.Second / time.Duration(watchPutRate))
 		}
@@ -166,16 +155,17 @@ func watchFunc(cmd *cobra.Command, args []string) {
 	<-pdoneC
 }
 
-func doWatch(stream etcdserverpb.Watch_WatchClient, requests <-chan etcdserverpb.WatchRequest) {
+func doWatch(stream v3.Watcher, requests <-chan string) {
 	for r := range requests {
 		st := time.Now()
-		err := stream.Send(&r)
+		wch := stream.Watch(context.TODO(), r)
 		var errStr string
-		if err != nil {
-			errStr = err.Error()
+		if wch == nil {
+			errStr = "could not open watch channel"
 		}
 		results <- result{errStr: errStr, duration: time.Since(st)}
 		bar.Increment()
+		go recvWatchChan(wch)
 	}
 	atomic.AddInt32(&nrWatchCompleted, 1)
 	if atomic.LoadInt32(&nrWatchCompleted) == int32(watchTotalStreams) {
@@ -183,15 +173,12 @@ func doWatch(stream etcdserverpb.Watch_WatchClient, requests <-chan etcdserverpb
 	}
 
 	<-putStartNotifier
+}
 
-	for {
+func recvWatchChan(wch v3.WatchChan) {
+	for range wch {
 		st := time.Now()
-		_, err := stream.Recv()
-		var errStr string
-		if err != nil {
-			errStr = err.Error()
-		}
-		results <- result{errStr: errStr, duration: time.Since(st)}
+		results <- result{duration: time.Since(st)}
 		bar.Increment()
 
 		atomic.AddInt32(&nrRecvCompleted, 1)
@@ -201,11 +188,11 @@ func doWatch(stream etcdserverpb.Watch_WatchClient, requests <-chan etcdserverpb
 	}
 }
 
-func doPutForWatch(ctx context.Context, client etcdserverpb.KVClient, requests <-chan etcdserverpb.PutRequest) {
-	for r := range requests {
-		_, err := client.Put(ctx, &r)
+func doPutForWatch(ctx context.Context, client v3.KV, requests <-chan v3.Op) {
+	for op := range requests {
+		_, err := client.Do(ctx, op)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "failed to Put for watch benchmark: %s", err)
+			fmt.Fprintf(os.Stderr, "failed to Put for watch benchmark: %v\n", err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
Having to call `NewWatcher`, `NewKV`, etc to invoke some sub-API is a pain. Instead, the client can create its own default instances of the interface which can be called directly on the client.

For example, this:
```go
w := v3.NewWatcher(client)
defer w.Close()
ch := w.Watch(...)
```
Becomes:
```go
ch := client.Watch(...)
```