### PR TITLE
*: nightly-build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,15 @@
-FROM golang:onbuild
+FROM alpine:latest
+RUN apk update
+RUN apk --update add bash
+
+# in case we need to run functional-tester
+RUN apk --update add iptables iproute2
+
+ADD bin/etcd /usr/local/bin/
+ADD bin/etcdctl /usr/local/bin/
+RUN mkdir -p /var/etcd/
+
 EXPOSE 2379 2380
+
+# Define default command.
+CMD ["bash"]

--- a/scripts/nightly.sh
+++ b/scripts/nightly.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+REGISTRY_NAME=$1
+if [ -z "${REGISTRY_NAME}" ]; then
+	echo "Usage: ${0} REGISTRY_NAME VERSION" >> /dev/stderr
+	exit 255
+fi
+
+VERSION=$2
+if [ -z "${VERSION}" ]; then
+	echo "Usage: ${0} REGISTRY_NAME VERSION" >> /dev/stderr
+	exit 255
+fi
+
+if ! command -v docker >/dev/null; then
+    echo "cannot find docker"
+    exit 1
+fi
+
+# TODO:
+# build binaries, ACI images, and serve in Google Cloud Storage
+
+source ./build
+sudo docker build -t $REGISTRY_NAME:${VERSION} .


### PR DESCRIPTION
For https://github.com/coreos/etcd/issues/5331.

Docker images are serving at https://quay.io/repository/coreos/etcd-nightly.

Once can do:

```
sudo docker run quay.io/coreos/etcd-nightly:v2016051201 /usr/local/bin/etcd --version
sudo docker run quay.io/coreos/etcd-nightly:v2016051201 /bin/sh -c "/usr/local/bin/etcd --version"
```