### PR TITLE
build: remove needless output

### DIFF
--- a/build
+++ b/build
@@ -41,4 +41,4 @@ etcd_build() {
 toggle_failpoints
 
 # don't build when sourced
-(echo "$0" | grep "/build$") && etcd_build || true
+(echo "$0" | grep "/build$" > /dev/null) && etcd_build || true


### PR DESCRIPTION

Current build script outputs its name to stdout because of its
checking argv[0].

$ ./build
./build

The line is a little bit mysterious so this commit removes it.