### PR TITLE
raft: fix flaky test

### DIFF
--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -159,7 +159,7 @@ func testNonleaderStartElection(t *testing.T, state StateType) {
 		r.becomeCandidate()
 	}
 
-	for i := 0; i < 2*et; i++ {
+	for i := 1; i < 2*et; i++ {
 		r.tick()
 	}
 
@@ -785,7 +785,7 @@ func TestVoteRequest(t *testing.T) {
 		})
 		r.readMessages()
 
-		for i := 0; i < r.electionTimeout*2; i++ {
+		for i := 1; i < r.electionTimeout*2; i++ {
 			r.tickElection()
 		}
 


### PR DESCRIPTION
We recently changed the randomized election timeout from (et, 2*et-1] tp
[et, 2*et-1], where et is user set election timeout.

So 2*et might trigger two elections instead of one. We need to fix the test
code accordingly.

Thanks Tikv (@ngaut @siddontang @BusyJay) guys for finding this issue. We probably need to randomize etcd/raft test more.

/cc @bdarnell @heyitsanthony @gyuho 