### PR TITLE
test: remove a directory correctly

### DIFF
--- a/test
+++ b/test
@@ -22,7 +22,7 @@ source ./build
 
 # Set up gopath so tests use vendored dependencies
 export GOPATH=${PWD}/gopath
-rm -f $GOPATH/src
+rm -rf $GOPATH/src
 mkdir -p $GOPATH
 ln -s ${PWD}/cmd/vendor $GOPATH/src
 


### PR DESCRIPTION
Current rm in the test script cannot the gopath/src correctly and
results test failure.