### PR TITLE
MAINTAINERS: updating email address of Hitoshi Mitake

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,4 +4,4 @@ Gyu-Ho Lee <gyu_ho.lee@coreos.com> (@gyuho) pkg:*
 Xiang Li <xiang.li@coreos.com> (@xiang90) pkg:*
 
 Ben Darnell <ben@cockroachlabs.com> (@bdarnell) pkg:github.com/coreos/etcd/raft
-Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:github.com/coreos/etcd/auth
+Hitoshi Mitake <mitake.hitoshi@lab.ntt.co.jp> (@mitake) pkg:github.com/coreos/etcd/auth


### PR DESCRIPTION
Very trivial PR: I'm mainly using the updated email address for working.

/cc @xiang90 