### PR TITLE
index is incremented in Watcher; remove double-increment

### DIFF
--- a/etcdctl/ctlv2/command/exec_watch_command.go
+++ b/etcdctl/ctlv2/command/exec_watch_command.go
@@ -77,7 +77,7 @@ func execWatchCommandFunc(c *cli.Context, ki client.KeysAPI) {
 
 	index := 0
 	if c.Int("after-index") != 0 {
-		index = c.Int("after-index") + 1
+		index = c.Int("after-index")
 	}
 
 	recursive := c.Bool("recursive")


### PR DESCRIPTION
Remove double-increment, closes #5741.

Watch index is incremented in both etcd-watch client and in Watcher method from keys.go. It makes more sense in Watcher(), so removed from etcd-watch.