### PR TITLE
benchmark: fix Compact request

### DIFF
--- a/tools/benchmark/cmd/put.go
+++ b/tools/benchmark/cmd/put.go
@@ -143,7 +143,7 @@ func compactKV(clients []*v3.Client) {
 	revToCompact := max(0, curRev-compactIndexDelta)
 	for _, c := range clients {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		err := c.KV.Compact(ctx, revToCompact)
+		_, err := c.KV.Compact(ctx, revToCompact)
 		cancel()
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Fix 

```
# github.com/coreos/etcd/tools/benchmark/cmd
cmd/put.go:146: multiple-value c.KV.Compact() in single-value context
```