### PR TITLE
update: Dockerfile, documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,10 @@
-FROM golang:onbuild
+FROM alpine:latest
+
+ADD bin/etcd /usr/local/bin/
+ADD bin/etcdctl /usr/local/bin/
+RUN mkdir -p /var/etcd/
+
 EXPOSE 2379 2380
+
+# Define default command.
+CMD ["/usr/local/bin/etcd"]

--- a/Documentation/op-guide/container.md
+++ b/Documentation/op-guide/container.md
@@ -23,6 +23,7 @@ CLUSTER=${NAME_1}=http://${HOST_1}:2380,${NAME_2}=http://${HOST_2}:2380,${NAME_3
 THIS_NAME=${NAME_1}
 THIS_IP=${HOST_1}
 sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
+	/usr/local/bin/etcd \
     --data-dir=data.etcd --name ${THIS_NAME} \
 	--initial-advertise-peer-urls http://${THIS_IP}:2380 --listen-peer-urls http://${THIS_IP}:2380 \
 	--advertise-client-urls http://${THIS_IP}:2379 --listen-client-urls http://${THIS_IP}:2379 \
@@ -33,6 +34,7 @@ sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
 THIS_NAME=${NAME_2}
 THIS_IP=${HOST_2}
 sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
+	/usr/local/bin/etcd \
     --data-dir=data.etcd --name ${THIS_NAME} \
 	--initial-advertise-peer-urls http://${THIS_IP}:2380 --listen-peer-urls http://${THIS_IP}:2380 \
 	--advertise-client-urls http://${THIS_IP}:2379 --listen-client-urls http://${THIS_IP}:2379 \
@@ -43,6 +45,7 @@ sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
 THIS_NAME=${NAME_3}
 THIS_IP=${HOST_3}
 sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
+	/usr/local/bin/etcd \
     --data-dir=data.etcd --name ${THIS_NAME} \
 	--initial-advertise-peer-urls http://${THIS_IP}:2380 --listen-peer-urls http://${THIS_IP}:2380 \
 	--advertise-client-urls http://${THIS_IP}:2379 --listen-client-urls http://${THIS_IP}:2379 \
@@ -50,5 +53,9 @@ sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
 	--initial-cluster-state ${CLUSTER_STATE} --initial-cluster-token ${TOKEN}
 ```
 
-TODO: current etcd docker container is shipped with etcdctl, but the `ETCDCTL_API` environment value is not set inside the container. So currently there's no way to use etcdctl for v3 directly from the container (e.g. `docker exec etcd /etcdctl put foo bar` won't work).
+To run `etcdctl` using API version 3:
+
+```
+docker exec etcd /bin/sh -c "export ETCDCTL_API=3 && /usr/local/bin/etcdctl put foo bar"
+```
 

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -8,12 +8,6 @@ IMAGEDIR=${BUILDDIR}/image-docker
 mkdir -p ${IMAGEDIR}
 cp ${BINARYDIR}/etcd ${BINARYDIR}/etcdctl ${IMAGEDIR}
 
-cat <<DF > ${IMAGEDIR}/Dockerfile
-FROM scratch
-ADD etcd /
-ADD etcdctl /
-EXPOSE 2379 2380
-ENTRYPOINT ["/etcd"]
-DF
+cat ./Dockerfile > ${IMAGEDIR}/Dockerfile
 
 docker build -t quay.io/coreos/etcd:${1} ${IMAGEDIR}


### PR DESCRIPTION
```
sudo docker pull quay.io/coreos/etcd:v3.0.0
sudo docker run --name etcd quay.io/coreos/etcd:v3.0.0 /usr/local/bin/etcd --version
sudo docker run --name etcd quay.io/coreos/etcd:v3.0.0 /bin/sh -c "/usr/local/bin/etcd --version"
sudo docker run --name etcd quay.io/coreos/etcd:v3.0.0 -e "ETCDCTL_API=3" /usr/local/bin/etcdctl version

sudo docker run --name etcd quay.io/coreos/etcd:v3.0.0 /usr/local/bin/etcd
sudo docker exec etcd /bin/sh -c "export ETCDCTL_API=3 && /usr/local/bin/etcdctl version"
```

I test-build docker image, now at https://quay.io/repository/coreos/etcd?tab=tags.

/cc @xiang90 @heyitsanthony 
