### PR TITLE
add a stub of etcdctlv3 auth enable

### DIFF
--- a/clientv3/auth.go
+++ b/clientv3/auth.go
@@ -1,0 +1,51 @@
+// Copyright 2016 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/Godeps/_workspace/src/google.golang.org/grpc"
+	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+)
+
+type (
+	AuthEnableResponse pb.AuthEnableResponse
+)
+
+type Auth interface {
+	// AuthEnable enables auth of a etcd cluster.
+	AuthEnable(ctx context.Context) (*AuthEnableResponse, error)
+}
+
+type auth struct {
+	c *Client
+
+	conn   *grpc.ClientConn // conn in-use
+	remote pb.AuthClient
+}
+
+func NewAuth(c *Client) Auth {
+	conn := c.ActiveConnection()
+	return &auth{
+		conn:   c.ActiveConnection(),
+		remote: pb.NewAuthClient(conn),
+		c:      c,
+	}
+}
+
+func (auth *auth) AuthEnable(ctx context.Context) (*AuthEnableResponse, error) {
+	resp, err := auth.remote.AuthEnable(ctx, &pb.AuthEnableRequest{})
+	return (*AuthEnableResponse)(resp), err
+}

--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	KV
 	Lease
 	Watcher
+	Auth
 
 	conn   *grpc.ClientConn
 	cfg    Config
@@ -152,6 +153,7 @@ func newClient(cfg *Config) (*Client, error) {
 	client.KV = NewKV(client)
 	client.Lease = NewLease(client)
 	client.Watcher = NewWatcher(client)
+	client.Auth = NewAuth(client)
 
 	return client, nil
 }

--- a/etcdctlv3/.gitignore
+++ b/etcdctlv3/.gitignore
@@ -1,0 +1,1 @@
+etcdctlv3

--- a/etcdctlv3/command/auth_command.go
+++ b/etcdctlv3/command/auth_command.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+// NewAuthCommand returns the cobra command for "auth".
+func NewAuthCommand() *cobra.Command {
+	ac := &cobra.Command{
+		Use:   "auth <enable or disable>",
+		Short: "Enable or disable authentication.",
+	}
+
+	ac.AddCommand(NewAuthEnableCommand())
+
+	return ac
+}
+
+func NewAuthEnableCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable",
+		Short: "enable authentication",
+		Run:   authEnableCommandFunc,
+	}
+}
+
+// authEnableCommandFunc executes the "auth enable" command.
+func authEnableCommandFunc(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		ExitWithError(ExitBadArgs, fmt.Errorf("auth enable command does not accept argument."))
+	}
+
+	_, err := mustClientFromCmd(cmd).Auth.AuthEnable(context.TODO())
+	if err != nil {
+		ExitWithError(ExitError, err)
+	}
+}

--- a/etcdctlv3/main.go
+++ b/etcdctlv3/main.go
@@ -63,6 +63,7 @@ func init() {
 		command.NewSnapshotCommand(),
 		command.NewMakeMirrorCommand(),
 		command.NewLockCommand(),
+		command.NewAuthCommand(),
 	)
 }
 

--- a/etcdserver/api/v3rpc/auth.go
+++ b/etcdserver/api/v3rpc/auth.go
@@ -1,0 +1,98 @@
+// Copyright 2016 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3rpc
+
+import (
+	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/etcd/etcdserver"
+	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+)
+
+type AuthServer struct {
+	authenticator etcdserver.Authenticator
+}
+
+func NewAuthServer(s *etcdserver.EtcdServer) *AuthServer {
+	return &AuthServer{authenticator: s}
+}
+
+func (as *AuthServer) AuthEnable(ctx context.Context, r *pb.AuthEnableRequest) (*pb.AuthEnableResponse, error) {
+	return as.authenticator.AuthEnable(ctx, r)
+}
+
+func (as *AuthServer) AuthDisable(ctx context.Context, r *pb.AuthDisableRequest) (*pb.AuthDisableResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) Authenticate(ctx context.Context, r *pb.AuthenticateRequest) (*pb.AuthenticateResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) RoleAdd(ctx context.Context, r *pb.RoleAddRequest) (*pb.RoleAddResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) RoleDelete(ctx context.Context, r *pb.RoleDeleteRequest) (*pb.RoleDeleteResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) RoleGet(ctx context.Context, r *pb.RoleGetRequest) (*pb.RoleGetResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) RoleRevoke(ctx context.Context, r *pb.RoleRevokeRequest) (*pb.RoleRevokeResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) RoleGrant(ctx context.Context, r *pb.RoleGrantRequest) (*pb.RoleGrantResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) UserAdd(ctx context.Context, r *pb.UserAddRequest) (*pb.UserAddResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) UserDelete(ctx context.Context, r *pb.UserDeleteRequest) (*pb.UserDeleteResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) UserGet(ctx context.Context, r *pb.UserGetRequest) (*pb.UserGetResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) UserGrant(ctx context.Context, r *pb.UserGrantRequest) (*pb.UserGrantResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) UserRevoke(ctx context.Context, r *pb.UserRevokeRequest) (*pb.UserRevokeResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}
+
+func (as *AuthServer) UserChangePassword(ctx context.Context, r *pb.UserChangePasswordRequest) (*pb.UserChangePasswordResponse, error) {
+	plog.Info("not implemented yet")
+	return nil, nil
+}

