### PR TITLE
*: bump to 3.0.0-beta.0

### DIFF
--- a/etcdserver/api/v2http/capability.go
+++ b/etcdserver/api/v2http/capability.go
@@ -38,6 +38,7 @@ var (
 		"2.1.0": {authCapability: true},
 		"2.2.0": {authCapability: true},
 		"2.3.0": {authCapability: true},
+		"3.0.0": {authCapability: true},
 	}
 
 	enableMapMu sync.Mutex

--- a/version/version.go
+++ b/version/version.go
@@ -28,8 +28,8 @@ import (
 
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
-	MinClusterVersion = "2.2.0"
-	Version           = "2.3.0+git"
+	MinClusterVersion = "2.3.0"
+	Version           = "3.0.0-beta.0"
 
 	// Git SHA Value will be set during build
 	GitSHA = "Not provided (use ./build instead of go build)"


### PR DESCRIPTION
Tested locally