### PR TITLE
storage/backend: set InitialMmapSize to 2GB on 32-bit to prevent overflow

### DIFF
--- a/storage/backend/backend.go
+++ b/storage/backend/backend.go
@@ -34,11 +34,6 @@ var (
 	defaultBatchInterval = 100 * time.Millisecond
 
 	defragLimit = 10000
-
-	// InitialMmapSize is the initial size of the mmapped region. Setting this larger than
-	// the potential max db size can prevent writer from blocking reader.
-	// This only works for linux.
-	InitialMmapSize = int64(10 * 1024 * 1024 * 1024)
 )
 
 type Backend interface {

--- a/storage/backend/boltoption_386.go
+++ b/storage/backend/boltoption_386.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux,!arm,!386
+// +build linux,386
 
 package backend
 
 import (
+	"math"
 	"syscall"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt"
@@ -25,8 +26,9 @@ import (
 var (
 	// InitialMmapSize is the initial size of the mmapped region. Setting this larger than
 	// the potential max db size can prevent writer from blocking reader.
-	// This only works for linux.
-	InitialMmapSize = int64(10 * 1024 * 1024 * 1024)
+	// This only works for linux and only on arm 32-bit
+	// This sets InitialMmapSize to 2GB, or (2 * 1024 * 1024 * 1024) - 1
+	InitialMmapSize = math.MaxInt32
 )
 
 // syscall.MAP_POPULATE on linux 2.6.23+ does sequential read-ahead
@@ -37,5 +39,5 @@ var (
 // silently ignore this flag. Please update your kernel to prevent this.
 var boltOpenOptions = &bolt.Options{
 	MmapFlags:       syscall.MAP_POPULATE,
-	InitialMmapSize: int(InitialMmapSize),
+	InitialMmapSize: InitialMmapSize,
 }

--- a/storage/backend/boltoption_arm.go
+++ b/storage/backend/boltoption_arm.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux,!arm,!386
+// +build linux,arm
 
 package backend
 
 import (
+	"math"
 	"syscall"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/boltdb/bolt"
@@ -25,8 +26,9 @@ import (
 var (
 	// InitialMmapSize is the initial size of the mmapped region. Setting this larger than
 	// the potential max db size can prevent writer from blocking reader.
-	// This only works for linux.
-	InitialMmapSize = int64(10 * 1024 * 1024 * 1024)
+	// This only works for linux and only on arm 32-bit
+	// This sets InitialMmapSize to 2GB, or (2 * 1024 * 1024 * 1024) - 1
+	InitialMmapSize = math.MaxInt32
 )
 
 // syscall.MAP_POPULATE on linux 2.6.23+ does sequential read-ahead
@@ -37,5 +39,5 @@ var (
 // silently ignore this flag. Please update your kernel to prevent this.
 var boltOpenOptions = &bolt.Options{
 	MmapFlags:       syscall.MAP_POPULATE,
-	InitialMmapSize: int(InitialMmapSize),
+	InitialMmapSize: InitialMmapSize,
 }


### PR DESCRIPTION
Fixes #4700
@xiang90 @hongchaodeng 