### PR TITLE
mvcc: don't cancel watcher if stream is already closed

### DIFF
--- a/mvcc/watcher.go
+++ b/mvcc/watcher.go
@@ -117,13 +117,18 @@ func (ws *watchStream) Chan() <-chan WatchResponse {
 }
 
 func (ws *watchStream) Cancel(id WatchID) error {
+	ws.mu.Lock()
 	cancel, ok := ws.cancels[id]
+	ok = ok && !ws.closed
+	if ok {
+		delete(ws.cancels, id)
+		delete(ws.watchers, id)
+	}
+	ws.mu.Unlock()
 	if !ok {
 		return ErrWatcherNotExist
 	}
 	cancel()
-	delete(ws.cancels, id)
-	delete(ws.watchers, id)
 	return nil
 }
 


### PR DESCRIPTION
Close() already cancels all the watchers but doesn't bother to clear out
the bookkeeping maps so Cancel() may try to cancel twice.

Fixes #5533