### PR TITLE
integration: always return active client

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -795,7 +795,15 @@ func (c *ClusterV3) Terminate(t *testing.T) {
 }
 
 func (c *ClusterV3) RandClient() *clientv3.Client {
-	return c.clients[rand.Intn(len(c.clients))]
+	for i := 0; i < 100; i++ {
+		cli := c.clients[rand.Intn(len(c.clients))]
+		if cli.ActiveConnection() == nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		return cli
+	}
+	panic("failed to get a active client")
 }
 
 func (c *ClusterV3) Client(i int) *clientv3.Client {


### PR DESCRIPTION
In the integration test, we sometimes stop/restart an etcd server.
Now our client has internal connection monitoring logic that might
set conn to nil when there is a connection failure and the redial
also fails.

Changing randClient to always return a client with active connection
to make integration test reliable.

Fix #5527 and #5544