### PR TITLE
show leader/member information when run 'etcdctl member list' command

### DIFF
--- a/etcdctl/command/member_commands.go
+++ b/etcdctl/command/member_commands.go
@@ -63,17 +63,27 @@ func actionMemberList(c *cli.Context) {
 	mAPI := mustNewMembersAPI(c)
 	ctx, cancel := contextWithTotalTimeout(c)
 	defer cancel()
+
 	members, err := mAPI.List(ctx)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
+	leader, err := mAPI.Leader(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to get leader: ", err)
+		os.Exit(1)
+	}
 
 	for _, m := range members {
+		isLeader := false
+		if m.ID == leader.ID {
+			isLeader = true
+		}
 		if len(m.Name) == 0 {
 			fmt.Printf("%s[unstarted]: peerURLs=%s\n", m.ID, strings.Join(m.PeerURLs, ","))
 		} else {
-			fmt.Printf("%s: name=%s peerURLs=%s clientURLs=%s\n", m.ID, m.Name, strings.Join(m.PeerURLs, ","), strings.Join(m.ClientURLs, ","))
+			fmt.Printf("%s: name=%s peerURLs=%s clientURLs=%s isLeader=%v\n", m.ID, m.Name, strings.Join(m.PeerURLs, ","), strings.Join(m.ClientURLs, ","), isLeader)
 		}
 	}
 }

--- a/etcdctlv3/command/member_command.go
+++ b/etcdctlv3/command/member_command.go
@@ -171,7 +171,7 @@ func memberListCommandFunc(cmd *cobra.Command, args []string) {
 		if len(m.Name) == 0 {
 			fmt.Printf("%16x[unstarted]: peerURLs=%s\n", m.ID, strings.Join(m.PeerURLs, ","))
 		} else {
-			fmt.Printf("%16x: name=%s peerURLs=%s clientURLs=%s\n", m.ID, m.Name, strings.Join(m.PeerURLs, ","), strings.Join(m.ClientURLs, ","))
+			fmt.Printf("%16x: name=%s peerURLs=%s clientURLs=%s isLeader=%v\n", m.ID, m.Name, strings.Join(m.PeerURLs, ","), strings.Join(m.ClientURLs, ","), m.IsLeader)
 		}
 	}
 }


### PR DESCRIPTION
This information is very helpful. Otherwise, we must get this information by `curl http://127.0.0.1:2379/v2/stats/self`. 