### PR TITLE
clientv3: Renaming SortByCreatedRev to maintain consistency.

### DIFF
--- a/clientv3/concurrency/key.go
+++ b/clientv3/concurrency/key.go
@@ -74,7 +74,7 @@ func waitDelete(ctx context.Context, client *v3.Client, key string, rev int64) e
 
 // waitDeletes efficiently waits until all keys matched by Get(key, opts...) are deleted
 func waitDeletes(ctx context.Context, client *v3.Client, key string, opts ...v3.OpOption) error {
-	getOpts := []v3.OpOption{v3.WithSort(v3.SortByCreatedRev, v3.SortAscend)}
+	getOpts := []v3.OpOption{v3.WithSort(v3.SortByCreateRevision, v3.SortAscend)}
 	getOpts = append(getOpts, opts...)
 	resp, err := client.Get(ctx, key, getOpts...)
 	maxRev := int64(math.MaxInt64)

--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -148,11 +148,11 @@ func TestKVRange(t *testing.T) {
 				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},
 			},
 		},
-		// range all with SortByCreatedRev, SortDescend
+		// range all with SortByCreateRevision, SortDescend
 		{
 			"a", "x",
 			0,
-			[]clientv3.OpOption{clientv3.WithSort(clientv3.SortByCreatedRev, clientv3.SortDescend)},
+			[]clientv3.OpOption{clientv3.WithSort(clientv3.SortByCreateRevision, clientv3.SortDescend)},
 
 			[]*storagepb.KeyValue{
 				{Key: []byte("fop"), Value: nil, CreateRevision: 9, ModRevision: 9, Version: 1},

--- a/clientv3/op.go
+++ b/clientv3/op.go
@@ -209,10 +209,10 @@ func WithSerializable() OpOption {
 }
 
 // WithFirstCreate gets the key with the oldest creation revision in the request range.
-func WithFirstCreate() []OpOption { return withTop(SortByCreatedRev, SortAscend) }
+func WithFirstCreate() []OpOption { return withTop(SortByCreateRevision, SortAscend) }
 
 // WithLastCreate gets the key with the latest creation revision in the request range.
-func WithLastCreate() []OpOption { return withTop(SortByCreatedRev, SortDescend) }
+func WithLastCreate() []OpOption { return withTop(SortByCreateRevision, SortDescend) }
 
 // WithFirstKey gets the lexically first key in the request range.
 func WithFirstKey() []OpOption { return withTop(SortByKey, SortAscend) }

--- a/clientv3/sort.go
+++ b/clientv3/sort.go
@@ -26,7 +26,7 @@ const (
 const (
 	SortByKey SortTarget = iota
 	SortByVersion
-	SortByCreatedRev
+	SortByCreateRevision
 	SortByModRevision
 	SortByValue
 )

--- a/etcdctlv3/command/get_command.go
+++ b/etcdctlv3/command/get_command.go
@@ -96,7 +96,7 @@ func getGetOp(cmd *cobra.Command, args []string) (string, []clientv3.OpOption) {
 	sortTarget := strings.ToUpper(getSortTarget)
 	switch {
 	case sortTarget == "CREATE":
-		sortByTarget = clientv3.SortByCreatedRev
+		sortByTarget = clientv3.SortByCreateRevision
 	case sortTarget == "KEY":
 		sortByTarget = clientv3.SortByKey
 	case sortTarget == "MODIFY":


### PR DESCRIPTION
Renamed SortByCreatedRev to SortByCreatedRevision to be consistent
with the naming used for SortByModRevision.