### PR TITLE
wal: improve tmp file handling

### DIFF
--- a/e2e/etcd_test.go
+++ b/e2e/etcd_test.go
@@ -137,8 +137,8 @@ type etcdProcessConfig struct {
 }
 
 type etcdProcessClusterConfig struct {
-	dataDirPathPrefix string
-	keepDataDir       bool
+	dataDirPath string
+	keepDataDir bool
 
 	clusterSize       int
 	basePort          int
@@ -226,10 +226,8 @@ func (cfg *etcdProcessClusterConfig) etcdProcessConfigs() []*etcdProcessConfig {
 
 		purl := url.URL{Scheme: peerScheme, Host: fmt.Sprintf("localhost:%d", port+1)}
 		name := fmt.Sprintf("testname%d", i)
-		var dataDirPath string
-		if cfg.dataDirPathPrefix != "" {
-			dataDirPath = fmt.Sprintf("%s%d.etcd", cfg.dataDirPathPrefix, i)
-		} else {
+		dataDirPath := cfg.dataDirPath
+		if cfg.dataDirPath == "" {
 			var derr error
 			dataDirPath, derr = ioutil.TempDir("", name+".etcd")
 			if derr != nil {

--- a/wal/file_pipeline.go
+++ b/wal/file_pipeline.go
@@ -48,7 +48,8 @@ func newFilePipeline(dir string, fileSize int64) *filePipeline {
 	return fp
 }
 
-// Open returns a fresh file for writing
+// Open returns a fresh file for writing. Rename the file before calling
+// Open again or there will be file collisions.
 func (fp *filePipeline) Open() (f *fileutil.LockedFile, err error) {
 	select {
 	case f = <-fp.filec:
@@ -63,7 +64,8 @@ func (fp *filePipeline) Close() error {
 }
 
 func (fp *filePipeline) alloc() (f *fileutil.LockedFile, err error) {
-	fpath := path.Join(fp.dir, fmt.Sprintf("%d.tmp", fp.count))
+	// count % 2 so this file isn't the same as the one last published
+	fpath := path.Join(fp.dir, fmt.Sprintf("%d.tmp", fp.count%2))
 	if f, err = fileutil.LockFile(fpath, os.O_CREATE|os.O_WRONLY, 0600); err != nil {
 		return nil, err
 	}

--- a/wal/repair.go
+++ b/wal/repair.go
@@ -90,13 +90,9 @@ func Repair(dirpath string) bool {
 
 // openLast opens the last wal file for read and write.
 func openLast(dirpath string) (*fileutil.LockedFile, error) {
-	names, err := fileutil.ReadDir(dirpath)
+	names, err := readWalNames(dirpath)
 	if err != nil {
 		return nil, err
-	}
-	names = checkWalNames(names)
-	if len(names) == 0 {
-		return nil, ErrFileNotFound
 	}
 	last := path.Join(dirpath, names[len(names)-1])
 	return fileutil.LockFile(last, os.O_RDWR, 0600)

--- a/wal/util.go
+++ b/wal/util.go
@@ -67,12 +67,26 @@ func isValidSeq(names []string) bool {
 	}
 	return true
 }
+func readWalNames(dirpath string) ([]string, error) {
+	names, err := fileutil.ReadDir(dirpath)
+	if err != nil {
+		return nil, err
+	}
+	wnames := checkWalNames(names)
+	if len(wnames) == 0 {
+		return nil, ErrFileNotFound
+	}
+	return wnames, nil
+}
 
 func checkWalNames(names []string) []string {
 	wnames := make([]string, 0)
 	for _, name := range names {
 		if _, _, err := parseWalName(name); err != nil {
-			plog.Warningf("ignored file %v in wal", name)
+			// don't complain about left over tmp files
+			if !strings.HasSuffix(name, ".tmp") {
+				plog.Warningf("ignored file %v in wal", name)
+			}
 			continue
 		}
 		wnames = append(wnames, name)

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -156,13 +156,9 @@ func OpenForRead(dirpath string, snap walpb.Snapshot) (*WAL, error) {
 }
 
 func openAtIndex(dirpath string, snap walpb.Snapshot, write bool) (*WAL, error) {
-	names, err := fileutil.ReadDir(dirpath)
+	names, err := readWalNames(dirpath)
 	if err != nil {
 		return nil, err
-	}
-	names = checkWalNames(names)
-	if len(names) == 0 {
-		return nil, ErrFileNotFound
 	}
 
 	nameIndex, ok := searchIndex(names, snap.Index)


### PR DESCRIPTION
Gets rid of a superfluous warning and a storage leak.