### PR TITLE
storage: have Range on rev=0 work even if compacted to current revision

### DIFF
--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -290,10 +290,8 @@ message TxnResponse {
   repeated ResponseUnion responses = 3;
 }
 
-// Compaction compacts the kv store upto the given revision (including).
-// It removes the old versions of a key. It keeps the newest version of
-// the key even if its latest modification revision is smaller than the given
-// revision.
+// Compaction compacts the kv store upto a given revision. All superseded keys
+// with a revision less than the compaction revision will be removed.
 message CompactionRequest {
   int64 revision = 1;
   // physical is set so the RPC will wait until the compaction is physically

--- a/storage/kv.go
+++ b/storage/kv.go
@@ -67,6 +67,7 @@ type KV interface {
 	TxnPut(txnID int64, key, value []byte, lease lease.LeaseID) (rev int64, err error)
 	TxnDeleteRange(txnID int64, key, end []byte) (n, rev int64, err error)
 
+	// Compact frees all superseded keys with revisions less than rev.
 	Compact(rev int64) (<-chan struct{}, error)
 
 	// Hash retrieves the hash of KV state.

--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -194,9 +194,11 @@ func testKVRangeBadRev(t *testing.T, f rangeFunc) {
 		rev  int64
 		werr error
 	}{
-		{-1, ErrCompacted},
+		{-1, nil}, // <= 0 is most recent store
+		{0, nil},
 		{1, ErrCompacted},
 		{2, ErrCompacted},
+		{4, nil},
 		{5, ErrFutureRev},
 		{100, ErrFutureRev},
 	}

--- a/storage/kvstore.go
+++ b/storage/kvstore.go
@@ -425,7 +425,7 @@ func (s *store) rangeKeys(key, end []byte, limit, rangeRev int64) (kvs []storage
 	} else {
 		rev = rangeRev
 	}
-	if rev <= s.compactMainRev {
+	if rev < s.compactMainRev {
 		return nil, 0, ErrCompacted
 	}
 

--- a/storage/kvstore_test.go
+++ b/storage/kvstore_test.go
@@ -440,12 +440,11 @@ func TestRestoreContinueUnfinishedCompaction(t *testing.T) {
 	// wait for scheduled compaction to be finished
 	time.Sleep(100 * time.Millisecond)
 
-	if _, _, err := s1.Range([]byte("foo"), nil, 0, 2); err != ErrCompacted {
+	if _, _, err := s1.Range([]byte("foo"), nil, 0, 1); err != ErrCompacted {
 		t.Errorf("range on compacted rev error = %v, want %v", err, ErrCompacted)
 	}
 	// check the key in backend is deleted
 	revbytes := newRevBytes()
-	// TODO: compact should delete main=2 key too
 	revToBytes(revision{main: 1}, revbytes)
 
 	// The disk compaction is done asynchronously and requires more time on slow disk.


### PR DESCRIPTION
to repro, from fresh kvstore:
ETCDCTL_API=3 ./bin/etcdctl put abc 123
ETCDCTL_API=3 ./bin/etcdctl compaction 2
ETCDCTL_API=3 ./bin/etcdctl get abc