### PR TITLE
/health endpoint behavior in case of failure

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -384,7 +384,7 @@ func healthHandler(server *etcdserver.EtcdServer) http.HandlerFunc {
 			}
 		}
 
-		http.Error(w, `{"health": "false"}`, http.StatusServiceUnavailable)
+		http.Error(w, `{"health": "false"}`, http.StatusInternalServerError)
 		return
 	}
 }

--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -369,7 +369,7 @@ func healthHandler(server *etcdserver.EtcdServer) http.HandlerFunc {
 		}
 
 		if uint64(server.Leader()) == raft.None {
-			http.Error(w, `{"health": "false"}`, http.StatusServiceUnavailable)
+			http.Error(w, `{"health": "false"}`, http.StatusInternalServerError)
 			return
 		}
 
@@ -384,7 +384,7 @@ func healthHandler(server *etcdserver.EtcdServer) http.HandlerFunc {
 			}
 		}
 
-		http.Error(w, `{"health": "false"}`, http.StatusInternalServerError)
+		http.Error(w, `{"health": "false"}`, http.StatusServiceUnavailable)
 		return
 	}
 }


### PR DESCRIPTION
Hi,

This pull request to differentiate health status from a regular Raft fail and a Raft in progress process from whom the client exceeds the maximum number of retries.
## Noticed Behavior :
- Internally I have a kubernetes cluster and I associated one single etcd server.
- On top of that I monitor healtchchecks by runnning on a regular basis : **kubectl get cs** and get results.

Frequently I see this status :

```
etcd-0               Unhealthy   {"health": "false"}
                     unhealthy http status code: 503
```

I have the same output by doing a curl command when etcd is in that state, of course.

While reading the /health endpoint code, I was not able to fully determine which part of the /health failed.

It can makes sense to have :
-  HTTP 500 : when raft fails
-  HTTP 503 : when the service is really not available

Moreover, it seems the raft process takes more than 1 second to proceed, I think it could be advised to increment the number of retries of the time to wait for the process to finish.

Bhaal22.
