### PR TITLE
v3rpc: bytes-key map look-up gc optimization

### DIFF
--- a/etcdserver/api/v3rpc/key.go
+++ b/etcdserver/api/v3rpc/key.go
@@ -185,11 +185,10 @@ func checkRequestDupKeys(reqs []*pb.RequestUnion) error {
 		if preq == nil {
 			continue
 		}
-		key := string(preq.Key)
-		if _, ok := keys[key]; ok {
+		if _, ok := keys[string(preq.Key)]; ok {
 			return rpctypes.ErrDuplicateKey
 		}
-		keys[key] = struct{}{}
+		keys[string(preq.Key)] = struct{}{}
 	}
 
 	// no need to check deletes if no puts; delete overlaps are permitted
@@ -214,13 +213,12 @@ func checkRequestDupKeys(reqs []*pb.RequestUnion) error {
 		if dreq == nil {
 			continue
 		}
-		key := string(dreq.Key)
 		if dreq.RangeEnd == nil {
-			if _, found := keys[key]; found {
+			if _, found := keys[string(dreq.Key)]; found {
 				return rpctypes.ErrDuplicateKey
 			}
 		} else {
-			lo := sort.SearchStrings(sortedKeys, key)
+			lo := sort.SearchStrings(sortedKeys, string(dreq.Key))
 			hi := sort.SearchStrings(sortedKeys, string(dreq.RangeEnd))
 			if lo != hi {
 				// element between lo and hi => overlap


### PR DESCRIPTION
This change https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf ~~just got merged to `go1.6.1`~~ where Go does special optimization for `x =
m[string(k)]` where k is `[]byte`.