### PR TITLE
rafthttp: report error to correct chan

### DIFF
--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -279,7 +279,7 @@ type streamReader struct {
 func (r *streamReader) start() {
 	r.stopc = make(chan struct{})
 	r.done = make(chan struct{})
-	if r.errorc != nil {
+	if r.errorc == nil {
 		r.errorc = r.tr.ErrorC
 	}
 


### PR DESCRIPTION
Fix #5535.

I messed this up when refactoring the rafthttp. So if the node is removed before it receives the removal command, it will be stuck there since the network layer is not able to report error. This pr fixes it.

