### PR TITLE
raft: give correct offset in unstable test

### DIFF
--- a/raft/log_unstable_test.go
+++ b/raft/log_unstable_test.go
@@ -237,9 +237,9 @@ func TestUnstableStableTo(t *testing.T) {
 			6, 1,
 		},
 		{
-			[]pb.Entry{{Index: 6, Term: 2}}, 5, nil,
+			[]pb.Entry{{Index: 6, Term: 2}}, 6, nil,
 			6, 1, // stable to the first entry and term mismatch
-			5, 1,
+			6, 1,
 		},
 		{
 			[]pb.Entry{{Index: 5, Term: 1}}, 5, nil,
@@ -263,9 +263,9 @@ func TestUnstableStableTo(t *testing.T) {
 			6, 1,
 		},
 		{
-			[]pb.Entry{{Index: 6, Term: 2}}, 5, &pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: 5, Term: 1}},
+			[]pb.Entry{{Index: 6, Term: 2}}, 6, &pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: 5, Term: 1}},
 			6, 1, // stable to the first entry and term mismatch
-			5, 1,
+			6, 1,
 		},
 		{
 			[]pb.Entry{{Index: 5, Term: 1}}, 5, &pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: 4, Term: 1}},


### PR DESCRIPTION
`unstable.entries[i] has raft log position i+unstable.offset`

So, this fixes some test cases by giving them correct
offsets.