### PR TITLE
expose APIs to recognize event type

### DIFF
--- a/clientv3/watch_test.go
+++ b/clientv3/watch_test.go
@@ -1,0 +1,55 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"testing"
+
+	"github.com/coreos/etcd/storage/storagepb"
+)
+
+func TestEvent(t *testing.T) {
+	tests := []struct {
+		ev       *Event
+		isCreate bool
+		isModify bool
+	}{{
+		ev: &Event{
+			Type: EventTypePut,
+			Kv: &storagepb.KeyValue{
+				CreateRevision: 3,
+				ModRevision:    3,
+			},
+		},
+		isCreate: true,
+	}, {
+		ev: &Event{
+			Type: EventTypePut,
+			Kv: &storagepb.KeyValue{
+				CreateRevision: 3,
+				ModRevision:    4,
+			},
+		},
+		isModify: false,
+	}}
+	for i, tt := range tests {
+		if tt.isCreate && !tt.ev.IsCreate() {
+			t.Errorf("#%d: event should be Create event", i)
+		}
+		if tt.isModify && !tt.ev.IsModify() {
+			t.Errorf("#%d: event should be Modify event", i)
+		}
+	}
+}

--- a/contrib/recipes/watch.go
+++ b/contrib/recipes/watch.go
@@ -21,7 +21,7 @@ import (
 )
 
 // WaitEvents waits on a key until it observes the given events and returns the final one.
-func WaitEvents(c *clientv3.Client, key string, rev int64, evs []storagepb.Event_EventType) (*storagepb.Event, error) {
+func WaitEvents(c *clientv3.Client, key string, rev int64, evs []storagepb.Event_EventType) (*clientv3.Event, error) {
 	wc := c.Watch(context.Background(), key, clientv3.WithRev(rev))
 	if wc == nil {
 		return nil, ErrNoWatcher
@@ -29,7 +29,7 @@ func WaitEvents(c *clientv3.Client, key string, rev int64, evs []storagepb.Event
 	return waitEvents(wc, evs), nil
 }
 
-func WaitPrefixEvents(c *clientv3.Client, prefix string, rev int64, evs []storagepb.Event_EventType) (*storagepb.Event, error) {
+func WaitPrefixEvents(c *clientv3.Client, prefix string, rev int64, evs []storagepb.Event_EventType) (*clientv3.Event, error) {
 	wc := c.Watch(context.Background(), prefix, clientv3.WithPrefix(), clientv3.WithRev(rev))
 	if wc == nil {
 		return nil, ErrNoWatcher
@@ -37,7 +37,7 @@ func WaitPrefixEvents(c *clientv3.Client, prefix string, rev int64, evs []storag
 	return waitEvents(wc, evs), nil
 }
 
-func waitEvents(wc clientv3.WatchChan, evs []storagepb.Event_EventType) *storagepb.Event {
+func waitEvents(wc clientv3.WatchChan, evs []storagepb.Event_EventType) *clientv3.Event {
 	i := 0
 	for wresp := range wc {
 		for _, ev := range wresp.Events {


### PR DESCRIPTION
This is to fix https://github.com/coreos/etcd/issues/4981

What's in this PR:
- user APIs for recognizing event type. Besides the three existing types, also add three new APIs that I can think of are used in kubernetes and should also be pretty common in my mind.
- fix existing use cases
- some testing