### PR TITLE
etcdserver: do not serve requests before finish the first internal proposal

### DIFF
--- a/etcdmain/serve.go
+++ b/etcdmain/serve.go
@@ -42,6 +42,9 @@ type serveCtx struct {
 func serve(sctx *serveCtx, s *etcdserver.EtcdServer, tlscfg *tls.Config, handler http.Handler) error {
 	logger := defaultLog.New(ioutil.Discard, "etcdhttp", 0)
 
+	<-s.ReadyNotify()
+	plog.Info("ready to serve client requests")
+
 	m := cmux.New(sctx.l)
 
 	if sctx.insecure {

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1155,6 +1155,7 @@ func TestPublish(t *testing.T) {
 	ch <- Response{}
 	w := wait.NewWithResponse(ch)
 	srv := &EtcdServer{
+		readych:    make(chan struct{}),
 		cfg:        &ServerConfig{TickMs: 1},
 		id:         1,
 		r:          raftNode{Node: n},

--- a/integration/member_test.go
+++ b/integration/member_test.go
@@ -61,6 +61,7 @@ func TestRestartMember(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+
 	clusterMustProgress(t, c.Members)
 }
 
@@ -105,6 +106,7 @@ func TestSnapshotAndRestartMember(t *testing.T) {
 	m.Stop(t)
 	m.Restart(t)
 
+	m.WaitOK(t)
 	for i := 0; i < 120; i++ {
 		cc := mustNewHTTPClient(t, []string{m.URL()}, nil)
 		kapi := client.NewKeysAPI(cc)


### PR DESCRIPTION
The downside is that the server wont serve any read before it connects to the majority and finishes applies the first internal proposal. but i feel it actually makes more sense.