### PR TITLE
rafthttp: fix race on peer status activeSince

### DIFF
--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -219,7 +219,7 @@ func (p *peer) attachOutgoingConn(conn *outgoingConn) {
 	}
 }
 
-func (p *peer) activeSince() time.Time { return p.status.activeSince }
+func (p *peer) activeSince() time.Time { return p.status.activeSince() }
 
 // Pause pauses the peer. The peer will simply drops all incoming
 // messages without returning an error.

--- a/rafthttp/peer_status.go
+++ b/rafthttp/peer_status.go
@@ -28,10 +28,10 @@ type failureType struct {
 }
 
 type peerStatus struct {
-	id          types.ID
-	mu          sync.Mutex // protect variables below
-	active      bool
-	activeSince time.Time
+	id     types.ID
+	mu     sync.Mutex // protect variables below
+	active bool
+	since  time.Time
 }
 
 func newPeerStatus(id types.ID) *peerStatus {
@@ -46,7 +46,7 @@ func (s *peerStatus) activate() {
 	if !s.active {
 		plog.Infof("the connection with %s became active", s.id)
 		s.active = true
-		s.activeSince = time.Now()
+		s.since = time.Now()
 	}
 }
 
@@ -58,7 +58,7 @@ func (s *peerStatus) deactivate(failure failureType, reason string) {
 		plog.Errorf(msg)
 		plog.Infof("the connection with %s became inactive", s.id)
 		s.active = false
-		s.activeSince = time.Time{}
+		s.since = time.Time{}
 		return
 	}
 	plog.Debugf(msg)
@@ -68,4 +68,10 @@ func (s *peerStatus) isActive() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.active
+}
+
+func (s *peerStatus) activeSince() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.since
 }


### PR DESCRIPTION
```
11:05:58      etcd1 | WARNING: DATA RACE
11:05:58      etcd1 | Read by
11:05:58      etcd1 | goroutine 101:
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp.(*peer).activeSince()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp/peer.go:222 +0x67
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp.(*Transport).ActiveSince()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp/transport.go:296 +0x136
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver.isConnectedSince()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver/util.go:40 +0x56
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver.(*EtcdServer).parseProposeCtxErr()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver/server.go:1258 +0x6f3
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver.(*v2apiStore).processRaftRequest()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver/v2_server.go:74 +0x708
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver.(*v2apiStore).Put()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver/v2_server.go:40 +0xa3
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver.(*EtcdServer).Do()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver/v2_server.go:118 +0x44f
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver.(*EtcdServer).publish()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver/server.go:894 +0x3ba
11:05:58      etcd1 | Previous write by goroutine 86:
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp.(*peerStatus).deactivate()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp/peer_status.go:61 +0x558
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp.(*pipeline).handle()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp/pipeline.go:97 +0x380
11:05:58      etcd1 | Goroutine 101 (running) created at:
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver.(*EtcdServer).Start()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver/server.go:447 +0x89
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain.startEtcd()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain/etcd.go:373 +0x34ec
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain.Main()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain/etcd.go:118 +0x290a
11:05:58      etcd1 |   main.main()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/main.go:28 +0x25
11:05:58      etcd1 | Goroutine 86 (running) created at:
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp.newPipeline()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp/pipeline.go:76 +0x31c
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp.startPeer()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp/peer.go:130 +0x2b0
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp.(*Transport).AddPeer()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/rafthttp/transport.go:245 +0x576
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver.NewServer()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdserver/server.go:434 +0x31f8
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain.startEtcd()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain/etcd.go:369 +0x33c9
11:05:58      etcd1 |   github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain.Main()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain/etcd.go:118 +0x290a
11:05:58      etcd1 |   main.main()
11:05:58      etcd1 |       /home/anthony/go/src/github.com/coreos/etcd/cmd/main.go:28 +0x25
```