### PR TITLE
e2e: Test case for the etcdctlv3 'role grant' command.

### DIFF
--- a/e2e/ctl_v3_role_test.go
+++ b/e2e/ctl_v3_role_test.go
@@ -22,15 +22,19 @@ func TestCtlV3RoleAddClientTLS(t *testing.T) { testCtl(t, roleAddTest, withCfg(c
 func TestCtlV3RoleAddPeerTLS(t *testing.T)   { testCtl(t, roleAddTest, withCfg(configPeerTLS)) }
 func TestCtlV3RoleAddTimeout(t *testing.T)   { testCtl(t, roleAddTest, withDialTimeout(0)) }
 
+func TestCtlV3RoleGrant(t *testing.T) { testCtl(t, roleGrantTest) }
+
 func roleAddTest(cx ctlCtx) {
 	cmdSet := []struct {
 		args        []string
 		expectedStr string
 	}{
+		// Add a role.
 		{
 			args:        []string{"add", "root"},
 			expectedStr: "Role root created",
 		},
+		// Try adding the same role.
 		{
 			args:        []string{"add", "root"},
 			expectedStr: "role name already exists",
@@ -42,6 +46,45 @@ func roleAddTest(cx ctlCtx) {
 			if cx.dialTimeout > 0 && !isGRPCTimedout(err) {
 				cx.t.Fatalf("roleAddTest #%d: ctlV3Role error (%v)", i, err)
 			}
+		}
+	}
+}
+
+func roleGrantTest(cx ctlCtx) {
+	cmdSet := []struct {
+		args        []string
+		expectedStr string
+	}{
+		// Add a role.
+		{
+			args:        []string{"add", "root"},
+			expectedStr: "Role root created",
+		},
+		// Grant read permission to the role.
+		{
+			args:        []string{"grant", "root", "read", "foo"},
+			expectedStr: "Role root updated",
+		},
+		// Grant write permission to the role.
+		{
+			args:        []string{"grant", "root", "write", "foo"},
+			expectedStr: "Role root updated",
+		},
+		// Grant rw permission to the role.
+		{
+			args:        []string{"grant", "root", "readwrite", "foo"},
+			expectedStr: "Role root updated",
+		},
+		// Try granting invalid permission to the role.
+		{
+			args:        []string{"grant", "root", "123", "foo"},
+			expectedStr: "invalid permission type",
+		},
+	}
+
+	for i, cmd := range cmdSet {
+		if err := ctlV3Role(cx, cmd.args, cmd.expectedStr); err != nil {
+			cx.t.Fatalf("roleGrantTest #%d: ctlV3Role error (%v)", i, err)
 		}
 	}
 }


### PR DESCRIPTION
Adding a test case to test the 'role grant' sub-command.