### PR TITLE
storage: implement requestProgress

### DIFF
--- a/storage/watcher.go
+++ b/storage/watcher.go
@@ -42,6 +42,14 @@ type WatchStream interface {
 	// Chan returns a chan. All watch response will be sent to the returned chan.
 	Chan() <-chan WatchResponse
 
+	// RequestProgress requests the progress of the watcher with given ID. The response
+	// will only be sent if the watcher is currently synced.
+	// The responses will be sent through the WatchRespone Chan attached
+	// with this stream to ensure correct ordering.
+	// The responses contains no events. The revision in the response is the progress
+	// of the watchers since the watcher is currently synced.
+	RequestProgress(id WatchID)
+
 	// Cancel cancels a watcher by giving its ID. If watcher does not exist, an error will be
 	// returned.
 	Cancel(id WatchID) error
@@ -79,9 +87,10 @@ type watchStream struct {
 
 	mu sync.Mutex // guards fields below it
 	// nextID is the ID pre-allocated for next new watcher in this stream
-	nextID  WatchID
-	closed  bool
-	cancels map[WatchID]cancelFunc
+	nextID   WatchID
+	closed   bool
+	cancels  map[WatchID]cancelFunc
+	watchers map[WatchID]*watcher
 }
 
 // Watch creates a new watcher in the stream and returns its WatchID.
@@ -96,9 +105,10 @@ func (ws *watchStream) Watch(key, end []byte, startRev int64) WatchID {
 	id := ws.nextID
 	ws.nextID++
 
-	_, c := ws.watchable.watch(key, end, startRev, id, ws.ch)
+	w, c := ws.watchable.watch(key, end, startRev, id, ws.ch)
 
 	ws.cancels[id] = c
+	ws.watchers[id] = w
 	return id
 }
 
@@ -113,6 +123,7 @@ func (ws *watchStream) Cancel(id WatchID) error {
 	}
 	cancel()
 	delete(ws.cancels, id)
+	delete(ws.watchers, id)
 	return nil
 }
 
@@ -132,4 +143,14 @@ func (ws *watchStream) Rev() int64 {
 	ws.mu.Lock()
 	defer ws.mu.Unlock()
 	return ws.watchable.rev()
+}
+
+func (ws *watchStream) RequestProgress(id WatchID) {
+	ws.mu.Lock()
+	w, ok := ws.watchers[id]
+	ws.mu.Unlock()
+	if !ok {
+		return
+	}
+	ws.watchable.progress(w)
 }

--- a/storage/watcher_group.go
+++ b/storage/watcher_group.go
@@ -75,6 +75,11 @@ func (wb watcherBatch) add(w *watcher, ev storagepb.Event) {
 	eb.add(ev)
 }
 
+func (wb watcherBatch) contains(w *watcher) bool {
+	_, ok := wb[w]
+	return ok
+}
+
 // newWatcherBatch maps watchers to their matched events. It enables quick
 // events look up by watcher.
 func newWatcherBatch(wg *watcherGroup, evs []storagepb.Event) watcherBatch {


### PR DESCRIPTION
@gyuho @heyitsanthony 

So here is a simple implementation for the progress thing.

The assumption here is that only reporting progress of synced watchers are good enough.

The use case is to notify the watchers that started watching a while ago (minutes ago) about its progress.

So in this case, these watchers should already be synced. If they are still syncing, there should be stuff sending to them. So we do not need to send progress notification at all.