### PR TITLE
raft: correct regression in `pastElectionTimeout`

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -869,9 +869,9 @@ func (r *raft) loadState(state pb.HardState) {
 	r.Vote = state.Vote
 }
 
-// pastElectionTimeout returns true if r.electionElapsed is greater than the
-// randomized election timeout in [electiontimeout, 2 * electiontimeout - 1].
-// Otherwise, it returns false.
+// pastElectionTimeout returns true iff r.electionElapsed is greater
+// than or equal to the randomized election timeout in
+// [electiontimeout, 2 * electiontimeout - 1].
 func (r *raft) pastElectionTimeout() bool {
 	return r.electionElapsed >= r.randomizedElectionTimeout
 }

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -877,7 +877,7 @@ func (r *raft) pastElectionTimeout() bool {
 }
 
 func (r *raft) resetRandomizedElectionTimeout() {
-	r.randomizedElectionTimeout = r.electionTimeout + r.rand.Int()%r.electionTimeout
+	r.randomizedElectionTimeout = r.electionTimeout + r.rand.Intn(r.electionTimeout)
 }
 
 // checkQuorumActive returns true if the quorum is active from

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -747,7 +747,7 @@ func TestCommit(t *testing.T) {
 	}
 }
 
-func TestIsElectionTimeout(t *testing.T) {
+func TestPastElectionTimeout(t *testing.T) {
 	tests := []struct {
 		elapse       int
 		wprobability float64
@@ -776,7 +776,7 @@ func TestIsElectionTimeout(t *testing.T) {
 			got = math.Floor(got*10+0.5) / 10.0
 		}
 		if got != tt.wprobability {
-			t.Errorf("#%d: possibility = %v, want %v", i, got, tt.wprobability)
+			t.Errorf("#%d: probability = %v, want %v", i, got, tt.wprobability)
 		}
 	}
 }


### PR DESCRIPTION
The comparison here was incorrectly changed to `>=` in 5d431b4.

@xiang90 cc @bdarnell 