### PR TITLE
benchmark: use Procfile endpoints as default

### DIFF
--- a/tools/benchmark/cmd/root.go
+++ b/tools/benchmark/cmd/root.go
@@ -49,7 +49,7 @@ var (
 )
 
 func init() {
-	RootCmd.PersistentFlags().StringSliceVar(&endpoints, "endpoints", []string{"127.0.0.1:2378"}, "gRPC endpoints")
+	RootCmd.PersistentFlags().StringSliceVar(&endpoints, "endpoints", []string{"127.0.0.1:2378", "127.0.0.1:22378", "127.0.0.1:32378"}, "gRPC endpoints")
 	RootCmd.PersistentFlags().UintVar(&totalConns, "conns", 1, "Total number of gRPC connections")
 	RootCmd.PersistentFlags().UintVar(&totalClients, "clients", 1, "Total number of gRPC clients")
 


### PR DESCRIPTION
https://github.com/coreos/etcd/blob/master/etcdctlv3/main.go#L44  uses our endpoints in Procfile.

Would be useful for quick local testing.

/cc @xiang90 @heyitsanthony 
