### PR TITLE
batch watcher sync to reduce request latency

### DIFF
--- a/tools/benchmark/cmd/watch_get.go
+++ b/tools/benchmark/cmd/watch_get.go
@@ -48,6 +48,7 @@ func init() {
 
 func watchGetFunc(cmd *cobra.Command, args []string) {
 	clients := mustCreateClients(totalClients, totalConns)
+	getClient := mustCreateClients(1, 1)
 
 	// setup keys for watchers
 	watchRev := int64(0)
@@ -78,7 +79,7 @@ func watchGetFunc(cmd *cobra.Command, args []string) {
 	wg.Add(len(streams))
 	ctx, cancel := context.WithCancel(context.TODO())
 	f := func() {
-		doSerializedGet(ctx, clients[0], results)
+		doSerializedGet(ctx, getClient[0], results)
 	}
 	for i := range streams {
 		go doUnsyncWatch(streams[i], watchRev, f)

--- a/tools/benchmark/cmd/watch_get.go
+++ b/tools/benchmark/cmd/watch_get.go
@@ -35,14 +35,16 @@ var watchGetCmd = &cobra.Command{
 }
 
 var (
-	watchGetTotalStreams int
-	watchEvents          int
-	firstWatch           sync.Once
+	watchGetTotalWatchers int
+	watchGetTotalStreams  int
+	watchEvents           int
+	firstWatch            sync.Once
 )
 
 func init() {
 	RootCmd.AddCommand(watchGetCmd)
-	watchGetCmd.Flags().IntVar(&watchGetTotalStreams, "watchers", 10000, "Total number of watchers")
+	watchGetCmd.Flags().IntVar(&watchGetTotalWatchers, "watchers", 10000, "Total number of watchers")
+	watchGetCmd.Flags().IntVar(&watchGetTotalStreams, "streams", 1, "Total number of watcher streams")
 	watchGetCmd.Flags().IntVar(&watchEvents, "events", 8, "Number of events per watcher")
 }
 
@@ -71,18 +73,18 @@ func watchGetFunc(cmd *cobra.Command, args []string) {
 	// results from trying to do serialized gets with concurrent watchers
 	results = make(chan result)
 
-	bar = pb.New(watchGetTotalStreams * watchEvents)
+	bar = pb.New(watchGetTotalWatchers * watchEvents)
 	bar.Format("Bom !")
 	bar.Start()
 
 	pdoneC := printReport(results)
-	wg.Add(len(streams))
+	wg.Add(watchGetTotalWatchers)
 	ctx, cancel := context.WithCancel(context.TODO())
 	f := func() {
 		doSerializedGet(ctx, getClient[0], results)
 	}
-	for i := range streams {
-		go doUnsyncWatch(streams[i], watchRev, f)
+	for i := 0; i < watchGetTotalWatchers; i++ {
+		go doUnsyncWatch(streams[i%len(streams)], watchRev, f)
 	}
 	wg.Wait()
 	cancel()


### PR DESCRIPTION
Average time for a watcher sync on my machine:
512 watchers: 4.5ms
1024 watchers: 7.0ms
10000 watchers: 36ms (but only observed a max of 5000 simultaneous watchers in one sync)

I'm still seeing occasional 100ms latencies in the benchmark, but I think it's from scheduling 10k goroutines and registering 10k watchers and not the watcher sync latency itself.