### PR TITLE
*: refresh the lease TTL correctly when a leader is elected.

### DIFF
--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -134,6 +134,10 @@ func (c *ServerConfig) ReqTimeout() time.Duration {
 	return 5*time.Second + 2*time.Duration(c.ElectionTicks)*time.Duration(c.TickMs)*time.Millisecond
 }
 
+func (c *ServerConfig) electionTimeout() time.Duration {
+	return time.Duration(c.ElectionTicks) * time.Duration(c.TickMs) * time.Millisecond
+}
+
 func (c *ServerConfig) peerDialTimeout() time.Duration {
 	// 1s for queue wait and system delay
 	// + one RTT, which is smaller than 1/5 election timeout

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -165,7 +165,7 @@ func (r *raftNode) start(s *EtcdServer) {
 						// it promotes or demotes instead of modifying server directly.
 						syncC = r.s.SyncTicker
 						if r.s.lessor != nil {
-							r.s.lessor.Promote()
+							r.s.lessor.Promote(r.s.cfg.electionTimeout())
 						}
 						// TODO: remove the nil checking
 						// current test utility does not provide the stats

--- a/lease/lessor_test.go
+++ b/lease/lessor_test.go
@@ -34,7 +34,7 @@ func TestLessorGrant(t *testing.T) {
 	defer be.Close()
 
 	le := newLessor(be)
-	le.Promote()
+	le.Promote(0)
 
 	l, err := le.Grant(1, 1)
 	if err != nil {
@@ -128,7 +128,7 @@ func TestLessorRenew(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	le := newLessor(be)
-	le.Promote()
+	le.Promote(0)
 
 	l, err := le.Grant(1, 5)
 	if err != nil {


### PR DESCRIPTION
The new leader needs to refresh with an extened TTL to gracefully handle
the potential concurrent leaders issue. Clients might still send keep alive
to old leader until the old leader itself gives up leadership at most after
an election timeout.