### PR TITLE
etcd-tester: cleanup in compact error, log level

### DIFF
--- a/tools/functional-tester/etcd-tester/cluster.go
+++ b/tools/functional-tester/etcd-tester/cluster.go
@@ -344,7 +344,7 @@ func (c *cluster) compactKV(rev int64, timeout time.Duration) (err error) {
 			if strings.Contains(cerr.Error(), "required revision has been compacted") && i > 0 {
 				plog.Printf("[compact kv #%d] already compacted (endpoint %s)", i, u)
 			} else {
-				plog.Printf("[compact kv #%d] error %v (endpoint %s)", i, cerr, u)
+				plog.Warningf("[compact kv #%d] error %v (endpoint %s)", i, cerr, u)
 				err = cerr
 				succeed = false
 			}

--- a/tools/functional-tester/etcd-tester/tester.go
+++ b/tools/functional-tester/etcd-tester/tester.go
@@ -206,19 +206,13 @@ func (tt *tester) checkConsistency() (failed bool, err error) {
 func (tt *tester) compact(rev int64, timeout time.Duration) error {
 	plog.Printf("%s compacting storage (current revision %d, compact revision %d)", tt.logPrefix(), tt.currentRevision, rev)
 	if err := tt.cluster.compactKV(rev, timeout); err != nil {
-		if cerr := tt.cleanup(); cerr != nil {
-			return fmt.Errorf("%s, %s", err, cerr)
-		}
 		return err
 	}
 	plog.Printf("%s compacted storage (compact revision %d)", tt.logPrefix(), rev)
 
 	plog.Printf("%s checking compaction (compact revision %d)", tt.logPrefix(), rev)
 	if err := tt.cluster.checkCompact(rev); err != nil {
-		plog.Printf("%s checkCompact error (%v)", tt.logPrefix(), err)
-		if cerr := tt.cleanup(); cerr != nil {
-			return fmt.Errorf("%s, %s", err, cerr)
-		}
+		plog.Warningf("%s checkCompact error (%v)", tt.logPrefix(), err)
 		return err
 	}
 
@@ -229,7 +223,7 @@ func (tt *tester) compact(rev int64, timeout time.Duration) error {
 func (tt *tester) defrag() error {
 	plog.Printf("%s defragmenting...", tt.logPrefix())
 	if err := tt.cluster.defrag(); err != nil {
-		plog.Printf("%s defrag error (%v)", tt.logPrefix(), err)
+		plog.Warningf("%s defrag error (%v)", tt.logPrefix(), err)
 		if cerr := tt.cleanup(); cerr != nil {
 			return fmt.Errorf("%s, %s", err, cerr)
 		}
@@ -262,12 +256,12 @@ func (tt *tester) cleanup() error {
 
 	plog.Printf("%s cleaning up...", tt.logPrefix())
 	if err := tt.cluster.Cleanup(); err != nil {
-		plog.Printf("%s cleanup error: %v", tt.logPrefix(), err)
+		plog.Warningf("%s cleanup error: %v", tt.logPrefix(), err)
 		return err
 	}
 
 	if err := tt.cluster.Bootstrap(); err != nil {
-		plog.Printf("%s cleanup Bootstrap error: %v", tt.logPrefix(), err)
+		plog.Warningf("%s cleanup Bootstrap error: %v", tt.logPrefix(), err)
 		return err
 	}
 


### PR DESCRIPTION
```
2016-06-10 17:37:33.672174 I | etcd-tester: [round#32] compacting 613905 entries (timeout 22s)
2016-06-10 17:37:33.672186 I | etcd-tester: [round#32] compacting storage (current revision 22587950, compact revision 22577950)
2016-06-10 17:37:33.672235 I | etcd-tester: [compact kv #0] starting (endpoint 10.240.0.2:2379)
2016-06-10 17:37:55.672368 I | etcd-tester: [compact kv #0] error rpc error: code = 4 desc = context deadline exceeded (endpoint 10.240.0.2:2379)
2016-06-10 17:37:55.672454 I | etcd-tester: [compact kv #1] starting (endpoint 10.240.0.3:2379)
2016-06-10 17:37:55.690250 I | etcd-tester: [compact kv #1] already compacted (endpoint 10.240.0.3:2379)
2016-06-10 17:37:55.690296 I | etcd-tester: [compact kv #1] done (endpoint 10.240.0.3:2379)
2016-06-10 17:37:55.690342 I | etcd-tester: [compact kv #2] starting (endpoint 10.240.0.4:2379)
2016-06-10 17:37:55.703003 I | etcd-tester: [compact kv #2] already compacted (endpoint 10.240.0.4:2379)
2016-06-10 17:37:55.703062 I | etcd-tester: [compact kv #2] done (endpoint 10.240.0.4:2379)
2016-06-10 17:37:55.703102 I | etcd-tester: [round#32] cleaning up...
2016-06-10 17:38:01.606349 W | etcd-tester: [round#32] functional-tester compact got error (rpc error: code = 4 desc = context deadline exceeded)
2016-06-10 17:38:01.606409 I | etcd-tester: [round#32] cleaning up...
```

Currently, clean up after compaction failure is done in main tester routine. No need to clean up before we return error. (It's duplicate)