### PR TITLE
scripts: add etcd v3 gRPC port to Dockerfile

### DIFF
--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -12,7 +12,7 @@ cat <<DF > ${IMAGEDIR}/Dockerfile
 FROM scratch
 ADD etcd /
 ADD etcdctl /
-EXPOSE 4001 7001 2379 2380
+EXPOSE 4001 7001 2378 2379 2380
 ENTRYPOINT ["/etcd"]
 DF
 


### PR DESCRIPTION
since the next release would be 3+, and also for the
people just trying out v3 features in Docker container.
docker run can still talk to port 2380. This just makes
the port exposed automatically when docker run pass --publish
flag.