### PR TITLE
etcd-agent: SIGQUIT when cleanup

### DIFF
--- a/tools/functional-tester/etcd-agent/rpc.go
+++ b/tools/functional-tester/etcd-agent/rpc.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"net/rpc"
+	"syscall"
 
 	"github.com/coreos/etcd/tools/functional-tester/etcd-agent/client"
 )
@@ -47,7 +48,7 @@ func (a *Agent) RPCStart(args []string, pid *int) error {
 
 func (a *Agent) RPCStop(args struct{}, reply *struct{}) error {
 	plog.Printf("stop etcd")
-	err := a.stop()
+	err := a.stopWithSig(syscall.SIGTERM)
 	if err != nil {
 		plog.Println("error stopping etcd", err)
 		return err


### PR DESCRIPTION
Example:

```
2016-06-15 15:36:58.470291 N | osutil: received quit signal, shutting down...
2016-06-15 15:36:58.470371 I | osutil: stack trace
goroutine 114 [running]:
runtime/debug.Stack(0x0, 0x0, 0x0)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x80
github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/pkg/osutil.HandleInterrupts.func1(0xc8203c4060)
	/home/gyuho/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/pkg/osutil/interrupt_unix.go:63 +0x26c
created by github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/pkg/osutil.HandleInterrupts
	/home/gyuho/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/pkg/osutil/interrupt_unix.go:76 +0x27b

SIGQUIT: quit
PC=0x46010d m=1

goroutine 0 [idle]:
runtime.usleep(0xa0, 0x145862b74ef4f3ab, 0x1, 0x7fa0, 0xa00042a1d7, 0x145862b76227dd89, 0x45d964b800, 0x0, 0x153277341b72, 0x0, ...)
	/usr/local/go/src/runtime/sys_linux_amd64.s:95 +0x2d
runtime.sysmon()
	/usr/local/go/src/runtime/proc.go:3468 +0x9d
runtime.mstart1()
	/usr/local/go/src/runtime/proc.go:1098 +0xec
runtime.mstart()
	/usr/local/go/src/runtime/proc.go:1068 +0x72

goroutine 1 [semacquire]:
sync.runtime_Semacquire(0x1743fb4)
	/usr/local/go/src/runtime/sema.go:47 +0x26
sync.(*Mutex).Lock(0x1743fb0)
	/usr/local/go/src/sync/mutex.go:83 +0x1c4
github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/pkg/osutil.Exit(0x0)
	/home/gyuho/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/pkg/osutil/interrupt_unix.go:81 +0x23
github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain.startEtcdOrProxyV2()
	/home/gyuho/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain/etcd.go:192 +0x1978
github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain.Main()
	/home/gyuho/go/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/etcdmain/main.go:36 +0x21e
main.main()
	/home/gyuho/go/src/github.com/coreos/etcd/cmd/main.go:28 +0x14

```
