### PR TITLE
clientv3/integration: remove invalid future revision test

### DIFF
--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -333,31 +333,6 @@ func putAndWatch(t *testing.T, wctx *watchctx, key, val string) {
 	}
 }
 
-func TestWatchInvalidFutureRevision(t *testing.T) {
-	defer testutil.AfterTest(t)
-
-	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
-	defer clus.Terminate(t)
-
-	w := clientv3.NewWatcher(clus.RandClient())
-	defer w.Close()
-
-	rch := w.Watch(context.Background(), "foo", clientv3.WithRev(100))
-
-	wresp, ok := <-rch // WatchResponse from canceled one
-	if !ok {
-		t.Fatalf("expected wresp 'open'(ok true), but got ok %v", ok)
-	}
-	if wresp.Err() != v3rpc.ErrFutureRev {
-		t.Fatalf("wresp.Err() expected ErrFutureRev, but got %v", wresp.Err())
-	}
-
-	_, ok = <-rch // ensure the channel is closed
-	if ok != false {
-		t.Fatalf("expected wresp 'closed'(ok false), but got ok %v", ok)
-	}
-}
-
 // TestWatchCompactRevision ensures the CompactRevision error is given on a
 // compaction event ahead of a watcher.
 func TestWatchCompactRevision(t *testing.T) {


### PR DESCRIPTION
Future revisions are now supported, so test is outdated.