### PR TITLE
etcdserver: fix typo in server.go

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -277,7 +277,7 @@ func NewServer(cfg *ServerConfig) (srv *EtcdServer, err error) {
 			return nil, fmt.Errorf("error validating peerURLs %s: %v", existingCluster, err)
 		}
 		if !isCompatibleWithCluster(cl, cl.MemberByName(cfg.Name).ID, prt) {
-			return nil, fmt.Errorf("incomptible with current running cluster")
+			return nil, fmt.Errorf("incompatible with current running cluster")
 		}
 
 		remotes = existingCluster.Members()


### PR DESCRIPTION
### Fix Output error

In `etcd/etcdserver/server.go` file, the author misspelled the "**incompatible**" word.


