### PR TITLE
mvcc: Reduce number of allocs in PUT when watchableStore has no watchers.

### DIFF
--- a/mvcc/watcher_group.go
+++ b/mvcc/watcher_group.go
@@ -83,6 +83,10 @@ func (wb watcherBatch) contains(w *watcher) bool {
 // newWatcherBatch maps watchers to their matched events. It enables quick
 // events look up by watcher.
 func newWatcherBatch(wg *watcherGroup, evs []mvccpb.Event) watcherBatch {
+	if len(wg.watchers) == 0 {
+		return nil
+	}
+
 	wb := make(watcherBatch)
 	for _, ev := range evs {
 		for w := range wg.watcherSetByKey(string(ev.Kv.Key)) {


### PR DESCRIPTION
When there are no watchers the number of allocations made while handling
a PUT operation can be reduced by exiting early.