### PR TITLE
raft: reuse slice for truncation

### DIFF
--- a/raft/storage.go
+++ b/raft/storage.go
@@ -248,7 +248,7 @@ func (ms *MemoryStorage) Append(entries []pb.Entry) error {
 	offset := entries[0].Index - ms.ents[0].Index
 	switch {
 	case uint64(len(ms.ents)) > offset:
-		ms.ents = append([]pb.Entry{}, ms.ents[:offset]...)
+		ms.ents = ms.ents[:offset]
 		ms.ents = append(ms.ents, entries...)
 	case uint64(len(ms.ents)) == offset:
 		ms.ents = append(ms.ents, entries...)

--- a/raft/storage_test.go
+++ b/raft/storage_test.go
@@ -192,7 +192,6 @@ func TestStorageCreateSnapshot(t *testing.T) {
 }
 
 func TestStorageAppend(t *testing.T) {
-	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
 	tests := []struct {
 		entries []pb.Entry
 
@@ -235,6 +234,7 @@ func TestStorageAppend(t *testing.T) {
 	}
 
 	for i, tt := range tests {
+		ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
 		s := &MemoryStorage{ents: ents}
 		err := s.Append(tt.entries)
 		if err != tt.werr {


### PR DESCRIPTION
'append' to an empty entry slice will allocate a
new underlying array. Since 'ents' is internal to
`MemoryStorage`, we can just reuse the existing 'ents'
slice for truncation.