### PR TITLE
etcd-agent: set up directory for etcd logs

### DIFF
--- a/tools/functional-tester/etcd-agent/main.go
+++ b/tools/functional-tester/etcd-agent/main.go
@@ -26,11 +26,11 @@ var plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "etcd-agent")
 
 func main() {
 	etcdPath := flag.String("etcd-path", filepath.Join(os.Getenv("GOPATH"), "bin/etcd"), "the path to etcd binary")
-	etcdLogPath := flag.String("etcd-log-path", "etcd.log", "the path to etcd log")
+	etcdLogDir := flag.String("etcd-log-dir", "etcd-log", "directory to store etcd logs")
 	port := flag.String("port", ":9027", "port to serve agent server")
 	flag.Parse()
 
-	a, err := newAgent(*etcdPath, *etcdLogPath)
+	a, err := newAgent(*etcdPath, *etcdLogDir)
 	if err != nil {
 		plog.Fatal(err)
 	}


### PR DESCRIPTION
- use `filepath` instead, to make it consistent
- use `fileutil.TouchDirAll` when possible
- archive log directory when cleaning up (previously just archive etcd.log)

/cc @heyitsanthony @xiang90 

After this, I will deploy 5-node etcd cluster.