### PR TITLE
Reuse timer in backend.run.

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -179,15 +179,17 @@ func (b *backend) Size() int64 {
 
 func (b *backend) run() {
 	defer close(b.donec)
-
+	t := time.NewTimer(b.batchInterval)
+	defer t.Stop()
 	for {
 		select {
-		case <-time.After(b.batchInterval):
+		case <-t.C:
 		case <-b.stopc:
 			b.batchTx.CommitAndStop()
 			return
 		}
 		b.batchTx.Commit()
+		t.Reset(b.batchInterval)
 	}
 }
 


### PR DESCRIPTION
Hi!
This is my first and pretty trivial attempt to contribute to etcd. Was reading code and this particular piece of code made me interested. It runs every 100ms and starts new timer on every iteration. Seems that it is a bit wasteful and can be easily avoided.

I guess producing 30 objects/s is not that much, but it is a low hanging fruit, so I took a bite.
Feel free to reject it.

Benchmarks:

```
import (
	"testing"
	"time"
)

func BenchmarkTimeAfter(b *testing.B) {
	b.ReportAllocs()
	for n := 0; n < b.N; n++ {
		select {
		case <- time.After(1 * time.Millisecond):
		}
	}
}

func BenchmarkTimerReset(b *testing.B) {
	b.ReportAllocs()
	t := time.NewTimer(1 * time.Millisecond)
	for n := 0; n < b.N; n++ {
		select {
		case <- t.C:
		}
		t.Reset(1 * time.Millisecond)
	}
}
```

Running reveals that each loop results in 3 allocs:

```
BenchmarkTimeAfter-4 	    2000	   1112134 ns/op	     192 B/op	       3 allocs/op
BenchmarkTimerReset-4	    2000	   1109774 ns/op	       0 B/op	       0 allocs/op
```