### PR TITLE
etcdctl: Add command to create in-order keys.

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -110,6 +110,12 @@ $ etcdctl mk /foo/new_bar "Hello world"
 Hello world
 ```
 
+Create a new in-order key under dir `/fooDir`:
+
+```
+$ etcdctl mk --in-order /fooDir "Hello world"
+```
+
 Create a new dir `/fooDir`, only if the key did not previously exist:
 
 ```


### PR DESCRIPTION
Adding a new mk-inorder command to etcdctl to create in-order keys
under a given directory with a given value. Optionally, TTL can
also be set on the newly created in-order key.

Fixes #4588