### PR TITLE
etcdctl: print full json response for Get

### DIFF
--- a/e2e/ctl_v3_kv_test.go
+++ b/e2e/ctl_v3_kv_test.go
@@ -100,7 +100,7 @@ func getFormatTest(cx ctlCtx) {
 		wstr string
 	}{
 		{"simple", "abc"},
-		{"json", "\"key\":\"YWJj\""},
+		{"json", `"kvs":[{"key":"YWJj"`},
 		{"protobuf", "\x17\b\x93\xe7\xf6\x93\xd4ņ\xe14\x10\xed"},
 	}
 

--- a/etcdctl/READMEv3.md
+++ b/etcdctl/READMEv3.md
@@ -80,7 +80,7 @@ TODO: add consistency, from, prefix
 
 ##### JSON reply
 
-The JSON encoding of the [RPC message][etcdrpc] for a key-value pair for each fetched key-value.
+The JSON encoding of the [RPC response][etcdrpc] for the GET's Range request.
 
 ##### Protobuf reply
 

--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -163,12 +163,8 @@ func (s *simplePrinter) DBStatus(ds dbstatus) {
 
 type jsonPrinter struct{}
 
-func (p *jsonPrinter) Del(r v3.DeleteResponse) { printJSON(r) }
-func (p *jsonPrinter) Get(r v3.GetResponse) {
-	for _, kv := range r.Kvs {
-		printJSON(kv)
-	}
-}
+func (p *jsonPrinter) Del(r v3.DeleteResponse)            { printJSON(r) }
+func (p *jsonPrinter) Get(r v3.GetResponse)               { printJSON(r) }
 func (p *jsonPrinter) Put(r v3.PutResponse)               { printJSON(r) }
 func (p *jsonPrinter) Txn(r v3.TxnResponse)               { printJSON(r) }
 func (p *jsonPrinter) Watch(r v3.WatchResponse)           { printJSON(r) }


### PR DESCRIPTION
Otherwise parsing get/txn output with json is somewhat complicated
because in some cases there's a json message and sometimes not.
Likewise, a get on an absent key has to return the current revision for
some algorithms to work.