### PR TITLE
fileutil: Sync on HFS/OSX needs to be handled differently.

### DIFF
--- a/etcdctl/ctlv3/command/snapshot_command.go
+++ b/etcdctl/ctlv3/command/snapshot_command.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/etcdserver/membership"
+	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -121,7 +122,7 @@ func snapshotSaveCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitInterrupted, rerr)
 	}
 
-	f.Sync()
+	fileutil.Fsync(f)
 
 	if rerr := os.Rename(partpath, path); rerr != nil {
 		exiterr := fmt.Errorf("could not rename %s to %s (%v)", partpath, path, rerr)

--- a/pkg/fileutil/sync_darwin.go
+++ b/pkg/fileutil/sync_darwin.go
@@ -12,18 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !linux,!darwin
+// +build darwin
 
 package fileutil
 
-import "os"
+import (
+	"os"
+	"syscall"
+)
 
-// Fsync is a wrapper around file.Sync(). Special handling is needed on darwin platform.
+// Fsync on HFS/OSX flushes the data on to the physical drive but the drive
+// may not write it to the persistent media for quite sometime and it may be
+// written in out-of-order sequence. Using F_FULLFSYNC ensures that the
+// physical drive's buffer will also get flushed to the media.
 func Fsync(f *os.File) error {
-	return f.Sync()
+	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), uintptr(syscall.F_FULLFSYNC), uintptr(0))
+	if errno == 0 {
+		return nil
+	}
+	return errno
 }
 
-// Fdatasync is a wrapper around file.Sync(). Special handling is needed on linux platform.
+// Fdatasync on darwin platform invokes fcntl(F_FULLFSYNC) for actual persistence
+// on physical drive media.
 func Fdatasync(f *os.File) error {
-	return f.Sync()
+	return Fsync(f)
 }

--- a/pkg/fileutil/sync_linux.go
+++ b/pkg/fileutil/sync_linux.go
@@ -21,6 +21,11 @@ import (
 	"syscall"
 )
 
+// Fsync is a wrapper around file.Sync(). Special handling is needed on darwin platform.
+func Fsync(f *os.File) error {
+	return f.Sync()
+}
+
 // Fdatasync is similar to fsync(), but does not flush modified metadata
 // unless that metadata is needed in order to allow a subsequent data retrieval
 // to be correctly handled.

--- a/pkg/ioutil/util.go
+++ b/pkg/ioutil/util.go
@@ -17,6 +17,8 @@ package ioutil
 import (
 	"io"
 	"os"
+
+	"github.com/coreos/etcd/pkg/fileutil"
 )
 
 // WriteAndSyncFile behaves just like ioutil.WriteFile in the standard library,
@@ -32,7 +34,7 @@ func WriteAndSyncFile(filename string, data []byte, perm os.FileMode) error {
 		err = io.ErrShortWrite
 	}
 	if err == nil {
-		err = f.Sync()
+		err = fileutil.Fsync(f)
 	}
 	if err1 := f.Close(); err == nil {
 		err = err1

--- a/snap/db.go
+++ b/snap/db.go
@@ -34,7 +34,7 @@ func (s *Snapshotter) SaveDBFrom(r io.Reader, id uint64) error {
 	var n int64
 	n, err = io.Copy(f, r)
 	if err == nil {
-		err = f.Sync()
+		err = fileutil.Fsync(f)
 	}
 	f.Close()
 	if err != nil {

--- a/wal/repair.go
+++ b/wal/repair.go
@@ -78,7 +78,7 @@ func Repair(dirpath string) bool {
 				plog.Errorf("could not repair %v, failed to truncate file", f.Name())
 				return false
 			}
-			if err = f.Sync(); err != nil {
+			if err = fileutil.Fsync(f); err != nil {
 				plog.Errorf("could not repair %v, failed to sync file", f.Name())
 				return false
 			}


### PR DESCRIPTION
A call to file.Sync on OSX doesn't guarantee actual persistence on
physical drive media as the data can be cached in physical drive's
buffers. Hence calls to file.Sync need to be replaced with
fcntl(F_FULLFSYNC).

Fixes #5029 