### PR TITLE
clientv3/integration: fix TestTxnWriteFail

### DIFF
--- a/clientv3/integration/txn_test.go
+++ b/clientv3/integration/txn_test.go
@@ -45,8 +45,9 @@ func TestTxnWriteFail(t *testing.T) {
 		donec <- struct{}{}
 	}()
 
+	dialTimeout := 5 * time.Second
 	select {
-	case <-time.After(5 * time.Second):
+	case <-time.After(2*dialTimeout + time.Second):
 		t.Fatalf("timed out waiting for txn to fail")
 	case <-donec:
 		// don't restart cluster until txn errors out


### PR DESCRIPTION
It might take client request more than dialtimeout to fail when
we kill the connection when the client is sending request.

Fix #4424 

/cc @heyitsanthony 