### PR TITLE
docs: Clustering.md: Switch "command line" and "environment variables"

### DIFF
--- a/Documentation/op-guide/clustering.md
+++ b/Documentation/op-guide/clustering.md
@@ -22,7 +22,7 @@ Each of the bootstrapping mechanisms will be used to create a three machine etcd
 
 ## Static
 
-As we know the cluster members, their addresses and the size of the cluster before starting, we can use an offline bootstrap configuration by setting the `initial-cluster` flag. Each machine will get either the following command line or environment variables:
+As we know the cluster members, their addresses and the size of the cluster before starting, we can use an offline bootstrap configuration by setting the `initial-cluster` flag. Each machine will get either the following environment variables or command line:
 
 ```
 ETCD_INITIAL_CLUSTER="infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380"


### PR DESCRIPTION
In the Static paragraph of the Clustering.md doc variant with environment variables is shown first, followed by command line variant. The sentence right above mentions environment variables variant as second.

This is a small nit. Worth fixing for a sake of general consistency.