### PR TITLE
*: add log rotator for functional-tester

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/pkg/cors"
@@ -135,6 +136,11 @@ type config struct {
 	// Debug logging
 	Debug        bool   `json:"debug"`
 	LogPkgLevels string `json:"log-package-levels"`
+
+	// RotateLogDir is directory to store segmented log files.
+	RotateLogDir      string        `json:"rotate-log-dir"`
+	RotateLogSize     int64         `json:"rotate-log-size"`
+	RotateLogDuration time.Duration `json:"rotate-log-duration"`
 
 	// ForceNewCluster is unsafe
 	ForceNewCluster bool `json:"force-new-cluster"`
@@ -249,6 +255,9 @@ func NewConfig() *config {
 	// logging
 	fs.BoolVar(&cfg.Debug, "debug", false, "Enable debug-level logging for etcd.")
 	fs.StringVar(&cfg.LogPkgLevels, "log-package-levels", "", "Specify a particular log level for each etcd package (eg: 'etcdmain=CRITICAL,etcdserver=DEBUG').")
+	fs.StringVar(&cfg.RotateLogDir, "rotate-log-dir", "", "Specify a directory to store segmented etcd logging files. If empty, logging to stderr by default.")
+	fs.Int64Var(&cfg.RotateLogSize, "rotate-log-size", 1024*1024, "Specify a log file size to rotate in bytes. This is ignored if 'rotate-log-dir' is empty.")
+	fs.DurationVar(&cfg.RotateLogDuration, "rotate-log-duration", time.Duration(0), "Specify an interval to rotate logs. This is ignored if 'rotate-log-dir' is empty.")
 
 	// unsafe
 	fs.BoolVar(&cfg.ForceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster.")

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/coreos/etcd/pkg/cors"
 	"github.com/coreos/etcd/pkg/fileutil"
 	pkgioutil "github.com/coreos/etcd/pkg/ioutil"
+	"github.com/coreos/etcd/pkg/logutil"
 	"github.com/coreos/etcd/pkg/osutil"
 	runtimeutil "github.com/coreos/etcd/pkg/runtime"
 	"github.com/coreos/etcd/pkg/transport"
@@ -617,6 +618,20 @@ func setupLogging(cfg *config) {
 			return
 		}
 		repoLog.SetLogLevel(settings)
+	}
+	if cfg.RotateLogDir != "" {
+		rc := logutil.RotateConfig{
+			Dir:            cfg.RotateLogDir,
+			Debug:          cfg.Debug,
+			RotateFileSize: cfg.RotateLogSize,
+			RotateDuration: cfg.RotateLogDuration,
+		}
+		ft, err := logutil.NewRotateFormatter(rc)
+		if err != nil {
+			plog.Warningf("failed to start log rotation %+v (%v)", rc, err)
+			return
+		}
+		capnslog.SetFormatter(ft)
 	}
 }
 

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -135,6 +135,12 @@ logging flags
 		enable debug-level logging for etcd.
 	--log-package-levels ''
 		specify a particular log level for each etcd package (eg: 'etcdmain=CRITICAL,etcdserver=DEBUG').
+	--rotate-log-dir ''
+		specify a directory to store segmented etcd logging files. If empty, logging to stderr by default.
+	--rotate-log-size 1048576
+		specify a log file size to rotate in bytes. This is ignored if 'rotate-log-dir' is empty.
+	--rotate-log-duration 0
+		specify an interval to rotate logs. This is ignored if 'rotate-log-dir' is empty.
 
 unsafe flags:
 

--- a/pkg/logutil/doc.go
+++ b/pkg/logutil/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logutil includes utilities to facilitate logging.
+package logutil

--- a/pkg/logutil/log_bench_test.go
+++ b/pkg/logutil/log_bench_test.go
@@ -1,0 +1,118 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/coreos/pkg/capnslog"
+)
+
+func Benchmark_capnslog_rotate(b *testing.B) {
+	dir, err := ioutil.TempDir(os.TempDir(), "log_test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		rotateFileSize int64 = 3 * 1024 // 3KB
+		rotateDuration       = time.Duration(0)
+	)
+	ft, err := NewRotateFormatter(RotateConfig{
+		Dir:            dir,
+		RotateFileSize: rotateFileSize,
+		RotateDuration: rotateDuration,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	capnslog.SetFormatter(ft)
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Println("TEST")
+	}
+}
+
+func Benchmark_capnslog(b *testing.B) {
+	dir, err := ioutil.TempDir(os.TempDir(), "log_test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	fpath := filepath.Join(dir, "test.log")
+
+	f, err := openToAppendOnly(fpath)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	capnslog.SetFormatter(capnslog.NewPrettyFormatter(f, true))
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Println("TEST")
+	}
+
+	if err = f.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func Benchmark_standard_log(b *testing.B) {
+	dir, err := ioutil.TempDir(os.TempDir(), "log_test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	fpath := filepath.Join(dir, "test.log")
+
+	f, err := openToAppendOnly(fpath)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	logger := log.New(f, "", log.Ldate|log.Ltime|log.Lmicroseconds)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Println("TEST")
+	}
+
+	if err = f.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func openToAppendOnly(fpath string) (*os.File, error) {
+	f, err := os.OpenFile(fpath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/pkg/logutil/merge_logger.go
+++ b/pkg/logutil/merge_logger.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package logutil includes utilities to facilitate logging.
 package logutil
 
 import (

--- a/pkg/logutil/rotate_formatter.go
+++ b/pkg/logutil/rotate_formatter.go
@@ -1,0 +1,178 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/coreos/pkg/capnslog"
+)
+
+var numRegex = regexp.MustCompile("[0-9]+")
+
+// getLogName generates a log file name based on current time
+// (e.g. 20160619-142321-397035.log).
+func getLogName() string {
+	txt := time.Now().String()[:26]
+	txt = strings.Join(numRegex.FindAllString(txt, -1), "")
+	return txt[:8] + "-" + txt[8:14] + "-" + txt[14:] + ".log"
+}
+
+// RotateConfig contains configuration for log rotation.
+type RotateConfig struct {
+	// Dir is the directory to put log files.
+	Dir   string
+	Debug bool
+
+	RotateFileSize int64
+	RotateDuration time.Duration
+}
+
+type formatter struct {
+	dir   string
+	debug bool
+
+	rotateFileSize int64
+
+	rotateDuration time.Duration
+	started        time.Time
+
+	w    *bufio.Writer
+	file *os.File
+}
+
+// NewRotateFormatter returns a new formatter.
+func NewRotateFormatter(cfg RotateConfig) (capnslog.Formatter, error) {
+	if err := fileutil.TouchDirAll(cfg.Dir); err != nil {
+		return nil, err
+	}
+
+	// create temporary directory, and rename later to make it appear atomic
+	tmpDir := filepath.Clean(cfg.Dir) + ".tmp"
+	if fileutil.Exist(tmpDir) {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			return nil, err
+		}
+	}
+	if err := fileutil.TouchDirAll(tmpDir); err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var (
+		logName    = getLogName()
+		logPath    = filepath.Join(cfg.Dir, logName)
+		logPathTmp = filepath.Join(tmpDir, logName)
+	)
+	f, err := os.OpenFile(logPathTmp, os.O_WRONLY|os.O_CREATE, fileutil.PrivateFileMode)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = os.Rename(logPathTmp, logPath); err != nil {
+		return nil, err
+	}
+
+	ft := &formatter{
+		dir:            cfg.Dir,
+		debug:          cfg.Debug,
+		rotateFileSize: cfg.RotateFileSize,
+		rotateDuration: cfg.RotateDuration,
+		started:        time.Now(),
+		w:              bufio.NewWriter(f),
+		file:           f,
+	}
+	return ft, nil
+}
+
+// Format writes log and flushes it. This is protected by mutex in capnslog.
+func (ft *formatter) Format(pkg string, lvl capnslog.LogLevel, depth int, entries ...interface{}) {
+	if !ft.debug && lvl == capnslog.DEBUG {
+		return
+	}
+
+	ft.w.WriteString(time.Now().String()[:26])
+	ft.w.WriteString(" " + lvl.String() + " | ")
+	if pkg != "" {
+		ft.w.WriteString(pkg + ": ")
+	}
+
+	txt := fmt.Sprint(entries...)
+	ft.w.WriteString(txt)
+
+	if !strings.HasSuffix(txt, "\n") {
+		ft.w.WriteString("\n")
+	}
+
+	ft.w.Flush()
+
+	// seek the current location, and get the offset
+	curOffset, err := ft.file.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		panic(err)
+	}
+
+	var (
+		needRotateBySize     = ft.rotateFileSize > 0 && curOffset > ft.rotateFileSize
+		needRotateByDuration = ft.rotateDuration > time.Duration(0) && time.Since(ft.started) > ft.rotateDuration
+	)
+	if needRotateBySize || needRotateByDuration {
+		ft.unsafeRotate()
+	}
+}
+
+func (ft *formatter) unsafeRotate() {
+	if err := ft.file.Close(); err != nil {
+		panic(err)
+	}
+
+	var (
+		logPath    = filepath.Join(ft.dir, getLogName())
+		logPathTmp = logPath + ".tmp"
+	)
+	fileTmp, err := os.OpenFile(logPathTmp, os.O_WRONLY|os.O_CREATE, fileutil.PrivateFileMode)
+	if err != nil {
+		panic(err)
+	}
+
+	if err = os.Rename(logPathTmp, logPath); err != nil {
+		panic(err)
+	}
+
+	if err = fileTmp.Close(); err != nil {
+		panic(err)
+	}
+
+	fileTmp, err = os.OpenFile(logPath, os.O_WRONLY, fileutil.PrivateFileMode)
+	if err != nil {
+		panic(err)
+	}
+
+	ft.w = bufio.NewWriter(fileTmp)
+	ft.file = fileTmp
+
+	ft.started = time.Now()
+}
+
+func (ft *formatter) Flush() {
+	ft.w.Flush()
+}

--- a/pkg/logutil/rotate_formatter_test.go
+++ b/pkg/logutil/rotate_formatter_test.go
@@ -1,0 +1,133 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/coreos/pkg/capnslog"
+)
+
+func TestGetLogName(t *testing.T) {
+	name := getLogName()
+	if len(name) != 26 {
+		t.Fatalf("unexpected %q", name)
+	}
+}
+
+func TestRotateByFileSize(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "logtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		rotateFileSize int64 = 100
+		rotateDuration       = time.Duration(0)
+	)
+	ft, err := NewRotateFormatter(RotateConfig{
+		Dir:            dir,
+		RotateFileSize: rotateFileSize,
+		RotateDuration: rotateDuration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	capnslog.SetFormatter(ft)
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	logger.Println(strings.Repeat("a", 101))
+	logger.Println("Hello World!")
+	logger.Println("Hey!")
+
+	fs, err := fileutil.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 2 {
+		t.Fatalf("expected 2 files, got %q", fs)
+	}
+
+	bts, err := ioutil.ReadFile(filepath.Join(dir, fs[1]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(bts), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %q", lines)
+	}
+	if !strings.HasSuffix(lines[1], "Hey!") {
+		t.Fatalf("unexpected line %q", lines[1])
+	}
+}
+
+func TestRotateByDuration(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "logtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	var (
+		rotateFileSize int64
+		rotateDuration = 50 * time.Millisecond
+	)
+	ft, err := NewRotateFormatter(RotateConfig{
+		Dir:            dir,
+		RotateFileSize: rotateFileSize,
+		RotateDuration: rotateDuration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	capnslog.SetFormatter(ft)
+
+	logger := capnslog.NewPackageLogger("test", "")
+
+	time.Sleep(rotateDuration)
+	logger.Println("Hello World!")
+	logger.Println("Hello World!")
+	logger.Println("Hey!")
+
+	fs, err := fileutil.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fs) != 2 {
+		t.Fatalf("expected 2 files, got %q", fs)
+	}
+
+	bts, err := ioutil.ReadFile(filepath.Join(dir, fs[1]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(bts), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %q", lines)
+	}
+	if !strings.HasSuffix(lines[1], "Hey!") {
+		t.Fatalf("unexpected line %q", lines[1])
+	}
+}


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/5680.

I tested `logrotate` but they keep corrupting the log files. It seems fine when I just cat the log files inside the VMs but when we move those directories or copy to cloud storage, they all seem broken (e.g. Broken files are here https://console.cloud.google.com/storage/browser/etcd-functional-tester/test/?project=etcd-development&authuser=1)

My logrotate config was 

```
/home/gyuho/etcd-log/etcd.log {
	size 500k
	daily
	missingok
	notifempty
	rotate 50000
	copytruncate
}
```

We don't need advanced log rotation. We just need to segment log files, and I think just implementing log rotation is much simpler which requires no operational cost.

/cc @heyitsanthony @xiang90 