### PR TITLE
*: fix races from clientv3/integration tests

### DIFF
--- a/clientv3/logger.go
+++ b/clientv3/logger.go
@@ -1,0 +1,64 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"log"
+	"os"
+	"sync"
+
+	"google.golang.org/grpc/grpclog"
+)
+
+type Logger grpclog.Logger
+
+var (
+	logger settableLogger
+)
+
+type settableLogger struct {
+	l  grpclog.Logger
+	mu sync.RWMutex
+}
+
+func init() {
+	// use go's standard logger by default like grpc
+	logger.mu.Lock()
+	logger.l = log.New(os.Stderr, "", log.LstdFlags)
+	grpclog.SetLogger(&logger)
+	logger.mu.Unlock()
+}
+
+func (s *settableLogger) Set(l Logger) {
+	s.mu.Lock()
+	logger.l = l
+	s.mu.Unlock()
+}
+
+func (s *settableLogger) Get() Logger {
+	s.mu.RLock()
+	l := logger.l
+	s.mu.RUnlock()
+	return l
+}
+
+// implement the grpclog.Logger interface
+
+func (s *settableLogger) Fatal(args ...interface{})                 { s.Get().Fatal(args...) }
+func (s *settableLogger) Fatalf(format string, args ...interface{}) { s.Get().Fatalf(format, args...) }
+func (s *settableLogger) Fatalln(args ...interface{})               { s.Get().Fatalln(args...) }
+func (s *settableLogger) Print(args ...interface{})                 { s.Get().Print(args...) }
+func (s *settableLogger) Printf(format string, args ...interface{}) { s.Get().Printf(format, args...) }
+func (s *settableLogger) Println(args ...interface{})               { s.Get().Println(args...) }

--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -240,11 +240,11 @@ func (w *watcher) addStream(resp *pb.WatchResponse, pendingReq *watchRequest) {
 	w.streams[ws.id] = ws
 	w.mu.Unlock()
 
-	// send messages to subscriber
-	go w.serveStream(ws)
-
 	// pass back the subscriber channel for the watcher
 	pendingReq.retc <- ret
+
+	// send messages to subscriber
+	go w.serveStream(ws)
 }
 
 // closeStream closes the watcher resources and removes it

