### PR TITLE
etcdserver: stop raft after stopping apply scheduler

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -537,8 +537,11 @@ func (s *EtcdServer) run() {
 	}
 
 	defer func() {
-		s.r.stop()
 		sched.Stop()
+
+		// must stop raft after scheduler-- etcdserver can leak rafthttp pipelines
+		// by adding a peer after raft stops the transport
+		s.r.stop()
 
 		s.wg.Wait()
 


### PR DESCRIPTION
Was causing a pipeline leak.