### PR TITLE
pkg/fileutil: add flock to Windows

### DIFF
--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -20,6 +20,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -41,10 +42,10 @@ func TestIsDirWriteable(t *testing.T) {
 		// http://stackoverflow.com/questions/20609415/cross-compiling-user-current-not-implemented-on-linux-amd64
 		t.Skipf("failed to get current user: %v", err)
 	}
-	if me.Name == "root" || me.Name == "Administrator" {
+	if me.Name == "root" || me.Name == "Administrator" || runtime.GOOS == "windows" {
 		// ideally we should check CAP_DAC_OVERRIDE.
 		// but it does not matter for tests.
-		t.Skipf("running as a superuser")
+		t.Skipf("running as a superuser or in windows")
 	}
 	if err := IsDirWriteable(tmpdir); err == nil {
 		t.Fatalf("expected IsDirWriteable to error")

--- a/pkg/fileutil/purge.go
+++ b/pkg/fileutil/purge.go
@@ -15,6 +15,7 @@
 package fileutil
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"sort"


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/1972.
Related to https://github.com/coreos/etcd/issues/2515.
Windows LockFile doesn't work the same way as linux.
In linux, we can have file lock and write to the file,
but windows doesn't allow that. Once you open a file with
Windows API LockFile, you cannot write, which is what we need
in WAL package. So this adds dummy file to indicate the
file is locked.