### PR TITLE
etcdctl: add short flag for 'ls' command

### DIFF
--- a/etcdctl/command/ls_command.go
+++ b/etcdctl/command/ls_command.go
@@ -28,7 +28,7 @@ func NewLsCommand() cli.Command {
 		ArgsUsage: "[key]",
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "sort", Usage: "returns result in sorted order"},
-			cli.BoolFlag{Name: "recursive", Usage: "returns all key names recursively for the given path"},
+			cli.BoolFlag{Name: "recursive, r", Usage: "returns all key names recursively for the given path"},
 			cli.BoolFlag{Name: "p", Usage: "append slash (/) to directories"},
 			cli.BoolFlag{Name: "quorum", Usage: "require quorum for get request"},
 		},


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/4866.