### PR TITLE
apiv3: Absolute imports in .proto files

### DIFF
--- a/etcdserver/etcdserverpb/raft_internal.proto
+++ b/etcdserver/etcdserverpb/raft_internal.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 package etcdserverpb;
 
 import "gogoproto/gogo.proto";
-import "etcdserver.proto";
-import "rpc.proto";
+import "etcd/etcdserver/etcdserverpb/etcdserver.proto";
+import "etcd/etcdserver/etcdserverpb/authpb/rpc.proto";
 
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.sizer_all) = true;


### PR DESCRIPTION
Using absolute imports in .proto files makes it easier to compile them
in automated and consistent way to a package that would also contain
absolute imports. It e.g. makes work much easier when creating Python
package. Vide
https://github.com/zefciu/python-etcd-apiv3/blob/master/make.py
for example automation script that would benefit for this.

fixes: #5156