### PR TITLE
storage: support seq put to make db more compact

### DIFF
--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -453,7 +453,7 @@ func (s *store) put(key, value []byte, leaseID lease.LeaseID) {
 		log.Fatalf("storage: cannot marshal event: %v", err)
 	}
 
-	s.tx.UnsafePut(keyBucketName, ibytes, d)
+	s.tx.UnsafeSeqPut(keyBucketName, ibytes, d)
 	s.kvindex.Put(key, revision{main: rev, sub: s.currentRev.sub})
 	s.changes = append(s.changes, kv)
 	s.currentRev.sub += 1
@@ -514,7 +514,7 @@ func (s *store) delete(key []byte, rev revision) {
 		log.Fatalf("storage: cannot marshal event: %v", err)
 	}
 
-	s.tx.UnsafePut(keyBucketName, ibytes, d)
+	s.tx.UnsafeSeqPut(keyBucketName, ibytes, d)
 	err = s.kvindex.Tombstone(key, revision{main: mainrev, sub: s.currentRev.sub})
 	if err != nil {
 		log.Fatalf("storage: cannot tombstone an existing key (%s): %v", string(key), err)

--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -139,13 +139,13 @@ func TestStorePut(t *testing.T) {
 		}
 
 		wact := []testutil.Action{
-			{"put", []interface{}{keyBucketName, tt.wkey, data}},
+			{"seqput", []interface{}{keyBucketName, tt.wkey, data}},
 		}
 
 		if tt.rr != nil {
 			wact = []testutil.Action{
 				{"range", []interface{}{keyBucketName, newTestKeyBytes(tt.r.rev, false), []byte(nil), int64(0)}},
-				{"put", []interface{}{keyBucketName, tt.wkey, data}},
+				{"seqput", []interface{}{keyBucketName, tt.wkey, data}},
 			}
 		}
 
@@ -305,7 +305,7 @@ func TestStoreDeleteRange(t *testing.T) {
 			t.Errorf("#%d: marshal err = %v, want nil", i, err)
 		}
 		wact := []testutil.Action{
-			{"put", []interface{}{keyBucketName, tt.wkey, data}},
+			{"seqput", []interface{}{keyBucketName, tt.wkey, data}},
 			{"range", []interface{}{keyBucketName, newTestKeyBytes(revision{2, 0}, false), []byte(nil), int64(0)}},
 		}
 		if g := b.tx.Action(); !reflect.DeepEqual(g, wact) {
@@ -572,6 +572,9 @@ func (b *fakeBatchTx) Unlock()                        {}
 func (b *fakeBatchTx) UnsafeCreateBucket(name []byte) {}
 func (b *fakeBatchTx) UnsafePut(bucketName []byte, key []byte, value []byte) {
 	b.Recorder.Record(testutil.Action{Name: "put", Params: []interface{}{bucketName, key, value}})
+}
+func (b *fakeBatchTx) UnsafeSeqPut(bucketName []byte, key []byte, value []byte) {
+	b.Recorder.Record(testutil.Action{Name: "seqput", Params: []interface{}{bucketName, key, value}})
 }
 func (b *fakeBatchTx) UnsafeRange(bucketName []byte, key, endKey []byte, limit int64) (keys [][]byte, vals [][]byte) {
 	b.Recorder.Record(testutil.Action{Name: "range", Params: []interface{}{bucketName, key, endKey, limit}})


### PR DESCRIPTION
When we know most of puts are sequential puts, we can increase the fillPrecent of the bucket to delay split. We can then get a better space utilization.

For putting 1M 136bytes kv:

Previously take 329MB (140% overhead)

Now take 226MB (60% overhead)