### PR TITLE
*: fix protodoc, consistent casing in api doc

### DIFF
--- a/Documentation/dev-guide/api_reference_v3.md
+++ b/Documentation/dev-guide/api_reference_v3.md
@@ -39,7 +39,7 @@
 | ------ | ------------ | ------------- | ----------- |
 | Range | RangeRequest | RangeResponse | Range gets the keys in the range from the key-value store. |
 | Put | PutRequest | PutResponse | Put puts the given key into the key-value store. A put request increments the revision of the key-value store and generates one event in the event history. |
-| DeleteRange | DeleteRangeRequest | DeleteRangeResponse | Delete deletes the given range from the key-value store. A delete request increments the revision of the key-value store and generates a delete event in the event history for every deleted key. |
+| DeleteRange | DeleteRangeRequest | DeleteRangeResponse | DeleteRange deletes the given range from the key-value store. A delete request increments the revision of the key-value store and generates a delete event in the event history for every deleted key. |
 | Txn | TxnRequest | TxnResponse | Txn processes multiple requests in a single transaction. A txn request increments the revision of the key-value store and generates events with the same revision for every completed request. It is not allowed to modify the same key several times within one txn. |
 | Compact | CompactionRequest | CompactionResponse | Compact compacts the event history in the etcd key-value store. The key-value store should be periodically compacted or the event history will continue to grow indefinitely. |
 
@@ -381,7 +381,7 @@ Empty field.
 | Field | Description | Type |
 | ----- | ----------- | ---- |
 | header |  | ResponseHeader |
-| deleted | Deleted is the number of keys deleted by the delete range request. | int64 |
+| deleted | deleted is the number of keys deleted by the delete range request. | int64 |
 
 
 
@@ -646,7 +646,7 @@ From google paxosdb paper: Our implementation hinges around a powerful primitive
 
 | Field | Description | Type |
 | ----- | ----------- | ---- |
-| compare | Compare is a list of predicates representing a conjunction of terms. If the comparisons succeed, then the success requests will be processed in order, and the response will contain their respective responses in order. If the comparisons fail, then the failure requests will be processed in order, and the response will contain their respective responses in order. | (slice of) Compare |
+| compare | compare is a list of predicates representing a conjunction of terms. If the comparisons succeed, then the success requests will be processed in order, and the response will contain their respective responses in order. If the comparisons fail, then the failure requests will be processed in order, and the response will contain their respective responses in order. | (slice of) Compare |
 | success | success is a list of requests which will be applied when compare evaluates to true. | (slice of) RequestUnion |
 | failure | failure is a list of requests which will be applied when compare evaluates to false. | (slice of) RequestUnion |
 

--- a/etcdserver/etcdserverpb/rpc.pb.go
+++ b/etcdserver/etcdserverpb/rpc.pb.go
@@ -300,7 +300,7 @@ func (*DeleteRangeRequest) Descriptor() ([]byte, []int) { return fileDescriptorR
 
 type DeleteRangeResponse struct {
 	Header *ResponseHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
-	// Deleted is the number of keys deleted by the delete range request.
+	// deleted is the number of keys deleted by the delete range request.
 	Deleted int64 `protobuf:"varint,2,opt,name=deleted,proto3" json:"deleted,omitempty"`
 }
 
@@ -816,7 +816,7 @@ func _Compare_OneofSizer(msg proto.Message) (n int) {
 // true.
 // 3. A list of database operations called f op. Like t op, but executed if guard evaluates to false.
 type TxnRequest struct {
-	// Compare is a list of predicates representing a conjunction of terms.
+	// compare is a list of predicates representing a conjunction of terms.
 	// If the comparisons succeed, then the success requests will be processed in order,
 	// and the response will contain their respective responses in order.
 	// If the comparisons fail, then the failure requests will be processed in order,
@@ -1975,7 +1975,7 @@ type KVClient interface {
 	// A put request increments the revision of the key-value store
 	// and generates one event in the event history.
 	Put(ctx context.Context, in *PutRequest, opts ...grpc.CallOption) (*PutResponse, error)
-	// Delete deletes the given range from the key-value store.
+	// DeleteRange deletes the given range from the key-value store.
 	// A delete request increments the revision of the key-value store
 	// and generates a delete event in the event history for every deleted key.
 	DeleteRange(ctx context.Context, in *DeleteRangeRequest, opts ...grpc.CallOption) (*DeleteRangeResponse, error)
@@ -2052,7 +2052,7 @@ type KVServer interface {
 	// A put request increments the revision of the key-value store
 	// and generates one event in the event history.
 	Put(context.Context, *PutRequest) (*PutResponse, error)
-	// Delete deletes the given range from the key-value store.
+	// DeleteRange deletes the given range from the key-value store.
 	// A delete request increments the revision of the key-value store
 	// and generates a delete event in the event history for every deleted key.
 	DeleteRange(context.Context, *DeleteRangeRequest) (*DeleteRangeResponse, error)

--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -17,7 +17,7 @@ service KV {
   // and generates one event in the event history.
   rpc Put(PutRequest) returns (PutResponse) {}
 
-  // Delete deletes the given range from the key-value store.
+  // DeleteRange deletes the given range from the key-value store.
   // A delete request increments the revision of the key-value store
   // and generates a delete event in the event history for every deleted key.
   rpc DeleteRange(DeleteRangeRequest) returns (DeleteRangeResponse) {}
@@ -222,7 +222,7 @@ message DeleteRangeRequest {
 
 message DeleteRangeResponse {
   ResponseHeader header = 1;
-  // Deleted is the number of keys deleted by the delete range request.
+  // deleted is the number of keys deleted by the delete range request.
   int64 deleted = 2;
 }
 
@@ -290,7 +290,7 @@ message Compare {
 // true.
 // 3. A list of database operations called f op. Like t op, but executed if guard evaluates to false.
 message TxnRequest {
-  // Compare is a list of predicates representing a conjunction of terms.
+  // compare is a list of predicates representing a conjunction of terms.
   // If the comparisons succeed, then the success requests will be processed in order,
   // and the response will contain their respective responses in order.
   // If the comparisons fail, then the failure requests will be processed in order,

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -67,7 +67,7 @@ done
 if [ "$1" = "-g" ]; then
 	echo "protodoc is auto-generating grpc API reference documentation..."
 	go get -v -u github.com/coreos/protodoc
-	SHA_PROTODOC="58fed2ed069a962509b782b25f48d3e05146c3d9"
+	SHA_PROTODOC="150f6f93d89aedb208f443d38f50bb03abbc9290"
 	PROTODOC_PATH="${GOPATH}/src/github.com/coreos/protodoc"
 	pushd "${PROTODOC_PATH}"
 		git reset --hard "${SHA_PROTODOC}"


### PR DESCRIPTION
There was a bug in protodoc.
This changes git SHA to use the latest protodoc.
And make the letter casing consistent with original
Protocol Buffer. Go capitalizes the member variables,
but the protocol buffer documentation should be same as
original proto files.