### PR TITLE
pkg/types: Build a urls map from a string map

### DIFF
--- a/pkg/types/urlsmap.go
+++ b/pkg/types/urlsmap.go
@@ -40,6 +40,20 @@ func NewURLsMap(s string) (URLsMap, error) {
 	return cl, nil
 }
 
+// NewURLsMapFromStringMap takes a map of strings and returns a URLsMap. The
+// string values in the map can be multiple values separated by the sep string.
+func NewURLsMapFromStringMap(m map[string]string, sep string) (URLsMap, error) {
+	var err error
+	um := URLsMap{}
+	for k, v := range m {
+		um[k], err = NewURLs(strings.Split(v, sep))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return um, nil
+}
+
 // String turns URLsMap into discovery-formatted name-to-URLs sorted by name.
 func (c URLsMap) String() string {
 	var pairs []string

--- a/pkg/types/urlsmap_test.go
+++ b/pkg/types/urlsmap_test.go
@@ -112,3 +112,44 @@ func TestNewURLsMapIPV6(t *testing.T) {
 		t.Errorf("cluster = %#v, want %#v", c, wc)
 	}
 }
+
+func TestNewURLsMapFromStringMapEmpty(t *testing.T) {
+	mss := make(map[string]string)
+	urlsMap, err := NewURLsMapFromStringMap(mss, ",")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	s := ""
+	um, err := NewURLsMap(s)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if um.String() != urlsMap.String() {
+		t.Errorf("Expected:\n%+v\ngot:\n%+v", um, urlsMap)
+	}
+}
+
+func TestNewURLsMapFromStringMapNormal(t *testing.T) {
+	mss := make(map[string]string)
+	mss["host0"] = "http://127.0.0.1:2379,http://127.0.0.1:2380"
+	mss["host1"] = "http://127.0.0.1:2381,http://127.0.0.1:2382"
+	mss["host2"] = "http://127.0.0.1:2383,http://127.0.0.1:2384"
+	mss["host3"] = "http://127.0.0.1:2385,http://127.0.0.1:2386"
+	urlsMap, err := NewURLsMapFromStringMap(mss, ",")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	s := "host0=http://127.0.0.1:2379,host0=http://127.0.0.1:2380," +
+		"host1=http://127.0.0.1:2381,host1=http://127.0.0.1:2382," +
+		"host2=http://127.0.0.1:2383,host2=http://127.0.0.1:2384," +
+		"host3=http://127.0.0.1:2385,host3=http://127.0.0.1:2386"
+	um, err := NewURLsMap(s)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if um.String() != urlsMap.String() {
+		t.Errorf("Expected:\n%+v\ngot:\n%+v", um, urlsMap)
+	}
+}

--- a/pkg/types/urlsmap_test.go
+++ b/pkg/types/urlsmap_test.go
@@ -15,10 +15,9 @@
 package types
 
 import (
+	"github.com/coreos/etcd/pkg/testutil"
 	"reflect"
 	"testing"
-
-	"github.com/coreos/etcd/pkg/testutil"
 )
 
 func TestParseInitialCluster(t *testing.T) {


### PR DESCRIPTION
This adds a simple transformation function which is helpful when
manipulating the different etcd internal data representations.

If this is a patch you'd like upstream, let me know and I'm happy to rebase to git master if you'd like. Alternatively, I don't mind if you rebase this for me.