### PR TITLE
test: use merge-base for commit title checking

### DIFF
--- a/test
+++ b/test
@@ -148,7 +148,7 @@ function fmt_tests {
 	fi
 
 	echo "Checking commit titles..."
-	git log master..HEAD --oneline | while read l; do
+	git log --oneline `git merge-base HEAD master`...HEAD | while read l; do
 		commitMsg=`echo "$l" | cut -f2- -d' '`
 		if [[ "$commitMsg" == Merge* ]]; then
 			# ignore "Merge pull" commits


### PR DESCRIPTION
Otherwise, will compare branch with forked master against upstream master.

I tested this against @davygeek's branch, added a few commits, and it seems to work fine now.

/cc @gyuho @davygeek