### PR TITLE
client: fix go vet error at tip

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -851,7 +851,7 @@ func TestHTTPClusterClientSyncPinEndpoint(t *testing.T) {
 		}
 
 		if g := hc.endpoints[hc.pinned]; g != pinnedEndpoint {
-			t.Errorf("#%d: pinned endpoint = %s, want %s", i, g, pinnedEndpoint)
+			t.Errorf("#%d: pinned endpoint = %v, want %v", i, g, pinnedEndpoint)
 		}
 	}
 }


### PR DESCRIPTION
It was getting `gopath/src/github.com/coreos/etcd/client/client_test.go:854: arg g for printf verb %s of wrong type: net/url.URL`