### PR TITLE
raft: len(entries) before Lock, use firstIndex

### DIFF
--- a/raft/storage.go
+++ b/raft/storage.go
@@ -226,12 +226,14 @@ func (ms *MemoryStorage) Compact(compactIndex uint64) error {
 // TODO (xiangli): ensure the entries are continuous and
 // entries[0].Index > ms.entries[0].Index
 func (ms *MemoryStorage) Append(entries []pb.Entry) error {
-	ms.Lock()
-	defer ms.Unlock()
 	if len(entries) == 0 {
 		return nil
 	}
-	first := ms.ents[0].Index + 1
+
+	ms.Lock()
+	defer ms.Unlock()
+
+	first := ms.firstIndex()
 	last := entries[0].Index + uint64(len(entries)) - 1
 
 	// shortcut if there is no new entry.


### PR DESCRIPTION
- To avoid unnecessary locking in case len(entries) == 0
- use firstIndex method