### PR TITLE
use sed instead of cut to accomodate GNU and BSD differences

### DIFF
--- a/build
+++ b/build
@@ -11,7 +11,7 @@ GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
 
 LINK_OPERATOR="="
 
-host_arch=$(GOARCH="" go env | egrep 'GOARCH=' | cut --delimiter='"' --field=2)
+host_arch=$(GOARCH="" go env | egrep 'GOARCH=' | sed 's/^GOARCH="\(.*\)".*/\1/')
 
 if [ -z "${GOARCH}" ] || [ "${GOARCH}" = "${host_arch}" ]; then
 	out="bin"


### PR DESCRIPTION
There are differences between the GNU and BSD versions of `cut` which cause the following error to be reported when attempting to build `etcd` on OSX:

```
cut: illegal option -- -
usage: cut -b list [-n] [file ...]
       cut -c list [file ...]
       cut -f list [-s] [-d delim] [file ...]
```

This pull request modifies the `build` script to use `sed` instead of `cut` to extract the GOARCH setting so that the `build` script also works on OSX.


