### PR TITLE
doc: sign release artifacts in armor mode

### DIFF
--- a/Documentation/dev-internal/release.md
+++ b/Documentation/dev-internal/release.md
@@ -66,7 +66,7 @@ The following commands are used for public release sign:
 
 ```
 cd release
-for i in etcd-*{.zip,.tar.gz}; do gpg2 --default-key $SUBKEYID --output ${i}.asc --detach-sign ${i}; done
+for i in etcd-*{.zip,.tar.gz}; do gpg2 --default-key $SUBKEYID --armor --output ${i}.asc --detach-sign ${i}; done
 for i in etcd-*{.zip,.tar.gz}; do gpg2 --verify ${i}.asc ${i}; done
 ```
 


### PR DESCRIPTION
Release guide's steps to artifacts signing default to binary
signatures, while producing .asc files.
This commit changes to armored signatures, also matching appc
requirements.

Fixes #5594