### PR TITLE
etcdctlv3: support secure connection without key/cert

### DIFF
--- a/etcdctlv3/command/ep_health_command.go
+++ b/etcdctlv3/command/ep_health_command.go
@@ -41,11 +41,11 @@ func epHealthCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitError, err)
 	}
 
-	cert, key, cacert := keyAndCertFromCmd(cmd)
+	sec := secureCfgFromCmd(cmd)
 	dt := dialTimeoutFromCmd(cmd)
 	cfgs := []*clientv3.Config{}
 	for _, ep := range endpoints {
-		cfg, err := newClientCfg([]string{ep}, dt, cert, key, cacert)
+		cfg, err := newClientCfg([]string{ep}, dt, sec)
 		if err != nil {
 			ExitWithError(ExitBadArgs, err)
 		}

--- a/etcdctlv3/main.go
+++ b/etcdctlv3/main.go
@@ -51,6 +51,8 @@ func init() {
 
 	rootCmd.PersistentFlags().DurationVar(&globalFlags.DialTimeout, "dial-timeout", defaultDialTimeout, "dial timeout for client connections")
 
+	// TODO: secure by default when etcd enables secure gRPC by default.
+	rootCmd.PersistentFlags().BoolVar(&globalFlags.Insecure, "insecure-transport", true, "disable transport security for client connections")
 	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.CertFile, "cert", "", "identify secure client using this TLS certificate file")
 	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.KeyFile, "key", "", "identify secure client using this TLS key file")
 	rootCmd.PersistentFlags().StringVar(&globalFlags.TLS.CAFile, "cacert", "", "verify certificates of TLS-enabled secure servers using this CA bundle")


### PR DESCRIPTION
Perviously we imply secure connection from key/cert. However user should be able to setup secure connection without specifying key/cert. 