### PR TITLE
mvcc: log when compaction is done

### DIFF
--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -15,7 +15,6 @@
 package mvcc
 
 import (
-	"log"
 	"sort"
 	"sync"
 
@@ -169,7 +168,7 @@ func (ti *treeIndex) RangeSince(key, end []byte, rev int64) []revision {
 func (ti *treeIndex) Compact(rev int64) map[revision]struct{} {
 	available := make(map[revision]struct{})
 	var emptyki []*keyIndex
-	log.Printf("store.index: compact %d", rev)
+	plog.Printf("store.index: compact %d", rev)
 	// TODO: do not hold the lock for long time?
 	// This is probably OK. Compacting 10M keys takes O(10ms).
 	ti.Lock()
@@ -178,7 +177,7 @@ func (ti *treeIndex) Compact(rev int64) map[revision]struct{} {
 	for _, ki := range emptyki {
 		item := ti.tree.Delete(ki)
 		if item == nil {
-			log.Panic("store.index: unexpected delete failure during compaction")
+			plog.Panic("store.index: unexpected delete failure during compaction")
 		}
 	}
 	return available

--- a/mvcc/key_index.go
+++ b/mvcc/key_index.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/google/btree"
 )
@@ -78,7 +77,7 @@ func (ki *keyIndex) put(main int64, sub int64) {
 	rev := revision{main: main, sub: sub}
 
 	if !rev.GreaterThan(ki.modified) {
-		log.Panicf("store.keyindex: put with unexpected smaller revision [%v / %v]", rev, ki.modified)
+		plog.Panicf("store.keyindex: put with unexpected smaller revision [%v / %v]", rev, ki.modified)
 	}
 	if len(ki.generations) == 0 {
 		ki.generations = append(ki.generations, generation{})
@@ -95,7 +94,7 @@ func (ki *keyIndex) put(main int64, sub int64) {
 
 func (ki *keyIndex) restore(created, modified revision, ver int64) {
 	if len(ki.generations) != 0 {
-		log.Panicf("store.keyindex: cannot restore non-empty keyIndex")
+		plog.Panicf("store.keyindex: cannot restore non-empty keyIndex")
 	}
 
 	ki.modified = modified
@@ -109,7 +108,7 @@ func (ki *keyIndex) restore(created, modified revision, ver int64) {
 // It returns ErrRevisionNotFound when tombstone on an empty generation.
 func (ki *keyIndex) tombstone(main int64, sub int64) error {
 	if ki.isEmpty() {
-		log.Panicf("store.keyindex: unexpected tombstone on empty keyIndex %s", string(ki.key))
+		plog.Panicf("store.keyindex: unexpected tombstone on empty keyIndex %s", string(ki.key))
 	}
 	if ki.generations[len(ki.generations)-1].isEmpty() {
 		return ErrRevisionNotFound
@@ -124,7 +123,7 @@ func (ki *keyIndex) tombstone(main int64, sub int64) error {
 // Rev must be higher than or equal to the given atRev.
 func (ki *keyIndex) get(atRev int64) (modified, created revision, ver int64, err error) {
 	if ki.isEmpty() {
-		log.Panicf("store.keyindex: unexpected get on empty keyIndex %s", string(ki.key))
+		plog.Panicf("store.keyindex: unexpected get on empty keyIndex %s", string(ki.key))
 	}
 	g := ki.findGeneration(atRev)
 	if g.isEmpty() {
@@ -144,7 +143,7 @@ func (ki *keyIndex) get(atRev int64) (modified, created revision, ver int64, err
 // main revision.
 func (ki *keyIndex) since(rev int64) []revision {
 	if ki.isEmpty() {
-		log.Panicf("store.keyindex: unexpected get on empty keyIndex %s", string(ki.key))
+		plog.Panicf("store.keyindex: unexpected get on empty keyIndex %s", string(ki.key))
 	}
 	since := revision{rev, 0}
 	var gi int
@@ -185,7 +184,7 @@ func (ki *keyIndex) since(rev int64) []revision {
 // If a generation becomes empty during compaction, it will be removed.
 func (ki *keyIndex) compact(atRev int64, available map[revision]struct{}) {
 	if ki.isEmpty() {
-		log.Panicf("store.keyindex: unexpected compact on empty keyIndex %s", string(ki.key))
+		plog.Panicf("store.keyindex: unexpected compact on empty keyIndex %s", string(ki.key))
 	}
 
 	// walk until reaching the first revision that has an revision smaller or equal to

--- a/mvcc/kvstore_bench_test.go
+++ b/mvcc/kvstore_bench_test.go
@@ -15,7 +15,6 @@
 package mvcc
 
 import (
-	"log"
 	"sync/atomic"
 	"testing"
 
@@ -64,7 +63,7 @@ func BenchmarkStoreTxnPut(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		id := s.TxnBegin()
 		if _, err := s.TxnPut(id, keys[i], vals[i], lease.NoLease); err != nil {
-			log.Fatalf("txn put error: %v", err)
+			plog.Fatalf("txn put error: %v", err)
 		}
 		s.TxnEnd(id)
 	}

--- a/mvcc/kvstore_compaction.go
+++ b/mvcc/kvstore_compaction.go
@@ -48,6 +48,7 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 			revToBytes(revision{main: compactMainRev}, rbytes)
 			tx.UnsafePut(metaBucketName, finishedCompactKeyName, rbytes)
 			tx.Unlock()
+			plog.Printf("finished scheduled compaction at %d (took %v)", compactMainRev, time.Since(totalStart))
 			return true
 		}
 

--- a/mvcc/util.go
+++ b/mvcc/util.go
@@ -16,7 +16,6 @@ package mvcc
 
 import (
 	"encoding/binary"
-	"log"
 
 	"github.com/coreos/etcd/mvcc/backend"
 	"github.com/coreos/etcd/mvcc/mvccpb"
@@ -48,7 +47,7 @@ func WriteKV(be backend.Backend, kv mvccpb.KeyValue) {
 
 	d, err := kv.Marshal()
 	if err != nil {
-		log.Fatalf("mvcc: cannot marshal event: %v", err)
+		plog.Fatalf("cannot marshal event: %v", err)
 	}
 
 	be.BatchTx().Lock()

--- a/mvcc/watchable_store.go
+++ b/mvcc/watchable_store.go
@@ -15,7 +15,6 @@
 package mvcc
 
 import (
-	"log"
 	"sync"
 	"time"
 
@@ -94,7 +93,7 @@ func (s *watchableStore) Put(key, value []byte, lease lease.LeaseID) (rev int64)
 	rev = s.store.Put(key, value, lease)
 	changes := s.store.getChanges()
 	if len(changes) != 1 {
-		log.Panicf("unexpected len(changes) != 1 after put")
+		plog.Panicf("unexpected len(changes) != 1 after put")
 	}
 
 	ev := mvccpb.Event{
@@ -113,7 +112,7 @@ func (s *watchableStore) DeleteRange(key, end []byte) (n, rev int64) {
 	changes := s.store.getChanges()
 
 	if len(changes) != int(n) {
-		log.Panicf("unexpected len(changes) != n after deleteRange")
+		plog.Panicf("unexpected len(changes) != n after deleteRange")
 	}
 
 	if n == 0 {
@@ -432,7 +431,7 @@ func kvsToEvents(wg *watcherGroup, revs, vals [][]byte) (evs []mvccpb.Event) {
 	for i, v := range vals {
 		var kv mvccpb.KeyValue
 		if err := kv.Unmarshal(v); err != nil {
-			log.Panicf("mvcc: cannot unmarshal event: %v", err)
+			plog.Panicf("cannot unmarshal event: %v", err)
 		}
 
 		if !wg.contains(string(kv.Key)) {
@@ -456,7 +455,7 @@ func (s *watchableStore) notify(rev int64, evs []mvccpb.Event) {
 	var victim watcherBatch
 	for w, eb := range newWatcherBatch(&s.synced, evs) {
 		if eb.revs != 1 {
-			log.Panicf("mvcc: unexpected multiple revisions in notification")
+			plog.Panicf("unexpected multiple revisions in notification")
 		}
 		select {
 		case w.ch <- WatchResponse{WatchID: w.id, Events: eb.evs, Revision: s.Rev()}:


### PR DESCRIPTION
I am debugging `context timeout` issues on compact request call, where I need to look at the time the compact request gets sent out, and the time when the compact operation finishes. (https://github.com/coreos/etcd/pull/5421)

/cc @heyitsanthony @xiang90 