### PR TITLE
storage: don't timeout in TestWatchableKVWatch()

### DIFF
--- a/storage/kv_test.go
+++ b/storage/kv_test.go
@@ -771,9 +771,6 @@ func TestWatchableKVWatch(t *testing.T) {
 		if !reflect.DeepEqual(ev, wev[0]) {
 			t.Errorf("watched event = %+v, want %+v", ev, wev[0])
 		}
-	case <-time.After(5 * time.Second):
-		// CPU might be too slow, and the routine is not able to switch around
-		testutil.FatalStack(t, "failed to watch the event")
 	}
 
 	s.Put([]byte("foo1"), []byte("bar1"), 2)
@@ -786,8 +783,6 @@ func TestWatchableKVWatch(t *testing.T) {
 		if !reflect.DeepEqual(ev, wev[1]) {
 			t.Errorf("watched event = %+v, want %+v", ev, wev[1])
 		}
-	case <-time.After(5 * time.Second):
-		testutil.FatalStack(t, "failed to watch the event")
 	}
 
 	w = s.NewWatchStream()
@@ -802,8 +797,6 @@ func TestWatchableKVWatch(t *testing.T) {
 		if !reflect.DeepEqual(ev, wev[1]) {
 			t.Errorf("watched event = %+v, want %+v", ev, wev[1])
 		}
-	case <-time.After(5 * time.Second):
-		testutil.FatalStack(t, "failed to watch the event")
 	}
 
 	s.Put([]byte("foo1"), []byte("bar11"), 3)
@@ -816,8 +809,6 @@ func TestWatchableKVWatch(t *testing.T) {
 		if !reflect.DeepEqual(ev, wev[2]) {
 			t.Errorf("watched event = %+v, want %+v", ev, wev[2])
 		}
-	case <-time.After(5 * time.Second):
-		testutil.FatalStack(t, "failed to watch the event")
 	}
 }
 


### PR DESCRIPTION
TestWatchableKVWatch() stops its test in 5 seconds and reports
failure. However, slow CPUs can cause this timeout easily. This commit
removes the timeout mechanism for reducing false positive reports.

This change is also useful for diagnosing real problems. If the watch
mechanism is causing deadlock, go's scheduler can report the deadlock
because it can know the entire goroutines cannot make progress. On my
environment, actually this change simply removed the test failure.

For ensuring latency of the watch notifications, e2e should do
performance test. I think unit test isn't a suitable place for doing
it.

Fixes https://github.com/coreos/etcd/issues/5104

/cc @gyuho 