### PR TITLE
clientv3: Fix inconsistent naming convention in v3 client.

### DIFF
--- a/clientv3/compare.go
+++ b/clientv3/compare.go
@@ -76,7 +76,7 @@ func CreatedRevision(key string) Cmp {
 	return Cmp{Key: []byte(key), Target: pb.Compare_CREATE}
 }
 
-func ModifiedRevision(key string) Cmp {
+func ModRevision(key string) Cmp {
 	return Cmp{Key: []byte(key), Target: pb.Compare_MOD}
 }
 

--- a/clientv3/concurrency/key.go
+++ b/clientv3/concurrency/key.go
@@ -33,7 +33,7 @@ func NewUniqueKV(ctx context.Context, kv v3.KV, pfx, val string, opts ...v3.OpOp
 	for {
 		newKey := fmt.Sprintf("%s/%v", pfx, time.Now().UnixNano())
 		put := v3.OpPut(newKey, val, opts...)
-		cmp := v3.Compare(v3.ModifiedRevision(newKey), "=", 0)
+		cmp := v3.Compare(v3.ModRevision(newKey), "=", 0)
 		resp, err := kv.Txn(ctx).If(cmp).Then(put).Commit()
 		if err != nil {
 			return "", 0, err

--- a/clientv3/concurrency/stm.go
+++ b/clientv3/concurrency/stm.go
@@ -235,7 +235,7 @@ func isKeyCurrent(k string, r *v3.GetResponse) v3.Cmp {
 	if len(r.Kvs) != 0 {
 		rev = r.Kvs[0].ModRevision + 1
 	}
-	return v3.Compare(v3.ModifiedRevision(k), "<", rev)
+	return v3.Compare(v3.ModRevision(k), "<", rev)
 }
 
 func respToValue(resp *v3.GetResponse) string {

--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -163,11 +163,11 @@ func TestKVRange(t *testing.T) {
 				{Key: []byte("a"), Value: nil, CreateRevision: 2, ModRevision: 2, Version: 1},
 			},
 		},
-		// range all with SortByModifiedRev, SortDescend
+		// range all with SortByModRevision, SortDescend
 		{
 			"a", "x",
 			0,
-			[]clientv3.OpOption{clientv3.WithSort(clientv3.SortByModifiedRev, clientv3.SortDescend)},
+			[]clientv3.OpOption{clientv3.WithSort(clientv3.SortByModRevision, clientv3.SortDescend)},
 
 			[]*storagepb.KeyValue{
 				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},

--- a/clientv3/op.go
+++ b/clientv3/op.go
@@ -221,10 +221,10 @@ func WithFirstKey() []OpOption { return withTop(SortByKey, SortAscend) }
 func WithLastKey() []OpOption { return withTop(SortByKey, SortDescend) }
 
 // WithFirstRev gets the key with the oldest modification revision in the request range.
-func WithFirstRev() []OpOption { return withTop(SortByModifiedRev, SortAscend) }
+func WithFirstRev() []OpOption { return withTop(SortByModRevision, SortAscend) }
 
 // WithLastRev gets the key with the latest modification revision in the request range.
-func WithLastRev() []OpOption { return withTop(SortByModifiedRev, SortDescend) }
+func WithLastRev() []OpOption { return withTop(SortByModRevision, SortDescend) }
 
 // withTop gets the first key over the get's prefix given a sort order
 func withTop(target SortTarget, order SortOrder) []OpOption {

--- a/clientv3/sort.go
+++ b/clientv3/sort.go
@@ -27,7 +27,7 @@ const (
 	SortByKey SortTarget = iota
 	SortByVersion
 	SortByCreatedRev
-	SortByModifiedRev
+	SortByModRevision
 	SortByValue
 )
 

--- a/contrib/recipes/client.go
+++ b/contrib/recipes/client.go
@@ -31,7 +31,7 @@ var (
 
 // deleteRevKey deletes a key by revision, returning false if key is missing
 func deleteRevKey(kv v3.KV, key string, rev int64) (bool, error) {
-	cmp := v3.Compare(v3.ModifiedRevision(key), "=", rev)
+	cmp := v3.Compare(v3.ModRevision(key), "=", rev)
 	req := v3.OpDelete(key)
 	txnresp, err := kv.Txn(context.TODO()).If(cmp).Then(req).Commit()
 	if err != nil {

--- a/contrib/recipes/key.go
+++ b/contrib/recipes/key.go
@@ -123,7 +123,7 @@ func newSequentialKV(kv v3.KV, prefix, val string, leaseID v3.LeaseID) (*RemoteK
 	baseKey := "__" + prefix
 
 	// current revision might contain modification so +1
-	cmp := v3.Compare(v3.ModifiedRevision(baseKey), "<", resp.Header.Revision+1)
+	cmp := v3.Compare(v3.ModRevision(baseKey), "<", resp.Header.Revision+1)
 	reqPrefix := v3.OpPut(baseKey, "", v3.WithLease(leaseID))
 	reqNewKey := v3.OpPut(newKey, val, v3.WithLease(leaseID))
 

--- a/etcdctlv3/command/get_command.go
+++ b/etcdctlv3/command/get_command.go
@@ -100,7 +100,7 @@ func getGetOp(cmd *cobra.Command, args []string) (string, []clientv3.OpOption) {
 	case sortTarget == "KEY":
 		sortByTarget = clientv3.SortByKey
 	case sortTarget == "MODIFY":
-		sortByTarget = clientv3.SortByModifiedRev
+		sortByTarget = clientv3.SortByModRevision
 	case sortTarget == "VALUE":
 		sortByTarget = clientv3.SortByValue
 	case sortTarget == "VERSION":

--- a/etcdctlv3/command/txn_command.go
+++ b/etcdctlv3/command/txn_command.go
@@ -187,7 +187,7 @@ func parseCompare(line string) (*clientv3.Cmp, error) {
 		}
 	case "m", "mod":
 		if v, err = strconv.ParseInt(val, 10, 64); err == nil {
-			cmp = clientv3.Compare(clientv3.ModifiedRevision(key), op, v)
+			cmp = clientv3.Compare(clientv3.ModRevision(key), op, v)
 		}
 	case "val", "value":
 		cmp = clientv3.Compare(clientv3.Value(key), op, val)


### PR DESCRIPTION
In order to have a consistent naming for variable/function names
pertaining to ModifiedRevision, all occurrences have been renamed
to ModRevision.

Fixes #4767 