### PR TITLE
Handle EINTR in fixed preallocation

### DIFF
--- a/pkg/fileutil/preallocate_unix.go
+++ b/pkg/fileutil/preallocate_unix.go
@@ -41,7 +41,8 @@ func preallocFixed(f *os.File, sizeInBytes int64) error {
 	if err != nil {
 		errno, ok := err.(syscall.Errno)
 		// treat not supported as nil error
-		if ok && errno == syscall.ENOTSUP {
+		// fallocate EINTRs frequently in some enviroments; fallback
+		if ok && (errno == syscall.ENOTSUP || errno == syscall.EINTR) {
 			return nil
 		}
 	}


### PR DESCRIPTION
@heyitsanthony this seems to be still needed otherwise etcd crashes on tmpfs with SIGINT.