### PR TITLE
etcd-tester: match ErrTimeoutDueToLeaderFail

### DIFF
--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -105,12 +105,22 @@ func (s *stresser) Stress() error {
 						// as well. We want to keep stressing until the cluster elects a
 						// new leader and start processing requests again.
 						shouldContinue = true
+
+					case etcdserver.ErrTimeoutDueToLeaderFail.Error():
+						// This retries when request is triggered at the same time as
+						// leader failure and follower nodes receive time out errors
+						// from losing their leader. Followers should retry to connect
+						// to the new leader.
+						shouldContinue = true
+
 					case etcdserver.ErrStopped.Error():
 						// one of the etcd nodes stopped from failure injection
 						shouldContinue = true
+
 					case transport.ErrConnClosing.Desc:
 						// server closed the transport (failure injected node)
 						shouldContinue = true
+
 					case rpctypes.ErrNotCapable.Error():
 						// capability check has not been done (in the beginning)
 						shouldContinue = true


### PR DESCRIPTION
stresser in followers should retry when failure is injected to
their leader.

When follower started dialing, and leader fails, then etcd server returns `ErrTimeoutDueToLeaderFail` and all stressers will exit.

Example logs happening:


> 2016-06-28 03:24:49.792875 I | etcd-tester: [round#0 case#5] injecting failure "kill the leader for long time and expect it to recover from incoming snapshot"
2016-06-28 03:24:49.803393 I | etcd-agent: stopping "10.240.0.4:9027"
2016-06-28 03:24:49.814205 I | etcd-tester: transport: http2Client.notifyError got notified that the client transport was broken read tcp 10.240.0.5:47336->10.240.0.4:2379: read: connection reset by peer.
2016-06-28 03:24:50.814600 I | etcd-tester: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 10.240.0.4:2379: getsockopt: connection refused"; Reconnecting to {"10.240.0.4:2379" <nil>}
2016-06-28 03:24:52.441190 I | etcd-tester: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 10.240.0.4:2379: getsockopt: connection refused"; Reconnecting to {"10.240.0.4:2379" <nil>}
2016-06-28 03:24:54.799654 I | etcd-tester: client error [endpoint: "10.240.0.2:2379", took 5.009258015s | error (rpc error: code = 13 desc = etcdserver: request timed out, possibly due to previous leader failure | "etcdserver: request timed out, possibly due to previous leader failure")]
2016-06-28 03:24:54.799692 I | etcd-tester: client error [endpoint: "10.240.0.2:2379", took 5.009351051s | error (rpc error: code = 13 desc = etcdserver: request timed out, possibly due to previous leader failure | "etcdserver: request timed out, possibly due to previous leader failure")]
2016-06-28 03:24:54.799746 I | etcd-tester: client error [endpoint: "10.240.0.2:2379", took 5.00929857s | error (rpc error: code = 13 desc = etcdserver: request timed out, possibly due to previous leader failure | "etcdserver: request timed out, possibly due to previous leader failure")]
2016-06-28 03:24:54.800198 I | etcd-tester: client error [endpoint: "10.240.0.2:2379", took 5.008206942s | error (rpc error: code = 13 desc = etcdserver: request timed out, possibly due to previous leader failure | "etcdserver: request timed out, possibly due to previous leader failure")]

