### PR TITLE
[WIP] Add initial OpenTracing instrumentation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -442,7 +442,6 @@ type simpleHTTPClient struct {
 
 func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Response, []byte, error) {
 	req := act.HTTPRequest(c.endpoint)
-
 	if err := printcURL(req); err != nil {
 		return nil, nil, err
 	}

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -125,6 +125,14 @@ type config struct {
 	ProxyReadTimeoutMs     uint   `json:"proxy-read-timeout"`
 	ProxyCfgFile           string `json:"proxy"`
 
+	// tracing
+	TracingLightstepToken      string `json:"tracing-lightstep-token"`
+	TracingLightstepHost       string `json:"tracing-lighstep-host"`
+	TracingLightstepCollector  string `json:"tracing-lighstep-collector"`
+	TracingAppdashHost         string `json:"tracing-appdash-host"`
+	TracingAppdashVerbose      bool   `json:"tracing-appdash-verbose"`
+	TracingAppdashSamplingRate uint64 `json:"tracing-appdash-sampling-rate"`
+
 	// security
 	clientTLSInfo, peerTLSInfo transport.TLSInfo
 	ClientAutoTLS              bool
@@ -249,6 +257,14 @@ func NewConfig() *config {
 	// logging
 	fs.BoolVar(&cfg.Debug, "debug", false, "Enable debug-level logging for etcd.")
 	fs.StringVar(&cfg.LogPkgLevels, "log-package-levels", "", "Specify a particular log level for each etcd package (eg: 'etcdmain=CRITICAL,etcdserver=DEBUG').")
+
+	// tracing
+	fs.StringVar(&cfg.TracingLightstepToken, "tracing-lightstep-token", "", "Lightstep access token")
+	fs.StringVar(&cfg.TracingLightstepHost, "tracing-lightstep-host", "", "Lightstep API host")
+	fs.StringVar(&cfg.TracingLightstepCollector, "tracing-lightstep-collector", "", "Lightstep collector host")
+	fs.StringVar(&cfg.TracingAppdashHost, "tracing-appdash-host", "", "Appdash remote collector address (host:port)")
+	fs.Uint64Var(&cfg.TracingAppdashSamplingRate, "tracing-appdash-sampling-rate", 128, "Trace sampling rate for Appdash")
+	fs.BoolVar(&cfg.TracingAppdashVerbose, "tracing-appdash-verbose", false, "Enable verbose logging for Appdash")
 
 	// unsafe
 	fs.BoolVar(&cfg.ForceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster.")

--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -36,6 +36,7 @@ import (
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/etcdserver/membership"
 	"github.com/coreos/etcd/etcdserver/stats"
+	"github.com/coreos/etcd/pkg/httputil"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/store"
@@ -208,6 +209,8 @@ type membersHandler struct {
 }
 
 func (h *membersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sp := httputil.JoinOrCreateSpanFromHeader("membershandler/ServeHTTP", r.Header)
+	defer sp.Finish()
 	if !allowMethod(w, r.Method, "GET", "POST", "DELETE", "PUT") {
 		return
 	}

--- a/etcdserver/api/v3rpc/auth.go
+++ b/etcdserver/api/v3rpc/auth.go
@@ -29,6 +29,8 @@ func NewAuthServer(s *etcdserver.EtcdServer) *AuthServer {
 }
 
 func (as *AuthServer) AuthEnable(ctx context.Context, r *pb.AuthEnableRequest) (*pb.AuthEnableResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/AuthEnable")
+	defer sp.Finish()
 	resp, err := as.authenticator.AuthEnable(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -37,6 +39,8 @@ func (as *AuthServer) AuthEnable(ctx context.Context, r *pb.AuthEnableRequest) (
 }
 
 func (as *AuthServer) AuthDisable(ctx context.Context, r *pb.AuthDisableRequest) (*pb.AuthDisableResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/AuthDisable")
+	defer sp.Finish()
 	resp, err := as.authenticator.AuthDisable(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -45,6 +49,8 @@ func (as *AuthServer) AuthDisable(ctx context.Context, r *pb.AuthDisableRequest)
 }
 
 func (as *AuthServer) Authenticate(ctx context.Context, r *pb.AuthenticateRequest) (*pb.AuthenticateResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/Authenticate")
+	defer sp.Finish()
 	resp, err := as.authenticator.Authenticate(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -53,6 +59,8 @@ func (as *AuthServer) Authenticate(ctx context.Context, r *pb.AuthenticateReques
 }
 
 func (as *AuthServer) RoleAdd(ctx context.Context, r *pb.AuthRoleAddRequest) (*pb.AuthRoleAddResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/RoleAdd")
+	defer sp.Finish()
 	resp, err := as.authenticator.RoleAdd(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -76,6 +84,8 @@ func (as *AuthServer) RoleRevoke(ctx context.Context, r *pb.AuthRoleRevokeReques
 }
 
 func (as *AuthServer) RoleGrant(ctx context.Context, r *pb.AuthRoleGrantRequest) (*pb.AuthRoleGrantResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/RoleGrant")
+	defer sp.Finish()
 	resp, err := as.authenticator.RoleGrant(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -84,6 +94,8 @@ func (as *AuthServer) RoleGrant(ctx context.Context, r *pb.AuthRoleGrantRequest)
 }
 
 func (as *AuthServer) UserAdd(ctx context.Context, r *pb.AuthUserAddRequest) (*pb.AuthUserAddResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/UserAdd")
+	defer sp.Finish()
 	resp, err := as.authenticator.UserAdd(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -92,6 +104,8 @@ func (as *AuthServer) UserAdd(ctx context.Context, r *pb.AuthUserAddRequest) (*p
 }
 
 func (as *AuthServer) UserDelete(ctx context.Context, r *pb.AuthUserDeleteRequest) (*pb.AuthUserDeleteResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/UserDelete")
+	defer sp.Finish()
 	resp, err := as.authenticator.UserDelete(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -105,6 +119,8 @@ func (as *AuthServer) UserGet(ctx context.Context, r *pb.AuthUserGetRequest) (*p
 }
 
 func (as *AuthServer) UserGrant(ctx context.Context, r *pb.AuthUserGrantRequest) (*pb.AuthUserGrantResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/UserGrant")
+	defer sp.Finish()
 	resp, err := as.authenticator.UserGrant(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -118,6 +134,8 @@ func (as *AuthServer) UserRevoke(ctx context.Context, r *pb.AuthUserRevokeReques
 }
 
 func (as *AuthServer) UserChangePassword(ctx context.Context, r *pb.AuthUserChangePasswordRequest) (*pb.AuthUserChangePasswordResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "authserver/UserChangePassword")
+	defer sp.Finish()
 	resp, err := as.authenticator.UserChangePassword(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)

--- a/etcdserver/api/v3rpc/grpc.go
+++ b/etcdserver/api/v3rpc/grpc.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/coreos/etcd/etcdserver"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -32,7 +33,7 @@ func Server(s *etcdserver.EtcdServer, tls *tls.Config) *grpc.Server {
 	opts = append(opts, grpc.StreamInterceptor(newStreamInterceptor(s)))
 
 	grpcServer := grpc.NewServer(opts...)
-	pb.RegisterKVServer(grpcServer, NewQuotaKVServer(s))
+	pb.RegisterKVServer(grpcServer, NewTracedKVServer(opentracing.GlobalTracer(), NewQuotaKVServer(s)))
 	pb.RegisterWatchServer(grpcServer, NewWatchServer(s))
 	pb.RegisterLeaseServer(grpcServer, NewQuotaLeaseServer(s))
 	pb.RegisterClusterServer(grpcServer, NewClusterServer(s))

--- a/etcdserver/api/v3rpc/key.go
+++ b/etcdserver/api/v3rpc/key.go
@@ -18,10 +18,14 @@ package v3rpc
 import (
 	"sort"
 
+	"google.golang.org/grpc/metadata"
+
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/etcd/pkg/pbutil"
 	"github.com/coreos/pkg/capnslog"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
 
@@ -43,6 +47,9 @@ func NewKVServer(s *etcdserver.EtcdServer) pb.KVServer {
 }
 
 func (s *kvServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeResponse, error) {
+	var sp opentracing.Span
+	var err error
+	defer sp.Finish()
 	if err := checkRangeRequest(r); err != nil {
 		return nil, err
 	}
@@ -60,6 +67,8 @@ func (s *kvServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeResp
 }
 
 func (s *kvServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/Range")
+	defer sp.Finish()
 	if err := checkPutRequest(r); err != nil {
 		return nil, err
 	}
@@ -77,6 +86,8 @@ func (s *kvServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, 
 }
 
 func (s *kvServer) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/Range")
+	defer sp.Finish()
 	if err := checkDeleteRequest(r); err != nil {
 		return nil, err
 	}
@@ -94,6 +105,8 @@ func (s *kvServer) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) (*
 }
 
 func (s *kvServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/Range")
+	defer sp.Finish()
 	if err := checkTxnRequest(r); err != nil {
 		return nil, err
 	}
@@ -111,6 +124,8 @@ func (s *kvServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse, 
 }
 
 func (s *kvServer) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.CompactionResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/Range")
+	defer sp.Finish()
 	resp, err := s.kv.Compact(ctx, r)
 	if err != nil {
 		return nil, togRPCError(err)
@@ -250,4 +265,19 @@ func checkRequestUnion(u *pb.RequestUnion) error {
 		return nil
 	}
 	return nil
+}
+
+func startSpanFromMetadata(ctx context.Context, operationName string) (opentracing.Span, context.Context) {
+	md, ok := metadata.FromContext(ctx)
+	if ok {
+		sp, err := opentracing.GlobalTracer().Join(operationName, opentracing.TextMap, pbutil.MetadataReaderWriter{&md})
+		if err != nil {
+			plog.Warningf("Couldn't join trace %v", err)
+			return opentracing.StartSpanFromContext(ctx, operationName)
+		} else {
+			return sp, opentracing.ContextWithSpan(ctx, sp)
+		}
+	}
+	plog.Infof("Couldn't find metadata")
+	return opentracing.StartSpanFromContext(ctx, operationName)
 }

--- a/etcdserver/api/v3rpc/member.go
+++ b/etcdserver/api/v3rpc/member.go
@@ -23,6 +23,7 @@ import (
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/etcdserver/membership"
 	"github.com/coreos/etcd/pkg/types"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -43,6 +44,9 @@ func NewClusterServer(s *etcdserver.EtcdServer) *ClusterServer {
 }
 
 func (cs *ClusterServer) MemberAdd(ctx context.Context, r *pb.MemberAddRequest) (*pb.MemberAddResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "clusterserver/MemberAdd")
+	defer sp.Finish()
+
 	urls, err := types.NewURLs(r.PeerURLs)
 	if err != nil {
 		return nil, rpctypes.ErrGRPCMemberBadURLs
@@ -67,6 +71,9 @@ func (cs *ClusterServer) MemberAdd(ctx context.Context, r *pb.MemberAddRequest) 
 }
 
 func (cs *ClusterServer) MemberRemove(ctx context.Context, r *pb.MemberRemoveRequest) (*pb.MemberRemoveResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "clusterserver/MemberRemove")
+	defer sp.Finish()
+
 	err := cs.server.RemoveMember(ctx, r.ID)
 	switch {
 	case err == membership.ErrIDRemoved:
@@ -81,6 +88,9 @@ func (cs *ClusterServer) MemberRemove(ctx context.Context, r *pb.MemberRemoveReq
 }
 
 func (cs *ClusterServer) MemberUpdate(ctx context.Context, r *pb.MemberUpdateRequest) (*pb.MemberUpdateResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "clusterserver/MemberUpdate")
+	defer sp.Finish()
+
 	m := membership.Member{
 		ID:             types.ID(r.ID),
 		RaftAttributes: membership.RaftAttributes{PeerURLs: r.PeerURLs},
@@ -99,6 +109,9 @@ func (cs *ClusterServer) MemberUpdate(ctx context.Context, r *pb.MemberUpdateReq
 }
 
 func (cs *ClusterServer) MemberList(ctx context.Context, r *pb.MemberListRequest) (*pb.MemberListResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "clusterserver/MemberList")
+	defer sp.Finish()
+
 	membs := cs.cluster.Members()
 
 	protoMembs := make([]*pb.Member, len(membs))

--- a/etcdserver/api/v3rpc/tracing.go
+++ b/etcdserver/api/v3rpc/tracing.go
@@ -1,0 +1,86 @@
+package v3rpc
+
+import (
+	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/etcd/pkg/pbutil"
+	"github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/metadata"
+)
+
+type tracedKVServer struct {
+	pb.KVServer
+	tracer opentracing.Tracer
+}
+
+func NewTracedKVServer(tracer opentracing.Tracer, kv pb.KVServer) pb.KVServer {
+	return &tracedKVServer{
+		KVServer: kv,
+		tracer:   tracer,
+	}
+}
+
+func (t *tracedKVServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/Range")
+	defer sp.Finish()
+	return t.KVServer.Range(ctx, r)
+}
+
+func (t *tracedKVServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/Put")
+	defer sp.Finish()
+
+	return t.KVServer.Put(ctx, r)
+}
+
+func (t *tracedKVServer) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/DeleteRange")
+	defer sp.Finish()
+
+	return t.KVServer.DeleteRange(ctx, r)
+}
+
+func (t *tracedKVServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/DeleteRange")
+	defer sp.Finish()
+
+	return t.KVServer.Txn(ctx, r)
+}
+
+// Compact compacts the event history in the etcd key-value store. The key-value
+// store should be periodically compacted or the event history will continue to grow
+// indefinitely.
+func (t *tracedKVServer) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.CompactionResponse, error) {
+	sp, ctx := startSpanFromMetadata(ctx, "kvServer/v3/Compact")
+	defer sp.Finish()
+
+	return t.KVServer.Compact(ctx, r)
+}
+
+func (t *tracedKVServer) startSpanFromMetadata(ctx context.Context, operationName string) (opentracing.Span, context.Context) {
+	md, ok := metadata.FromContext(ctx)
+	if ok {
+		sp, err := t.tracer.Join(operationName, opentracing.TextMap, pbutil.MetadataReaderWriter{&md})
+		if err != nil {
+			plog.Warningf("Couldn't join trace %v", err)
+			sp = t.tracer.StartSpan(operationName)
+		}
+		return sp, opentracing.ContextWithSpan(ctx, sp)
+	}
+	sp := t.tracer.StartSpan(operationName)
+	return sp, opentracing.ContextWithSpan(ctx, sp)
+}
+
+func startSpanFromMetadata(ctx context.Context, operationName string) (opentracing.Span, context.Context) {
+	md, ok := metadata.FromContext(ctx)
+	if ok {
+		sp, err := opentracing.GlobalTracer().Join(operationName, opentracing.TextMap, pbutil.MetadataReaderWriter{&md})
+		if err != nil {
+			plog.Warningf("Couldn't join trace %v", err)
+			sp = opentracing.StartSpan(operationName)
+		}
+		return sp, opentracing.ContextWithSpan(ctx, sp)
+	}
+	sp := opentracing.StartSpan(operationName)
+	return sp, opentracing.ContextWithSpan(ctx, sp)
+}

--- a/etcdserver/v2_server.go
+++ b/etcdserver/v2_server.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
 
@@ -33,22 +34,32 @@ type v2API interface {
 type v2apiStore struct{ s *EtcdServer }
 
 func (a *v2apiStore) Post(ctx context.Context, r *pb.Request) (Response, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "v2apiStore/Post")
+	defer sp.Finish()
 	return a.processRaftRequest(ctx, r)
 }
 
 func (a *v2apiStore) Put(ctx context.Context, r *pb.Request) (Response, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "v2apiStore/Put")
+	defer sp.Finish()
 	return a.processRaftRequest(ctx, r)
 }
 
 func (a *v2apiStore) Delete(ctx context.Context, r *pb.Request) (Response, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "v2apiStore/Delete")
+	defer sp.Finish()
 	return a.processRaftRequest(ctx, r)
 }
 
 func (a *v2apiStore) QGet(ctx context.Context, r *pb.Request) (Response, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "v2apiStore/QGet")
+	defer sp.Finish()
 	return a.processRaftRequest(ctx, r)
 }
 
 func (a *v2apiStore) processRaftRequest(ctx context.Context, r *pb.Request) (Response, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "v2apiStore/processRaftRequest")
+	defer sp.Finish()
 	data, err := r.Marshal()
 	if err != nil {
 		return Response{}, err
@@ -78,6 +89,8 @@ func (a *v2apiStore) processRaftRequest(ctx context.Context, r *pb.Request) (Res
 }
 
 func (a *v2apiStore) Get(ctx context.Context, r *pb.Request) (Response, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "v2apiStore/Get")
+	defer sp.Finish()
 	if r.Wait {
 		wc, err := a.s.store.Watch(r.Path, r.Recursive, r.Stream, r.Since)
 		if err != nil {
@@ -93,6 +106,9 @@ func (a *v2apiStore) Get(ctx context.Context, r *pb.Request) (Response, error) {
 }
 
 func (a *v2apiStore) Head(ctx context.Context, r *pb.Request) (Response, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "v2apiStore/Post")
+	defer sp.Finish()
+
 	ev, err := a.s.store.Get(r.Path, r.Recursive, r.Sorted)
 	if err != nil {
 		return Response{}, err
@@ -106,6 +122,8 @@ func (a *v2apiStore) Head(ctx context.Context, r *pb.Request) (Response, error) 
 // respective operation. Do will block until an action is performed or there is
 // an error.
 func (s *EtcdServer) Do(ctx context.Context, r pb.Request) (Response, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/Do")
+	defer sp.Finish()
 	r.ID = s.reqIDGen.Next()
 	if r.Method == "GET" && r.Quorum {
 		r.Method = "QGET"

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coreos/etcd/lease"
 	"github.com/coreos/etcd/lease/leasehttp"
 	"github.com/coreos/etcd/mvcc"
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
 
@@ -67,6 +68,8 @@ type Authenticator interface {
 }
 
 func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/Range")
+	defer sp.Finish()
 	if r.Serializable {
 		return s.applyV3.Range(noTxn, r)
 	}
@@ -79,6 +82,9 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 }
 
 func (s *EtcdServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/Put")
+	defer sp.Finish()
+
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{Put: r})
 	if err != nil {
 		return nil, err
@@ -87,6 +93,9 @@ func (s *EtcdServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse
 }
 
 func (s *EtcdServer) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/DeleteRange")
+	defer sp.Finish()
+
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{DeleteRange: r})
 	if err != nil {
 		return nil, err
@@ -95,6 +104,9 @@ func (s *EtcdServer) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) 
 }
 
 func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/Txn")
+	defer sp.Finish()
+
 	if isTxnSerializable(r) {
 		return s.applyV3.Txn(r)
 	}
@@ -121,6 +133,9 @@ func isTxnSerializable(r *pb.TxnRequest) bool {
 }
 
 func (s *EtcdServer) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.CompactionResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/Compact")
+	defer sp.Finish()
+
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{Compaction: r})
 	if r.Physical && result != nil && result.physc != nil {
 		<-result.physc
@@ -146,6 +161,8 @@ func (s *EtcdServer) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.
 }
 
 func (s *EtcdServer) LeaseGrant(ctx context.Context, r *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/LeaseGrant")
+	defer sp.Finish()
 	// no id given? choose one
 	for r.ID == int64(lease.NoLease) {
 		// only use positive int64 id's
@@ -159,6 +176,8 @@ func (s *EtcdServer) LeaseGrant(ctx context.Context, r *pb.LeaseGrantRequest) (*
 }
 
 func (s *EtcdServer) LeaseRevoke(ctx context.Context, r *pb.LeaseRevokeRequest) (*pb.LeaseRevokeResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/LeaseRevoke")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{LeaseRevoke: r})
 	if err != nil {
 		return nil, err
@@ -202,6 +221,8 @@ func (s *EtcdServer) LeaseRenew(id lease.LeaseID) (int64, error) {
 }
 
 func (s *EtcdServer) Alarm(ctx context.Context, r *pb.AlarmRequest) (*pb.AlarmResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/Alarm")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{Alarm: r})
 	if err != nil {
 		return nil, err
@@ -210,6 +231,8 @@ func (s *EtcdServer) Alarm(ctx context.Context, r *pb.AlarmRequest) (*pb.AlarmRe
 }
 
 func (s *EtcdServer) AuthEnable(ctx context.Context, r *pb.AuthEnableRequest) (*pb.AuthEnableResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/AuthEnable")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{AuthEnable: r})
 	if err != nil {
 		return nil, err
@@ -218,6 +241,8 @@ func (s *EtcdServer) AuthEnable(ctx context.Context, r *pb.AuthEnableRequest) (*
 }
 
 func (s *EtcdServer) AuthDisable(ctx context.Context, r *pb.AuthDisableRequest) (*pb.AuthDisableResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/Authenticate")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{AuthDisable: r})
 	if err != nil {
 		return nil, err
@@ -226,6 +251,8 @@ func (s *EtcdServer) AuthDisable(ctx context.Context, r *pb.AuthDisableRequest) 
 }
 
 func (s *EtcdServer) Authenticate(ctx context.Context, r *pb.AuthenticateRequest) (*pb.AuthenticateResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/Authenticate")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{Authenticate: r})
 	if err != nil {
 		return nil, err
@@ -234,6 +261,8 @@ func (s *EtcdServer) Authenticate(ctx context.Context, r *pb.AuthenticateRequest
 }
 
 func (s *EtcdServer) UserAdd(ctx context.Context, r *pb.AuthUserAddRequest) (*pb.AuthUserAddResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/UserAdd")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{AuthUserAdd: r})
 	if err != nil {
 		return nil, err
@@ -242,6 +271,8 @@ func (s *EtcdServer) UserAdd(ctx context.Context, r *pb.AuthUserAddRequest) (*pb
 }
 
 func (s *EtcdServer) UserDelete(ctx context.Context, r *pb.AuthUserDeleteRequest) (*pb.AuthUserDeleteResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/UserDelete")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{AuthUserDelete: r})
 	if err != nil {
 		return nil, err
@@ -250,6 +281,8 @@ func (s *EtcdServer) UserDelete(ctx context.Context, r *pb.AuthUserDeleteRequest
 }
 
 func (s *EtcdServer) UserChangePassword(ctx context.Context, r *pb.AuthUserChangePasswordRequest) (*pb.AuthUserChangePasswordResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/UserChangePassword")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{AuthUserChangePassword: r})
 	if err != nil {
 		return nil, err
@@ -258,6 +291,8 @@ func (s *EtcdServer) UserChangePassword(ctx context.Context, r *pb.AuthUserChang
 }
 
 func (s *EtcdServer) UserGrant(ctx context.Context, r *pb.AuthUserGrantRequest) (*pb.AuthUserGrantResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/UserGrant")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{AuthUserGrant: r})
 	if err != nil {
 		return nil, err
@@ -266,6 +301,8 @@ func (s *EtcdServer) UserGrant(ctx context.Context, r *pb.AuthUserGrantRequest) 
 }
 
 func (s *EtcdServer) RoleAdd(ctx context.Context, r *pb.AuthRoleAddRequest) (*pb.AuthRoleAddResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/RoleAdd")
+	defer sp.Finish()
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{AuthRoleAdd: r})
 	if err != nil {
 		return nil, err
@@ -274,6 +311,9 @@ func (s *EtcdServer) RoleAdd(ctx context.Context, r *pb.AuthRoleAddRequest) (*pb
 }
 
 func (s *EtcdServer) RoleGrant(ctx context.Context, r *pb.AuthRoleGrantRequest) (*pb.AuthRoleGrantResponse, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/RoleGrant")
+	defer sp.Finish()
+
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{AuthRoleGrant: r})
 	if err != nil {
 		return nil, err
@@ -282,6 +322,8 @@ func (s *EtcdServer) RoleGrant(ctx context.Context, r *pb.AuthRoleGrantRequest) 
 }
 
 func (s *EtcdServer) processInternalRaftRequest(ctx context.Context, r pb.InternalRaftRequest) (*applyResult, error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "etcdserver/processInternalRaftRequest")
+	defer sp.Finish()
 	r.ID = s.reqIDGen.Next()
 
 	data, err := r.Marshal()

--- a/proxy/httpproxy/reverse.go
+++ b/proxy/httpproxy/reverse.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coreos/etcd/etcdserver/api/v2http/httptypes"
 	"github.com/coreos/etcd/pkg/httputil"
 	"github.com/coreos/pkg/capnslog"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 var (
@@ -63,6 +64,8 @@ type reverseProxy struct {
 }
 
 func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request) {
+	sp := httputil.JoinOrCreateSpanFromHeader("reverse-proxy", clientreq.Header)
+	defer sp.Finish()
 	reportIncomingRequest(clientreq)
 	proxyreq := new(http.Request)
 	*proxyreq = *clientreq
@@ -89,6 +92,10 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 	proxyreq.Header = make(http.Header)
 	copyHeader(proxyreq.Header, clientreq.Header)
 
+	err = sp.Tracer().Inject(sp, opentracing.TextMap, opentracing.HTTPHeaderTextMapCarrier(proxyreq.Header))
+	if err != nil {
+		plog.Debugf("Error injecting header")
+	}
 	normalizeRequest(proxyreq)
 	removeSingleHopHeaders(&proxyreq.Header)
 	maybeSetForwardedFor(proxyreq)

--- a/raft/raftpb/raft.pb.go
+++ b/raft/raftpb/raft.pb.go
@@ -230,6 +230,7 @@ type Message struct {
 	Snapshot         Snapshot    `protobuf:"bytes,9,opt,name=snapshot" json:"snapshot"`
 	Reject           bool        `protobuf:"varint,10,opt,name=reject" json:"reject"`
 	RejectHint       uint64      `protobuf:"varint,11,opt,name=rejectHint" json:"rejectHint"`
+	TraceContext     []byte      `protobuf:"bytes,12,opt,name=traceContext" json:"traceContext,omitempty"`
 	XXX_unrecognized []byte      `json:"-"`
 }
 
@@ -458,6 +459,12 @@ func (m *Message) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x58
 	i++
 	i = encodeVarintRaft(data, i, uint64(m.RejectHint))
+	if m.TraceContext != nil {
+		data[i] = 0x62
+		i++
+		i = encodeVarintRaft(data, i, uint64(len(m.TraceContext)))
+		i += copy(data[i:], m.TraceContext)
+	}
 	if m.XXX_unrecognized != nil {
 		i += copy(data[i:], m.XXX_unrecognized)
 	}
@@ -649,6 +656,10 @@ func (m *Message) Size() (n int) {
 	n += 1 + l + sovRaft(uint64(l))
 	n += 2
 	n += 1 + sovRaft(uint64(m.RejectHint))
+	if m.TraceContext != nil {
+		l = len(m.TraceContext)
+		n += 1 + l + sovRaft(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -1342,6 +1353,37 @@ func (m *Message) Unmarshal(data []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TraceContext", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRaft
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthRaft
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TraceContext = append(m.TraceContext[:0], data[iNdEx:postIndex]...)
+			if m.TraceContext == nil {
+				m.TraceContext = []byte{}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipRaft(data[iNdEx:])

--- a/raft/raftpb/raft.proto
+++ b/raft/raftpb/raft.proto
@@ -51,17 +51,18 @@ enum MessageType {
 }
 
 message Message {
-	optional MessageType type        = 1  [(gogoproto.nullable) = false];
-	optional uint64      to          = 2  [(gogoproto.nullable) = false];
-	optional uint64      from        = 3  [(gogoproto.nullable) = false];
-	optional uint64      term        = 4  [(gogoproto.nullable) = false];
-	optional uint64      logTerm     = 5  [(gogoproto.nullable) = false];
-	optional uint64      index       = 6  [(gogoproto.nullable) = false];
-	repeated Entry       entries     = 7  [(gogoproto.nullable) = false];
-	optional uint64      commit      = 8  [(gogoproto.nullable) = false];
-	optional Snapshot    snapshot    = 9  [(gogoproto.nullable) = false];
-	optional bool        reject      = 10 [(gogoproto.nullable) = false];
-	optional uint64      rejectHint  = 11 [(gogoproto.nullable) = false];
+	optional MessageType type         = 1  [(gogoproto.nullable) = false];
+	optional uint64      to           = 2  [(gogoproto.nullable) = false];
+	optional uint64      from         = 3  [(gogoproto.nullable) = false];
+	optional uint64      term         = 4  [(gogoproto.nullable) = false];
+	optional uint64      logTerm      = 5  [(gogoproto.nullable) = false];
+	optional uint64      index        = 6  [(gogoproto.nullable) = false];
+	repeated Entry       entries      = 7  [(gogoproto.nullable) = false];
+	optional uint64      commit       = 8  [(gogoproto.nullable) = false];
+	optional Snapshot    snapshot     = 9  [(gogoproto.nullable) = false];
+	optional bool        reject       = 10 [(gogoproto.nullable) = false];
+	optional uint64      rejectHint   = 11 [(gogoproto.nullable) = false];
+  optional bytes       traceContext = 12;
 }
 
 message HardState {


### PR DESCRIPTION
This PR adds some basic [OpenTracing](http://opentracing.io) instrumentation to etcd. 
## Background

The idea behind OpenTracing is to provide a standardized interface across languages to various distributed tracing systems(such as zipkin). Once you instrument your system, you can swap the underlying tracer with an O(1) switch. In case you aren't familiar with distributed tracing, the basic idea is that you can trace a request as it branches out to multiple machines and services, making it very easy to diagnose various problems such as latency, limping hardware, and events that lead up to an error deep in the stack
## Goal

The goal behind the pr is to a) show what a request trace looks like in an etcd cluster and b) to start a discussion about what components of etcd need to be traced. I'm not extremely familiar with how etcd works, so there's a lot left to be desired when it comes to the number of possible endpoints that can be traced and noise reduction. I'm probably creating spans for parts that don't really matter and not creating them for key things that I don't know about, etc.

What's really neat is that gRPC allows for metadata, which makes sending traces across process boundaries using gRPC a breeze. This can be seen in the v3 KV client and server. Here's a [gist](https://gist.github.com/bg451/237700ad2d501776bd823eb31a1f81f1) of what a simple client using opentracing and the etcd client looks like.
## Screenshot
#### [Appdash](https://github.com/sourcegraph/appdash)

 There is currently an issue open due to the fact that Appdash can't render spans that are less than 1ms. However, if you look at the table, you can see all of the various spans from a specific trace.
![screen shot 2016-05-20 at 3 08 30 pm](https://cloud.githubusercontent.com/assets/1350653/15443662/eef08afa-1e9e-11e6-9f96-7eb711c11093.png)
#### [Lighstep](https://github.com/lightstep/lightstep-tracer-go)

Since a trace in a 3 node cluster is pretty big, I couldn't fit it all in in a screenshot so I saved the page as a PDF, which you can view here: https://drive.google.com/file/d/0BxWuGMMFc4K0RDZVcGYzUWhkNkk/view?usp=sharing
Colors aren't printing correctly, but any time there's an `encode`->`decode` span set, the message is being decoded on a different node
cc @philips 
