### PR TITLE
httpproxy: init the rand that we use to randomize endpoints

### DIFF
--- a/proxy/httpproxy/director.go
+++ b/proxy/httpproxy/director.go
@@ -27,6 +27,10 @@ const defaultRefreshInterval = 30000 * time.Millisecond
 
 var once sync.Once
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 func newDirector(urlsFunc GetProxyURLs, failureWait time.Duration, refreshInterval time.Duration) *director {
 	d := &director{
 		uf:          urlsFunc,


### PR DESCRIPTION
This is actually does not change anything. The endpoints are already
randomized before feeding into proxy. But it makes the proxy more safe.