### PR TITLE
pkg/fileutil: wait up to 300ms for purge test

### DIFF
--- a/pkg/fileutil/purge_test.go
+++ b/pkg/fileutil/purge_test.go
@@ -58,9 +58,9 @@ func TestPurgeFile(t *testing.T) {
 
 	// purge routine should purge 7 out of 10 files and only keep the
 	// 3 most recent ones.
-	// wait for purging for at most 100ms.
+	// Wait for purging for at most 300ms.
 	var fnames []string
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 30; i++ {
 		fnames, err = ReadDir(dir)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION

Fix https://github.com/coreos/etcd/issues/5231.

The issue shows that slow CI can take more than 200ms
for purging. This increase the loop iteration to wait
up to 300ms in case the disk is being slow.