### PR TITLE
functional-tester: use revision from hash method

### DIFF
--- a/mvcc/kv.go
+++ b/mvcc/kv.go
@@ -70,9 +70,9 @@ type KV interface {
 	// Compact frees all superseded keys with revisions less than rev.
 	Compact(rev int64) (<-chan struct{}, error)
 
-	// Hash retrieves the hash of KV state.
+	// Hash retrieves the hash of KV state and revision.
 	// This method is designed for consistency checking purpose.
-	Hash() (uint32, error)
+	Hash() (hash uint32, revision int64, err error)
 
 	// Commit commits txns into the underlying backend.
 	Commit()

--- a/mvcc/kv_test.go
+++ b/mvcc/kv_test.go
@@ -620,7 +620,7 @@ func TestKVHash(t *testing.T) {
 		kv := NewStore(b, &lease.FakeLessor{}, nil)
 		kv.Put([]byte("foo0"), []byte("bar0"), lease.NoLease)
 		kv.Put([]byte("foo1"), []byte("bar0"), lease.NoLease)
-		hashes[i], err = kv.Hash()
+		hashes[i], _, err = kv.Hash()
 		if err != nil {
 			t.Fatalf("failed to get hash: %v", err)
 		}

--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -293,9 +293,15 @@ func (s *store) Compact(rev int64) (<-chan struct{}, error) {
 	return ch, nil
 }
 
-func (s *store) Hash() (uint32, error) {
+func (s *store) Hash() (uint32, int64, error) {
 	s.b.ForceCommit()
-	return s.b.Hash()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	h, err := s.b.Hash()
+	rev := s.currentRev.main
+	return h, rev, err
 }
 
 func (s *store) Commit() { s.b.ForceCommit() }


### PR DESCRIPTION
This is for https://github.com/coreos/etcd/issues/5220#issuecomment-216369347.

We had a lot of issues in the past, when the tester gets inconsistent hash values across the cluster, because of one or two nodes were falling behind. Actual data files show that they were all consistent, but had some extra writes after we stopped the stressers.

The hash inconsistency happens when those extra writes are processed between the time we cancel the stresser and the time we get revision *after we call `Hash` method*. This PR makes those revision and hash call happen at the same time, so that functional-tester can retry with more accurate revisions.

