### PR TITLE
authentication.md: fix formatting of fenced code block

### DIFF
--- a/Documentation/authentication.md
+++ b/Documentation/authentication.md
@@ -94,6 +94,7 @@ Roles are granted access to various parts of the keyspace, a single path at a ti
 Reading a path is simple; if the path ends in `*`, that key **and all keys prefixed with it**, are granted to holders of this role. If it does not end in `*`, only that key and that key alone is granted.
 
 Access can be granted as either read, write, or both, as in the following examples:
+
 ```
 # Give read access to keys under the /foo directory
 $ etcdctl role grant myrolename -path '/foo/*' -read


### PR DESCRIPTION
Add a missing blank line to one of the fenced code blocks in the
"Working with roles" section to conform with the formatting best
practice recommended in the GitHub guide "Creating and highlighting code
blocks"[1]:

> We recommend placing a blank line before and after code blocks to make
> the raw formatting easier to read.

The missing blank line prior to the code block causes incorrect HTML
rendering of this section within the CoreOS etcd Authentication
Guide[2]. This commit fixes the problem, but the underlying issue seems
to be a quirk of the markdown render used for the CoreOS documentation
pages, as the same markdown source does not exhibit the issue when
viewed on GitHub[3] or viewed through the python markdown module.

[1] https://help.github.com/articles/creating-and-highlighting-code-blocks/
[2] https://coreos.com/etcd/docs/2.2.5/authentication.html
[3] https://github.com/coreos/etcd/blob/v2.2.5/Documentation/authentication.md