### PR TITLE
*: use capnslog for grpclog

### DIFF
--- a/cmd/Godeps/Godeps.json
+++ b/cmd/Godeps/Godeps.json
@@ -53,7 +53,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/pkg/capnslog",
-			"Rev": "2c77715c4df99b5420ffcae14ead08f52104065d"
+			"Comment": "v2-8-gfa29b1d",
+			"Rev": "fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8"
 		},
 		{
 			"ImportPath": "github.com/cpuguy83/go-md2man/md2man",

--- a/cmd/vendor/github.com/coreos/pkg/capnslog/formatters.go
+++ b/cmd/vendor/github.com/coreos/pkg/capnslog/formatters.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"log"
 	"runtime"
 	"strings"
 	"time"
@@ -28,7 +29,7 @@ type Formatter interface {
 	Flush()
 }
 
-func NewStringFormatter(w io.Writer) *StringFormatter {
+func NewStringFormatter(w io.Writer) Formatter {
 	return &StringFormatter{
 		w: bufio.NewWriter(w),
 	}
@@ -103,4 +104,54 @@ func (c *PrettyFormatter) Format(pkg string, l LogLevel, depth int, entries ...i
 
 func (c *PrettyFormatter) Flush() {
 	c.w.Flush()
+}
+
+// LogFormatter emulates the form of the traditional built-in logger.
+type LogFormatter struct {
+	logger *log.Logger
+	prefix string
+}
+
+// NewLogFormatter is a helper to produce a new LogFormatter struct. It uses the
+// golang log package to actually do the logging work so that logs look similar.
+func NewLogFormatter(w io.Writer, prefix string, flag int) Formatter {
+	return &LogFormatter{
+		logger: log.New(w, "", flag), // don't use prefix here
+		prefix: prefix,               // save it instead
+	}
+}
+
+// Format builds a log message for the LogFormatter. The LogLevel is ignored.
+func (lf *LogFormatter) Format(pkg string, _ LogLevel, _ int, entries ...interface{}) {
+	str := fmt.Sprint(entries...)
+	prefix := lf.prefix
+	if pkg != "" {
+		prefix = fmt.Sprintf("%s%s: ", prefix, pkg)
+	}
+	lf.logger.Output(5, fmt.Sprintf("%s%v", prefix, str)) // call depth is 5
+}
+
+// Flush is included so that the interface is complete, but is a no-op.
+func (lf *LogFormatter) Flush() {
+	// noop
+}
+
+// NilFormatter is a no-op log formatter that does nothing.
+type NilFormatter struct {
+}
+
+// NewNilFormatter is a helper to produce a new LogFormatter struct. It logs no
+// messages so that you can cause part of your logging to be silent.
+func NewNilFormatter() Formatter {
+	return &NilFormatter{}
+}
+
+// Format does nothing.
+func (_ *NilFormatter) Format(_ string, _ LogLevel, _ int, _ ...interface{}) {
+	// noop
+}
+
+// Flush is included so that the interface is complete, but is a no-op.
+func (_ *NilFormatter) Flush() {
+	// noop
 }

--- a/cmd/vendor/github.com/coreos/pkg/capnslog/pkg_logger.go
+++ b/cmd/vendor/github.com/coreos/pkg/capnslog/pkg_logger.go
@@ -27,17 +27,19 @@ type PackageLogger struct {
 const calldepth = 2
 
 func (p *PackageLogger) internalLog(depth int, inLevel LogLevel, entries ...interface{}) {
+	logger.Lock()
+	defer logger.Unlock()
 	if inLevel != CRITICAL && p.level < inLevel {
 		return
 	}
-	logger.Lock()
-	defer logger.Unlock()
 	if logger.formatter != nil {
 		logger.formatter.Format(p.pkg, inLevel, depth+1, entries...)
 	}
 }
 
 func (p *PackageLogger) LevelAt(l LogLevel) bool {
+	logger.Lock()
+	defer logger.Unlock()
 	return p.level >= l
 }
 
@@ -58,7 +60,7 @@ func (p *PackageLogger) Println(args ...interface{}) {
 }
 
 func (p *PackageLogger) Printf(format string, args ...interface{}) {
-	p.internalLog(calldepth, INFO, fmt.Sprintf(format, args...))
+	p.Logf(INFO, format, args...)
 }
 
 func (p *PackageLogger) Print(args ...interface{}) {
@@ -80,8 +82,7 @@ func (p *PackageLogger) Panic(args ...interface{}) {
 }
 
 func (p *PackageLogger) Fatalf(format string, args ...interface{}) {
-	s := fmt.Sprintf(format, args...)
-	p.internalLog(calldepth, CRITICAL, s)
+	p.Logf(CRITICAL, format, args...)
 	os.Exit(1)
 }
 
@@ -91,10 +92,16 @@ func (p *PackageLogger) Fatal(args ...interface{}) {
 	os.Exit(1)
 }
 
+func (p *PackageLogger) Fatalln(args ...interface{}) {
+	s := fmt.Sprintln(args...)
+	p.internalLog(calldepth, CRITICAL, s)
+	os.Exit(1)
+}
+
 // Error Functions
 
 func (p *PackageLogger) Errorf(format string, args ...interface{}) {
-	p.internalLog(calldepth, ERROR, fmt.Sprintf(format, args...))
+	p.Logf(ERROR, format, args...)
 }
 
 func (p *PackageLogger) Error(entries ...interface{}) {
@@ -104,7 +111,7 @@ func (p *PackageLogger) Error(entries ...interface{}) {
 // Warning Functions
 
 func (p *PackageLogger) Warningf(format string, args ...interface{}) {
-	p.internalLog(calldepth, WARNING, fmt.Sprintf(format, args...))
+	p.Logf(WARNING, format, args...)
 }
 
 func (p *PackageLogger) Warning(entries ...interface{}) {
@@ -114,7 +121,7 @@ func (p *PackageLogger) Warning(entries ...interface{}) {
 // Notice Functions
 
 func (p *PackageLogger) Noticef(format string, args ...interface{}) {
-	p.internalLog(calldepth, NOTICE, fmt.Sprintf(format, args...))
+	p.Logf(NOTICE, format, args...)
 }
 
 func (p *PackageLogger) Notice(entries ...interface{}) {
@@ -124,7 +131,7 @@ func (p *PackageLogger) Notice(entries ...interface{}) {
 // Info Functions
 
 func (p *PackageLogger) Infof(format string, args ...interface{}) {
-	p.internalLog(calldepth, INFO, fmt.Sprintf(format, args...))
+	p.Logf(INFO, format, args...)
 }
 
 func (p *PackageLogger) Info(entries ...interface{}) {
@@ -134,20 +141,32 @@ func (p *PackageLogger) Info(entries ...interface{}) {
 // Debug Functions
 
 func (p *PackageLogger) Debugf(format string, args ...interface{}) {
-	p.internalLog(calldepth, DEBUG, fmt.Sprintf(format, args...))
+	if p.level < DEBUG {
+		return
+	}
+	p.Logf(DEBUG, format, args...)
 }
 
 func (p *PackageLogger) Debug(entries ...interface{}) {
+	if p.level < DEBUG {
+		return
+	}
 	p.internalLog(calldepth, DEBUG, entries...)
 }
 
 // Trace Functions
 
 func (p *PackageLogger) Tracef(format string, args ...interface{}) {
-	p.internalLog(calldepth, TRACE, fmt.Sprintf(format, args...))
+	if p.level < TRACE {
+		return
+	}
+	p.Logf(TRACE, format, args...)
 }
 
 func (p *PackageLogger) Trace(entries ...interface{}) {
+	if p.level < TRACE {
+		return
+	}
 	p.internalLog(calldepth, TRACE, entries...)
 }
 

--- a/etcdserver/api/v3rpc/grpc.go
+++ b/etcdserver/api/v3rpc/grpc.go
@@ -20,9 +20,15 @@ import (
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/api"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/pkg/capnslog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/grpclog"
 )
+
+func init() {
+	grpclog.SetLogger(capnslog.NewPackageLogger("github.com/coreos/etcd/etcdserver", "v3rpc/grpc"))
+}
 
 func Server(s *etcdserver.EtcdServer, tls *tls.Config) *grpc.Server {
 	var opts []grpc.ServerOption

--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
 	"math/rand"
 	"net"
 	"net/http"
@@ -35,7 +33,7 @@ import (
 )
 
 func init() {
-	grpclog.SetLogger(log.New(ioutil.Discard, "", 0))
+	grpclog.SetLogger(plog)
 }
 
 type Stresser interface {


### PR DESCRIPTION
```
# client
2016-06-20 17:09:03.921856 I | clientv3: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 127.0.0.1:22379: getsockopt: connection refused"; Reconnecting to {"127.0.0.1:22379" <nil>}

2016-06-20 17:14:19.988867 I | clientv3: transport: http2Client.notifyError got notified that the client transport was broken read tcp 127.0.0.1:45078->127.0.0.1:2379: read: connection reset by peer.
```

