### PR TITLE
clientv3/concurrency: fix godoc

### DIFF
--- a/clientv3/concurrency/doc.go
+++ b/clientv3/concurrency/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package concurrency implements concurrency operations on top of
+// etcd such as distributed locks, barriers, and elections.
+package concurrency

--- a/clientv3/concurrency/key.go
+++ b/clientv3/concurrency/key.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package concurrency
 
 import (


### PR DESCRIPTION
https://godoc.org/github.com/coreos/etcd/clientv3/concurrency has license in godoc. We need blank line between.

And @heyitsanthony Could you check my package description? Is that correct?

Thanks.