### PR TITLE
membership: save/update the whole member information into backend

### DIFF
--- a/etcdserver/membership/cluster.go
+++ b/etcdserver/membership/cluster.go
@@ -311,6 +311,9 @@ func (c *RaftCluster) UpdateAttributes(id types.ID, attr Attributes) {
 		if c.store != nil {
 			mustUpdateMemberAttrInStore(c.store, m)
 		}
+		if c.be != nil {
+			mustSaveMemberToBackend(c.be, m)
+		}
 		return
 	}
 	_, ok := c.removed[id]

--- a/etcdserver/membership/store.go
+++ b/etcdserver/membership/store.go
@@ -42,7 +42,7 @@ var (
 
 func mustSaveMemberToBackend(be backend.Backend, m *Member) {
 	mkey := backendMemberKey(m.ID)
-	mvalue, err := json.Marshal(m.RaftAttributes)
+	mvalue, err := json.Marshal(m)
 	if err != nil {
 		plog.Panicf("marshal raftAttributes should never fail: %v", err)
 	}
@@ -134,7 +134,7 @@ func nodeToMember(n *store.NodeExtern) (*Member, error) {
 }
 
 func backendMemberKey(id types.ID) []byte {
-	return []byte(path.Join(id.String(), raftAttributesSuffix))
+	return []byte(id.String())
 }
 
 func MemberStoreKey(id types.ID) string {


### PR DESCRIPTION
In v2 store, we save normal attributes and raftAttributes of a member into different keys. But I feel it is not necessary. So for v3, we always save a full member info into one key.