### PR TITLE
scripts: include v2 README in the release

### DIFF
--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -33,7 +33,7 @@ TMPHOSTS="$(mktemp)"
 acbuildEnd() {
     rm "$TMPHOSTS"
     export EXIT=$?
-    acbuild --debug end && exit $EXIT 
+    acbuild --debug end && exit $EXIT
 }
 trap acbuildEnd EXIT
 
@@ -46,6 +46,7 @@ acbuild --debug set-name coreos.com/etcd
 acbuild --debug copy --to-dir $BINARYDIR/etcd $BINARYDIR/etcdctl /
 acbuild --debug copy README.md /README.md
 acbuild --debug copy etcdctl/README.md /README-etcdctl.md
+acbuild --debug copy etcdctl/READMEv2.md /READMEv2-etcdctl.md
 acbuild --debug copy --to-dir Documentation /
 
 acbuild --debug environment add ETCD_DATA_DIR /data-dir

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -47,6 +47,7 @@ function package {
 
 	cp etcd/README.md ${target}/README.md
 	cp etcd/etcdctl/README.md ${target}/README-etcdctl.md
+	cp etcd/etcdctl/READMEv2.md ${target}/READMEv2-etcdctl.md
 
 	cp -R etcd/Documentation ${target}/Documentation
 }


### PR DESCRIPTION
We will be shipping etcd v2 with v3 releases. So should be documents for v2.