### PR TITLE
etcdctl/*: print API version

### DIFF
--- a/etcdctl/ctlv2/ctl.go
+++ b/etcdctl/ctlv2/ctl.go
@@ -16,6 +16,7 @@
 package ctlv2
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -28,6 +29,10 @@ func Start() {
 	app := cli.NewApp()
 	app.Name = "etcdctl"
 	app.Version = version.Version
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Fprintf(c.App.Writer, "etcdctl version: %v\n", c.App.Version)
+		fmt.Fprintln(c.App.Writer, "API version: 2")
+	}
 	app.Usage = "A simple command line client for etcd."
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{Name: "debug", Usage: "output cURL commands which can be used to reproduce the request"},

--- a/etcdctl/ctlv3/command/version_command.go
+++ b/etcdctl/ctlv3/command/version_command.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/coreos/etcd/version"
+	"github.com/coreos/go-semver/semver"
 	"github.com/spf13/cobra"
 )
 
@@ -31,5 +32,13 @@ func NewVersionCommand() *cobra.Command {
 }
 
 func versionCommandFunc(cmd *cobra.Command, args []string) {
-	fmt.Println(version.Version)
+	fmt.Println("etcdctl version:", version.Version)
+	ver, err := semver.NewVersion(version.Version)
+	var vs string
+	if err == nil {
+		vs = fmt.Sprintf("%d.%d", ver.Major, ver.Minor)
+	} else {
+		vs = "unknown"
+	}
+	fmt.Println("API version:", vs)
 }


### PR DESCRIPTION
Same etcdctl can have different API versions.
Printing them out in version commands would help clarify.