### PR TITLE
mvcc: add benchmark for watch put and improve it

### DIFF
--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -580,7 +580,7 @@ func (s *store) delete(key []byte, rev revision) {
 
 func (s *store) getChanges() []mvccpb.KeyValue {
 	changes := s.changes
-	s.changes = make([]mvccpb.KeyValue, 0, 128)
+	s.changes = make([]mvccpb.KeyValue, 0, 4)
 	return changes
 }
 

--- a/mvcc/watchable_store_bench_test.go
+++ b/mvcc/watchable_store_bench_test.go
@@ -23,6 +23,22 @@ import (
 	"github.com/coreos/etcd/mvcc/backend"
 )
 
+func BenchmarkWatchableStorePut(b *testing.B) {
+	be, tmpPath := backend.NewDefaultTmpBackend()
+	s := New(be, &lease.FakeLessor{}, nil)
+	defer cleanup(s, be, tmpPath)
+
+	// arbitrary number of bytes
+	bytesN := 64
+	keys := createBytesSlice(bytesN, b.N)
+	vals := createBytesSlice(bytesN, b.N)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Put(keys[i], vals[i], lease.NoLease)
+	}
+}
+
 // Benchmarks on cancel function performance for unsynced watchers
 // in a WatchableStore. It creates k*N watchers to populate unsynced
 // with a reasonably large number of watchers. And measures the time it


### PR DESCRIPTION
Remove the aggressive array preallocation. Improve benchmark result 100%

Before change
```
go test -bench=BenchmarkWatchableStorePut -run=xxx -benchmem -cpu=1,2,4
PASS
BenchmarkWatchableStorePut  	   50000	     28181 ns/op	   12157 B/op	      19 allocs/op
BenchmarkWatchableStorePut-2	  100000	     21586 ns/op	   12032 B/op	      17 allocs/op
BenchmarkWatchableStorePut-4	  100000	     19479 ns/op	   12028 B/op	      18 allocs/op
ok  	github.com/coreos/etcd/mvcc	9.143s
```

After change
```
go test -bench=BenchmarkWatchableStorePut -run=xxx -benchmem -cpu=1,2,4
PASS
BenchmarkWatchableStorePut  	  100000	     12463 ns/op	    2014 B/op	      19 allocs/op
BenchmarkWatchableStorePut-2	  200000	      9679 ns/op	    1836 B/op	      17 allocs/op
BenchmarkWatchableStorePut-4	  200000	      9222 ns/op	    1877 B/op	      18 allocs/op
ok  	github.com/coreos/etcd/mvcc	10.716s
```

@gyuho Probably you want to rerun the e2e benchmark to verify the change?