### PR TITLE
improve error message for ClusterError

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -855,7 +855,7 @@ func TestHTTPClusterClientAutoSyncFail(t *testing.T) {
 	}
 
 	err = hc.AutoSync(context.Background(), time.Hour)
-	if err.Error() != ErrClusterUnavailable.Error() {
+	if !strings.HasPrefix(err.Error(), ErrClusterUnavailable.Error()) {
 		t.Fatalf("incorrect error value: want=%v got=%v", ErrClusterUnavailable, err)
 	}
 }

--- a/client/cluster_error.go
+++ b/client/cluster_error.go
@@ -21,7 +21,11 @@ type ClusterError struct {
 }
 
 func (ce *ClusterError) Error() string {
-	return ErrClusterUnavailable.Error()
+	s := ErrClusterUnavailable.Error()
+	for i, e := range ce.Errors {
+		s += fmt.Sprintf("; error #%d: %s\n", i, e)
+	}
+	return s
 }
 
 func (ce *ClusterError) Detail() string {


### PR DESCRIPTION
https://github.com/coreos/etcd/blob/66e5e4f298e66bdd72307336935e192aa66097c0/client/cluster_error.go#L24

This one line of code has been haunting me ever since I stared using etcd. Every time anything goes wrong the only error returned is "etcd cluster is unavailable or misconfigured" because most users of the etcd client library don't bother to figure out how to extract the detailed error message from your errors.

I'm sure my fix is not ideal. Let me know what the idea solution would be. Maybe we don't need a Detail() function at all? I'll do whatever it takes to stop seeing the same unhelpful message everywhere.