### PR TITLE
KeepAliveOnce error fix (when the lease not found)

### DIFF
--- a/clientv3/integration/lease_test.go
+++ b/clientv3/integration/lease_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/coreos/etcd/integration"
 	"github.com/coreos/etcd/pkg/testutil"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 func TestLeaseGrant(t *testing.T) {
@@ -91,6 +93,11 @@ func TestLeaseKeepAliveOnce(t *testing.T) {
 	_, err = lapi.KeepAliveOnce(context.Background(), clientv3.LeaseID(resp.ID))
 	if err != nil {
 		t.Errorf("failed to keepalive lease %v", err)
+	}
+
+	_, err = lapi.KeepAliveOnce(context.Background(), clientv3.LeaseID(0))
+	if grpc.Code(err) != codes.NotFound {
+		t.Errorf("invalid error returned %v", err)
 	}
 }
 

--- a/clientv3/lease.go
+++ b/clientv3/lease.go
@@ -181,6 +181,9 @@ func (l *lessor) KeepAliveOnce(ctx context.Context, id LeaseID) (*LeaseKeepAlive
 		if err == nil {
 			return resp, err
 		}
+		if isHalted(ctx, err) {
+			return resp, err
+		}
 
 		nerr := l.switchRemoteAndStream(err)
 		if nerr != nil {


### PR DESCRIPTION
When call KeepAliveOnce with a invlid leaseId, it returns a unmatched error. Because it does not check the codes.NotFould code.

before `grpc.rpcError{code:0x1, desc:"context canceled"}`
after `grpc.rpcError{code:0x5, desc:"etcdserver: requested lease not found"}`