### PR TITLE
doc: fix header formatting

### DIFF
--- a/Documentation/op-guide/clustering.md
+++ b/Documentation/op-guide/clustering.md
@@ -380,6 +380,7 @@ infra0.example.com.  300  IN  A  10.0.1.10
 infra1.example.com.  300  IN  A  10.0.1.11
 infra2.example.com.  300  IN  A  10.0.1.12
 ```
+
 #### Bootstrap the etcd cluster using DNS
 
 etcd cluster members can listen on domain names or IP address, the bootstrap process will resolve DNS A records.

--- a/Documentation/v2/clustering.md
+++ b/Documentation/v2/clustering.md
@@ -309,6 +309,7 @@ infra0.example.com.  300  IN  A  10.0.1.10
 infra1.example.com.  300  IN  A  10.0.1.11
 infra2.example.com.  300  IN  A  10.0.1.12
 ```
+
 #### Bootstrap the etcd cluster using DNS
 
 etcd cluster members can listen on domain names or IP address, the bootstrap process will resolve DNS A records.


### PR DESCRIPTION
`Bootstrap the etcd cluster using DNS` section is not rendered properly.

![Screenshot of documentation](https://i.snag.gy/y9Lc18.jpg)
