### PR TITLE
auth: protect cached range permission

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -134,7 +134,8 @@ type authStore struct {
 	enabled   bool
 	enabledMu sync.RWMutex
 
-	rangePermCache map[string]*unifiedRangePermissions // username -> unifiedRangePermissions
+	rangePermCache   map[string]*unifiedRangePermissions // username -> unifiedRangePermissions
+	rangePermCacheMu sync.RWMutex
 
 	simpleTokensMu sync.RWMutex
 	simpleTokens   map[string]string // token -> username


### PR DESCRIPTION

It is required for serialized range and txn requests. These
serializable requests and ordinal requests are processed in parallel.

/cc @heyitsanthony 