### PR TITLE
etcdserver, auth: not return grpc error code directly in the apply phase

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -42,6 +42,7 @@ var (
 	ErrRoleAlreadyExist = errors.New("auth: role already exists")
 	ErrRoleNotFound     = errors.New("auth: role not found")
 	ErrAuthFailed       = errors.New("auth: authentication failed, invalid user ID or password")
+	ErrPermissionDenied = errors.New("auth: permission denied")
 )
 
 type AuthStore interface {

--- a/etcdserver/api/v3rpc/rpctypes/error.go
+++ b/etcdserver/api/v3rpc/rpctypes/error.go
@@ -71,6 +71,7 @@ var (
 		grpc.ErrorDesc(ErrGRPCRoleAlreadyExist): ErrGRPCRoleAlreadyExist,
 		grpc.ErrorDesc(ErrGRPCRoleNotFound):     ErrGRPCRoleNotFound,
 		grpc.ErrorDesc(ErrGRPCAuthFailed):       ErrGRPCAuthFailed,
+		grpc.ErrorDesc(ErrGRPCPermissionDenied): ErrGRPCPermissionDenied,
 
 		grpc.ErrorDesc(ErrGRPCNoLeader):   ErrGRPCNoLeader,
 		grpc.ErrorDesc(ErrGRPCNotCapable): ErrGRPCNotCapable,
@@ -99,6 +100,7 @@ var (
 	ErrRoleAlreadyExist = Error(ErrGRPCRoleAlreadyExist)
 	ErrRoleNotFound     = Error(ErrGRPCRoleNotFound)
 	ErrAuthFailed       = Error(ErrGRPCAuthFailed)
+	ErrPermissionDenied = Error(ErrGRPCPermissionDenied)
 
 	ErrNoLeader   = Error(ErrGRPCNoLeader)
 	ErrNotCapable = Error(ErrGRPCNotCapable)

--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -47,6 +47,8 @@ func togRPCError(err error) error {
 		return rpctypes.ErrGRPCRoleNotFound
 	case auth.ErrAuthFailed:
 		return rpctypes.ErrGRPCAuthFailed
+	case auth.ErrPermissionDenied:
+		return rpctypes.ErrGRPCPermissionDenied
 	default:
 		return grpc.Errorf(codes.Internal, err.Error())
 	}

--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
+	"github.com/coreos/etcd/auth"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/lease"
 	"github.com/coreos/etcd/mvcc"
@@ -76,13 +76,13 @@ func (s *EtcdServer) applyV3Request(r *pb.InternalRaftRequest) *applyResult {
 		if s.AuthStore().IsRangePermitted(r.Header, string(r.Range.Key)) {
 			ar.resp, ar.err = s.applyV3.Range(noTxn, r.Range)
 		} else {
-			ar.err = rpctypes.ErrGRPCPermissionDenied
+			ar.err = auth.ErrPermissionDenied
 		}
 	case r.Put != nil:
 		if s.AuthStore().IsPutPermitted(r.Header, string(r.Put.Key)) {
 			ar.resp, ar.err = s.applyV3.Put(noTxn, r.Put)
 		} else {
-			ar.err = rpctypes.ErrGRPCPermissionDenied
+			ar.err = auth.ErrPermissionDenied
 		}
 	case r.DeleteRange != nil:
 		ar.resp, ar.err = s.applyV3.DeleteRange(noTxn, r.DeleteRange)


### PR DESCRIPTION

Current permission checking mechanism doesn't return its error code
well. The internal error (code = 13) is returned to client and the
retry mechanism doesn't work well. This commit fixes the problem.