### PR TITLE
e2e: wait for member publishing after backup

### DIFF
--- a/e2e/ctl_v2_test.go
+++ b/e2e/ctl_v2_test.go
@@ -257,6 +257,10 @@ func TestCtlV2Backup(t *testing.T) { // For https://github.com/coreos/etcd/issue
 	cfg2.forceNewCluster = true
 	epc2 := setupEtcdctlTest(t, &cfg2, false)
 
+	if _, err := epc2.procs[0].proc.Expect("etcdserver: published"); err != nil {
+		t.Fatal(err)
+	}
+
 	// check if backup went through correctly
 	if err := etcdctlGet(epc2, "foo1", "bar", false); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When the cluster restarts from the backup directory, I see these logs:

```
2016-05-17 21:11:15.739562 N | etcdserver: removed member ca50e9357181d758 from cluster 54c20f5a9e02
2016-05-17 21:11:15.739942 E | rafthttp: failed to find member 54c20f5a9e01 in cluster 54c20f5a9e02
2016-05-17 21:11:15.739994 N | etcdserver: added local member 54c20f5a9e01 [http://localhost:2380] to cluster 54c20f5a9e02
2016-05-17 21:11:15.740218 E | rafthttp: failed to find member 54c20f5a9e01 in cluster 54c20f5a9e02
2016-05-17 21:11:16.224333 I | v2http: enabled capabilities for version 3.0.0
2016-05-17 21:11:17.600602 I | raft: 54c20f5a9e01 is starting a new election at term 2
2016-05-17 21:11:17.600682 I | raft: 54c20f5a9e01 became candidate at term 3
2016-05-17 21:11:17.600688 I | raft: 54c20f5a9e01 received vote from 54c20f5a9e01 at term 3
2016-05-17 21:11:17.600729 I | raft: 54c20f5a9e01 became leader at term 3
```

@xiang90 Is this expected that the cluster fails to recognize the member first?