### PR TITLE
RFC: etcdserver: check permission in Txn() RPC

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -121,8 +121,15 @@ func (s *EtcdServer) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) 
 }
 
 func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse, error) {
+	header := &pb.RequestHeader{} // just for permission checking purpose
+	username, err := s.usernameFromCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	header.Username = username
+
 	if isTxnSerializable(r) {
-		return s.applyV3.Txn(r)
+		return s.applyV3.Txn(header, r)
 	}
 
 	result, err := s.processInternalRaftRequest(ctx, pb.InternalRaftRequest{Txn: r})


### PR DESCRIPTION
This PR adds permission checking in Txn() RPC. Currently, the check works like below:
1. check compare requests and return permission denied error if the requests has denied range operations
2. check one of the request sequences for success and failure cases and return permission denied error if the requests has denied operations

It means that the transaction request can be completed even if the request sequences that aren't executed has invalid permission. I think it is ok but how do you think? @xiang90 @heyitsanthony 