### PR TITLE
*: change ctlv3 flag peerURLs to 'peer-urls'

### DIFF
--- a/e2e/ctl_v3_member_test.go
+++ b/e2e/ctl_v3_member_test.go
@@ -106,7 +106,7 @@ func ctlV3MemberRemove(cx ctlCtx, memberID, clusterID string) error {
 
 func memberAddTest(cx ctlCtx) {
 	peerURL := fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)
-	cmdArgs := append(cx.PrefixArgs(), "member", "add", "newmember", fmt.Sprintf("--peerURLs=%s", peerURL))
+	cmdArgs := append(cx.PrefixArgs(), "member", "add", "newmember", fmt.Sprintf("--peer-urls=%s", peerURL))
 	if err := spawnWithExpect(cmdArgs, " added to cluster "); err != nil {
 		cx.t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func memberUpdateTest(cx ctlCtx) {
 	}
 
 	peerURL := fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)
-	cmdArgs := append(cx.PrefixArgs(), "member", "update", fmt.Sprintf("%x", mr.Members[0].ID), fmt.Sprintf("--peerURLs=%s", peerURL))
+	cmdArgs := append(cx.PrefixArgs(), "member", "update", fmt.Sprintf("%x", mr.Members[0].ID), fmt.Sprintf("--peer-urls=%s", peerURL))
 	if err = spawnWithExpect(cmdArgs, " updated in cluster "); err != nil {
 		cx.t.Fatal(err)
 	}

--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -351,7 +351,7 @@ MEMBER ADD introduces a new member into the etcd cluster as a new peer.
 
 #### Options
 
-- peerURLs -- comma separated list of URLs to associate with the new member.
+- peer-urls -- comma separated list of URLs to associate with the new member.
 
 #### Return value
 
@@ -362,7 +362,7 @@ MEMBER ADD introduces a new member into the etcd cluster as a new peer.
 #### Example
 
 ```bash
-./etcdctl member add newMember --peerURLs=https://127.0.0.1:12345
+./etcdctl member add newMember --peer-urls=https://127.0.0.1:12345
 Member 2be1eb8f84b7f63e added to cluster ef37ad9dc622a7c4
 ```
 
@@ -373,7 +373,7 @@ MEMBER UPDATE sets the peer URLs for an existing member in the etcd cluster.
 
 #### Options
 
-- peerURLs -- comma separated list of URLs to associate with the updated member.
+- peer-urls -- comma separated list of URLs to associate with the updated member.
 
 #### Return value
 
@@ -384,7 +384,7 @@ MEMBER UPDATE sets the peer URLs for an existing member in the etcd cluster.
 #### Example
 
 ```bash
-./etcdctl member update 2be1eb8f84b7f63e --peerURLs=https://127.0.0.1:11112
+./etcdctl member update 2be1eb8f84b7f63e --peer-urls=https://127.0.0.1:11112
 Member 2be1eb8f84b7f63e updated in cluster ef37ad9dc622a7c4
 ```
 

--- a/etcdctl/ctlv3/command/member_command.go
+++ b/etcdctl/ctlv3/command/member_command.go
@@ -48,7 +48,7 @@ func NewMemberAddCommand() *cobra.Command {
 		Run: memberAddCommandFunc,
 	}
 
-	cc.Flags().StringVar(&memberPeerURLs, "peerURLs", "", "comma separated peer URLs for the new member.")
+	cc.Flags().StringVar(&memberPeerURLs, "peer-urls", "", "comma separated peer URLs for the new member.")
 
 	return cc
 }
@@ -74,7 +74,7 @@ func NewMemberUpdateCommand() *cobra.Command {
 		Run: memberUpdateCommandFunc,
 	}
 
-	cc.Flags().StringVar(&memberPeerURLs, "peerURLs", "", "comma separated peer URLs for the updated member.")
+	cc.Flags().StringVar(&memberPeerURLs, "peer-urls", "", "comma separated peer URLs for the updated member.")
 
 	return cc
 }


### PR DESCRIPTION
`peer-urls` to be more consistent with other flag names