### PR TITLE
etcdserver: do not send out out of date appResp

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -938,9 +938,18 @@ func (s *EtcdServer) publish(timeout time.Duration) {
 
 // TODO: move this function into raft.go
 func (s *EtcdServer) send(ms []raftpb.Message) {
-	for i := range ms {
+	sentAppResp := false
+	for i := len(ms) - 1; i >= 0; i-- {
 		if s.cluster.IsIDRemoved(types.ID(ms[i].To)) {
 			ms[i].To = 0
+		}
+
+		if ms[i].Type == raftpb.MsgAppResp {
+			if sentAppResp {
+				ms[i].To = 0
+			} else {
+				sentAppResp = true
+			}
 		}
 
 		if ms[i].Type == raftpb.MsgSnap {


### PR DESCRIPTION
When the messages contains multiple AppResp, we only need to send out the last one since it contains all the information needed. 

This improves the overall performance/latency around 10% for 1000 client case based on my experiments.

/cc @gyuho Can you check with your dbtester to confirm this does improve the perf?