### PR TITLE
doc: fix https omission in documentation.

### DIFF
--- a/Documentation/op-guide/clustering.md
+++ b/Documentation/op-guide/clustering.md
@@ -129,7 +129,7 @@ If the cluster needs encrypted communication but does not require authenticated 
 On each machine, etcd would be started with these flag:
 
 ```
-$ etcd --name infra0 --initial-advertise-peer-urls http://10.0.1.10:2380 \
+$ etcd --name infra0 --initial-advertise-peer-urls https://10.0.1.10:2380 \
   --listen-peer-urls https://10.0.1.10:2380 \
   --listen-client-urls https://10.0.1.10:2379,https://127.0.0.1:2379 \
   --advertise-client-urls https://10.0.1.10:2379 \


### PR DESCRIPTION
Documentation: added missing (http)s to tls setup guide

This fixes a minor documentation typo, where the 1st initial-advertise-peer-url for tls setup appears to be http.

fixes documentation