### PR TITLE
build: build etcdctlv3 by default

### DIFF
--- a/build
+++ b/build
@@ -31,3 +31,4 @@ fi
 # Static compilation is useful when etcd is run in a container
 CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "-s -X ${REPO_PATH}/version.GitSHA${LINK_OPERATOR}${GIT_SHA}" -o bin/etcd ${REPO_PATH}
 CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "-s" -o bin/etcdctl ${REPO_PATH}/etcdctl
+CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "-s" -o bin/etcdctlv3 ${REPO_PATH}/etcdctlv3


### PR DESCRIPTION
Any reason not to? It makes demoing etcd easier with the V3 procfile.