### PR TITLE
etcd-tester: record git commit hash at deployment

### DIFF
--- a/tools/functional-tester/etcd-tester/http.go
+++ b/tools/functional-tester/etcd-tester/http.go
@@ -20,7 +20,8 @@ import (
 )
 
 type statusHandler struct {
-	status *Status
+	status        *Status
+	gitCommitHash string
 }
 
 func (sh statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -31,13 +32,14 @@ func (sh statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer sh.status.mu.Unlock()
 
 	if err := en.Encode(Status{
-		Since:      sh.status.Since,
-		Failures:   sh.status.Failures,
-		RoundLimit: sh.status.RoundLimit,
-		Cluster:    sh.status.cluster.Status(),
-		cluster:    sh.status.cluster,
-		Round:      sh.status.Round,
-		Case:       sh.status.Case,
+		Since:         sh.status.Since,
+		Failures:      sh.status.Failures,
+		RoundLimit:    sh.status.RoundLimit,
+		Cluster:       sh.status.cluster.Status(),
+		cluster:       sh.status.cluster,
+		Round:         sh.status.Round,
+		Case:          sh.status.Case,
+		GitCommitHash: sh.gitCommitHash,
 	}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -35,6 +35,7 @@ func main() {
 	schedCases := flag.String("schedule-cases", "", "test case schedule")
 	consistencyCheck := flag.Bool("consistency-check", true, "true to check consistency (revision, hash)")
 	isV2Only := flag.Bool("v2-only", false, "'true' to run V2 only tester.")
+	gitCommitHash := flag.String("git-commit-hash", "", "git commit SHA hash at the time of deployment")
 	flag.Parse()
 
 	endpoints := strings.Split(*endpointStr, ",")
@@ -79,7 +80,7 @@ func main() {
 		consistencyCheck: *consistencyCheck,
 	}
 
-	sh := statusHandler{status: &t.status}
+	sh := statusHandler{status: &t.status, gitCommitHash: *gitCommitHash}
 	http.Handle("/status", sh)
 	http.Handle("/metrics", prometheus.Handler())
 	go func() { plog.Fatal(http.ListenAndServe(":9028", nil)) }()

--- a/tools/functional-tester/etcd-tester/tester.go
+++ b/tools/functional-tester/etcd-tester/tester.go
@@ -217,9 +217,10 @@ type Status struct {
 	Cluster ClusterStatus
 	cluster *cluster
 
-	mu    sync.Mutex // guards Round and Case
-	Round int
-	Case  int
+	mu            sync.Mutex // guards Round and Case
+	Round         int
+	Case          int
+	GitCommitHash string
 }
 
 func (s *Status) setRound(r int) {


### PR DESCRIPTION
Since we have more than one testing cluster, we need to keep track of our deployment. In general, tester and agents share the same git commit, so we can keep git SHA hash in tester status.
