### PR TITLE
tools/benchmark: a new benchmark for storage compaction

### DIFF
--- a/storage/kv.go
+++ b/storage/kv.go
@@ -68,6 +68,7 @@ type KV interface {
 	TxnDeleteRange(txnID int64, key, end []byte) (n, rev int64, err error)
 
 	Compact(rev int64) error
+	SyncCompact(rev int64) error
 
 	// Hash retrieves the hash of KV state.
 	// This method is designed for consistency checking purpose.

--- a/storage/kvstore_compaction.go
+++ b/storage/kvstore_compaction.go
@@ -63,3 +63,38 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 		}
 	}
 }
+
+// bundleCompaction is only used from tools/benchmark for now
+func (s *store) bundleCompaction(compactMainRev int64, keep map[revision]struct{}) {
+	end := make([]byte, 8)
+	binary.BigEndian.PutUint64(end, uint64(compactMainRev+1))
+
+	batchsize := int64(10000)
+	last := make([]byte, 8+1+8)
+	for {
+		var rev revision
+
+		tx := s.b.BatchTx()
+		tx.Lock()
+
+		keys, _ := tx.UnsafeRange(keyBucketName, last, end, batchsize)
+		for _, key := range keys {
+			rev = bytesToRev(key)
+			if _, ok := keep[rev]; !ok {
+				tx.UnsafeDelete(keyBucketName, key)
+			}
+		}
+
+		if len(keys) < int(batchsize) {
+			rbytes := make([]byte, 8+1+8)
+			revToBytes(revision{main: compactMainRev}, rbytes)
+			tx.UnsafePut(metaBucketName, finishedCompactKeyName, rbytes)
+			tx.Unlock()
+			return
+		}
+
+		// update last
+		revToBytes(revision{main: rev.main, sub: rev.sub + 1}, last)
+		tx.Unlock()
+	}
+}

--- a/tools/benchmark/cmd/storage-compaction.go
+++ b/tools/benchmark/cmd/storage-compaction.go
@@ -1,0 +1,101 @@
+// Copyright 2016 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"time"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/etcd/lease"
+)
+
+// storageCompactionCmd represents a storage compaction performance benchmarking tool
+var storageCompactionCmd = &cobra.Command{
+	Use:   "compaction",
+	Short: "Benchmark compaction performance of storage",
+
+	Run: storageCompactionFunc,
+}
+
+var (
+	totalPut int
+	nrKeys   int
+)
+
+func init() {
+	storageCmd.AddCommand(storageCompactionCmd)
+
+	// basically variables for parameters are shared with storage-put.go
+	storageCompactionCmd.Flags().IntVar(&totalPut, "total", 100, "a total number of put operations")
+	storageCompactionCmd.Flags().IntVar(&storageKeySize, "key-size", 64, "a size of key (Byte)")
+	storageCompactionCmd.Flags().IntVar(&valueSize, "value-size", 64, "a size of value (Byte)")
+	storageCompactionCmd.Flags().IntVar(&nrKeys, "keys", 1, "a number of keys for put operations")
+
+	// TODO: after the PR https://github.com/spf13/cobra/pull/220 is merged, the below pprof related flags should be moved to RootCmd
+	storageCompactionCmd.Flags().StringVar(&cpuProfPath, "cpuprofile", "", "the path of file for storing cpu profile result")
+	storageCompactionCmd.Flags().StringVar(&memProfPath, "memprofile", "", "the path of file for storing heap profile result")
+
+}
+
+func storageCompactionFunc(cmd *cobra.Command, args []string) {
+	if cpuProfPath != "" {
+		f, err := os.Create(cpuProfPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to create a file for storing cpu profile result: ", err)
+			os.Exit(1)
+		}
+
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to start cpu profile: ", err)
+			os.Exit(1)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	if memProfPath != "" {
+		f, err := os.Create(memProfPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to create a file for storing heap profile result: ", err)
+			os.Exit(1)
+		}
+
+		defer func() {
+			err := pprof.WriteHeapProfile(f)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Failed to write heap profile result: ", err)
+				// can do nothing for handling the error
+			}
+		}()
+	}
+
+	keys := createBytesSlice(storageKeySize, nrKeys)
+	vals := createBytesSlice(valueSize, nrKeys)
+
+	var rev int64
+
+	for i := 0; i < totalPut; i++ {
+		rev = s.Put(keys[i%nrKeys], vals[i%nrKeys], lease.NoLease)
+	}
+
+	begin := time.Now()
+	s.SyncCompact(rev)
+	end := time.Now()
+
+	fmt.Printf("required time for compaction: %v\n", end.Sub(begin))
+}


### PR DESCRIPTION
This commit introduces a new benchmark "benchmark storage compaction"
for measuring performance of storage compaction. It will be useful
for understanding how the compaction performance relates with key
divergence.

Example usage:
$ ./benchmark storage compaction --total=100000 --keys=100000
2016/02/29 17:04:46 store.index: compact 100001
required time for compaction: 111.669817ms
$ ./benchmark storage compaction --total=100000 --keys=10000
2016/02/29 17:04:57 store.index: compact 100001
required time for compaction: 317.27783ms
$ ./benchmark storage compaction --total=100000 --keys=1000
2016/02/29 17:05:19 store.index: compact 100001
required time for compaction: 305.353167ms
$ ./benchmark storage compaction --total=100000 --keys=100
2016/02/29 17:05:30 store.index: compact 100001
required time for compaction: 346.639984ms
$ ./benchmark storage compaction --total=100000 --keys=10
2016/02/29 17:05:41 store.index: compact 100001
required time for compaction: 400.922644ms
$ ./benchmark storage compaction --total=100000 --keys=1
2016/02/29 17:06:02 store.index: compact 100001
required time for compaction: 347.749895ms