### PR TITLE
v3rpc: only fill lease grant header if no error

### DIFF
--- a/etcdserver/api/v3rpc/lease.go
+++ b/etcdserver/api/v3rpc/lease.go
@@ -38,6 +38,9 @@ func (ls *LeaseServer) LeaseGrant(ctx context.Context, cr *pb.LeaseGrantRequest)
 	if err == lease.ErrLeaseExists {
 		return nil, rpctypes.ErrLeaseExist
 	}
+	if err != nil {
+		return nil, err
+	}
 	ls.hdr.fill(resp.Header)
 	return resp, err
 }


### PR DESCRIPTION
Was panicking under cluster fault injection.