### PR TITLE
integration: remove parallel testing

### DIFF
--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -111,9 +111,6 @@ func TestKVPut(t *testing.T) {
 }
 
 func TestKVPutWithRequireLeader(t *testing.T) {
-	// this test might block for a few seconds, make it parallel to speed up the test.
-	t.Parallel()
-
 	defer testutil.AfterTest(t)
 
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
@@ -576,7 +573,6 @@ func TestKVGetCancel(t *testing.T) {
 
 // TestKVPutStoppedServerAndClose ensures closing after a failed Put works.
 func TestKVPutStoppedServerAndClose(t *testing.T) {
-	t.Parallel()
 	defer testutil.AfterTest(t)
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)

--- a/integration/v3_grpc_test.go
+++ b/integration/v3_grpc_test.go
@@ -78,9 +78,6 @@ func TestV3PutOverwrite(t *testing.T) {
 
 // TestPutRestart checks if a put after an unrelated member restart succeeds
 func TestV3PutRestart(t *testing.T) {
-	// this test might block for 5 seconds, make it parallel to speed up the test.
-	t.Parallel()
-
 	defer testutil.AfterTest(t)
 	clus := NewClusterV3(t, &ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
@@ -979,8 +976,6 @@ func TestTLSGRPCAcceptSecureAll(t *testing.T) {
 }
 
 func TestGRPCRequireLeader(t *testing.T) {
-	t.Parallel()
-
 	defer testutil.AfterTest(t)
 
 	cfg := ClusterConfig{Size: 3}
@@ -1008,8 +1003,6 @@ func TestGRPCRequireLeader(t *testing.T) {
 }
 
 func TestGRPCStreamRequireLeader(t *testing.T) {
-	t.Parallel()
-
 	defer testutil.AfterTest(t)
 
 	cfg := ClusterConfig{Size: 3}


### PR DESCRIPTION
Fix #5346

We cannot do testing in parallel since leak testing will detect the goroutines
in other tests running in parallel.