### PR TITLE
*: gateway initial commit

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -75,9 +75,7 @@ var (
 	dirEmpty  = dirType("empty")
 )
 
-func Main() {
-	checkSupportArch()
-
+func startEtcdOrProxyV2() {
 	cfg := NewConfig()
 	err := cfg.Parse(os.Args[1:])
 	if err != nil {

--- a/etcdmain/gateway.go
+++ b/etcdmain/gateway.go
@@ -1,0 +1,83 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdmain
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/coreos/etcd/proxy/tcpproxy"
+	"github.com/spf13/cobra"
+)
+
+var (
+	gatewayListenAddr string
+	gatewayEndpoints  string
+)
+
+var (
+	rootCmd = &cobra.Command{
+		Use:        "etcd",
+		Short:      "etcd server",
+		SuggestFor: []string{"etcd"},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(newGatewayCommand())
+}
+
+// newGatewayCommand returns the cobra command for "gateway".
+func newGatewayCommand() *cobra.Command {
+	lpc := &cobra.Command{
+		Use:   "gateway <subcommand>",
+		Short: "gateway related command",
+	}
+	lpc.AddCommand(newGatewayStartCommand())
+
+	return lpc
+}
+
+func newGatewayStartCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "start",
+		Short: "start the gateway",
+		Run:   startGateway,
+	}
+
+	cmd.Flags().StringVar(&gatewayListenAddr, "listen-addr", "127.0.0.1:23790", "listen address")
+	cmd.Flags().StringVar(&gatewayEndpoints, "endpoints", "127.0.0.1:2379", "comma separated etcd cluster endpoints")
+
+	return &cmd
+}
+
+func startGateway(cmd *cobra.Command, args []string) {
+	endpoints := strings.Split(gatewayEndpoints, ",")
+
+	l, err := net.Listen("tcp", gatewayListenAddr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	tp := tcpproxy.TCPProxy{
+		Listener:  l,
+		Endpoints: endpoints,
+	}
+
+	tp.Run()
+}

--- a/etcdmain/main.go
+++ b/etcdmain/main.go
@@ -1,0 +1,37 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdmain
+
+import (
+	"fmt"
+	"os"
+)
+
+func Main() {
+	checkSupportArch()
+
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "gateway":
+			if err := rootCmd.Execute(); err != nil {
+				fmt.Fprint(os.Stderr, err)
+				os.Exit(1)
+			}
+			return
+		}
+	}
+
+	startEtcdOrProxyV2()
+}

--- a/proxy/tcpproxy/userspace_test.go
+++ b/proxy/tcpproxy/userspace_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
-	"time"
 )
 
 func TestUserspaceProxy(t *testing.T) {
@@ -43,17 +42,12 @@ func TestUserspaceProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := tcpProxy{
-		l:               l,
-		donec:           make(chan struct{}),
-		monitorInterval: time.Second,
-
-		remotes: []*remote{
-			{addr: u.Host},
-		},
+	p := TCPProxy{
+		Listener:  l,
+		Endpoints: []string{u.Host},
 	}
-	go p.run()
-	defer p.stop()
+	go p.Run()
+	defer p.Stop()
 
 	u.Host = l.Addr().String()
 


### PR DESCRIPTION
it works.

```
./goreman start
```

```
./etcd gateway start --endpoints=127.0.0.1:12379,127.0.0.1:22379,127.0.0.1:32379,127.0.0.1:42379
```

```
➜  etcdctl git:(etcdlet) ✗ ETCDCTL_API=3 ./etcdctl --endpoints=127.0.0.1:4379 get foo
foo
bar
➜  etcdctl git:(etcdlet) ✗ ETCDCTL_API=3 ./etcdctl --endpoints=127.0.0.1:4379 get foo
foo
bar
➜  etcdctl git:(etcdlet) ✗ ETCDCTL_API=3 ./etcdctl --endpoints=127.0.0.1:4379 get foo
foo
bar
➜  etcdctl git:(etcdlet) ✗ ETCDCTL_API=3 ./etcdctl --endpoints=127.0.0.1:4379 get foo
foo
bar
➜  etcdctl git:(etcdlet) ✗ ETCDCTL_API=3 ./etcdctl --endpoints=127.0.0.1:4379 get foo
foo
bar
```

now etcdctl can talk to etcd gateway and gateway handles failure transparently if dial fails (the last endpoint :42379 is actually invalid).