### PR TITLE
*: minor updates for godoc

### DIFF
--- a/clientv3/concurrency/session.go
+++ b/clientv3/concurrency/session.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package concurrency
 
 import (

--- a/clientv3/doc.go
+++ b/clientv3/doc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// clientv3 is the official Go etcd client for v3.
+// Package clientv3 implements the official Go etcd client for v3.
 //
 // Create client using `clientv3.New`:
 //

--- a/clientv3/mirror/syncer.go
+++ b/clientv3/mirror/syncer.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package mirror implements etcd mirroring operations.
 package mirror
 
 import (

--- a/error/error.go
+++ b/error/error.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// error package describes errors in etcd project. When any change happens,
+// Package error describes errors in etcd project. When any change happens,
 // Documentation/errorcode.md needs to be updated correspondingly.
 package error
 

--- a/etcdserver/api/v3rpc/grpc.go
+++ b/etcdserver/api/v3rpc/grpc.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package v3rpc
 
 import (

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package recipe
+// limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_barrier_test.go
+++ b/integration/v3_barrier_test.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package recipe
+// limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_double_barrier_test.go
+++ b/integration/v3_double_barrier_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_election_test.go
+++ b/integration/v3_election_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_grpc_test.go
+++ b/integration/v3_grpc_test.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package recipe
+// limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_lease_test.go
+++ b/integration/v3_lease_test.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package recipe
+// limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_lock_test.go
+++ b/integration/v3_lock_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_queue_test.go
+++ b/integration/v3_queue_test.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package recipe
+// limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_stm_test.go
+++ b/integration/v3_stm_test.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package recipe
+// limitations under the License.
+
 package integration
 
 import (

--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.package recipe
+// limitations under the License.
+
 package integration
 
 import (

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@
 // This package should NOT be extended or modified in any way; to modify the
 // etcd binary, work in the `github.com/coreos/etcd/etcdmain` package.
 //
-
 package main
 
 import "github.com/coreos/etcd/etcdmain"

--- a/pkg/transport/limit_listen.go
+++ b/pkg/transport/limit_listen.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package netutil provides network utility functions, complementing the more
+// Package transport provides network utility functions, complementing the more
 // common ones in the net package.
 package transport
 

--- a/storage/kvstore_bench_test.go
+++ b/storage/kvstore_bench_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package storage
 
 import (


### PR DESCRIPTION
/cc @xiang90 @heyitsanthony 

I missed one file in concurrency package. And found another one in `v3rpc`.
And this adds package description in godoc. Not every package has to have
package description, but the `mirror` package locates under `clientv3`, so it
will get more traffic in godoc.org.
