### PR TITLE
clientv3: check stream context in lease keep alive send loop

### DIFF
--- a/clientv3/lease.go
+++ b/clientv3/lease.go
@@ -351,6 +351,8 @@ func (l *lessor) sendKeepAliveLoop(stream pb.Lease_LeaseKeepAliveClient) {
 	for {
 		select {
 		case <-time.After(500 * time.Millisecond):
+		case <-stream.Context().Done():
+			return
 		case <-l.donec:
 			return
 		case <-l.stopCtx.Done():


### PR DESCRIPTION
If no leases are being kept alive, a connection reset would leak
the send routine since it would only test the stream when sending
keep alives.

Fixes #5200