### PR TITLE
snap: fix write snap

### DIFF
--- a/snap/snapshotter.go
+++ b/snap/snapshotter.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	pioutil "github.com/coreos/etcd/pkg/ioutil"
 	"github.com/coreos/etcd/pkg/pbutil"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -83,9 +84,14 @@ func (s *Snapshotter) save(snapshot *raftpb.Snapshot) error {
 		marshallingDurations.Observe(float64(time.Since(start)) / float64(time.Second))
 	}
 
-	err = ioutil.WriteFile(path.Join(s.dir, fname), d, 0666)
+	err = pioutil.WriteAndSyncFile(path.Join(s.dir, fname), d, 0666)
 	if err == nil {
 		saveDurations.Observe(float64(time.Since(start)) / float64(time.Second))
+	} else {
+		err1 := os.Remove(path.Join(s.dir, fname))
+		if err1 != nil {
+			plog.Errorf("failed to remove broken snapshot file %s", path.Join(s.dir, fname))
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Do not use writeFile since it does not sync file before closing.
This can lead to silent file corruption when disk is full.