### PR TITLE
auth: correct checking of range permission

### DIFF
--- a/auth/range_perm_cache.go
+++ b/auth/range_perm_cache.go
@@ -119,11 +119,11 @@ func checkCachedPerm(cachedPerms *unifiedRangePermissions, userName string, key,
 
 	for _, perm := range perms {
 		if strings.Compare(rangeEnd, "") != 0 {
-			if strings.Compare(perm.begin, key) <= 0 && strings.Compare(rangeEnd, perm.end) <= 0 {
+			if strings.Compare(perm.begin, key) <= 0 && strings.Compare(rangeEnd, perm.end) < 0 {
 				return true
 			}
 		} else {
-			if strings.Compare(perm.begin, key) <= 0 && strings.Compare(key, perm.end) <= 0 {
+			if strings.Compare(perm.begin, key) <= 0 && strings.Compare(key, perm.end) < 0 {
 				return true
 			}
 		}


### PR DESCRIPTION
Current range permission mechanism checks range as [begin, end], not
[begin, end). This commit fixes the mistake.