### PR TITLE
*: move Cluster interface to api

### DIFF
--- a/etcdserver/api/cluster.go
+++ b/etcdserver/api/cluster.go
@@ -1,0 +1,41 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"github.com/coreos/etcd/etcdserver"
+	"github.com/coreos/etcd/pkg/types"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+// Cluster is an interface representing a collection of members in one etcd cluster.
+type Cluster interface {
+	// ID returns the cluster ID
+	ID() types.ID
+	// ClientURLs returns an aggregate set of all URLs on which this
+	// cluster is listening for client requests
+	ClientURLs() []string
+	// Members returns a slice of members sorted by their ID
+	Members() []*etcdserver.Member
+	// Member retrieves a particular member based on ID, or nil if the
+	// member does not exist in the cluster
+	Member(id types.ID) *etcdserver.Member
+	// IsIDRemoved checks whether the given ID has been removed from this
+	// cluster at some point in the past
+	IsIDRemoved(id types.ID) bool
+	// Version is the cluster-wide minimum major.minor version.
+	Version() *semver.Version
+}

--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -30,6 +30,7 @@ import (
 
 	etcdErr "github.com/coreos/etcd/error"
 	"github.com/coreos/etcd/etcdserver"
+	"github.com/coreos/etcd/etcdserver/api"
 	"github.com/coreos/etcd/etcdserver/api/v2http/httptypes"
 	"github.com/coreos/etcd/etcdserver/auth"
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
@@ -133,7 +134,7 @@ func NewClientHandler(server *etcdserver.EtcdServer, timeout time.Duration) http
 type keysHandler struct {
 	sec     auth.Store
 	server  etcdserver.Server
-	cluster etcdserver.Cluster
+	cluster api.Cluster
 	timer   etcdserver.RaftTimer
 	timeout time.Duration
 }
@@ -186,7 +187,7 @@ func (h *keysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type deprecatedMachinesHandler struct {
-	cluster etcdserver.Cluster
+	cluster api.Cluster
 }
 
 func (h *deprecatedMachinesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -200,7 +201,7 @@ func (h *deprecatedMachinesHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 type membersHandler struct {
 	sec     auth.Store
 	server  etcdserver.Server
-	cluster etcdserver.Cluster
+	cluster api.Cluster
 	timeout time.Duration
 	clock   clockwork.Clock
 }
@@ -389,7 +390,7 @@ func healthHandler(server *etcdserver.EtcdServer) http.HandlerFunc {
 	}
 }
 
-func versionHandler(c etcdserver.Cluster, fn func(http.ResponseWriter, *http.Request, string)) http.HandlerFunc {
+func versionHandler(c api.Cluster, fn func(http.ResponseWriter, *http.Request, string)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		v := c.Version()
 		if v != nil {

--- a/etcdserver/api/v2http/client_auth.go
+++ b/etcdserver/api/v2http/client_auth.go
@@ -20,14 +20,14 @@ import (
 	"path"
 	"strings"
 
-	"github.com/coreos/etcd/etcdserver"
+	"github.com/coreos/etcd/etcdserver/api"
 	"github.com/coreos/etcd/etcdserver/api/v2http/httptypes"
 	"github.com/coreos/etcd/etcdserver/auth"
 )
 
 type authHandler struct {
 	sec     auth.Store
-	cluster etcdserver.Cluster
+	cluster api.Cluster
 }
 
 func hasWriteRootAccess(sec auth.Store, r *http.Request) bool {

--- a/etcdserver/api/v2http/peer.go
+++ b/etcdserver/api/v2http/peer.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/coreos/etcd/etcdserver"
+	"github.com/coreos/etcd/etcdserver/api"
 	"github.com/coreos/etcd/lease/leasehttp"
 	"github.com/coreos/etcd/rafthttp"
 )
@@ -37,7 +38,7 @@ func NewPeerHandler(s *etcdserver.EtcdServer) http.Handler {
 	return newPeerHandler(s.Cluster(), s.RaftHandler(), lh)
 }
 
-func newPeerHandler(cluster etcdserver.Cluster, raftHandler http.Handler, leaseHandler http.Handler) http.Handler {
+func newPeerHandler(cluster api.Cluster, raftHandler http.Handler, leaseHandler http.Handler) http.Handler {
 	mh := &peerMembersHandler{
 		cluster: cluster,
 	}
@@ -55,7 +56,7 @@ func newPeerHandler(cluster etcdserver.Cluster, raftHandler http.Handler, leaseH
 }
 
 type peerMembersHandler struct {
-	cluster etcdserver.Cluster
+	cluster api.Cluster
 }
 
 func (h *peerMembersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/etcdserver/api/v3rpc/member.go
+++ b/etcdserver/api/v3rpc/member.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/etcdserver"
+	"github.com/coreos/etcd/etcdserver/api"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/pkg/types"
@@ -27,7 +28,7 @@ import (
 )
 
 type ClusterServer struct {
-	cluster   etcdserver.Cluster
+	cluster   api.Cluster
 	server    etcdserver.Server
 	raftTimer etcdserver.RaftTimer
 }

--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -39,24 +39,6 @@ const (
 	attributesSuffix     = "attributes"
 )
 
-type Cluster interface {
-	// ID returns the cluster ID
-	ID() types.ID
-	// ClientURLs returns an aggregate set of all URLs on which this
-	// cluster is listening for client requests
-	ClientURLs() []string
-	// Members returns a slice of members sorted by their ID
-	Members() []*Member
-	// Member retrieves a particular member based on ID, or nil if the
-	// member does not exist in the cluster
-	Member(id types.ID) *Member
-	// IsIDRemoved checks whether the given ID has been removed from this
-	// cluster at some point in the past
-	IsIDRemoved(id types.ID) bool
-	// Version is the cluster-wide minimum major.minor version.
-	Version() *semver.Version
-}
-
 // Cluster is a list of Members that belong to the same raft cluster
 type cluster struct {
 	id    types.ID

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -99,7 +99,7 @@ func getClusterFromRemotePeers(urls []string, timeout time.Duration, logerr bool
 
 // getRemotePeerURLs returns peer urls of remote members in the cluster. The
 // returned list is sorted in ascending lexicographical order.
-func getRemotePeerURLs(cl Cluster, local string) []string {
+func getRemotePeerURLs(cl *cluster, local string) []string {
 	us := make([]string, 0)
 	for _, m := range cl.Members() {
 		if m.Name == local {
@@ -115,7 +115,7 @@ func getRemotePeerURLs(cl Cluster, local string) []string {
 // The key of the returned map is the member's ID. The value of the returned map
 // is the semver versions string, including server and cluster.
 // If it fails to get the version of a member, the key will be nil.
-func getVersions(cl Cluster, local types.ID, rt http.RoundTripper) map[string]*version.Versions {
+func getVersions(cl *cluster, local types.ID, rt http.RoundTripper) map[string]*version.Versions {
 	members := cl.Members()
 	vers := make(map[string]*version.Versions)
 	for _, m := range members {
@@ -173,7 +173,7 @@ func decideClusterVersion(vers map[string]*version.Versions) *semver.Version {
 // cluster version in the range of [MinClusterVersion, Version] and no known members has a cluster version
 // out of the range.
 // We set this rule since when the local member joins, another member might be offline.
-func isCompatibleWithCluster(cl Cluster, local types.ID, rt http.RoundTripper) bool {
+func isCompatibleWithCluster(cl *cluster, local types.ID, rt http.RoundTripper) bool {
 	vers := getVersions(cl, local, rt)
 	minV := semver.Must(semver.NewVersion(version.MinClusterVersion))
 	maxV := semver.Must(semver.NewVersion(version.Version))

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -466,7 +466,7 @@ func (s *EtcdServer) purgeFile() {
 
 func (s *EtcdServer) ID() types.ID { return s.id }
 
-func (s *EtcdServer) Cluster() Cluster { return s.cluster }
+func (s *EtcdServer) Cluster() *cluster { return s.cluster }
 
 func (s *EtcdServer) RaftHandler() http.Handler { return s.r.transport.Handler() }
 


### PR DESCRIPTION
Cluster interface is not required/or used by etcdserver pkg. It exists to provide a way to specify the cluster information retrieval behavior and is used by api layer. So we move Cluster Interface to pkg api.