### PR TITLE
raft: lower split vote rate

### DIFF
--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -381,8 +381,8 @@ func testNonleadersElectionTimeoutNonconflict(t *testing.T, state StateType) {
 		}
 	}
 
-	if g := float64(conflicts) / 1000; g > 0.4 {
-		t.Errorf("probability of conflicts = %v, want <= 0.4", g)
+	if g := float64(conflicts) / 1000; g > 0.3 {
+		t.Errorf("probability of conflicts = %v, want <= 0.3", g)
 	}
 }
 

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -754,9 +754,10 @@ func TestIsElectionTimeout(t *testing.T) {
 		round        bool
 	}{
 		{5, 0, false},
-		{13, 0.3, true},
-		{15, 0.5, true},
-		{18, 0.8, true},
+		{10, 0.1, true},
+		{13, 0.4, true},
+		{15, 0.6, true},
+		{18, 0.9, true},
 		{20, 1, false},
 	}
 
@@ -765,7 +766,8 @@ func TestIsElectionTimeout(t *testing.T) {
 		sm.electionElapsed = tt.elapse
 		c := 0
 		for j := 0; j < 10000; j++ {
-			if sm.isElectionTimeout() {
+			sm.resetRandomizedElectionTimeout()
+			if sm.pastElectionTimeout() {
 				c++
 			}
 		}


### PR DESCRIPTION
This reduces the confits rate in the test for 10% (this is not accurate). I would expect this reduces the conflict rates in reality for less than 10%. I will get some data soon.

/cc @bdarnell @ngaut @superfell @ongardie

