### PR TITLE
clientv3: add Err() to WatchResponse

### DIFF
--- a/clientv3/concurrency/election.go
+++ b/clientv3/concurrency/election.go
@@ -139,7 +139,7 @@ func (e *Election) observe(ctx context.Context, ch chan<- v3.GetResponse) {
 
 			for kv == nil {
 				wr, ok := <-wch
-				if !ok || len(wr.Events) == 0 {
+				if !ok || wr.Err() != nil {
 					cancel()
 					return
 				}

--- a/clientv3/concurrency/key.go
+++ b/clientv3/concurrency/key.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	v3 "github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/etcdserver/api/v3rpc"
 	"github.com/coreos/etcd/storage/storagepb"
 )
 
@@ -52,10 +51,7 @@ func waitUpdate(ctx context.Context, client *v3.Client, key string, opts ...v3.O
 	if !ok {
 		return ctx.Err()
 	}
-	if len(wresp.Events) == 0 {
-		return v3rpc.ErrCompacted
-	}
-	return nil
+	return wresp.Err()
 }
 
 func waitDelete(ctx context.Context, client *v3.Client, key string, rev int64) error {


### PR DESCRIPTION
Checking for number of events as a failure condition was a kludge.