### PR TITLE
raft: fix comment, method name in progress

### DIFF
--- a/raft/progress.go
+++ b/raft/progress.go
@@ -167,9 +167,9 @@ func (pr *Progress) isPaused() bool {
 
 func (pr *Progress) snapshotFailure() { pr.PendingSnapshot = 0 }
 
-// maybeSnapshotAbort unsets pendingSnapshot if Match is equal or higher than
-// the pendingSnapshot
-func (pr *Progress) maybeSnapshotAbort() bool {
+// needSnapshotAbort returns true if snapshot progress's Match
+// is equal or higher than the pendingSnapshot.
+func (pr *Progress) needSnapshotAbort() bool {
 	return pr.State == ProgressStateSnapshot && pr.Match >= pr.PendingSnapshot
 }
 

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -670,7 +670,7 @@ func stepLeader(r *raft, m pb.Message) {
 				switch {
 				case pr.State == ProgressStateProbe:
 					pr.becomeReplicate()
-				case pr.State == ProgressStateSnapshot && pr.maybeSnapshotAbort():
+				case pr.State == ProgressStateSnapshot && pr.needSnapshotAbort():
 					r.logger.Debugf("%x snapshot aborted, resumed sending replication messages to %x [%s]", r.id, m.From, pr)
 					pr.becomeProbe()
 				case pr.State == ProgressStateReplicate:


### PR DESCRIPTION
Fix some typos. And 'maybeSnapshotAbort' does not 'unset'
the pendingSnapshot. 'resetState', which is called after this
metho, is the one that unsets pendingSnapshot. So this changes
the method name.