### PR TITLE
fileutil, wal: refactor file locking

### DIFF
--- a/pkg/fileutil/lock.go
+++ b/pkg/fileutil/lock.go
@@ -14,16 +14,13 @@
 
 package fileutil
 
-type Lock interface {
-	// Name returns the name of the file.
-	Name() string
-	// TryLock acquires exclusivity on the lock without blocking.
-	TryLock() error
-	// Lock acquires exclusivity on the lock.
-	Lock() error
-	// Unlock unlocks the lock.
-	Unlock() error
-	// Destroy should be called after Unlock to clean up
-	// the resources.
-	Destroy() error
-}
+import (
+	"errors"
+	"os"
+)
+
+var (
+	ErrLocked = errors.New("fileutil: file already locked")
+)
+
+type LockedFile struct{ *os.File }

--- a/pkg/fileutil/lock_solaris.go
+++ b/pkg/fileutil/lock_solaris.go
@@ -17,25 +17,11 @@
 package fileutil
 
 import (
-	"errors"
 	"os"
 	"syscall"
 )
 
-var (
-	ErrLocked = errors.New("file already locked")
-)
-
-type lock struct {
-	fd   int
-	file *os.File
-}
-
-func (l *lock) Name() string {
-	return l.file.Name()
-}
-
-func (l *lock) TryLock() error {
+func TryLockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
 	var lock syscall.Flock_t
 	lock.Start = 0
 	lock.Len = 0
@@ -43,45 +29,34 @@ func (l *lock) TryLock() error {
 	lock.Type = syscall.F_WRLCK
 	lock.Whence = 0
 	lock.Pid = 0
-	err := syscall.FcntlFlock(uintptr(l.fd), syscall.F_SETLK, &lock)
-	if err != nil && err == syscall.EAGAIN {
-		return ErrLocked
-	}
-	return err
-}
-
-func (l *lock) Lock() error {
-	var lock syscall.Flock_t
-	lock.Start = 0
-	lock.Len = 0
-	lock.Type = syscall.F_WRLCK
-	lock.Whence = 0
-	lock.Pid = 0
-	return syscall.FcntlFlock(uintptr(l.fd), syscall.F_SETLK, &lock)
-}
-
-func (l *lock) Unlock() error {
-	var lock syscall.Flock_t
-	lock.Start = 0
-	lock.Len = 0
-	lock.Type = syscall.F_UNLCK
-	lock.Whence = 0
-	err := syscall.FcntlFlock(uintptr(l.fd), syscall.F_SETLK, &lock)
-	if err != nil && err == syscall.EAGAIN {
-		return ErrLocked
-	}
-	return err
-}
-
-func (l *lock) Destroy() error {
-	return l.file.Close()
-}
-
-func NewLock(file string) (Lock, error) {
-	f, err := os.OpenFile(file, os.O_WRONLY, 0600)
+	f, err := os.OpenFile(path, flag, perm)
 	if err != nil {
 		return nil, err
 	}
-	l := &lock{int(f.Fd()), f}
-	return l, nil
+	if err := syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, &lock); err != nil {
+		f.Close()
+		if err == syscall.EAGAIN {
+			err = ErrLocked
+		}
+		return nil, err
+	}
+	return &LockedFile{f}, nil
+}
+
+func LockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	var lock syscall.Flock_t
+	lock.Start = 0
+	lock.Len = 0
+	lock.Pid = 0
+	lock.Type = syscall.F_WRLCK
+	lock.Whence = 0
+	f, err := os.OpenFile(path, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	if err = syscall.FcntlFlock(f.Fd(), syscall.F_SETLKW, &lock); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &LockedFile{f}, nil
 }

--- a/pkg/fileutil/lock_test.go
+++ b/pkg/fileutil/lock_test.go
@@ -35,44 +35,38 @@ func TestLockAndUnlock(t *testing.T) {
 	}()
 
 	// lock the file
