### PR TITLE
etcdctlv3: use string slice for endpoints

### DIFF
--- a/etcdctlv3/command/global.go
+++ b/etcdctlv3/command/global.go
@@ -28,8 +28,9 @@ import (
 // GlobalFlags are flags that defined globally
 // and are inherited to all sub-commands.
 type GlobalFlags struct {
-	Endpoints string
-	TLS       transport.TLSInfo
+	Endpoints []string
+
+	TLS transport.TLSInfo
 
 	OutputFormat string
 	IsHex        bool
@@ -38,7 +39,7 @@ type GlobalFlags struct {
 var display printer = &simplePrinter{}
 
 func mustClientFromCmd(cmd *cobra.Command) *clientv3.Client {
-	endpoint, err := cmd.Flags().GetString("endpoint")
+	endpoints, err := cmd.Flags().GetStringSlice("endpoints")
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
@@ -68,10 +69,10 @@ func mustClientFromCmd(cmd *cobra.Command) *clientv3.Client {
 		ExitWithError(ExitBadFeature, errors.New("unsupported output format"))
 	}
 
-	return mustClient(endpoint, cert, key, cacert)
+	return mustClient(endpoints, cert, key, cacert)
 }
 
-func mustClient(endpoint, cert, key, cacert string) *clientv3.Client {
+func mustClient(endpoints []string, cert, key, cacert string) *clientv3.Client {
 	// set tls if any one tls option set
 	var cfgtls *transport.TLSInfo
 	tls := transport.TLSInfo{}
@@ -92,7 +93,7 @@ func mustClient(endpoint, cert, key, cacert string) *clientv3.Client {
 	}
 
 	cfg := clientv3.Config{
-		Endpoints:   []string{endpoint},
+		Endpoints:   endpoints,
 		TLS:         cfgtls,
 		DialTimeout: 20 * time.Second,
 	}

--- a/etcdctlv3/command/make_mirror_command.go
+++ b/etcdctlv3/command/make_mirror_command.go
@@ -57,7 +57,7 @@ func makeMirrorCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, errors.New("make-mirror takes one destination arguement."))
 	}
 
-	dc := mustClient(args[0], mmcert, mmkey, mmcacert)
+	dc := mustClient([]string{args[0]}, mmcert, mmkey, mmcacert)
 	c := mustClientFromCmd(cmd)
 
 	err := makeMirror(context.TODO(), c, dc)

--- a/etcdctlv3/main.go
+++ b/etcdctlv3/main.go
@@ -41,7 +41,7 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&globalFlags.Endpoints, "endpoint", "127.0.0.1:2378", "gRPC endpoint")
+	rootCmd.PersistentFlags().StringSliceVar(&globalFlags.Endpoints, "endpoints", []string{"127.0.0.1:2378", "127.0.0.1:22378", "127.0.0.1:32378"}, "gRPC endpoints")
 
 	rootCmd.PersistentFlags().StringVarP(&globalFlags.OutputFormat, "write-out", "w", "simple", "set the output format (simple, json, protobuf)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.IsHex, "hex", false, "print byte strings as hex encoded strings")


### PR DESCRIPTION
This deprecates 'endpoint' flag to enable etcdctl to parse
multi-endpoints flag.