### PR TITLE
clientv3: handle nil connection after *Client.Close (KV)

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -384,5 +384,5 @@ func dialEndpointList(c *Client) (*grpc.ClientConn, error) {
 // progress can be made, even after reconnecting.
 func isHaltErr(ctx context.Context, err error) bool {
 	isRPCError := strings.HasPrefix(grpc.ErrorDesc(err), "etcdserver: ")
-	return isRPCError || ctx.Err() != nil
+	return isRPCError || ctx.Err() != nil || err == rpctypes.ErrConnClosed
 }

--- a/clientv3/kv.go
+++ b/clientv3/kv.go
@@ -189,6 +189,7 @@ func (kv *kv) do(ctx context.Context, op Op) (OpResponse, error) {
 	return OpResponse{}, err
 }
 
+// getRemote must be followed by kv.rc.release() call.
 func (kv *kv) getRemote(ctx context.Context) (pb.KVClient, error) {
 	if err := kv.rc.acquire(ctx); err != nil {
 		return nil, err

--- a/etcdserver/api/v3rpc/rpctypes/error.go
+++ b/etcdserver/api/v3rpc/rpctypes/error.go
@@ -104,6 +104,8 @@ var (
 
 	ErrNoLeader   = Error(ErrGRPCNoLeader)
 	ErrNotCapable = Error(ErrGRPCNotCapable)
+
+	ErrConnClosed = EtcdError{code: codes.Unavailable, desc: "clientv3: connection closed"}
 )
 
 // EtcdError defines gRPC server errors.


### PR DESCRIPTION
For https://github.com/coreos/etcd/issues/5495.

This only handles KV operations for now.

Need to discuss how to handle this for watch operations.
