### PR TITLE
*: misc typos and go vet fixes

### DIFF
--- a/clientv3/lease.go
+++ b/clientv3/lease.go
@@ -354,8 +354,8 @@ func (l *lessor) recvKeepAlive(resp *pb.LeaseKeepAliveResponse) {
 	}
 }
 
-// deadlineLoop reaps any keep alive channels that have not recieved a resposne within
-// the lease TTL
+// deadlineLoop reaps any keep alive channels that have not received a response
+// within the lease TTL
 func (l *lessor) deadlineLoop() {
 	for {
 		select {

--- a/pkg/fileutil/preallocate_unix.go
+++ b/pkg/fileutil/preallocate_unix.go
@@ -27,7 +27,7 @@ func preallocExtend(f *os.File, sizeInBytes int64) error {
 	if err != nil {
 		errno, ok := err.(syscall.Errno)
 		// not supported; fallback
-		// fallocate EINTRs frequently in some enviroments; fallback
+		// fallocate EINTRs frequently in some environments; fallback
 		if ok && (errno == syscall.ENOTSUP || errno == syscall.EINTR) {
 			return preallocExtendTrunc(f, sizeInBytes)
 		}


### PR DESCRIPTION
Replacing https://github.com/coreos/etcd/pull/5675.

Cherry-picking this to fix other go vet issues in go tip.

@purpleidea please format your commit message like this next time.
