### PR TITLE
mvcc: add keyIndex, treeIndex Restore benchmark

### DIFF
--- a/mvcc/index_bench_test.go
+++ b/mvcc/index_bench_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mvcc
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkIndexRestore(b *testing.B) {
+	var (
+		keys            = make([][]byte, b.N)
+		createds        = make([]revision, b.N)
+		modifieds       = make([]revision, b.N)
+		ver       int64 = 1
+	)
+	for i := 0; i < b.N; i++ {
+		keys[i] = []byte(fmt.Sprintf("foo%d", i))
+		createds[i] = revision{int64(i), 0}
+		modifieds[i] = revision{int64(i), 1}
+	}
+
+	kvindex := newTreeIndex()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		kvindex.Restore(keys[i], createds[i], modifieds[i], ver)
+	}
+}


### PR DESCRIPTION
```
(pprof) top20   
14720ms of 19430ms total (75.76%)
Dropped 41 nodes (cum <= 97.15ms)
Showing top 20 nodes out of 91 (cum >= 310ms)
      flat  flat%   sum%        cum   cum%
    2330ms 11.99% 11.99%     2330ms 11.99%  runtime.cmpbody
    2110ms 10.86% 22.85%     4860ms 25.01%  github.com/coreos/etcd/mvcc.(*keyIndex).Less
    1790ms  9.21% 32.06%     5840ms 30.06%  github.com/google/btree.items.find.func1
    1260ms  6.48% 38.55%     2660ms 13.69%  runtime.mallocgc
    1160ms  5.97% 44.52%     7000ms 36.03%  sort.Search
     980ms  5.04% 49.56%     1770ms  9.11%  runtime.scanobject
     710ms  3.65% 53.22%      710ms  3.65%  runtime.memmove
     470ms  2.42% 55.64%     5870ms 30.21%  github.com/google/btree.(*node).insert
     470ms  2.42% 58.05%     8280ms 42.61%  github.com/google/btree.items.find
     430ms  2.21% 60.27%      470ms  2.42%  runtime.(*mcentral).grow
     420ms  2.16% 62.43%      420ms  2.16%  bytes.Compare
     400ms  2.06% 64.49%      400ms  2.06%  runtime.heapBitsSetType
     350ms  1.80% 66.29%     4670ms 24.03%  github.com/google/btree.(*node).get
     350ms  1.80% 68.09%      350ms  1.80%  runtime.heapBitsForObject
     300ms  1.54% 69.63%     1330ms  6.85%  runtime.growslice
     280ms  1.44% 71.08%     1040ms  5.35%  fmt.(*pp).doPrintf
     240ms  1.24% 72.31%      590ms  3.04%  runtime.greyobject
     230ms  1.18% 73.49%      410ms  2.11%  runtime.deferreturn
     230ms  1.18% 74.68%      230ms  1.18%  sync/atomic.AddUint32
     210ms  1.08% 75.76%      310ms  1.60%  fmt.(*fmt).integer
```

/cc @heyitsanthony @xiang90 