### PR TITLE
clientv3: add IsProgressNotify with example

### DIFF
--- a/clientv3/example_test.go
+++ b/clientv3/example_test.go
@@ -25,7 +25,7 @@ import (
 var (
 	dialTimeout    = 5 * time.Second
 	requestTimeout = 1 * time.Second
-	endpoints      = []string{"localhost:12378", "localhost:22378", "http://localhost:32380"}
+	endpoints      = []string{"localhost:2378", "localhost:22378", "http://localhost:32380"}
 )
 
 func Example() {

--- a/clientv3/example_watch_test.go
+++ b/clientv3/example_watch_test.go
@@ -59,3 +59,20 @@ func ExampleWatcher_watchPrefix() {
 	}
 	// PUT "foo1" : "bar"
 }
+
+func ExampleWatcher_watchProgressNotify() {
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: dialTimeout,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rch := cli.Watch(context.Background(), "foo", clientv3.WithProgressNotify())
+	wresp := <-rch
+	fmt.Printf("wresp.Header.Revision: %d\n", wresp.Header.Revision)
+	fmt.Println("wresp.IsProgressNotify:", wresp.IsProgressNotify())
+	// wresp.Header.Revision: 0
+	// wresp.IsProgressNotify: true
+}

--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -61,6 +61,11 @@ func (wr *WatchResponse) Err() error {
 	return nil
 }
 
+// IsProgressNotify returns true if the WatchResponse is progress notification.
+func (wr *WatchResponse) IsProgressNotify() bool {
+	return len(wr.Events) == 0 && !wr.Canceled
+}
+
 // watcher implements the Watcher interface
 type watcher struct {
 	c      *Client


### PR DESCRIPTION
This makes the test endpoints same as we have in
goreman proc file, and adds 'IsProgressNotify' method
and the 'WatchProgressNotify' code example to godoc.