### PR TITLE
integration: call waitLeader() before sending requests in TestIssue2746

### DIFF
--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -246,6 +246,7 @@ func testIssue2746(t *testing.T, members int) {
 	}
 
 	c.Launch(t)
+	c.waitLeader(t, c.Members)
 	defer c.Terminate(t)
 
 	// force a snapshot


### PR DESCRIPTION
Because of leader absence, TestIssue2746 fails occasionally. For
fixing the problem, this commit lets the test call waitLeader() before
sending requests.

The test failure is fixed partially. It is because the campaign can
happen during testing (not initialization phase). For handling it,
we would need to let clients retry the request.

Partially fixes https://github.com/coreos/etcd/issues/5022