### PR TITLE
Documentation: add gradle-etcd-rest-plugin to libraries-and-tools.md

### DIFF
--- a/Documentation/libraries-and-tools.md
+++ b/Documentation/libraries-and-tools.md
@@ -93,6 +93,10 @@
 
 - [efrecon/etcd-tcl](https://github.com/efrecon/etcd-tcl) - Supports v2, except wait.
 
+**Gradle Plugins**
+
+- [gradle-etcd-rest-plugin](https://github.com/cdancy/gradle-etcd-rest-plugin) - Supports v2
+
 **Chef Integration**
 
 - [coderanger/etcd-chef](https://github.com/coderanger/etcd-chef)


### PR DESCRIPTION
Add link to the [gradle-etcd-rest-plugin](https://github.com/cdancy/gradle-etcd-rest-plugin) client under the 'Gradle plugins' sub-section.

Fixes #5681