### PR TITLE
etcdserver: remove a data race of ServerStat

### DIFF
--- a/etcdserver/stats/server.go
+++ b/etcdserver/stats/server.go
@@ -142,6 +142,9 @@ func (ss *ServerStats) SendAppendReq(reqSize int) {
 }
 
 func (ss *ServerStats) BecomeLeader() {
+	ss.Lock()
+	defer ss.Unlock()
+
 	if ss.State != raft.StateLeader {
 		ss.State = raft.StateLeader
 		ss.LeaderInfo.Name = ss.ID


### PR DESCRIPTION
It seems that ServerStats.BecomeLeader() is missing a lock.

Fix https://github.com/coreos/etcd/issues/5155

@AkihiroSuda has a way of reliably reproducing the race. Could you test it?

/cc @xiang90 @heyitsanthony 