### PR TITLE
scripts: pass -u to go get in genproto.sh

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -38,8 +38,8 @@ ln -s "${PWD}" "${ETCD_ROOT}"
 
 # Ensure we have the right version of protoc-gen-gogo by building it every time.
 # TODO(jonboulle): vendor this instead of `go get`ting it.
-go get github.com/gogo/protobuf/{proto,protoc-gen-gogo,gogoproto}
-go get golang.org/x/tools/cmd/goimports
+go get -u github.com/gogo/protobuf/{proto,protoc-gen-gogo,gogoproto}
+go get -u golang.org/x/tools/cmd/goimports
 pushd "${GOGOPROTO_ROOT}"
 	git reset --hard "${SHA}"
 	make install


### PR DESCRIPTION
Current genproto.sh doesn't pass -u option to go get. It is
problematic because the script depends on a specific version of
gogoproto. Actually it causes build error if a repository already have
an old version of gogoproto that doesn't have a specified commit
($SHA). This commit lets the script pass -u to go get for avoid the
error.