--- a/etcdserver/api/v3rpc/grpc.go
+++ b/etcdserver/api/v3rpc/grpc.go
@@ -36,5 +36,6 @@ func Server(s *etcdserver.EtcdServer, tls *transport.TLSInfo) (*grpc.Server, err
 	pb.RegisterWatchServer(grpcServer, NewWatchServer(s))
 	pb.RegisterLeaseServer(grpcServer, NewLeaseServer(s))
 	pb.RegisterClusterServer(grpcServer, NewClusterServer(s))
+	pb.RegisterAuthServer(grpcServer, NewAuthServer(s))
 	return grpcServer, nil
 }

--- a/etcdserver/etcdserverpb/raft_internal.pb.go
+++ b/etcdserver/etcdserverpb/raft_internal.pb.go
@@ -31,6 +31,7 @@ type InternalRaftRequest struct {
 	Compaction  *CompactionRequest  `protobuf:"bytes,7,opt,name=compaction" json:"compaction,omitempty"`
 	LeaseCreate *LeaseCreateRequest `protobuf:"bytes,8,opt,name=lease_create" json:"lease_create,omitempty"`
 	LeaseRevoke *LeaseRevokeRequest `protobuf:"bytes,9,opt,name=lease_revoke" json:"lease_revoke,omitempty"`
+	AuthEnable  *AuthEnableRequest  `protobuf:"bytes,10,opt,name=auth_enable" json:"auth_enable,omitempty"`
 }
 
 func (m *InternalRaftRequest) Reset()         { *m = InternalRaftRequest{} }
@@ -148,6 +149,16 @@ func (m *InternalRaftRequest) MarshalTo(data []byte) (int, error) {
 		}
 		i += n8
 	}
+	if m.AuthEnable != nil {
+		data[i] = 0x52
+		i++
+		i = encodeVarintRaftInternal(data, i, uint64(m.AuthEnable.Size()))
+		n9, err := m.AuthEnable.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n9
+	}
 	return i, nil
 }
 
@@ -232,6 +243,10 @@ func (m *InternalRaftRequest) Size() (n int) {
 	}
 	if m.LeaseRevoke != nil {
 		l = m.LeaseRevoke.Size()
+		n += 1 + l + sovRaftInternal(uint64(l))
+	}
+	if m.AuthEnable != nil {
+		l = m.AuthEnable.Size()
 		n += 1 + l + sovRaftInternal(uint64(l))
 	}
 	return n
@@ -565,6 +580,39 @@ func (m *InternalRaftRequest) Unmarshal(data []byte) error {
 				m.LeaseRevoke = &LeaseRevokeRequest{}
 			}
 			if err := m.LeaseRevoke.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AuthEnable", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRaftInternal
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRaftInternal
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.AuthEnable == nil {
+				m.AuthEnable = &AuthEnableRequest{}
+			}
+			if err := m.AuthEnable.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/etcdserver/etcdserverpb/raft_internal.proto
+++ b/etcdserver/etcdserverpb/raft_internal.proto
@@ -24,6 +24,8 @@ message InternalRaftRequest {
 
   LeaseCreateRequest lease_create = 8;
   LeaseRevokeRequest lease_revoke = 9;
+
+  AuthEnableRequest auth_enable = 10;
 }
 
 message EmptyResponse {

--- a/etcdserver/v3demo_server.go
+++ b/etcdserver/v3demo_server.go
@@ -57,6 +57,10 @@ type Lessor interface {
 	LeaseRenew(id lease.LeaseID) (int64, error)
 }
 
+type Authenticator interface {
+	AuthEnable(ctx context.Context, r *pb.AuthEnableRequest) (*pb.AuthEnableResponse, error)
+}
+
 func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeResponse, error) {
 	if r.Serializable {
 		return applyRange(noTxn, s.kv, r)
@@ -173,6 +177,11 @@ func (s *EtcdServer) LeaseRenew(id lease.LeaseID) (int64, error) {
 	return ttl, err
 }
 
+func (s *EtcdServer) AuthEnable(ctx context.Context, r *pb.AuthEnableRequest) (*pb.AuthEnableResponse, error) {
+	plog.Info("EtcdServer.AuthEnable isn't implemented yet")
+	return &pb.AuthEnableResponse{}, nil
+}
+
 type applyResult struct {
 	resp proto.Message
 	err  error
@@ -238,6 +247,9 @@ func (s *EtcdServer) applyV3Request(r *pb.InternalRaftRequest) interface{} {
 		ar.resp, ar.err = applyLeaseCreate(le, r.LeaseCreate)
 	case r.LeaseRevoke != nil:
 		ar.resp, ar.err = applyLeaseRevoke(le, r.LeaseRevoke)
+	case r.AuthEnable != nil:
+		plog.Info("AuthEnable is not implemented yet")
+		ar.resp, ar.err = nil, nil
 	default:
 		panic("not implemented")
 	}


### PR DESCRIPTION
This PR  adds a stub of etcdctlv3 auth enable. Related RPC stubs are also implemented.