### PR TITLE
*: go vet, go lint fixes

### DIFF
--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -645,15 +645,14 @@ func assertRequest(got http.Request, wantMethod string, wantURL *url.URL, wantHe
 	} else {
 		if wantBody == nil {
 			return fmt.Errorf("want.Body=%v got.Body=%s", wantBody, got.Body)
-		} else {
-			gotBytes, err := ioutil.ReadAll(got.Body)
-			if err != nil {
-				return err
-			}
+		}
+		gotBytes, err := ioutil.ReadAll(got.Body)
+		if err != nil {
+			return err
+		}
 
-			if !reflect.DeepEqual(wantBody, gotBytes) {
-				return fmt.Errorf("want.Body=%s got.Body=%s", wantBody, gotBytes)
-			}
+		if !reflect.DeepEqual(wantBody, gotBytes) {
+			return fmt.Errorf("want.Body=%s got.Body=%s", wantBody, gotBytes)
 		}
 	}
 

--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -64,13 +64,13 @@ func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {
 			return
 		}
 
-		var data_kv kv
+		var dataKv kv
 		dec := gob.NewDecoder(bytes.NewBufferString(*data))
-		if err := dec.Decode(&data_kv); err != nil {
+		if err := dec.Decode(&dataKv); err != nil {
 			log.Fatalf("raftexample: could not decode message (%v)", err)
 		}
 		s.mu.Lock()
-		s.kvStore[data_kv.Key] = data_kv.Val
+		s.kvStore[dataKv.Key] = dataKv.Val
 		s.mu.Unlock()
 	}
 	if err, ok := <-errorC; ok {

--- a/contrib/raftexample/listener.go
+++ b/contrib/raftexample/listener.go
@@ -42,9 +42,9 @@ func (ln stoppableListener) Accept() (c net.Conn, err error) {
 		tc, err := ln.AcceptTCP()
 		if err != nil {
 			errc <- err
-		} else {
-			connc <- tc
+			return
 		}
+		connc <- tc
 	}()
 	select {
 	case <-ln.stopc:

--- a/etcdmain/serve.go
+++ b/etcdmain/serve.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/etcd/pkg/transport"
 
 	"github.com/cockroachdb/cmux"
 	gw "github.com/gengo/grpc-gateway/runtime"
@@ -81,10 +82,10 @@ func serve(sctx *serveCtx, s *etcdserver.EtcdServer, tlscfg *tls.Config, handler
 		gs := v3rpc.Server(s, tlscfg)
 		handler = grpcHandlerFunc(gs, handler)
 
-		dtls := *tlscfg
+		dtls := transport.ShallowCopyTLSConfig(tlscfg)
 		// trust local server
 		dtls.InsecureSkipVerify = true
-		creds := credentials.NewTLS(&dtls)
+		creds := credentials.NewTLS(dtls)
 		opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
 		gwmux, err := registerGateway(sctx.l.Addr().String(), opts)
 		if err != nil {

--- a/etcdserver/apply_v2.go
+++ b/etcdserver/apply_v2.go
@@ -65,9 +65,8 @@ func (a *applierV2store) Put(r *pb.Request) Response {
 		if exists {
 			if r.PrevIndex == 0 && r.PrevValue == "" {
 				return toResponse(a.store.Update(r.Path, r.Val, ttlOptions))
-			} else {
-				return toResponse(a.store.CompareAndSwap(r.Path, r.PrevValue, r.PrevIndex, r.Val, ttlOptions))
 			}
+			return toResponse(a.store.CompareAndSwap(r.Path, r.PrevValue, r.PrevIndex, r.Val, ttlOptions))
 		}
 		return toResponse(a.store.Create(r.Path, r.Dir, r.Val, false, ttlOptions))
 	case r.PrevIndex > 0 || r.PrevValue != "":

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -81,7 +81,8 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 	var err error
 
 	if r.Serializable {
-		user, err := s.usernameFromCtx(ctx)
+		var user string
+		user, err = s.usernameFromCtx(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -252,3 +252,32 @@ func (info TLSInfo) ClientConfig() (*tls.Config, error) {
 	}
 	return cfg, nil
 }
+
+// ShallowCopyTLSConfig copies *tls.Config. This is only
+// work-around for go-vet tests, which complains
+//
+//   assignment copies lock value to p: crypto/tls.Config contains sync.Once contains sync.Mutex
+//
+// Keep up-to-date with 'go/src/crypto/tls/common.go'
+func ShallowCopyTLSConfig(cfg *tls.Config) *tls.Config {
+	ncfg := tls.Config{
+		Time:                     cfg.Time,
+		Certificates:             cfg.Certificates,
+		NameToCertificate:        cfg.NameToCertificate,
+		GetCertificate:           cfg.GetCertificate,
+		RootCAs:                  cfg.RootCAs,
+		NextProtos:               cfg.NextProtos,
+		ServerName:               cfg.ServerName,
+		ClientAuth:               cfg.ClientAuth,
+		ClientCAs:                cfg.ClientCAs,
+		InsecureSkipVerify:       cfg.InsecureSkipVerify,
+		CipherSuites:             cfg.CipherSuites,
+		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
+		SessionTicketKey:         cfg.SessionTicketKey,
+		ClientSessionCache:       cfg.ClientSessionCache,
+		MinVersion:               cfg.MinVersion,
+		MaxVersion:               cfg.MaxVersion,
+		CurvePreferences:         cfg.CurvePreferences,
+	}
+	return &ncfg
+}

--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -196,15 +196,15 @@ func (h *snapshotHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	plog.Infof("receiving database snapshot [index:%d, from %s] ...", m.Snapshot.Metadata.Index, types.ID(m.From))
 	// save incoming database snapshot.
-	if n, err := h.snapshotter.SaveDBFrom(r.Body, m.Snapshot.Metadata.Index); err != nil {
+	n, err := h.snapshotter.SaveDBFrom(r.Body, m.Snapshot.Metadata.Index)
+	if err != nil {
 		msg := fmt.Sprintf("failed to save KV snapshot (%v)", err)
 		plog.Error(msg)
 		http.Error(w, msg, http.StatusInternalServerError)
 		return
-	} else {
-		receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(n))
-		plog.Infof("received and saved database snapshot [index: %d, from: %s] successfully", m.Snapshot.Metadata.Index, types.ID(m.From))
 	}
+	receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(n))
+	plog.Infof("received and saved database snapshot [index: %d, from: %s] successfully", m.Snapshot.Metadata.Index, types.ID(m.From))
 
 	if err := h.r.Process(context.TODO(), m); err != nil {
 		switch v := err.(type) {


### PR DESCRIPTION
Go tip vet complains:


> gopath/src/github.com/coreos/etcd/etcdmain/serve.go:84: assignment copies lock value to dtls: crypto/tls.Config contains sync.Once contains sync.Mutex


https://travis-ci.org/coreos/etcd/jobs/138364239#L810