### PR TITLE
etcdserver: align 64-bit atomics on 8-byte boundary

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -153,9 +153,13 @@ type Server interface {
 
 // EtcdServer is the production implementation of the Server interface
 type EtcdServer struct {
-	// r must be the first element to keep 64-bit alignment for atomic
+	// r and inflightSnapshots must be the first elements to keep 64-bit alignment for atomic
 	// access to fields
-	r raftNode
+
+	// count the number of inflight snapshots.
+	// MUST use atomic operation to access this field.
+	inflightSnapshots int64
+	r                 raftNode
 
 	cfg       *ServerConfig
 	snapCount uint64
@@ -195,10 +199,6 @@ type EtcdServer struct {
 	forceVersionC chan struct{}
 
 	msgSnapC chan raftpb.Message
-
-	// count the number of inflight snapshots.
-	// MUST use atomic operation to access this field.
-	inflightSnapshots int64
 }
 
 // NewServer creates a new EtcdServer from the supplied configuration. The


### PR DESCRIPTION
I read through the whole source code today, and came across this and #4733 that didn't obey the rules. 
@xiang90 @heyitsanthony 