### PR TITLE
raft: fix TestNodeStepUnblock

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -99,8 +99,8 @@ func TestNodeStepUnblock(t *testing.T) {
 				n.done = make(chan struct{})
 			default:
 			}
-		case <-time.After(time.Millisecond * 100):
-			t.Errorf("#%d: failed to unblock step", i)
+		case <-time.After(1 * time.Second):
+			t.Fatalf("#%d: failed to unblock step", i)
 		}
 	}
 }


### PR DESCRIPTION
The test cases have side-effect. We need to stop testing if one of the test
fails. Also timeout should be much longer to avoid false-positive.

Fix #5415