### PR TITLE
travis: drop go1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 sudo: false
 
 go:
-  - 1.4
   - 1.5
   - 1.6
   - tip


### PR DESCRIPTION
Related to https://github.com/coreos/etcd/issues/4790.

Still needs:

> drop any build tag that support < 1.4