### PR TITLE
clientv3: fix example code format, more examples

### DIFF
--- a/clientv3/example_kv_test.go
+++ b/clientv3/example_kv_test.go
@@ -69,6 +69,37 @@ func ExampleKV_get() {
 	// foo : bar
 }
 
+func ExampleKV_getWithRev() {
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: dialTimeout,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer cli.Close()
+
+	_, err = cli.Put(context.TODO(), "foo", "bar1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = cli.Put(context.TODO(), "foo", "bar2")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	resp, err := cli.Get(ctx, "foo", clientv3.WithRev(2))
+	cancel()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, ev := range resp.Kvs {
+		fmt.Printf("%s : %s\n", ev.Key, ev.Value)
+	}
+	// foo : bar1
+}
+
 func ExampleKV_getSortedPrefix() {
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:   endpoints,

--- a/clientv3/example_maintenence_test.go
+++ b/clientv3/example_maintenence_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 )
 
-func ExampleMaintenance_Status() {
+func ExampleMaintenance_status() {
 	for _, ep := range endpoints {
 		cli, err := clientv3.New(clientv3.Config{
 			Endpoints:   []string{ep},


### PR DESCRIPTION
godoc.org doesn't render `Maintenence` example correctly. This should fix the issue (https://godoc.org/github.com/coreos/etcd/clientv3#Maintenance).

And more example with `get` by `rev`.

Thanks.

/cc @xiang90 @heyitsanthony 