### PR TITLE
benchmark: return time series with missing periods filled in

### DIFF
--- a/tools/benchmark/cmd/timeseries.go
+++ b/tools/benchmark/cmd/timeseries.go
@@ -19,6 +19,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"log"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -68,16 +69,41 @@ func (sp *secondPoints) getTimeSeries() TimeSeries {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 
-	tslice := make(TimeSeries, len(sp.tm))
-	i := 0
+	var (
+		minTs int64 = math.MaxInt64
+		maxTs int64 = -1
+	)
+	for k := range sp.tm {
+		if minTs > k {
+			minTs = k
+		}
+		if maxTs < k {
+			maxTs = k
+		}
+	}
+	for ti := minTs; ti < maxTs; ti++ {
+		if _, ok := sp.tm[ti]; !ok { // fill-in empties
+			sp.tm[ti] = secondPoint{totalLatency: 0, count: 0}
+		}
+	}
+
+	var (
+		tslice = make(TimeSeries, len(sp.tm))
+		i      int
+	)
 	for k, v := range sp.tm {
+		var lat time.Duration
+		if v.count > 0 {
+			lat = time.Duration(v.totalLatency) / time.Duration(v.count)
+		}
 		tslice[i] = timeSeries{
 			timestamp:  k,
-			avgLatency: time.Duration(v.totalLatency) / time.Duration(v.count),
+			avgLatency: lat,
 			throughPut: v.count,
 		}
 		i++
 	}
+
 	sort.Sort(tslice)
 	return tslice
 }

--- a/tools/benchmark/cmd/timeseries_test.go
+++ b/tools/benchmark/cmd/timeseries_test.go
@@ -1,0 +1,31 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetTimeseries(t *testing.T) {
+	sp := newSecondPoints()
+	now := time.Now()
+	sp.Add(now, time.Second)
+	sp.Add(now.Add(5*time.Second), time.Second)
+	n := sp.getTimeSeries().Len()
+	if n < 3 {
+		t.Fatalf("expected at 6 points of time series, got %s", sp.getTimeSeries())
+	}
+}


### PR DESCRIPTION
Previous

```
unix_ts,avg_latency,throughput
1460436229,1s,1
1460436234,1s,1
```

After

```
unix_ts,avg_latency,throughput
1460436229,1s,1
1460436230,0,0
1460436231,0,0
1460436232,0,0
1460436233,0,0
1460436234,1s,1
```
