### PR TITLE
Documentation: v3 mem benchmark total watch value

### DIFF
--- a/Documentation/benchmarks/etcd-3-watch-memory-benchmark.md
+++ b/Documentation/benchmarks/etcd-3-watch-memory-benchmark.md
@@ -72,6 +72,6 @@ With the benchmark result, we can calculate roughly that `c1 = 17kb`, `c2 = 18kb
 | 5k | 50 |  10 | 2.5M | 5710MB |
 | 1k | 50 | 100 |   5M | 2380MB |
 | 2k | 50 | 100 |  10M | 4672MB |
-| 5k | 50 | 100 |  50M |  *OOM* |
+| 5k | 50 | 100 |  25M |  *OOM* |
 
 [rss]: https://en.wikipedia.org/wiki/Resident_set_size


### PR DESCRIPTION
Updating Documentation/benchmarks/etcd-3-watch-memory-benchmark.md with the correct 'total watching' value
earlier it was 50M but actual value is 25M