### PR TITLE
pkg/transport: use ProxyFromEnvironment when constructing a transport

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -67,6 +67,7 @@ func NewTransport(info TLSInfo, dialtimeoutd time.Duration) (*http.Transport, er
 	}
 
 	t := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: dialtimeoutd,
 			// value taken from http.DefaultTransport


### PR DESCRIPTION
this allows use of HTTP_PROXY/HTTPS_PROXY for etcdctl.