### PR TITLE
*: rename lease Create to Grant

### DIFF
--- a/auth/authpb/auth.pb.go
+++ b/auth/authpb/auth.pb.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/clientv3/concurrency/session.go
+++ b/clientv3/concurrency/session.go
@@ -49,7 +49,7 @@ func NewSession(client *v3.Client) (*Session, error) {
 		return s, nil
 	}
 
-	resp, err := client.Create(client.Ctx(), sessionTTL)
+	resp, err := client.Grant(client.Ctx(), sessionTTL)
 	if err != nil {
 		return nil, err
 	}

--- a/clientv3/example_lease_test.go
+++ b/clientv3/example_lease_test.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func ExampleLease_create() {
+func ExampleLease_grant() {
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:   endpoints,
 		DialTimeout: dialTimeout,
@@ -33,7 +33,7 @@ func ExampleLease_create() {
 	defer cli.Close()
 
 	// minimum lease TTL is 5-second
-	resp, err := cli.Create(context.TODO(), 5)
+	resp, err := cli.Grant(context.TODO(), 5)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func ExampleLease_revoke() {
 	}
 	defer cli.Close()
 
-	resp, err := cli.Create(context.TODO(), 5)
+	resp, err := cli.Grant(context.TODO(), 5)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func ExampleLease_keepAlive() {
 	}
 	defer cli.Close()
 
-	resp, err := cli.Create(context.TODO(), 5)
+	resp, err := cli.Grant(context.TODO(), 5)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func ExampleLease_keepAliveOnce() {
 	}
 	defer cli.Close()
 
-	resp, err := cli.Create(context.TODO(), 5)
+	resp, err := cli.Grant(context.TODO(), 5)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -40,7 +40,7 @@ func TestKVPut(t *testing.T) {
 	kv := clientv3.NewKV(clus.RandClient())
 	ctx := context.TODO()
 
-	resp, err := lapi.Create(context.Background(), 10)
+	resp, err := lapi.Grant(context.Background(), 10)
 	if err != nil {
 		t.Fatalf("failed to create lease %v", err)
 	}

--- a/clientv3/integration/lease_test.go
+++ b/clientv3/integration/lease_test.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func TestLeaseCreate(t *testing.T) {
+func TestLeaseGrant(t *testing.T) {
 	defer testutil.AfterTest(t)
 
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
@@ -36,7 +36,7 @@ func TestLeaseCreate(t *testing.T) {
 
 	kv := clientv3.NewKV(clus.RandClient())
 
-	resp, err := lapi.Create(context.Background(), 10)
+	resp, err := lapi.Grant(context.Background(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
@@ -58,7 +58,7 @@ func TestLeaseRevoke(t *testing.T) {
 
 	kv := clientv3.NewKV(clus.RandClient())
 
-	resp, err := lapi.Create(context.Background(), 10)
+	resp, err := lapi.Grant(context.Background(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
@@ -83,7 +83,7 @@ func TestLeaseKeepAliveOnce(t *testing.T) {
 	lapi := clientv3.NewLease(clus.RandClient())
 	defer lapi.Close()
 
-	resp, err := lapi.Create(context.Background(), 10)
+	resp, err := lapi.Grant(context.Background(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
@@ -102,7 +102,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 
 	lapi := clientv3.NewLease(clus.RandClient())
 
-	resp, err := lapi.Create(context.Background(), 10)
+	resp, err := lapi.Grant(context.Background(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
@@ -142,7 +142,7 @@ func TestLeaseKeepAliveHandleFailure(t *testing.T) {
 	// TODO: change this line to get a cluster client
 	lapi := clientv3.NewLease(clus.RandClient())
 
-	resp, err := lapi.Create(context.Background(), 10)
+	resp, err := lapi.Grant(context.Background(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}

--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -448,7 +448,7 @@ func TestWatchEventType(t *testing.T) {
 	if _, err := client.Delete(ctx, "/toDelete"); err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
-	lcr, err := client.Lease.Create(ctx, 1)
+	lcr, err := client.Lease.Grant(ctx, 1)
 	if err != nil {
 		t.Fatalf("lease create failed: %v", err)
 	}

--- a/clientv3/lease.go
+++ b/clientv3/lease.go
@@ -24,7 +24,7 @@ import (
 )
 
 type (
-	LeaseCreateResponse    pb.LeaseCreateResponse
+	LeaseGrantResponse     pb.LeaseGrantResponse
 	LeaseRevokeResponse    pb.LeaseRevokeResponse
 	LeaseKeepAliveResponse pb.LeaseKeepAliveResponse
 	LeaseID                int64
@@ -38,8 +38,8 @@ const (
 )
 
 type Lease interface {
-	// Create creates a new lease.
-	Create(ctx context.Context, ttl int64) (*LeaseCreateResponse, error)
+	// Grant creates a new lease.
+	Grant(ctx context.Context, ttl int64) (*LeaseGrantResponse, error)
 
 	// Revoke revokes the given lease.
 	Revoke(ctx context.Context, id LeaseID) (*LeaseRevokeResponse, error)
@@ -103,16 +103,16 @@ func NewLease(c *Client) Lease {
 	return l
 }
 
-func (l *lessor) Create(ctx context.Context, ttl int64) (*LeaseCreateResponse, error) {
+func (l *lessor) Grant(ctx context.Context, ttl int64) (*LeaseGrantResponse, error) {
 	cctx, cancel := context.WithCancel(ctx)
 	done := cancelWhenStop(cancel, l.stopCtx.Done())
 	defer close(done)
 
 	for {
-		r := &pb.LeaseCreateRequest{TTL: ttl}
-		resp, err := l.getRemote().LeaseCreate(cctx, r)
+		r := &pb.LeaseGrantRequest{TTL: ttl}
+		resp, err := l.getRemote().LeaseGrant(cctx, r)
 		if err == nil {
-			return (*LeaseCreateResponse)(resp), nil
+			return (*LeaseGrantResponse)(resp), nil
 		}
 		if isHalted(cctx, err) {
 			return nil, err

--- a/e2e/ctl_v3_lease_test.go
+++ b/e2e/ctl_v3_lease_test.go
@@ -28,9 +28,9 @@ func leaseTestKeepAlive(cx ctlCtx) {
 	defer close(cx.errc)
 
 	// put with TTL 10 seconds and keep-alive
-	leaseID, err := ctlV3LeaseCreate(cx, 10)
+	leaseID, err := ctlV3LeaseGrant(cx, 10)
 	if err != nil {
-		cx.t.Fatalf("leaseTestKeepAlive: ctlV3LeaseCreate error (%v)", err)
+		cx.t.Fatalf("leaseTestKeepAlive: ctlV3LeaseGrant error (%v)", err)
 	}
 	if err := ctlV3Put(cx, "key", "val", leaseID); err != nil {
 		cx.t.Fatalf("leaseTestKeepAlive: ctlV3Put error (%v)", err)
@@ -47,9 +47,9 @@ func leaseTestRevoke(cx ctlCtx) {
 	defer close(cx.errc)
 
 	// put with TTL 10 seconds and revoke
-	leaseID, err := ctlV3LeaseCreate(cx, 10)
+	leaseID, err := ctlV3LeaseGrant(cx, 10)
 	if err != nil {
-		cx.t.Fatalf("leaseTestRevoke: ctlV3LeaseCreate error (%v)", err)
+		cx.t.Fatalf("leaseTestRevoke: ctlV3LeaseGrant error (%v)", err)
 	}
 	if err := ctlV3Put(cx, "key", "val", leaseID); err != nil {
 		cx.t.Fatalf("leaseTestRevoke: ctlV3Put error (%v)", err)
@@ -62,14 +62,14 @@ func leaseTestRevoke(cx ctlCtx) {
 	}
 }
 
-func ctlV3LeaseCreate(cx ctlCtx, ttl int) (string, error) {
-	cmdArgs := append(ctlV3PrefixArgs(cx.epc, cx.dialTimeout), "lease", "create", strconv.Itoa(ttl))
+func ctlV3LeaseGrant(cx ctlCtx, ttl int) (string, error) {
+	cmdArgs := append(ctlV3PrefixArgs(cx.epc, cx.dialTimeout), "lease", "grant", strconv.Itoa(ttl))
 	proc, err := spawnCmd(cmdArgs)
 	if err != nil {
 		return "", err
 	}
 
-	line, err := proc.Expect(" created with TTL(")
+	line, err := proc.Expect(" granted with TTL(")
 	if err != nil {
 		return "", err
 	}
@@ -77,10 +77,10 @@ func ctlV3LeaseCreate(cx ctlCtx, ttl int) (string, error) {
 		return "", err
 	}
 
-	// parse 'line LEASE_ID created with TTL(5s)' to get lease ID
+	// parse 'line LEASE_ID granted with TTL(5s)' to get lease ID
 	hs := strings.Split(line, " ")
 	if len(hs) < 2 {
-		return "", fmt.Errorf("lease create failed with %q", line)
+		return "", fmt.Errorf("lease grant failed with %q", line)
 	}
 	return hs[1], nil
 }

--- a/etcdctl/ctlv3/command/lease_command.go
+++ b/etcdctl/ctlv3/command/lease_command.go
@@ -31,29 +31,29 @@ func NewLeaseCommand() *cobra.Command {
 		Short: "lease is used to manage leases.",
 	}
 
-	lc.AddCommand(NewLeaseCreateCommand())
+	lc.AddCommand(NewLeaseGrantCommand())
 	lc.AddCommand(NewLeaseRevokeCommand())
 	lc.AddCommand(NewLeaseKeepAliveCommand())
 
 	return lc
 }
 
-// NewLeaseCreateCommand returns the cobra command for "lease create".
-func NewLeaseCreateCommand() *cobra.Command {
+// NewLeaseGrantCommand returns the cobra command for "lease grant".
+func NewLeaseGrantCommand() *cobra.Command {
 	lc := &cobra.Command{
-		Use:   "create",
-		Short: "create is used to create leases.",
+		Use:   "grant",
+		Short: "grant is used to create leases.",
 
-		Run: leaseCreateCommandFunc,
+		Run: leaseGrantCommandFunc,
 	}
 
 	return lc
 }
 
-// leaseCreateCommandFunc executes the "lease create" command.
-func leaseCreateCommandFunc(cmd *cobra.Command, args []string) {
+// leaseGrantCommandFunc executes the "lease grant" command.
+func leaseGrantCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		ExitWithError(ExitBadArgs, fmt.Errorf("lease create command needs TTL argument."))
+		ExitWithError(ExitBadArgs, fmt.Errorf("lease grant command needs TTL argument."))
 	}
 
 	ttl, err := strconv.ParseInt(args[0], 10, 64)
@@ -62,13 +62,13 @@ func leaseCreateCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	ctx, cancel := commandCtx(cmd)
-	resp, err := mustClientFromCmd(cmd).Create(ctx, ttl)
+	resp, err := mustClientFromCmd(cmd).Grant(ctx, ttl)
 	cancel()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create lease (%v)\n", err)
+		fmt.Fprintf(os.Stderr, "failed to grant lease (%v)\n", err)
 		return
 	}
-	fmt.Printf("lease %016x created with TTL(%ds)\n", resp.ID, resp.TTL)
+	fmt.Printf("lease %016x granted with TTL(%ds)\n", resp.ID, resp.TTL)
 }
 
 // NewLeaseRevokeCommand returns the cobra command for "lease revoke".
@@ -83,7 +83,7 @@ func NewLeaseRevokeCommand() *cobra.Command {
 	return lc
 }
 
-// leaseRevokeCommandFunc executes the "lease create" command.
+// leaseRevokeCommandFunc executes the "lease grant" command.
 func leaseRevokeCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		ExitWithError(ExitBadArgs, fmt.Errorf("lease revoke command needs 1 argument"))

--- a/etcdserver/api/v3rpc/lease.go
+++ b/etcdserver/api/v3rpc/lease.go
@@ -32,8 +32,8 @@ func NewLeaseServer(le etcdserver.Lessor) pb.LeaseServer {
 	return &LeaseServer{le: le}
 }
 
-func (ls *LeaseServer) LeaseCreate(ctx context.Context, cr *pb.LeaseCreateRequest) (*pb.LeaseCreateResponse, error) {
-	resp, err := ls.le.LeaseCreate(ctx, cr)
+func (ls *LeaseServer) LeaseGrant(ctx context.Context, cr *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error) {
+	resp, err := ls.le.LeaseGrant(ctx, cr)
 	if err == lease.ErrLeaseExists {
 		return nil, rpctypes.ErrLeaseExist
 	}

--- a/etcdserver/api/v3rpc/quota.go
+++ b/etcdserver/api/v3rpc/quota.go
@@ -74,11 +74,11 @@ type quotaLeaseServer struct {
 	qa quotaAlarmer
 }
 
-func (s *quotaLeaseServer) LeaseCreate(ctx context.Context, cr *pb.LeaseCreateRequest) (*pb.LeaseCreateResponse, error) {
+func (s *quotaLeaseServer) LeaseGrant(ctx context.Context, cr *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error) {
 	if err := s.qa.check(ctx, cr); err != nil {
 		return nil, err
 	}
-	return s.LeaseServer.LeaseCreate(ctx, cr)
+	return s.LeaseServer.LeaseGrant(ctx, cr)
 }
 
 func NewQuotaLeaseServer(s *etcdserver.EtcdServer) pb.LeaseServer {

--- a/etcdserver/etcdserverpb/etcdserver.pb.go
+++ b/etcdserver/etcdserverpb/etcdserver.pb.go
@@ -35,8 +35,8 @@
 		WatchCreateRequest
 		WatchCancelRequest
 		WatchResponse
-		LeaseCreateRequest
-		LeaseCreateResponse
+		LeaseGrantRequest
+		LeaseGrantResponse
 		LeaseRevokeRequest
 		LeaseRevokeResponse
 		LeaseKeepAliveRequest
@@ -92,9 +92,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/etcdserver/etcdserverpb/raft_internal.pb.go
+++ b/etcdserver/etcdserverpb/raft_internal.pb.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 
@@ -29,7 +29,7 @@ type InternalRaftRequest struct {
 	DeleteRange            *DeleteRangeRequest            `protobuf:"bytes,5,opt,name=delete_range" json:"delete_range,omitempty"`
 	Txn                    *TxnRequest                    `protobuf:"bytes,6,opt,name=txn" json:"txn,omitempty"`
 	Compaction             *CompactionRequest             `protobuf:"bytes,7,opt,name=compaction" json:"compaction,omitempty"`
-	LeaseCreate            *LeaseCreateRequest            `protobuf:"bytes,8,opt,name=lease_create" json:"lease_create,omitempty"`
+	LeaseGrant             *LeaseGrantRequest             `protobuf:"bytes,8,opt,name=lease_grant" json:"lease_grant,omitempty"`
 	LeaseRevoke            *LeaseRevokeRequest            `protobuf:"bytes,9,opt,name=lease_revoke" json:"lease_revoke,omitempty"`
 	AuthEnable             *AuthEnableRequest             `protobuf:"bytes,10,opt,name=auth_enable" json:"auth_enable,omitempty"`
 	AuthUserAdd            *AuthUserAddRequest            `protobuf:"bytes,11,opt,name=auth_user_add" json:"auth_user_add,omitempty"`
@@ -134,11 +134,11 @@ func (m *InternalRaftRequest) MarshalTo(data []byte) (int, error) {
 		}
 		i += n6
 	}
-	if m.LeaseCreate != nil {
+	if m.LeaseGrant != nil {
 		data[i] = 0x42
 		i++
-		i = encodeVarintRaftInternal(data, i, uint64(m.LeaseCreate.Size()))
-		n7, err := m.LeaseCreate.MarshalTo(data[i:])
+		i = encodeVarintRaftInternal(data, i, uint64(m.LeaseGrant.Size()))
+		n7, err := m.LeaseGrant.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
@@ -292,8 +292,8 @@ func (m *InternalRaftRequest) Size() (n int) {
 		l = m.Compaction.Size()
 		n += 1 + l + sovRaftInternal(uint64(l))
 	}
-	if m.LeaseCreate != nil {
-		l = m.LeaseCreate.Size()
+	if m.LeaseGrant != nil {
+		l = m.LeaseGrant.Size()
 		n += 1 + l + sovRaftInternal(uint64(l))
 	}
 	if m.LeaseRevoke != nil {
@@ -594,7 +594,7 @@ func (m *InternalRaftRequest) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field LeaseCreate", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field LeaseGrant", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -618,10 +618,10 @@ func (m *InternalRaftRequest) Unmarshal(data []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.LeaseCreate == nil {
-				m.LeaseCreate = &LeaseCreateRequest{}
+			if m.LeaseGrant == nil {
+				m.LeaseGrant = &LeaseGrantRequest{}
 			}
-			if err := m.LeaseCreate.Unmarshal(data[iNdEx:postIndex]); err != nil {
+			if err := m.LeaseGrant.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/etcdserver/etcdserverpb/raft_internal.proto
+++ b/etcdserver/etcdserverpb/raft_internal.proto
@@ -22,7 +22,7 @@ message InternalRaftRequest {
   TxnRequest txn = 6;
   CompactionRequest compaction = 7;
 
-  LeaseCreateRequest lease_create = 8;
+  LeaseGrantRequest lease_grant = 8;
   LeaseRevokeRequest lease_revoke = 9;
 
   AuthEnableRequest auth_enable = 10;

--- a/etcdserver/etcdserverpb/rpc.pb.go
+++ b/etcdserver/etcdserverpb/rpc.pb.go
@@ -8,16 +8,15 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
 
-import storagepb "github.com/coreos/etcd/storage/storagepb"
-
-import (
 	context "golang.org/x/net/context"
+
 	grpc "google.golang.org/grpc"
 )
+
+import storagepb "github.com/coreos/etcd/storage/storagepb"
 
 import io "io"
 
@@ -983,18 +982,18 @@ func (m *WatchResponse) GetEvents() []*storagepb.Event {
 	return nil
 }
 
-type LeaseCreateRequest struct {
+type LeaseGrantRequest struct {
 	// advisory ttl in seconds
 	TTL int64 `protobuf:"varint,1,opt,name=TTL,proto3" json:"TTL,omitempty"`
 	// requested ID to create; 0 lets lessor choose
 	ID int64 `protobuf:"varint,2,opt,name=ID,proto3" json:"ID,omitempty"`
 }
 
-func (m *LeaseCreateRequest) Reset()         { *m = LeaseCreateRequest{} }
-func (m *LeaseCreateRequest) String() string { return proto.CompactTextString(m) }
-func (*LeaseCreateRequest) ProtoMessage()    {}
+func (m *LeaseGrantRequest) Reset()         { *m = LeaseGrantRequest{} }
+func (m *LeaseGrantRequest) String() string { return proto.CompactTextString(m) }
+func (*LeaseGrantRequest) ProtoMessage()    {}
 
-type LeaseCreateResponse struct {
+type LeaseGrantResponse struct {
 	Header *ResponseHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
 	ID     int64           `protobuf:"varint,2,opt,name=ID,proto3" json:"ID,omitempty"`
 	// server decided ttl in second
@@ -1002,11 +1001,11 @@ type LeaseCreateResponse struct {
 	Error string `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
 }
 
-func (m *LeaseCreateResponse) Reset()         { *m = LeaseCreateResponse{} }
-func (m *LeaseCreateResponse) String() string { return proto.CompactTextString(m) }
-func (*LeaseCreateResponse) ProtoMessage()    {}
+func (m *LeaseGrantResponse) Reset()         { *m = LeaseGrantResponse{} }
+func (m *LeaseGrantResponse) String() string { return proto.CompactTextString(m) }
+func (*LeaseGrantResponse) ProtoMessage()    {}
 
-func (m *LeaseCreateResponse) GetHeader() *ResponseHeader {
+func (m *LeaseGrantResponse) GetHeader() *ResponseHeader {
 	if m != nil {
 		return m.Header
 	}
@@ -1607,8 +1606,8 @@ func init() {
 	proto.RegisterType((*WatchCreateRequest)(nil), "etcdserverpb.WatchCreateRequest")
 	proto.RegisterType((*WatchCancelRequest)(nil), "etcdserverpb.WatchCancelRequest")
 	proto.RegisterType((*WatchResponse)(nil), "etcdserverpb.WatchResponse")
-	proto.RegisterType((*LeaseCreateRequest)(nil), "etcdserverpb.LeaseCreateRequest")
-	proto.RegisterType((*LeaseCreateResponse)(nil), "etcdserverpb.LeaseCreateResponse")
+	proto.RegisterType((*LeaseGrantRequest)(nil), "etcdserverpb.LeaseGrantRequest")
+	proto.RegisterType((*LeaseGrantResponse)(nil), "etcdserverpb.LeaseGrantResponse")
 	proto.RegisterType((*LeaseRevokeRequest)(nil), "etcdserverpb.LeaseRevokeRequest")
 	proto.RegisterType((*LeaseRevokeResponse)(nil), "etcdserverpb.LeaseRevokeResponse")
 	proto.RegisterType((*LeaseKeepAliveRequest)(nil), "etcdserverpb.LeaseKeepAliveRequest")
@@ -1966,11 +1965,11 @@ var _Watch_serviceDesc = grpc.ServiceDesc{
 // Client API for Lease service
 
 type LeaseClient interface {
-	// LeaseCreate creates a lease. A lease has a TTL. The lease will expire if the
+	// LeaseGrant creates a lease. A lease has a TTL. The lease will expire if the
 	// server does not receive a keepAlive within TTL from the lease holder.
 	// All keys attached to the lease will be expired and deleted if the lease expires.
 	// The key expiration generates an event in event history.
-	LeaseCreate(ctx context.Context, in *LeaseCreateRequest, opts ...grpc.CallOption) (*LeaseCreateResponse, error)
+	LeaseGrant(ctx context.Context, in *LeaseGrantRequest, opts ...grpc.CallOption) (*LeaseGrantResponse, error)
 	// LeaseRevoke revokes a lease. All the key attached to the lease will be expired and deleted.
 	LeaseRevoke(ctx context.Context, in *LeaseRevokeRequest, opts ...grpc.CallOption) (*LeaseRevokeResponse, error)
 	// KeepAlive keeps the lease alive.
@@ -1985,9 +1984,9 @@ func NewLeaseClient(cc *grpc.ClientConn) LeaseClient {
 	return &leaseClient{cc}
 }
 
-func (c *leaseClient) LeaseCreate(ctx context.Context, in *LeaseCreateRequest, opts ...grpc.CallOption) (*LeaseCreateResponse, error) {
-	out := new(LeaseCreateResponse)
-	err := grpc.Invoke(ctx, "/etcdserverpb.Lease/LeaseCreate", in, out, c.cc, opts...)
+func (c *leaseClient) LeaseGrant(ctx context.Context, in *LeaseGrantRequest, opts ...grpc.CallOption) (*LeaseGrantResponse, error) {
+	out := new(LeaseGrantResponse)
+	err := grpc.Invoke(ctx, "/etcdserverpb.Lease/LeaseGrant", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2037,11 +2036,11 @@ func (x *leaseLeaseKeepAliveClient) Recv() (*LeaseKeepAliveResponse, error) {
 // Server API for Lease service
 
 type LeaseServer interface {
-	// LeaseCreate creates a lease. A lease has a TTL. The lease will expire if the
+	// LeaseGrant creates a lease. A lease has a TTL. The lease will expire if the
 	// server does not receive a keepAlive within TTL from the lease holder.
 	// All keys attached to the lease will be expired and deleted if the lease expires.
 	// The key expiration generates an event in event history.
-	LeaseCreate(context.Context, *LeaseCreateRequest) (*LeaseCreateResponse, error)
+	LeaseGrant(context.Context, *LeaseGrantRequest) (*LeaseGrantResponse, error)
 	// LeaseRevoke revokes a lease. All the key attached to the lease will be expired and deleted.
 	LeaseRevoke(context.Context, *LeaseRevokeRequest) (*LeaseRevokeResponse, error)
 	// KeepAlive keeps the lease alive.
@@ -2052,12 +2051,12 @@ func RegisterLeaseServer(s *grpc.Server, srv LeaseServer) {
 	s.RegisterService(&_Lease_serviceDesc, srv)
 }
 
-func _Lease_LeaseCreate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
-	in := new(LeaseCreateRequest)
+func _Lease_LeaseGrant_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(LeaseGrantRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(LeaseServer).LeaseCreate(ctx, in)
+	out, err := srv.(LeaseServer).LeaseGrant(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -2107,8 +2106,8 @@ var _Lease_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*LeaseServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "LeaseCreate",
-			Handler:    _Lease_LeaseCreate_Handler,
+			MethodName: "LeaseGrant",
+			Handler:    _Lease_LeaseGrant_Handler,
 		},
 		{
 			MethodName: "LeaseRevoke",
@@ -3760,7 +3759,7 @@ func (m *WatchResponse) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
-func (m *LeaseCreateRequest) Marshal() (data []byte, err error) {
+func (m *LeaseGrantRequest) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
 	n, err := m.MarshalTo(data)
@@ -3770,7 +3769,7 @@ func (m *LeaseCreateRequest) Marshal() (data []byte, err error) {
 	return data[:n], nil
 }
 
-func (m *LeaseCreateRequest) MarshalTo(data []byte) (int, error) {
+func (m *LeaseGrantRequest) MarshalTo(data []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -3788,7 +3787,7 @@ func (m *LeaseCreateRequest) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
-func (m *LeaseCreateResponse) Marshal() (data []byte, err error) {
+func (m *LeaseGrantResponse) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
 	n, err := m.MarshalTo(data)
@@ -3798,7 +3797,7 @@ func (m *LeaseCreateResponse) Marshal() (data []byte, err error) {
 	return data[:n], nil
 }
 
-func (m *LeaseCreateResponse) MarshalTo(data []byte) (int, error) {
+func (m *LeaseGrantResponse) MarshalTo(data []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -5589,7 +5588,7 @@ func (m *WatchResponse) Size() (n int) {
 	return n
 }
 
-func (m *LeaseCreateRequest) Size() (n int) {
+func (m *LeaseGrantRequest) Size() (n int) {
 	var l int
 	_ = l
 	if m.TTL != 0 {
@@ -5601,7 +5600,7 @@ func (m *LeaseCreateRequest) Size() (n int) {
 	return n
 }
 
-func (m *LeaseCreateResponse) Size() (n int) {
+func (m *LeaseGrantResponse) Size() (n int) {
 	var l int
 	_ = l
 	if m.Header != nil {
@@ -8649,7 +8648,7 @@ func (m *WatchResponse) Unmarshal(data []byte) error {
 	}
 	return nil
 }
-func (m *LeaseCreateRequest) Unmarshal(data []byte) error {
+func (m *LeaseGrantRequest) Unmarshal(data []byte) error {
 	l := len(data)
 	iNdEx := 0
 	for iNdEx < l {
@@ -8672,10 +8671,10 @@ func (m *LeaseCreateRequest) Unmarshal(data []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: LeaseCreateRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: LeaseGrantRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: LeaseCreateRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: LeaseGrantRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -8737,7 +8736,7 @@ func (m *LeaseCreateRequest) Unmarshal(data []byte) error {
 	}
 	return nil
 }
-func (m *LeaseCreateResponse) Unmarshal(data []byte) error {
+func (m *LeaseGrantResponse) Unmarshal(data []byte) error {
 	l := len(data)
 	iNdEx := 0
 	for iNdEx < l {
@@ -8760,10 +8759,10 @@ func (m *LeaseCreateResponse) Unmarshal(data []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: LeaseCreateResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: LeaseGrantResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: LeaseCreateResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: LeaseGrantResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -41,11 +41,11 @@ service Watch {
 }
 
 service Lease {
-  // LeaseCreate creates a lease. A lease has a TTL. The lease will expire if the
+  // LeaseGrant creates a lease. A lease has a TTL. The lease will expire if the
   // server does not receive a keepAlive within TTL from the lease holder.
   // All keys attached to the lease will be expired and deleted if the lease expires.
   // The key expiration generates an event in event history.
-  rpc LeaseCreate(LeaseCreateRequest) returns (LeaseCreateResponse) {}
+  rpc LeaseGrant(LeaseGrantRequest) returns (LeaseGrantResponse) {}
 
   // LeaseRevoke revokes a lease. All the key attached to the lease will be expired and deleted.
   rpc LeaseRevoke(LeaseRevokeRequest) returns (LeaseRevokeResponse) {}
@@ -361,14 +361,14 @@ message WatchResponse {
   repeated storagepb.Event events = 11;
 }
 
-message LeaseCreateRequest {
+message LeaseGrantRequest {
   // advisory ttl in seconds
   int64 TTL = 1;
   // requested ID to create; 0 lets lessor choose
   int64 ID = 2;
 }
 
-message LeaseCreateResponse {
+message LeaseGrantResponse {
   ResponseHeader header = 1;
   int64 ID = 2;
   // server decided ttl in second

--- a/etcdserver/quota.go
+++ b/etcdserver/quota.go
@@ -77,7 +77,7 @@ func (b *backendQuota) Cost(v interface{}) int {
 		return costPut(r)
 	case *pb.TxnRequest:
 		return costTxn(r)
-	case *pb.LeaseCreateRequest:
+	case *pb.LeaseGrantRequest:
 		return leaseOverhead
 	default:
 		panic("unexpected cost")

--- a/etcdserver/v3demo_server.go
+++ b/etcdserver/v3demo_server.go
@@ -41,8 +41,8 @@ type RaftKV interface {
 }
 
 type Lessor interface {
-	// LeaseCreate sends LeaseCreate request to raft and apply it after committed.
-	LeaseCreate(ctx context.Context, r *pb.LeaseCreateRequest) (*pb.LeaseCreateResponse, error)
+	// LeaseGrant sends LeaseGrant request to raft and apply it after committed.
+	LeaseGrant(ctx context.Context, r *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error)
 	// LeaseRevoke sends LeaseRevoke request to raft and apply it after committed.
 	LeaseRevoke(ctx context.Context, r *pb.LeaseRevokeRequest) (*pb.LeaseRevokeResponse, error)
 
@@ -138,17 +138,17 @@ func (s *EtcdServer) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.
 	return resp, result.err
 }
 
-func (s *EtcdServer) LeaseCreate(ctx context.Context, r *pb.LeaseCreateRequest) (*pb.LeaseCreateResponse, error) {
+func (s *EtcdServer) LeaseGrant(ctx context.Context, r *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error) {
 	// no id given? choose one
 	for r.ID == int64(lease.NoLease) {
 		// only use positive int64 id's
 		r.ID = int64(s.reqIDGen.Next() & ((1 << 63) - 1))
 	}
-	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{LeaseCreate: r})
+	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{LeaseGrant: r})
 	if err != nil {
 		return nil, err
 	}
-	return result.resp.(*pb.LeaseCreateResponse), result.err
+	return result.resp.(*pb.LeaseGrantResponse), result.err
 }
 
 func (s *EtcdServer) LeaseRevoke(ctx context.Context, r *pb.LeaseRevokeRequest) (*pb.LeaseRevokeResponse, error) {

--- a/integration/v3_lease_test.go
+++ b/integration/v3_lease_test.go
@@ -34,7 +34,7 @@ func TestV3LeasePrmote(t *testing.T) {
 	defer clus.Terminate(t)
 
 	// create lease
-	lresp, err := toGRPC(clus.RandClient()).Lease.LeaseCreate(context.TODO(), &pb.LeaseCreateRequest{TTL: 5})
+	lresp, err := toGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 5})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,16 +85,16 @@ func TestV3LeaseRevoke(t *testing.T) {
 	})
 }
 
-// TestV3LeaseCreateById ensures leases may be created by a given id.
-func TestV3LeaseCreateByID(t *testing.T) {
+// TestV3LeaseGrantById ensures leases may be created by a given id.
+func TestV3LeaseGrantByID(t *testing.T) {
 	defer testutil.AfterTest(t)
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
 	// create fixed lease
-	lresp, err := toGRPC(clus.RandClient()).Lease.LeaseCreate(
+	lresp, err := toGRPC(clus.RandClient()).Lease.LeaseGrant(
 		context.TODO(),
-		&pb.LeaseCreateRequest{ID: 1, TTL: 1})
+		&pb.LeaseGrantRequest{ID: 1, TTL: 1})
 	if err != nil {
 		t.Errorf("could not create lease 1 (%v)", err)
 	}
@@ -103,17 +103,17 @@ func TestV3LeaseCreateByID(t *testing.T) {
 	}
 
 	// create duplicate fixed lease
-	lresp, err = toGRPC(clus.RandClient()).Lease.LeaseCreate(
+	lresp, err = toGRPC(clus.RandClient()).Lease.LeaseGrant(
 		context.TODO(),
-		&pb.LeaseCreateRequest{ID: 1, TTL: 1})
+		&pb.LeaseGrantRequest{ID: 1, TTL: 1})
 	if err != rpctypes.ErrLeaseExist {
 		t.Error(err)
 	}
 
 	// create fresh fixed lease
-	lresp, err = toGRPC(clus.RandClient()).Lease.LeaseCreate(
+	lresp, err = toGRPC(clus.RandClient()).Lease.LeaseGrant(
 		context.TODO(),
-		&pb.LeaseCreateRequest{ID: 2, TTL: 1})
+		&pb.LeaseGrantRequest{ID: 2, TTL: 1})
 	if err != nil {
 		t.Errorf("could not create lease 2 (%v)", err)
 	}
@@ -216,9 +216,9 @@ func TestV3LeaseExists(t *testing.T) {
 	// create lease
 	ctx0, cancel0 := context.WithCancel(context.Background())
 	defer cancel0()
-	lresp, err := toGRPC(clus.RandClient()).Lease.LeaseCreate(
+	lresp, err := toGRPC(clus.RandClient()).Lease.LeaseGrant(
 		ctx0,
-		&pb.LeaseCreateRequest{TTL: 30})
+		&pb.LeaseGrantRequest{TTL: 30})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,11 +258,11 @@ func TestV3LeaseSwitch(t *testing.T) {
 	// create lease
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	lresp1, err1 := toGRPC(clus.RandClient()).Lease.LeaseCreate(ctx, &pb.LeaseCreateRequest{TTL: 30})
+	lresp1, err1 := toGRPC(clus.RandClient()).Lease.LeaseGrant(ctx, &pb.LeaseGrantRequest{TTL: 30})
 	if err1 != nil {
 		t.Fatal(err1)
 	}
-	lresp2, err2 := toGRPC(clus.RandClient()).Lease.LeaseCreate(ctx, &pb.LeaseCreateRequest{TTL: 30})
+	lresp2, err2 := toGRPC(clus.RandClient()).Lease.LeaseGrant(ctx, &pb.LeaseGrantRequest{TTL: 30})
 	if err2 != nil {
 		t.Fatal(err2)
 	}
@@ -319,7 +319,7 @@ func TestV3LeaseFailover(t *testing.T) {
 	lc := toGRPC(clus.Client(toIsolate)).Lease
 
 	// create lease
-	lresp, err := lc.LeaseCreate(context.TODO(), &pb.LeaseCreateRequest{TTL: 5})
+	lresp, err := lc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 5})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -369,9 +369,9 @@ func TestV3LeaseFailover(t *testing.T) {
 // acquireLeaseAndKey creates a new lease and creates an attached key.
 func acquireLeaseAndKey(clus *ClusterV3, key string) (int64, error) {
 	// create lease
-	lresp, err := toGRPC(clus.RandClient()).Lease.LeaseCreate(
+	lresp, err := toGRPC(clus.RandClient()).Lease.LeaseGrant(
 		context.TODO(),
-		&pb.LeaseCreateRequest{TTL: 1})
+		&pb.LeaseGrantRequest{TTL: 1})
 	if err != nil {
 		return 0, err
 	}
@@ -415,7 +415,7 @@ func testLeaseRemoveLeasedKey(t *testing.T, act func(*ClusterV3, int64) error) {
 func leaseExist(t *testing.T, clus *ClusterV3, leaseID int64) bool {
 	l := toGRPC(clus.RandClient()).Lease
 
-	_, err := l.LeaseCreate(context.Background(), &pb.LeaseCreateRequest{ID: leaseID, TTL: 5})
+	_, err := l.LeaseGrant(context.Background(), &pb.LeaseGrantRequest{ID: leaseID, TTL: 5})
 	if err == nil {
 		_, err = l.LeaseRevoke(context.Background(), &pb.LeaseRevokeRequest{ID: leaseID})
 		if err != nil {

--- a/lease/leasepb/lease.pb.go
+++ b/lease/leasepb/lease.pb.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/raft/raftpb/raft.pb.go
+++ b/raft/raftpb/raft.pb.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/snap/snappb/snap.pb.go
+++ b/snap/snappb/snap.pb.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/storage/storagepb/kv.pb.go
+++ b/storage/storagepb/kv.pb.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/wal/walpb/record.pb.go
+++ b/wal/walpb/record.pb.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 


### PR DESCRIPTION
Creating a lease through the client API interface union looked like
"c.Create(...)"-- the method name wasn't very descriptive.