### PR TITLE
auth, etcdserver: change parameter type of IsRangeDeletePermitted()

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -114,7 +114,7 @@ type AuthStore interface {
 	IsRangePermitted(header *pb.RequestHeader, key, rangeEnd []byte) bool
 
 	// IsDeleteRangePermitted checks delete-range permission of the user
-	IsDeleteRangePermitted(username string, key, rangeEnd []byte) bool
+	IsDeleteRangePermitted(header *pb.RequestHeader, key, rangeEnd []byte) bool
 
 	// IsAdminPermitted checks admin permission of the user
 	IsAdminPermitted(username string) bool
@@ -578,8 +578,8 @@ func (as *authStore) IsRangePermitted(header *pb.RequestHeader, key, rangeEnd []
 	return as.isOpPermitted(header.Username, key, rangeEnd, authpb.READ)
 }
 
-func (as *authStore) IsDeleteRangePermitted(username string, key, rangeEnd []byte) bool {
-	return as.isOpPermitted(username, key, rangeEnd, authpb.WRITE)
+func (as *authStore) IsDeleteRangePermitted(header *pb.RequestHeader, key, rangeEnd []byte) bool {
+	return as.isOpPermitted(header.Username, key, rangeEnd, authpb.WRITE)
 }
 
 func (as *authStore) IsAdminPermitted(username string) bool {

--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -104,7 +104,7 @@ func (s *EtcdServer) applyV3Request(r *pb.InternalRaftRequest) *applyResult {
 			ar.err = auth.ErrPermissionDenied
 		}
 	case r.DeleteRange != nil:
-		if s.AuthStore().IsDeleteRangePermitted(r.Header.Username, r.DeleteRange.Key, r.DeleteRange.RangeEnd) {
+		if s.AuthStore().IsDeleteRangePermitted(r.Header, r.DeleteRange.Key, r.DeleteRange.RangeEnd) {
 			ar.resp, ar.err = s.applyV3.DeleteRange(noTxn, r.DeleteRange)
 		} else {
 			ar.err = auth.ErrPermissionDenied


### PR DESCRIPTION

Like other functions for permission checking, this commit lets
IsRangeDeletePermitted() receive etcdserverpb.RequestHeader. The
header will have more important data like revision number.

/cc @xiang90 