### PR TITLE
clientv3: Remove superfluous LeaseID casts in integration tests.

### DIFF
--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -50,7 +50,7 @@ func TestKVPut(t *testing.T) {
 		leaseID  clientv3.LeaseID
 	}{
 		{"foo", "bar", clientv3.NoLease},
-		{"hello", "world", clientv3.LeaseID(resp.ID)},
+		{"hello", "world", resp.ID},
 	}
 
 	for i, tt := range tests {

--- a/clientv3/integration/lease_test.go
+++ b/clientv3/integration/lease_test.go
@@ -43,7 +43,7 @@ func TestLeaseGrant(t *testing.T) {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	_, err = kv.Put(context.TODO(), "foo", "bar", clientv3.WithLease(clientv3.LeaseID(resp.ID)))
+	_, err = kv.Put(context.TODO(), "foo", "bar", clientv3.WithLease(resp.ID))
 	if err != nil {
 		t.Fatalf("failed to create key with lease %v", err)
 	}
@@ -70,7 +70,7 @@ func TestLeaseRevoke(t *testing.T) {
 		t.Errorf("failed to revoke lease %v", err)
 	}
 
-	_, err = kv.Put(context.TODO(), "foo", "bar", clientv3.WithLease(clientv3.LeaseID(resp.ID)))
+	_, err = kv.Put(context.TODO(), "foo", "bar", clientv3.WithLease(resp.ID))
 	if err != rpctypes.ErrLeaseNotFound {
 		t.Fatalf("err = %v, want %v", err, rpctypes.ErrLeaseNotFound)
 	}
@@ -90,7 +90,7 @@ func TestLeaseKeepAliveOnce(t *testing.T) {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	_, err = lapi.KeepAliveOnce(context.Background(), clientv3.LeaseID(resp.ID))
+	_, err = lapi.KeepAliveOnce(context.Background(), resp.ID)
 	if err != nil {
 		t.Errorf("failed to keepalive lease %v", err)
 	}
@@ -114,7 +114,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	rc, kerr := lapi.KeepAlive(context.Background(), clientv3.LeaseID(resp.ID))
+	rc, kerr := lapi.KeepAlive(context.Background(), resp.ID)
 	if kerr != nil {
 		t.Errorf("failed to keepalive lease %v", kerr)
 	}
@@ -154,7 +154,7 @@ func TestLeaseKeepAliveHandleFailure(t *testing.T) {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	rc, kerr := lapi.KeepAlive(context.Background(), clientv3.LeaseID(resp.ID))
+	rc, kerr := lapi.KeepAlive(context.Background(), resp.ID)
 	if kerr != nil {
 		t.Errorf("failed to keepalive lease %v", kerr)
 	}

--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -452,7 +452,7 @@ func TestWatchEventType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("lease create failed: %v", err)
 	}
-	if _, err := client.Put(ctx, "/toExpire", "foo", clientv3.WithLease(clientv3.LeaseID(lcr.ID))); err != nil {
+	if _, err := client.Put(ctx, "/toExpire", "foo", clientv3.WithLease(lcr.ID)); err != nil {
 		t.Fatalf("Put failed: %v", err)
 	}
 


### PR DESCRIPTION
The integration tests under clientv3 have superfluous LeaseID casts
that are not needed as the ID field of the lease responses are of
type LeaseID now.