--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -436,11 +436,15 @@ func (w *watcher) serveStream(ws *watcherStream) {
 			// TODO don't keep buffering if subscriber stops reading
 			wrs = append(wrs, wr)
 		case resumeRev := <-ws.resumec:
+			wrs = nil
+			resuming = true
+			if resumeRev == -1 {
+				// pause serving stream while resume gets set up
+				break
+			}
 			if resumeRev != ws.lastRev {
 				panic("unexpected resume revision")
 			}
-			wrs = nil
-			resuming = true
 		case <-w.donec:
 			closing = true
 		case <-ws.initReq.ctx.Done():
@@ -502,6 +506,9 @@ func (w *watcher) resumeWatchers(wc pb.Watch_WatchClient) error {
 	w.mu.RUnlock()
 
 	for _, ws := range streams {
+		// pause serveStream
+		ws.resumec <- -1
+
 		// reconstruct watcher from initial request
 		if ws.lastRev != 0 {
 			ws.initReq.rev = ws.lastRev
@@ -525,6 +532,7 @@ func (w *watcher) resumeWatchers(wc pb.Watch_WatchClient) error {
 		w.streams[ws.id] = ws
 		w.mu.Unlock()
 
+		// unpause serveStream
 		ws.resumec <- ws.lastRev
 	}
 	return nil

--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -16,6 +16,7 @@ package v3rpc
 
 import (
 	"io"
+	"sync"
 	"time"
 
 	"github.com/coreos/etcd/etcdserver"
@@ -72,6 +73,8 @@ type serverWatchStream struct {
 	// progress tracks the watchID that stream might need to send
 	// progress to.
 	progress map[storage.WatchID]bool
+	// mu protects progress
+	mu sync.Mutex
 
 	// closec indicates the stream is closed.
 	closec chan struct{}
@@ -145,7 +148,9 @@ func (sws *serverWatchStream) recvLoop() error {
 						WatchId:  id,
 						Canceled: true,
 					}
+					sws.mu.Lock()
 					delete(sws.progress, storage.WatchID(id))
+					sws.mu.Unlock()
 				}
 			}
 			// TODO: do we need to return error back to client?
@@ -200,9 +205,11 @@ func (sws *serverWatchStream) sendLoop() {
 				return
 			}
 
+			sws.mu.Lock()
 			if _, ok := sws.progress[wresp.WatchID]; ok {
 				sws.progress[wresp.WatchID] = false
 			}
+			sws.mu.Unlock()
 
 		case c, ok := <-sws.ctrlStream:
 			if !ok {

--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -922,10 +923,12 @@ func waitResponse(wc pb.Watch_WatchClient, timeout time.Duration) (bool, *pb.Wat
 }
 
 func TestWatchWithProgressNotify(t *testing.T) {
+	// accelerate report interval so test terminates quickly
+	oldpi := v3rpc.ProgressReportIntervalMilliseconds
+	// using atomics to avoid race warnings
+	atomic.StoreInt32(&v3rpc.ProgressReportIntervalMilliseconds, 3*1000)
 	testInterval := 3 * time.Second
-	pi := v3rpc.ProgressReportInterval
-	v3rpc.ProgressReportInterval = testInterval
-	defer func() { v3rpc.ProgressReportInterval = pi }()
+	defer func() { v3rpc.ProgressReportIntervalMilliseconds = oldpi }()
 
 	defer testutil.AfterTest(t)
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -165,10 +165,11 @@ func (t *Transport) Send(msgs []raftpb.Message) {
 		to := types.ID(m.To)
 
 		t.mu.RLock()
-		p, ok := t.peers[to]
+		p, pok := t.peers[to]
+		g, rok := t.remotes[to]
 		t.mu.RUnlock()
 
-		if ok {
+		if pok {
 			if m.Type == raftpb.MsgApp {
 				t.ServerStats.SendAppendReq(m.Size())
 			}
@@ -176,8 +177,7 @@ func (t *Transport) Send(msgs []raftpb.Message) {
 			continue
 		}
 
-		g, ok := t.remotes[to]
-		if ok {
+		if rok {
 			g.send(m)
 			continue
 		}

--- a/test
+++ b/test
@@ -45,14 +45,13 @@ split=(${TEST// / })
 TEST=${split[@]/#/${REPO_PATH}/}
 split=(${NO_RACE_TEST// / })
 NO_RACE_TEST=${split[@]/#/${REPO_PATH}/}
+MACHINE_TYPE=$(uname -m)
+if [ $MACHINE_TYPE != "armv7l" ]; then
+	RACE="--race"
+fi
 
 function unit_tests {
 	echo "Running tests..."
-
-	MACHINE_TYPE=$(uname -m)
-	if [ $MACHINE_TYPE != "armv7l" ]; then
-		RACE="--race"
-	fi
 	go test -timeout 3m ${COVER} ${RACE} -cpu 1,2,4 $@ ${TEST}
 	go test -timeout 3m ${COVER} -cpu 1,2,4 $@ ${NO_RACE_TEST}
 }
@@ -61,7 +60,7 @@ function integration_tests {
 	echo "Running integration tests..."
 	go test -timeout 10m -v -cpu 1,2,4 $@ ${REPO_PATH}/e2e
 	go test -timeout 15m -v -cpu 1,2,4 $@ ${REPO_PATH}/integration
-	go test -timeout 10m -v -cpu 1,2,4 $@ ${REPO_PATH}/clientv3/integration
+	go test -timeout 10m -v ${RACE} -cpu 1,2,4 $@ ${REPO_PATH}/clientv3/integration
 	go test -timeout 1m -v -cpu 1,2,4 $@ ${REPO_PATH}/contrib/raftexample
 }
 


### PR DESCRIPTION
```
================
WARNING: DATA RACE
Write by goroutine 146:
  github.com/coreos/etcd/clientv3.(*kv).switchRemote()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/kv.go:194 +0x158

Previous read by goroutine 307:
  github.com/coreos/etcd/clientv3.(*kv).switchRemote()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/kv.go:186 +0x63
  github.com/coreos/etcd/clientv3.(*kv).Do()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/kv.go:179 +0x490
  github.com/coreos/etcd/clientv3.(*kv).Get()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/kv.go:103 +0xdb
  github.com/coreos/etcd/clientv3/integration.TestKVPutFailGetRetry.func1()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/integration/kv_test.go:437 +0xa1

Goroutine 146 (running) created at:
  github.com/coreos/etcd/clientv3.(*kv).Do()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/kv.go:175 +0x41e
  github.com/coreos/etcd/clientv3.(*kv).Put()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/kv.go:98 +0xf5
  github.com/coreos/etcd/clientv3/integration.TestKVPutFailGetRetry()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/integration/kv_test.go:429 +0x4c0
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:473 +0xdc

Goroutine 307 (running) created at:
  github.com/coreos/etcd/clientv3/integration.TestKVPutFailGetRetry()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/integration/kv_test.go:445 +0x5a6
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:473 +0xdc
=================
```

```
==================
WARNING: DATA RACE
Write by goroutine 63:
  runtime.mapassign1()
      /usr/lib/go/src/runtime/hashmap.go:429 +0x0
  github.com/coreos/etcd/rafthttp.(*Transport).AddRemote()
      /home/anthony/go/src/github.com/coreos/etcd/rafthttp/transport.go:220 +0x525
  github.com/coreos/etcd/rafthttp.(*streamHandler).ServeHTTP()
      /home/anthony/go/src/github.com/coreos/etcd/rafthttp/http.go:283 +0xa46
  net/http.(*ServeMux).ServeHTTP()
      /usr/lib/go/src/net/http/server.go:1910 +0x212
  net/http.(*ServeMux).ServeHTTP()
      /usr/lib/go/src/net/http/server.go:1910 +0x212
  github.com/coreos/etcd/pkg/testutil.(*PauseableHandler).ServeHTTP()
      /home/anthony/go/src/github.com/coreos/etcd/pkg/testutil/pauseable_handler.go:33 +0xf8
  net/http.serverHandler.ServeHTTP()
      /usr/lib/go/src/net/http/server.go:2081 +0x206
  net/http.(*conn).serve()
      /usr/lib/go/src/net/http/server.go:1472 +0x1565

Previous read by goroutine 279:
  runtime.mapaccess2_fast64()
      /usr/lib/go/src/runtime/hashmap_fast.go:148 +0x0
  github.com/coreos/etcd/rafthttp.(*Transport).Send()
      /home/anthony/go/src/github.com/coreos/etcd/rafthttp/transport.go:179 +0x331
  github.com/coreos/etcd/etcdserver.(*EtcdServer).send()
      /home/anthony/go/src/github.com/coreos/etcd/etcdserver/server.go:954 +0x5b8
  github.com/coreos/etcd/etcdserver.(*raftNode).start.func1()
      /home/anthony/go/src/github.com/coreos/etcd/etcdserver/raft.go:224 +0xe7d

Goroutine 63 (running) created at:
  net/http.(*Server).Serve()
      /usr/lib/go/src/net/http/server.go:2137 +0x4d1
  net/http/httptest.(*Server).goServe.func1()
      /usr/lib/go/src/net/http/httptest/server.go:237 +0xac

Goroutine 279 (running) created at:
  github.com/coreos/etcd/etcdserver.(*raftNode).start()
      /home/anthony/go/src/github.com/coreos/etcd/etcdserver/raft.go:234 +0x329
  github.com/coreos/etcd/etcdserver.(*EtcdServer).run()
      /home/anthony/go/src/github.com/coreos/etcd/etcdserver/server.go:499 +0x1eb
==================
```

```
==================
WARNING: DATA RACE
Read by goroutine 759:
  github.com/coreos/etcd/clientv3.(*watcher).resumeWatchers()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/watch.go:506 +0x31a
  github.com/coreos/etcd/clientv3.(*watcher).resume()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/watch.go:470 +0x9e
  github.com/coreos/etcd/clientv3.(*watcher).newWatchClient()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/watch.go:457 +0x4a
  github.com/coreos/etcd/clientv3.(*watcher).run()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/watch.go:321 +0xb94

Previous write by goroutine 467:
  github.com/coreos/etcd/clientv3.(*watcher).serveStream()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/watch.go:412 +0x7d1

Goroutine 759 (running) created at:
  github.com/coreos/etcd/clientv3.NewWatcher()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/watch.go:145 +0x559
  github.com/coreos/etcd/clientv3/integration.runWatchTest()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/integration/watch_test.go:50 +0x11c
  github.com/coreos/etcd/clientv3/integration.TestWatchReconnRunning()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/integration/watch_test.go:231 +0x3a
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:473 +0xdc

Goroutine 467 (running) created at:
  github.com/coreos/etcd/clientv3.(*watcher).addStream()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/watch.go:244 +0x496
  github.com/coreos/etcd/clientv3.(*watcher).run()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/watch.go:295 +0x802
==================
```

```
==================
WARNING: DATA RACE
Write by goroutine 953:
  github.com/coreos/etcd/clientv3/integration.testWatchWithProgressNotify()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/integration/watch_test.go:390 +0x1d7
  github.com/coreos/etcd/clientv3/integration.TestWatchWithProgressNotify()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/integration/watch_test.go:376 +0x33
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:473 +0xdc

Previous read by goroutine 699:
  [failed to restore the stack]

Goroutine 953 (running) created at:
  testing.RunTests()
      /usr/lib/go/src/testing/testing.go:582 +0xae2
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:515 +0x11d
  github.com/coreos/etcd/clientv3/integration.TestMain()
      /home/anthony/go/src/github.com/coreos/etcd/clientv3/integration/main_test.go:15 +0x2e
  main.main()
      github.com/coreos/etcd/clientv3/integration/_test/_testmain.go:114 +0x20a

Goroutine 699 (finished) created at:
  github.com/coreos/etcd/etcdserver/api/v3rpc.(*watchServer).Watch()
      /home/anthony/go/src/github.com/coreos/etcd/etcdserver/api/v3rpc/watch.go:93 +0x2a4
  github.com/coreos/etcd/etcdserver/etcdserverpb._Watch_Watch_Handler()
      /home/anthony/go/src/github.com/coreos/etcd/etcdserver/etcdserverpb/rpc.pb.go:1834 +0xfe
  github.com/coreos/etcd/vendor/google.golang.org/grpc.(*Server).processStreamingRPC()
      /home/anthony/go/src/github.com/coreos/etcd/vendor/google.golang.org/grpc/server.go:586 +0x647
  github.com/coreos/etcd/vendor/google.golang.org/grpc.(*Server).handleStream()
      /home/anthony/go/src/github.com/coreos/etcd/vendor/google.golang.org/grpc/server.go:661 +0x150a
  github.com/coreos/etcd/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /home/anthony/go/src/github.com/coreos/etcd/vendor/google.golang.org/grpc/server.go:323 +0xad
==================
```
