### PR TITLE
wal: fix tail corruption

### DIFF
--- a/wal/repair.go
+++ b/wal/repair.go
@@ -55,9 +55,6 @@ func Repair(dirpath string) bool {
 			continue
 		case io.EOF:
 			return true
-		case ErrZeroTrailer:
-			plog.Noticef("found zero trailer in %v", f.Name())
-			fallthrough
 		case io.ErrUnexpectedEOF:
 			plog.Noticef("repairing %v", f.Name())
 			bf, bferr := os.Create(f.Name() + ".broken")

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -57,7 +57,6 @@ var (
 	ErrCRCMismatch      = errors.New("wal: crc mismatch")
 	ErrSnapshotMismatch = errors.New("wal: snapshot mismatch")
 	ErrSnapshotNotFound = errors.New("wal: snapshot not found")
-	ErrZeroTrailer      = errors.New("wal: zero trailer")
 	crcTable            = crc32.MakeTable(crc32.Castagnoli)
 )
 
@@ -273,9 +272,6 @@ func (w *WAL) ReadAll() (metadata []byte, state raftpb.HardState, ents []raftpb.
 		}
 	}
 
-	if err == ErrZeroTrailer {
-		err = io.EOF
-	}
 	switch w.tail() {
 	case nil:
 		// We do not have to read out all entries in read mode.


### PR DESCRIPTION
On ReadAll, WAL seeks to the end of the last record in the tail. If the tail did not
end with preallocated space, the decoder would report 0 as the last offset and begin
writing at offset 0 of the tail.

Fixes #4903