### PR TITLE
test: fix wait on integration tests

### DIFF
--- a/test
+++ b/test
@@ -66,7 +66,7 @@ function integration_tests {
 	go test -timeout 10m -v -cpu 1,2,4 $@ ${REPO_PATH}/e2e &
 	e2epid="$!"
 	go test -timeout 15m -v -cpu 1,2,4 $@ ${REPO_PATH}/integration &
-	intpid="$1"
+	intpid="$!"
 	wait $e2epid
 	wait $intpid
 	go test -timeout 10m -v ${RACE} -cpu 1,2,4 $@ ${REPO_PATH}/clientv3/integration


### PR DESCRIPTION
Typo was causing failed tests to look like they passed on CI.

Cf. https://semaphoreci.com/coreos/etcd/branches/pull-request-5353/builds/6