### PR TITLE
raft: truncateAndAppend no need the value of 'after' with subbing one

### DIFF
--- a/raft/log_unstable.go
+++ b/raft/log_unstable.go
@@ -101,23 +101,23 @@ func (u *unstable) restore(s pb.Snapshot) {
 }
 
 func (u *unstable) truncateAndAppend(ents []pb.Entry) {
-	after := ents[0].Index - 1
+	after := ents[0].Index
 	switch {
-	case after == u.offset+uint64(len(u.entries))-1:
-		// after is the last index in the u.entries
+	case after == u.offset+uint64(len(u.entries)):
+		// after is the next index in the u.entries
 		// directly append
 		u.entries = append(u.entries, ents...)
-	case after < u.offset:
-		u.logger.Infof("replace the unstable entries from index %d", after+1)
+	case after <= u.offset:
+		u.logger.Infof("replace the unstable entries from index %d", after)
 		// The log is being truncated to before our current offset
 		// portion, so set the offset and replace the entries
-		u.offset = after + 1
+		u.offset = after
 		u.entries = ents
 	default:
 		// truncate to after and copy to u.entries
 		// then append
-		u.logger.Infof("truncate the unstable entries to index %d", after)
-		u.entries = append([]pb.Entry{}, u.slice(u.offset, after+1)...)
+		u.logger.Infof("truncate the unstable entries before index %d", after)
+		u.entries = append([]pb.Entry{}, u.slice(u.offset, after)...)
 		u.entries = append(u.entries, ents...)
 	}
 }


### PR DESCRIPTION
In function: truncateAndAppend
after := ents[0].Index - 1

But every time use 'after + 1', so I thought no need init 'after' with sub 1. 
may be init 'after' As follow:
after := ents[0].Index