### PR TITLE
pkg/netutil: add linux netem functions

### DIFF
--- a/pkg/netutil/isolate_linux.go
+++ b/pkg/netutil/isolate_linux.go
@@ -40,3 +40,27 @@ func RecoverPort(port int) error {
 	_, err := exec.Command("/bin/sh", "-c", cmdStr).Output()
 	return err
 }
+
+// SetLatency adds latency in millisecond scale with random variations.
+func SetLatency(ms, rv int) error {
+	if rv > ms {
+		rv = 1
+	}
+	cmdStr := fmt.Sprintf("sudo tc qdisc add dev eth0 root netem delay %dms %dms distribution normal", ms, rv)
+	_, err := exec.Command("/bin/sh", "-c", cmdStr).Output()
+	if err != nil {
+		// the rule has already been added. Overwrite it.
+		cmdStr = fmt.Sprintf("sudo tc qdisc change dev eth0 root netem delay %dms %dms distribution normal", ms, rv)
+		_, err = exec.Command("/bin/sh", "-c", cmdStr).Output()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveLatency resets latency configurations.
+func RemoveLatency() error {
+	_, err := exec.Command("/bin/sh", "-c", "sudo tc qdisc del dev eth0 root netem").Output()
+	return err
+}

--- a/pkg/netutil/isolate_stub.go
+++ b/pkg/netutil/isolate_stub.go
@@ -19,3 +19,7 @@ package netutil
 func DropPort(port int) error { return nil }
 
 func RecoverPort(port int) error { return nil }
+
+func SetLatency(ms, rv int) error { return nil }
+
+func RemoveLatency() error { return nil }


### PR DESCRIPTION
This is useful for simulating bad networks by introducing
latencies to wide area networks.

Reference:
http://www.linuxfoundation.org/collaborate/workgroups/networking/netem

For https://github.com/coreos/etcd/issues/4666.