### PR TITLE
raft: fix detected race in node.go

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -325,7 +325,7 @@ func (n *node) run(r *raft) {
 				// block incoming proposal when local node is
 				// removed
 				if cc.NodeID == r.id {
-					n.propc = nil
+					propc = nil
 				}
 				r.removeNode(cc.NodeID)
 			case pb.ConfChangeUpdateNode:


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/5155

Only access the local copy of the chan not the field in node struct.