### PR TITLE
Metrics: Rename v3 metrics.

### DIFF
--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -22,7 +22,7 @@ var (
 	rangeCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "range_total",
 			Help:      "Total number of ranges seen by this member.",
 		})
@@ -30,7 +30,7 @@ var (
 	putCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "put_total",
 			Help:      "Total number of puts seen by this member.",
 		})
@@ -38,7 +38,7 @@ var (
 	deleteCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "delete_total",
 			Help:      "Total number of deletes seen by this member.",
 		})
@@ -46,7 +46,7 @@ var (
 	txnCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "txn_total",
 			Help:      "Total number of txns seen by this member.",
 		})
@@ -54,7 +54,7 @@ var (
 	keysGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "keys_total",
 			Help:      "Total number of keys.",
 		})
@@ -62,7 +62,7 @@ var (
 	watchStreamGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "watch_stream_total",
 			Help:      "Total number of watch streams.",
 		})
@@ -70,7 +70,7 @@ var (
 	watcherGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "watcher_total",
 			Help:      "Total number of watchers.",
 		})
@@ -78,7 +78,7 @@ var (
 	slowWatcherGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "slow_watcher_total",
 			Help:      "Total number of unsynced slow watchers.",
 		})
@@ -86,7 +86,7 @@ var (
 	totalEventsCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "events_total",
 			Help:      "Total number of events sent by this member.",
 		})
@@ -94,7 +94,7 @@ var (
 	pendingEventsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "pending_events_total",
 			Help:      "Total number of pending events to be sent.",
 		})
@@ -102,7 +102,7 @@ var (
 	indexCompactionPauseDurations = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "index_compaction_pause_duration_milliseconds",
 			Help:      "Bucketed histogram of index compaction pause duration.",
 			// 0.5ms -> 1second
@@ -112,7 +112,7 @@ var (
 	dbCompactionPauseDurations = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "db_compaction_pause_duration_milliseconds",
 			Help:      "Bucketed histogram of db compaction pause duration.",
 			// 1ms -> 4second
@@ -122,7 +122,7 @@ var (
 	dbCompactionTotalDurations = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "etcd",
-			Subsystem: "storage",
+			Subsystem: "store",
 			Name:      "db_compaction_total_duration_milliseconds",
 			Help:      "Bucketed histogram of db compaction total duration.",
 			// 100ms -> 800second
@@ -131,7 +131,7 @@ var (
 
 	dbTotalSize = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "etcd",
-		Subsystem: "storage",
+		Subsystem: "store",
 		Name:      "db_total_size_in_bytes",
 		Help:      "Total size of the underlying database in bytes.",
 	})

--- a/store/metrics.go
+++ b/store/metrics.go
@@ -27,7 +27,7 @@ var (
 	readCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "store",
+			Subsystem: "storev2",
 			Name:      "reads_total",
 			Help:      "Total number of reads action by (get/getRecursive), local to this member.",
 		}, []string{"action"})
@@ -35,7 +35,7 @@ var (
 	writeCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "store",
+			Subsystem: "storev2",
 			Name:      "writes_total",
 			Help:      "Total number of writes (e.g. set/compareAndDelete) seen by this member.",
 		}, []string{"action"})
@@ -43,7 +43,7 @@ var (
 	readFailedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "store",
+			Subsystem: "storev2",
 			Name:      "reads_failed_total",
 			Help:      "Failed read actions by (get/getRecursive), local to this member.",
 		}, []string{"action"})
@@ -51,7 +51,7 @@ var (
 	writeFailedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "store",
+			Subsystem: "storev2",
 			Name:      "writes_failed_total",
 			Help:      "Failed write actions (e.g. set/compareAndDelete), seen by this member.",
 		}, []string{"action"})
@@ -59,7 +59,7 @@ var (
 	expireCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "store",
+			Subsystem: "storev2",
 			Name:      "expires_total",
 			Help:      "Total number of expired keys.",
 		})
@@ -67,7 +67,7 @@ var (
 	watchRequests = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "store",
+			Subsystem: "storev2",
 			Name:      "watch_requests_total",
 			Help:      "Total number of incoming watch requests (new or reestablished).",
 		})
@@ -75,7 +75,7 @@ var (
 	watcherCount = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "etcd",
-			Subsystem: "store",
+			Subsystem: "storev2",
 			Name:      "watchers",
 			Help:      "Count of currently active watchers.",
 		})


### PR DESCRIPTION
The v3 metrics have been renamed from "storage" to "store" and the
v2 metrics have been renamed from "store" to "storev2". Versioned
names indicate older versions and un-versioned indicate the most
up-to-date version.

Fixes #3833