### PR TITLE
scripts: updatedep.sh to update vendored dependencies

### DIFF
--- a/scripts/updatedep.sh
+++ b/scripts/updatedep.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# A script for updating godep dependencies for the vendored directory /cmd/
+# without pulling in etcd itself as a dependency.
+
+rm -rf Godeps vendor
+ln -s cmd/vendor vendor
+godep save ./...
+rm -rf cmd/Godeps
+rm vendor
+mv Godeps cmd/
+


### PR DESCRIPTION
Running godep in the vendored cmd directory will try to pull etcd in
as a dependency. As a fix, this script safely vendors into cmd.