### PR TITLE
*: build phony etcd server binary for unsupported architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ The `v2` API responses should not change after the 2.0.0 release but new feature
 
 etcd has known issues on 32-bit systems due to a bug in the Go runtime. See #[358][358] for more information.
 
+To avoid inadvertantly producing an unstable etcd server, 32-bit builds emit an `etcd` that prints
+a warning message and immediately exits.
+
 [358]: https://github.com/coreos/etcd/issues/358
 
 ### License

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: support arm64
+// +build amd64
+
 package etcdmain
 
 import (

--- a/etcdmain/etcd_phony.go
+++ b/etcdmain/etcd_phony.go
@@ -1,0 +1,31 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !amd64
+
+package etcdmain
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/coreos/etcd/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
+)
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "etcdmain")
+
+func Main() {
+	fmt.Println("unsupported architecture; unreliable, unstable")
+	os.Exit(-1)
+}

--- a/storage/backend/backend.go
+++ b/storage/backend/backend.go
@@ -38,7 +38,7 @@ var (
 	// InitialMmapSize is the initial size of the mmapped region. Setting this larger than
 	// the potential max db size can prevent writer from blocking reader.
 	// This only works for linux.
-	InitialMmapSize = 10 * 1024 * 1024 * 1024
+	InitialMmapSize = int64(10 * 1024 * 1024 * 1024)
 )
 
 type Backend interface {

--- a/storage/backend/boltoption_unix.go
+++ b/storage/backend/boltoption_unix.go
@@ -30,5 +30,5 @@ import (
 // silently ignore this flag. Please update your kernel to prevent this.
 var boltOpenOptions = &bolt.Options{
 	MmapFlags:       syscall.MAP_POPULATE,
-	InitialMmapSize: InitialMmapSize,
+	InitialMmapSize: int(InitialMmapSize),
 }


### PR DESCRIPTION
We don't qualify etcdserver for anything other than amd64, so don't
build binaries that are untested and might be unreliable.