### PR TITLE
tcpproxy: log proxy start

### DIFF
--- a/proxy/tcpproxy/userspace.go
+++ b/proxy/tcpproxy/userspace.go
@@ -78,6 +78,7 @@ func (tp *TCPProxy) Run() error {
 		tp.remotes = append(tp.remotes, &remote{addr: ep})
 	}
 
+	plog.Printf("ready to proxy client requests to %v", tp.Endpoints)
 	go tp.runMonitor()
 	for {
 		in, err := tp.Listener.Accept()


### PR DESCRIPTION
Later when we do e2e tests using tcpproxy, we need a way to
figure out proxy has started or not. Currently there's no indication.