-	l, err := NewLock(f.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer l.Destroy()
-	err = l.Lock()
+	l, err := LockFile(f.Name(), os.O_WRONLY, 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// try lock a locked file
-	dupl, err := NewLock(f.Name())
-	if err != nil {
+	if _, err = TryLockFile(f.Name(), os.O_WRONLY, 0600); err != ErrLocked {
 		t.Fatal(err)
-	}
-	err = dupl.TryLock()
-	if err != ErrLocked {
-		t.Errorf("err = %v, want %v", err, ErrLocked)
 	}
 
 	// unlock the file
-	err = l.Unlock()
-	if err != nil {
+	if err = l.Close(); err != nil {
 		t.Fatal(err)
 	}
 
 	// try lock the unlocked file
-	err = dupl.TryLock()
+	dupl, err := TryLockFile(f.Name(), os.O_WRONLY, 0600)
 	if err != nil {
 		t.Errorf("err = %v, want %v", err, nil)
 	}
-	defer dupl.Destroy()
 
 	// blocking on locked file
 	locked := make(chan struct{}, 1)
 	go func() {
-		l.Lock()
+		bl, blerr := LockFile(f.Name(), os.O_WRONLY, 0600)
+		if blerr != nil {
+			t.Fatal(blerr)
+		}
 		locked <- struct{}{}
+		if blerr = bl.Close(); blerr != nil {
+			t.Fatal(blerr)
+		}
 	}()
 
 	select {
@@ -82,8 +76,7 @@ func TestLockAndUnlock(t *testing.T) {
 	}
 
 	// unlock
-	err = dupl.Unlock()
-	if err != nil {
+	if err = dupl.Close(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/fileutil/lock_windows.go
+++ b/pkg/fileutil/lock_windows.go
@@ -16,45 +16,17 @@
 
 package fileutil
 
-import (
-	"errors"
-	"os"
-)
+import "os"
 
-var (
-	ErrLocked = errors.New("file already locked")
-)
-
-type lock struct {
-	fd   int
-	file *os.File
+func TryLockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	return LockFile(path, flag, perm)
 }
 
-func (l *lock) Name() string {
-	return l.file.Name()
-}
-
-func (l *lock) TryLock() error {
-	return nil
-}
-
-func (l *lock) Lock() error {
-	return nil
-}
-
-func (l *lock) Unlock() error {
-	return nil
-}
-
-func (l *lock) Destroy() error {
-	return l.file.Close()
-}
-
-func NewLock(file string) (Lock, error) {
-	f, err := os.Open(file)
+func LockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	// TODO make this actually work
+	f, err := os.OpenFile(path, flag, perm)
 	if err != nil {
 		return nil, err
 	}
-	l := &lock{int(f.Fd()), f}
-	return l, nil
+	return &LockedFile{f}, nil
 }

--- a/pkg/fileutil/purge_test.go
+++ b/pkg/fileutil/purge_test.go
@@ -80,7 +80,7 @@ func TestPurgeFile(t *testing.T) {
 	close(stop)
 }
 
-func TestPurgeFileHoldingLock(t *testing.T) {
+func TestPurgeFileHoldingLockFile(t *testing.T) {
 	dir, err := ioutil.TempDir("", "purgefile")
 	if err != nil {
 		t.Fatal(err)
@@ -95,8 +95,8 @@ func TestPurgeFileHoldingLock(t *testing.T) {
 	}
 
 	// create a purge barrier at 5
-	l, err := NewLock(path.Join(dir, fmt.Sprintf("%d.test", 5)))
-	err = l.Lock()
+	p := path.Join(dir, fmt.Sprintf("%d.test", 5))
+	l, err := LockFile(p, os.O_WRONLY, 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,12 +127,7 @@ func TestPurgeFileHoldingLock(t *testing.T) {
 	}
 
 	// remove the purge barrier
-	err = l.Unlock()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = l.Destroy()
-	if err != nil {
+	if err = l.Close(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/wal/decoder.go
+++ b/wal/decoder.go
@@ -31,14 +31,12 @@ type decoder struct {
 	mu sync.Mutex
 	br *bufio.Reader
 
-	c   io.Closer
 	crc hash.Hash32
 }
 
-func newDecoder(rc io.ReadCloser) *decoder {
+func newDecoder(r io.Reader) *decoder {
 	return &decoder{
-		br:  bufio.NewReader(rc),
-		c:   rc,
+		br:  bufio.NewReader(r),
 		crc: crc.New(0, crcTable),
 	}
 }
@@ -78,10 +76,6 @@ func (d *decoder) updateCRC(prevCrc uint32) {
 
 func (d *decoder) lastCRC() uint32 {
 	return d.crc.Sum32()
-}
-
-func (d *decoder) close() error {
-	return d.c.Close()
 }
 
 func mustUnmarshalEntry(d []byte) raftpb.Entry {

--- a/wal/repair.go
+++ b/wal/repair.go
@@ -36,7 +36,6 @@ func Repair(dirpath string) bool {
 	rec := &walpb.Record{}
 
 	decoder := newDecoder(f)
-	defer decoder.close()
 	for {
 		err := decoder.decode(rec)
 		switch err {

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -38,11 +38,11 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
-	if g := path.Base(w.f.Name()); g != walName(0, 0) {
+	if g := path.Base(w.tail().Name()); g != walName(0, 0) {
 		t.Errorf("name = %+v, want %+v", g, walName(0, 0))
 	}
 	defer w.Close()
-	gd, err := ioutil.ReadFile(w.f.Name())
+	gd, err := ioutil.ReadFile(w.tail().Name())
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
@@ -100,11 +100,11 @@ func TestOpenAtIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
-	if g := path.Base(w.f.Name()); g != walName(0, 0) {
+	if g := path.Base(w.tail().Name()); g != walName(0, 0) {
 		t.Errorf("name = %+v, want %+v", g, walName(0, 0))
 	}
-	if w.seq != 0 {
-		t.Errorf("seq = %d, want %d", w.seq, 0)
+	if w.seq() != 0 {
+		t.Errorf("seq = %d, want %d", w.seq(), 0)
 	}
 	w.Close()
 
@@ -119,11 +119,11 @@ func TestOpenAtIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
-	if g := path.Base(w.f.Name()); g != wname {
+	if g := path.Base(w.tail().Name()); g != wname {
 		t.Errorf("name = %+v, want %+v", g, wname)
 	}
-	if w.seq != 2 {
-		t.Errorf("seq = %d, want %d", w.seq, 2)
+	if w.seq() != 2 {
+		t.Errorf("seq = %d, want %d", w.seq(), 2)
 	}
 	w.Close()
 
@@ -160,7 +160,7 @@ func TestCut(t *testing.T) {
 		t.Fatal(err)
 	}
 	wname := walName(1, 1)
-	if g := path.Base(w.f.Name()); g != wname {
+	if g := path.Base(w.tail().Name()); g != wname {
 		t.Errorf("name = %s, want %s", g, wname)
 	}
 
@@ -176,7 +176,7 @@ func TestCut(t *testing.T) {
 		t.Fatal(err)
 	}
 	wname = walName(2, 2)
-	if g := path.Base(w.f.Name()); g != wname {
+	if g := path.Base(w.tail().Name()); g != wname {
 		t.Errorf("name = %s, want %s", g, wname)
 	}
 
@@ -416,10 +416,10 @@ func TestOpenForRead(t *testing.T) {
 	defer os.RemoveAll(p)
 	// create WAL
 	w, err := Create(p, nil)
-	defer w.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer w.Close()
 	// make 10 separate files
 	for i := 0; i < 10; i++ {
 		es := []raftpb.Entry{{Index: uint64(i)}}
@@ -436,10 +436,10 @@ func TestOpenForRead(t *testing.T) {
 
 	// All are available for read
 	w2, err := OpenForRead(p, walpb.Snapshot{})
-	defer w2.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer w2.Close()
 	_, _, ents, err := w2.ReadAll()
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)


### PR DESCRIPTION
File lock interface was more verbose than it needed to be while
simultaneously making it difficult to support systems (e.g., Windows)
that only permit locked writes on a single fd holding the lock.