### PR TITLE
logutil: add log rotate

### DIFF
--- a/pkg/logutil/doc.go
+++ b/pkg/logutil/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logutil includes utilities to facilitate logging.
+package logutil

--- a/pkg/logutil/log_bench_test.go
+++ b/pkg/logutil/log_bench_test.go
@@ -1,0 +1,150 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coreos/pkg/capnslog"
+)
+
+func Benchmark_capnslog_rotate_without_flock(b *testing.B) {
+	dir, err := ioutil.TempDir(os.TempDir(), "log_test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		rotateFileSize int64 = 3 * 1024 // 3KB
+		rotateDuration       = time.Duration(0)
+	)
+	ft, err := NewRotateFormatter(Config{
+		Dir:            dir,
+		FileLock:       false,
+		RotateFileSize: rotateFileSize,
+		RotateDuration: rotateDuration,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	capnslog.SetFormatter(ft)
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Println("TEST")
+	}
+}
+
+func Benchmark_capnslog_rotate_with_flock(b *testing.B) {
+	dir, err := ioutil.TempDir(os.TempDir(), "log_test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		rotateFileSize int64 = 3 * 1024 // 3KB
+		rotateDuration       = time.Duration(0)
+	)
+	ft, err := NewRotateFormatter(Config{
+		Dir:            dir,
+		FileLock:       true,
+		RotateFileSize: rotateFileSize,
+		RotateDuration: rotateDuration,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	capnslog.SetFormatter(ft)
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Println("TEST")
+	}
+}
+
+func Benchmark_capnslog(b *testing.B) {
+	dir, err := ioutil.TempDir(os.TempDir(), "log_test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	fpath := filepath.Join(dir, "test.log")
+
+	f, err := openToAppendOnly(fpath)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	capnslog.SetFormatter(capnslog.NewPrettyFormatter(f, true))
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Println("TEST")
+	}
+
+	if err = f.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func Benchmark_log(b *testing.B) {
+	dir, err := ioutil.TempDir(os.TempDir(), "log_test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	fpath := filepath.Join(dir, "test.log")
+
+	f, err := openToAppendOnly(fpath)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	logger := log.New(f, "", log.Ldate|log.Ltime|log.Lmicroseconds)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Println("TEST")
+	}
+
+	if err = f.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func openToAppendOnly(fpath string) (*os.File, error) {
+	f, err := os.OpenFile(fpath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/pkg/logutil/merge_logger.go
+++ b/pkg/logutil/merge_logger.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package logutil includes utilities to facilitate logging.
 package logutil
 
 import (

--- a/pkg/logutil/rotate_formatter.go
+++ b/pkg/logutil/rotate_formatter.go
@@ -1,0 +1,223 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/coreos/pkg/capnslog"
+)
+
+var numRegex = regexp.MustCompile("[0-9]+")
+
+// getLogName generates a log file name based on current time
+// (e.g. 20160619-142321-397035.log).
+func getLogName() string {
+	txt := time.Now().String()[:26]
+	txt = strings.Join(numRegex.FindAllString(txt, -1), "")
+	return txt[:8] + "-" + txt[8:14] + "-" + txt[14:] + ".log"
+}
+
+// Config contains configuration for log rotation.
+type Config struct {
+	// Dir is the directory to put log files.
+	Dir      string
+	Debug    bool
+	FileLock bool
+
+	RotateFileSize int64
+	RotateDuration time.Duration
+}
+
+type formatter struct {
+	dir   string
+	debug bool
+
+	rotateFileSize int64
+
+	rotateDuration time.Duration
+	started        time.Time
+
+	w *bufio.Writer
+
+	fileLock bool
+	file     *fileutil.LockedFile
+}
+
+// NewRotateFormatter returns a new formatter.
+func NewRotateFormatter(cfg Config) (capnslog.Formatter, error) {
+	if err := fileutil.TouchDirAll(cfg.Dir); err != nil {
+		return nil, err
+	}
+
+	// create temporary directory, and rename later to make it appear atomic
+	tmpDir := filepath.Clean(cfg.Dir) + ".tmp"
+	if fileutil.Exist(tmpDir) {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			return nil, err
+		}
+	}
+	if err := fileutil.TouchDirAll(tmpDir); err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var (
+		logName    = getLogName()
+		logPath    = filepath.Join(cfg.Dir, logName)
+		logPathTmp = filepath.Join(tmpDir, logName)
+
+		f   *fileutil.LockedFile
+		err error
+	)
+	switch cfg.FileLock {
+	case true:
+		f, err = fileutil.LockFile(logPathTmp, os.O_WRONLY|os.O_CREATE, fileutil.PrivateFileMode)
+		if err != nil {
+			return nil, err
+		}
+	case false:
+		var tFile *os.File
+		tFile, err = os.OpenFile(logPathTmp, os.O_WRONLY|os.O_CREATE, fileutil.PrivateFileMode)
+		if err != nil {
+			return nil, err
+		}
+		f = &fileutil.LockedFile{tFile}
+	}
+
+	if err = os.Rename(logPathTmp, logPath); err != nil {
+		return nil, err
+	}
+
+	ft := &formatter{
+		dir:            cfg.Dir,
+		debug:          cfg.Debug,
+		rotateFileSize: cfg.RotateFileSize,
+		rotateDuration: cfg.RotateDuration,
+		started:        time.Now(),
+		w:              bufio.NewWriter(f),
+		fileLock:       cfg.FileLock,
+		file:           f,
+	}
+	return ft, nil
+}
+
+// Format writes log and flushes it. This is protected by mutex in capnslog.
+func (ft *formatter) Format(pkg string, lvl capnslog.LogLevel, depth int, entries ...interface{}) {
+	if !ft.debug && lvl == capnslog.DEBUG {
+		return
+	}
+
+	ft.w.WriteString(time.Now().String()[:26])
+	ft.w.WriteString(" " + lvl.String() + " | ")
+	if pkg != "" {
+		ft.w.WriteString(pkg + ": ")
+	}
+
+	txt := fmt.Sprint(entries...)
+	ft.w.WriteString(txt)
+
+	if !strings.HasSuffix(txt, "\n") {
+		ft.w.WriteString("\n")
+	}
+
+	// fsync to the disk
+	ft.w.Flush()
+
+	// seek the current location, and get the offset
+	curOffset, err := ft.file.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		panic(err)
+	}
+
+	var (
+		needRotateBySize     = ft.rotateFileSize > 0 && curOffset > ft.rotateFileSize
+		needRotateByDuration = ft.rotateDuration > time.Duration(0) && time.Since(ft.started) > ft.rotateDuration
+	)
+	if needRotateBySize || needRotateByDuration {
+		ft.unsafeRotate()
+	}
+}
+
+func (ft *formatter) unsafeRotate() {
+	// unlock the locked file
+	if err := ft.file.Close(); err != nil {
+		panic(err)
+	}
+
+	var (
+		logPath    = filepath.Join(ft.dir, getLogName())
+		logPathTmp = logPath + ".tmp"
+
+		fileTmp *fileutil.LockedFile
+		err     error
+	)
+	switch ft.fileLock {
+	case true:
+		fileTmp, err = fileutil.LockFile(logPathTmp, os.O_WRONLY|os.O_CREATE, fileutil.PrivateFileMode)
+		if err != nil {
+			panic(err)
+		}
+	case false:
+		var tFile *os.File
+		tFile, err = os.OpenFile(logPathTmp, os.O_WRONLY|os.O_CREATE, fileutil.PrivateFileMode)
+		if err != nil {
+			panic(err)
+		}
+		fileTmp = &fileutil.LockedFile{tFile}
+	}
+
+	// rename the file to WAL name atomically
+	if err = os.Rename(logPathTmp, logPath); err != nil {
+		panic(err)
+	}
+
+	// release the lock, flush buffer
+	if err = fileTmp.Close(); err != nil {
+		panic(err)
+	}
+
+	// create a new locked file for appends
+	switch ft.fileLock {
+	case true:
+		fileTmp, err = fileutil.LockFile(logPath, os.O_WRONLY, fileutil.PrivateFileMode)
+		if err != nil {
+			panic(err)
+		}
+	case false:
+		var tFile *os.File
+		tFile, err = os.OpenFile(logPath, os.O_WRONLY, fileutil.PrivateFileMode)
+		if err != nil {
+			panic(err)
+		}
+		fileTmp = &fileutil.LockedFile{tFile}
+	}
+
+	ft.w = bufio.NewWriter(fileTmp)
+	ft.file = fileTmp
+
+	ft.started = time.Now()
+}
+
+func (ft *formatter) Flush() {
+	ft.w.Flush()
+}

--- a/pkg/logutil/rotate_formatter_test.go
+++ b/pkg/logutil/rotate_formatter_test.go
@@ -1,0 +1,133 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/coreos/pkg/capnslog"
+)
+
+func TestGetLogName(t *testing.T) {
+	name := getLogName()
+	if len(name) != 26 {
+		t.Fatalf("unexpected %q", name)
+	}
+}
+
+func TestRotateByFileSize(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "logtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		rotateFileSize int64 = 100
+		rotateDuration       = time.Duration(0)
+	)
+	ft, err := NewRotateFormatter(Config{
+		Dir:            dir,
+		RotateFileSize: rotateFileSize,
+		RotateDuration: rotateDuration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	capnslog.SetFormatter(ft)
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	logger.Println(strings.Repeat("a", 101))
+	logger.Println("Hello World!")
+	logger.Println("Hey!")
+
+	fs, err := fileutil.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 2 {
+		t.Fatalf("expected 2 files, got %q", fs)
+	}
+
+	bts, err := ioutil.ReadFile(filepath.Join(dir, fs[1]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(bts), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %q", lines)
+	}
+	if !strings.HasSuffix(lines[1], "Hey!") {
+		t.Fatalf("unexpected line %q", lines[1])
+	}
+}
+
+func TestRotateByDuration(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "logtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		rotateFileSize int64
+		rotateDuration = 50 * time.Millisecond
+	)
+	ft, err := NewRotateFormatter(Config{
+		Dir:            dir,
+		RotateFileSize: rotateFileSize,
+		RotateDuration: rotateDuration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	capnslog.SetFormatter(ft)
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	time.Sleep(rotateDuration)
+	logger.Println("Hello World!")
+	logger.Println("Hello World!")
+	logger.Println("Hey!")
+
+	fs, err := fileutil.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 2 {
+		t.Fatalf("expected 2 files, got %q", fs)
+	}
+
+	bts, err := ioutil.ReadFile(filepath.Join(dir, fs[1]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(bts), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %q", lines)
+	}
+	if !strings.HasSuffix(lines[1], "Hey!") {
+		t.Fatalf("unexpected line %q", lines[1])
+	}
+}


### PR DESCRIPTION
For https://github.com/coreos/etcd/issues/5680.

```
Benchmark_capnslog_rotate_without_flock-8   	  500000	      2514 ns/op	     173 B/op	       6 allocs/op
Benchmark_capnslog_rotate_with_flock-8      	  500000	      2474 ns/op	     173 B/op	       6 allocs/op
Benchmark_capnslog-8                        	  500000	      3457 ns/op	     224 B/op	      15 allocs/op
Benchmark_log-8                             	 1000000	      1284 ns/op	      21 B/op	       2 allocs/op
```
