### PR TITLE
clientv3: Add missing mvccpb EXPIRE constant

### DIFF
--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -28,6 +28,7 @@ import (
 const (
 	EventTypeDelete = mvccpb.DELETE
 	EventTypePut    = mvccpb.PUT
+	EventTypeExpire = mvccpb.EXPIRE
 )
 
 type Event mvccpb.Event


### PR DESCRIPTION
This is useful to avoid importing the whole mvccpb library.