### PR TITLE
etcdserver: configurable backend size quota

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -123,6 +123,7 @@ type config struct {
 	printVersion bool
 
 	autoCompactionRetention int
+	quotaBackendBytes       int64
 
 	enablePprof bool
 
@@ -224,6 +225,7 @@ func NewConfig() *config {
 
 	// demo flag
 	fs.IntVar(&cfg.autoCompactionRetention, "experimental-auto-compaction-retention", 0, "Auto compaction retention in hour. 0 means disable auto compaction.")
+	fs.Int64Var(&cfg.quotaBackendBytes, "quota-backend-bytes", 0, "Raise alarms when backend size exceeds the given quota. 0 means use the default quota.")
 
 	// backwards-compatibility with v0.4.6
 	fs.Var(&flags.IPAddressPort{}, "addr", "DEPRECATED: Use --advertise-client-urls instead.")

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -347,6 +347,7 @@ func startEtcd(cfg *config) (<-chan struct{}, error) {
 		TickMs:                  cfg.TickMs,
 		ElectionTicks:           cfg.electionTicks(),
 		AutoCompactionRetention: cfg.autoCompactionRetention,
+		QuotaBackendBytes:       cfg.quotaBackendBytes,
 		StrictReconfigCheck:     cfg.strictReconfigCheck,
 		EnablePprof:             cfg.enablePprof,
 	}

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -51,6 +51,7 @@ type ServerConfig struct {
 	BootstrapTimeout time.Duration
 
 	AutoCompactionRetention int
+	QuotaBackendBytes       int64
 
 	StrictReconfigCheck bool
 

--- a/storage/backend/backend.go
+++ b/storage/backend/backend.go
@@ -41,6 +41,15 @@ var (
 	InitialMmapSize = int64(10 * 1024 * 1024 * 1024)
 )
 
+const (
+	// DefaultQuotaBytes is the number of bytes the backend Size may
+	// consume before exceeding the space quota.
+	DefaultQuotaBytes = int64(2 * 1024 * 1024 * 1024) // 2GB
+	// MaxQuotaBytes is the maximum number of bytes suggested for a backend
+	// quota. A larger quota may lead to degraded performance.
+	MaxQuotaBytes = int64(8 * 1024 * 1024 * 1024) // 8GB
+)
+
 type Backend interface {
 	BatchTx() BatchTx
 	Snapshot() Snapshot


### PR DESCRIPTION
Configurable with the flag --experimental-quota-backend-bytes and
through ServerConfig.QuotaBackendBytes.

Fixes #4894