### PR TITLE
*: Member api change

### DIFF
--- a/auth/authpb/auth.pb.go
+++ b/auth/authpb/auth.pb.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/clientv3/cluster.go
+++ b/clientv3/cluster.go
@@ -34,9 +34,6 @@ type Cluster interface {
 	// MemberList lists the current cluster membership.
 	MemberList(ctx context.Context) (*MemberListResponse, error)
 
-	// MemberLeader returns the current leader member.
-	MemberLeader(ctx context.Context) (*Member, error)
-
 	// MemberAdd adds a new member into the cluster.
 	MemberAdd(ctx context.Context, peerAddrs []string) (*MemberAddResponse, error)
 
@@ -133,19 +130,6 @@ func (c *cluster) MemberList(ctx context.Context) (*MemberListResponse, error) {
 			return nil, err
 		}
 	}
-}
-
-func (c *cluster) MemberLeader(ctx context.Context) (*Member, error) {
-	resp, err := c.MemberList(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, m := range resp.Members {
-		if m.IsLeader {
-			return (*Member)(m), nil
-		}
-	}
-	return nil, nil
 }
 
 func (c *cluster) getRemote() pb.ClusterClient {

--- a/clientv3/example_cluster_test.go
+++ b/clientv3/example_cluster_test.go
@@ -40,24 +40,6 @@ func ExampleCluster_memberList() {
 	// members: 3
 }
 
-func ExampleCluster_memberLeader() {
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   endpoints,
-		DialTimeout: dialTimeout,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer cli.Close()
-
-	resp, err := cli.MemberLeader(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println("leader:", resp.Name)
-	// leader: infra1
-}
-
 func ExampleCluster_memberAdd() {
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:   endpoints[:2],

--- a/clientv3/example_maintenence_test.go
+++ b/clientv3/example_maintenence_test.go
@@ -1,0 +1,51 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3_test
+
+import (
+	"fmt"
+	"log"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+func ExampleMaintenance_Status() {
+	for _, ep := range endpoints {
+		cli, err := clientv3.New(clientv3.Config{
+			Endpoints:   []string{ep},
+			DialTimeout: dialTimeout,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cli.Close()
+
+		// resp, err := cli.Status(context.Background(), ep)
+		//
+		// or
+		//
+		mapi := clientv3.NewMaintenance(cli)
+		resp, err := mapi.Status(context.Background(), ep)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("endpoint: %s / IsLeader: %v\n", ep, resp.Header.MemberId == resp.Leader)
+	}
+	// endpoint: localhost:2379 / IsLeader: false
+	// endpoint: localhost:22379 / IsLeader: false
+	// endpoint: localhost:32379 / IsLeader: true
+}

--- a/clientv3/example_test.go
+++ b/clientv3/example_test.go
@@ -25,7 +25,7 @@ import (
 var (
 	dialTimeout    = 5 * time.Second
 	requestTimeout = 1 * time.Second
-	endpoints      = []string{"localhost:2379", "localhost:22379", "http://localhost:32379"}
+	endpoints      = []string{"localhost:2379", "localhost:22379", "localhost:32379"}
 )
 
 func Example() {

--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -108,7 +108,7 @@ func (s *simplePrinter) Alarm(resp v3.AlarmResponse) {
 
 func (s *simplePrinter) MemberList(resp v3.MemberListResponse) {
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"ID", "Status", "Name", "Peer Addrs", "Client Addrs", "Is Leader"})
+	table.SetHeader([]string{"ID", "Status", "Name", "Peer Addrs", "Client Addrs"})
 
 	for _, m := range resp.Members {
 		status := "started"
@@ -122,7 +122,6 @@ func (s *simplePrinter) MemberList(resp v3.MemberListResponse) {
 			m.Name,
 			strings.Join(m.PeerURLs, ","),
 			strings.Join(m.ClientURLs, ","),
-			fmt.Sprint(m.IsLeader),
 		})
 	}
 

--- a/etcdserver/api/v3rpc/member.go
+++ b/etcdserver/api/v3rpc/member.go
@@ -62,7 +62,7 @@ func (cs *ClusterServer) MemberAdd(ctx context.Context, r *pb.MemberAddRequest) 
 
 	return &pb.MemberAddResponse{
 		Header: cs.header(),
-		Member: &pb.Member{ID: uint64(m.ID), IsLeader: m.ID == cs.server.Leader(), PeerURLs: m.PeerURLs},
+		Member: &pb.Member{ID: uint64(m.ID), PeerURLs: m.PeerURLs},
 	}, nil
 }
 
@@ -106,7 +106,6 @@ func (cs *ClusterServer) MemberList(ctx context.Context, r *pb.MemberListRequest
 		protoMembs[i] = &pb.Member{
 			Name:       membs[i].Name,
 			ID:         uint64(membs[i].ID),
-			IsLeader:   membs[i].ID == cs.server.Leader(),
 			PeerURLs:   membs[i].PeerURLs,
 			ClientURLs: membs[i].ClientURLs,
 		}

--- a/etcdserver/etcdserverpb/etcdserver.pb.go
+++ b/etcdserver/etcdserverpb/etcdserver.pb.go
@@ -94,9 +94,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/etcdserver/etcdserverpb/raft_internal.pb.go
+++ b/etcdserver/etcdserverpb/raft_internal.pb.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -417,11 +417,10 @@ message Member {
   uint64 ID = 1;
   // If the member is not started, name will be an empty string.
   string name = 2;
-  bool IsLeader = 3;
-  repeated string peerURLs = 4;
+  repeated string peerURLs = 3;
   // If the member is not started, client_URLs will be an zero length
   // string array.
-  repeated string clientURLs = 5;
+  repeated string clientURLs = 4;
 }
 
 message MemberAddRequest {
@@ -459,7 +458,6 @@ message MemberListResponse {
 }
 
 message DefragmentRequest {
-
 }
 
 message DefragmentResponse {

--- a/lease/leasepb/lease.pb.go
+++ b/lease/leasepb/lease.pb.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/raft/raftpb/raft.pb.go
+++ b/raft/raftpb/raft.pb.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/snap/snappb/snap.pb.go
+++ b/snap/snappb/snap.pb.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/storage/storagepb/kv.pb.go
+++ b/storage/storagepb/kv.pb.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 

--- a/wal/walpb/record.pb.go
+++ b/wal/walpb/record.pb.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	proto "github.com/gogo/protobuf/proto"
-)
 
-import math "math"
+	math "math"
+)
 
 import io "io"
 


### PR DESCRIPTION
1. First remove `IsLeader` field in `Member` proto, because member API is more for cluster attributes. Dynamic cluster information should be queried with `etcdctl endpoint status`.
2. Following changes in client side with examples in `clientv3`.

Sample output:

```
+------------------+---------+--------+------------------------+------------------------+
|        ID        | STATUS  |  NAME  |       PEER ADDRS       |      CLIENT ADDRS      |
+------------------+---------+--------+------------------------+------------------------+
| 8211f1d0f64f3269 | started | infra1 | http://127.0.0.1:12380 | http://127.0.0.1:2379  |
| 91bc3c398fb3c146 | started | infra2 | http://127.0.0.1:22380 | http://127.0.0.1:22379 |
| fd422379fda50e48 | started | infra3 | http://127.0.0.1:32380 | http://127.0.0.1:32379 |
+------------------+---------+--------+------------------------+------------------------+
```

Only change in `member status` command is the `IS LEADER` column.

/cc @xiang90 @heyitsanthony @mqliang 

