### PR TITLE
e2e: tests: fix small typo

### DIFF
--- a/e2e/ctl_v2_test.go
+++ b/e2e/ctl_v2_test.go
@@ -232,7 +232,7 @@ func TestCtlV2RoleList(t *testing.T) {
 func TestCtlV2Backup(t *testing.T) { // For https://github.com/coreos/etcd/issues/5360
 	defer testutil.AfterTest(t)
 
-	backupDir, err := ioutil.TempDir("", "testbakcup0.etcd")
+	backupDir, err := ioutil.TempDir("", "testbackup0.etcd")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Found when trying to get the e2e tests to run on Fedora which they
don't because of https://github.com/kr/pty/issues/21