### PR TITLE
*: fixes based on ineffassign

### DIFF
--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -720,20 +720,19 @@ func trimEventPrefix(ev *store.Event, prefix string) *store.Event {
 	// Since the *Event may reference one in the store history
 	// history, we must copy it before modifying
 	e := ev.Clone()
-	e.Node = trimNodeExternPrefix(e.Node, prefix)
-	e.PrevNode = trimNodeExternPrefix(e.PrevNode, prefix)
+	trimNodeExternPrefix(e.Node, prefix)
+	trimNodeExternPrefix(e.PrevNode, prefix)
 	return e
 }
 
-func trimNodeExternPrefix(n *store.NodeExtern, prefix string) *store.NodeExtern {
+func trimNodeExternPrefix(n *store.NodeExtern, prefix string) {
 	if n == nil {
-		return nil
+		return
 	}
 	n.Key = strings.TrimPrefix(n.Key, prefix)
 	for _, nn := range n.Nodes {
-		nn = trimNodeExternPrefix(nn, prefix)
+		trimNodeExternPrefix(nn, prefix)
 	}
-	return n
 }
 
 func trimErrorPrefix(err error, prefix string) error {

--- a/etcdserver/api/v2http/client_test.go
+++ b/etcdserver/api/v2http/client_test.go
@@ -1939,9 +1939,9 @@ func TestTrimNodeExternPrefix(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		n := trimNodeExternPrefix(tt.n, pre)
-		if !reflect.DeepEqual(n, tt.wn) {
-			t.Errorf("#%d: node = %+v, want %+v", i, n, tt.wn)
+		trimNodeExternPrefix(tt.n, pre)
+		if !reflect.DeepEqual(tt.n, tt.wn) {
+			t.Errorf("#%d: node = %+v, want %+v", i, tt.n, tt.wn)
 		}
 	}
 }

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -324,7 +324,7 @@ func TestIssue3699(t *testing.T) {
 	default:
 	}
 	// must waitLeader so goroutines don't leak on terminate
-	leaderID = c.waitLeader(t, c.Members)
+	c.waitLeader(t, c.Members)
 
 	// try to participate in cluster
 	cc := mustNewHTTPClient(t, []string{c.URL(0)}, c.cfg.ClientTLS)

--- a/store/event_test.go
+++ b/store/event_test.go
@@ -80,7 +80,7 @@ func TestScanHistory(t *testing.T) {
 		t.Fatalf("scan error [/foo/foo/foo] [6] %d (%v)", e.Index(), err)
 	}
 
-	e, err = eh.scan("/foo/bar", true, 7)
+	e, _ = eh.scan("/foo/bar", true, 7)
 	if e != nil {
 		t.Fatalf("bad index shoud reuturn nil")
 	}


### PR DESCRIPTION
To achieve 100% on https://goreportcard.com/report/github.com/coreos/etcd#ineffassign.