### PR TITLE
travis: Catch compilation errors in CI for arm and ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,26 @@ env:
   matrix:
    - TARGET=amd64
    - TARGET=arm64
+   - TARGET=arm
+   - TARGET=ppc64le
 
 matrix:
+  fast_finish: true
   allow_failures:
     - go: tip
+  exclude:
+  - go: 1.5
+    env: TARGET=arm
+  - go: 1.5
+    env: TARGET=ppc64le
+  - go: 1.6
+    env: TARGET=arm64
+  - go: tip
+    env: TARGET=arm
+  - go: tip
+    env: TARGET=arm64
+  - go: tip
+    env: TARGET=ppc64le
 
 addons:
   apt:
@@ -37,8 +53,8 @@ install:
 
 script:
  - >
-        if [ "${TARGET}" == "amd64" ]; then
-                 GOARCH="${TARGET}" ./test;
-        elif [ "${TARGET}" == "arm64" ]; then
-                GOARCH="${TARGET}" ./build;
-        fi
+    if [ "${TARGET}" == "amd64" ]; then
+      GOARCH="${TARGET}" ./test;
+    else
+      GOARCH="${TARGET}" ./build;
+    fi


### PR DESCRIPTION
This way we'll catch compile errors easily.

@glevand @xiang90 @heyitsanthony @gyuho 