### PR TITLE
raft: remove unnecessary waitSchedule in test

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -207,13 +207,12 @@ func TestBlockProposal(t *testing.T) {
 	}
 
 	n.Campaign(context.TODO())
-	testutil.WaitSchedule()
 	select {
 	case err := <-errc:
 		if err != nil {
 			t.Errorf("err = %v, want %v", err, nil)
 		}
-	default:
+	case <-time.After(10 * time.Second):
 		t.Errorf("blocking proposal, want unblocking")
 	}
 }


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/4326

WaitSchedule is not reliable. And in this case, we do not actually need it. Simply wait longer will reduce the false-positive rate dramatically without any speed impact.