### PR TITLE
etcdctl: a flag for getting detailed information of a user

### DIFF
--- a/etcdctl/ctlv3/command/role_command.go
+++ b/etcdctl/ctlv3/command/role_command.go
@@ -115,18 +115,7 @@ func roleDeleteCommandFunc(cmd *cobra.Command, args []string) {
 	fmt.Printf("Role %s deleted\n", args[0])
 }
 
-// roleGetCommandFunc executes the "role get" command.
-func roleGetCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
-		ExitWithError(ExitBadArgs, fmt.Errorf("role get command requires role name as its argument."))
-	}
-
-	name := args[0]
-	resp, err := mustClientFromCmd(cmd).Auth.RoleGet(context.TODO(), name)
-	if err != nil {
-		ExitWithError(ExitError, err)
-	}
-
+func printRolePermissions(name string, resp *clientv3.AuthRoleGetResponse) {
 	fmt.Printf("Role %s\n", name)
 	fmt.Println("KV Read:")
 	for _, perm := range resp.Perm {
@@ -148,6 +137,21 @@ func roleGetCommandFunc(cmd *cobra.Command, args []string) {
 			}
 		}
 	}
+}
+
+// roleGetCommandFunc executes the "role get" command.
+func roleGetCommandFunc(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		ExitWithError(ExitBadArgs, fmt.Errorf("role get command requires role name as its argument."))
+	}
+
+	name := args[0]
+	resp, err := mustClientFromCmd(cmd).Auth.RoleGet(context.TODO(), name)
+	if err != nil {
+		ExitWithError(ExitError, err)
+	}
+
+	printRolePermissions(name, resp)
 }
 
 // roleListCommandFunc executes the "role list" command.


### PR DESCRIPTION

This commit adds a new flag --detail to etcdctl user get command. The
flag enables printing the detailed permission information of the user
like below example:

$ ETCDCTL_API=3 bin/etcdctl --user root:p user get u1
User: u1
Roles: r1 r2
$ ETCDCTL_API=3 bin/etcdctl --user root:p user get u1 --detail
User: u1

Role r1
KV Read:
        [k1, k5)
KV Write:
        [k1, k5)

Role r2
KV Read:
        a
        b
        [k8, k9)
KV Write:
        a
        b
        [k8, k9)