### PR TITLE
ctlv3: make flags, commands formats consistent

### DIFF
--- a/etcdctl/ctlv3/command/alarm_command.go
+++ b/etcdctl/ctlv3/command/alarm_command.go
@@ -25,7 +25,7 @@ import (
 func NewAlarmCommand() *cobra.Command {
 	ac := &cobra.Command{
 		Use:   "alarm <subcommand>",
-		Short: "alarm related command",
+		Short: "Alarm related commands",
 	}
 
 	ac.AddCommand(NewAlarmDisarmCommand())
@@ -37,7 +37,7 @@ func NewAlarmCommand() *cobra.Command {
 func NewAlarmDisarmCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "disarm",
-		Short: "disarm all alarms",
+		Short: "Disarms all alarms",
 		Run:   alarmDisarmCommandFunc,
 	}
 	return &cmd
@@ -60,7 +60,7 @@ func alarmDisarmCommandFunc(cmd *cobra.Command, args []string) {
 func NewAlarmListCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "list",
-		Short: "list all alarms",
+		Short: "Lists all alarms",
 		Run:   alarmListCommandFunc,
 	}
 	return &cmd

--- a/etcdctl/ctlv3/command/auth_command.go
+++ b/etcdctl/ctlv3/command/auth_command.go
@@ -24,7 +24,7 @@ import (
 func NewAuthCommand() *cobra.Command {
 	ac := &cobra.Command{
 		Use:   "auth <enable or disable>",
-		Short: "Enable or disable authentication.",
+		Short: "Enable or disable authentication",
 	}
 
 	ac.AddCommand(newAuthEnableCommand())
@@ -36,7 +36,7 @@ func NewAuthCommand() *cobra.Command {
 func newAuthEnableCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "enable",
-		Short: "enable authentication",
+		Short: "Enables authentication",
 		Run:   authEnableCommandFunc,
 	}
 }
@@ -60,7 +60,7 @@ func authEnableCommandFunc(cmd *cobra.Command, args []string) {
 func newAuthDisableCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "disable",
-		Short: "disable authentication",
+		Short: "Disables authentication",
 		Run:   authDisableCommandFunc,
 	}
 }

--- a/etcdctl/ctlv3/command/compaction_command.go
+++ b/etcdctl/ctlv3/command/compaction_command.go
@@ -28,10 +28,10 @@ var compactPhysical bool
 func NewCompactionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compaction <revision>",
-		Short: "Compaction compacts the event history in etcd.",
+		Short: "Compacts the event history in etcd",
 		Run:   compactionCommandFunc,
 	}
-	cmd.Flags().BoolVar(&compactPhysical, "physical", false, "'true' to wait for compaction to physically remove all old revisions.")
+	cmd.Flags().BoolVar(&compactPhysical, "physical", false, "'true' to wait for compaction to physically remove all old revisions")
 	return cmd
 }
 

--- a/etcdctl/ctlv3/command/defrag_command.go
+++ b/etcdctl/ctlv3/command/defrag_command.go
@@ -25,7 +25,7 @@ import (
 func NewDefragCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "defrag",
-		Short: "defrag defragments the storage of the etcd members with given endpoints.",
+		Short: "Defragments the storage of the etcd members with given endpoints",
 		Run:   defragCommandFunc,
 	}
 }

--- a/etcdctl/ctlv3/command/del_command.go
+++ b/etcdctl/ctlv3/command/del_command.go
@@ -29,7 +29,7 @@ var (
 func NewDelCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "del [options] <key> [range_end]",
-		Short: "Removes the specified key or range of keys [key, range_end).",
+		Short: "Removes the specified key or range of keys [key, range_end)",
 		Run:   delCommandFunc,
 	}
 

--- a/etcdctl/ctlv3/command/elect_command.go
+++ b/etcdctl/ctlv3/command/elect_command.go
@@ -33,7 +33,7 @@ var (
 func NewElectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "elect <election-name> [proposal]",
-		Short: "elect observes and participates in leader election",
+		Short: "Observes and participates in leader election",
 		Run:   electCommandFunc,
 	}
 	cmd.Flags().BoolVarP(&electListen, "listen", "l", false, "observation mode")

--- a/etcdctl/ctlv3/command/ep_command.go
+++ b/etcdctl/ctlv3/command/ep_command.go
@@ -28,8 +28,8 @@ import (
 // NewEndpointCommand returns the cobra command for "endpoint".
 func NewEndpointCommand() *cobra.Command {
 	ec := &cobra.Command{
-		Use:   "endpoint",
-		Short: "endpoint is used to check endpoints.",
+		Use:   "endpoint <subcommand>",
+		Short: "Endpoint related commands",
 	}
 
 	ec.AddCommand(newEpHealthCommand())
@@ -41,7 +41,7 @@ func NewEndpointCommand() *cobra.Command {
 func newEpHealthCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "health",
-		Short: "health checks the healthiness of endpoints specified in `--endpoints` flag",
+		Short: "Checks the healthiness of endpoints specified in `--endpoints` flag",
 		Run:   epHealthCommandFunc,
 	}
 	return cmd
@@ -50,7 +50,7 @@ func newEpHealthCommand() *cobra.Command {
 func newEpStatusCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
-		Short: "status prints out the status of endpoints specified in `--endpoints` flag",
+		Short: "Prints out the status of endpoints specified in `--endpoints` flag",
 		Long: `When --write-out is set to simple, this command prints out comma-separated status lists for each endpoint.
 The items in the lists are endpoint, ID, version, db size, is leader, raft term, raft index.
 `,

--- a/etcdctl/ctlv3/command/get_command.go
+++ b/etcdctl/ctlv3/command/get_command.go
@@ -37,18 +37,18 @@ var (
 func NewGetCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get [options] <key> [range_end]",
-		Short: "Get gets the key or a range of keys.",
+		Short: "Gets the key or a range of keys",
 		Run:   getCommandFunc,
 	}
 
 	cmd.Flags().StringVar(&getConsistency, "consistency", "l", "Linearizable(l) or Serializable(s)")
-	cmd.Flags().StringVar(&getSortOrder, "order", "", "order of results; ASCEND or DESCEND")
-	cmd.Flags().StringVar(&getSortTarget, "sort-by", "", "sort target; CREATE, KEY, MODIFY, VALUE, or VERSION")
-	cmd.Flags().Int64Var(&getLimit, "limit", 0, "maximum number of results")
-	cmd.Flags().BoolVar(&getPrefix, "prefix", false, "get keys with matching prefix")
-	cmd.Flags().BoolVar(&getFromKey, "from-key", false, "get keys that are greater than or equal to the given key")
-	cmd.Flags().Int64Var(&getRev, "rev", 0, "specify the kv revision")
-	cmd.Flags().BoolVar(&getKeysOnly, "keys-only", false, "get only the keys")
+	cmd.Flags().StringVar(&getSortOrder, "order", "", "Order of results; ASCEND or DESCEND")
+	cmd.Flags().StringVar(&getSortTarget, "sort-by", "", "Sort target; CREATE, KEY, MODIFY, VALUE, or VERSION")
+	cmd.Flags().Int64Var(&getLimit, "limit", 0, "Maximum number of results")
+	cmd.Flags().BoolVar(&getPrefix, "prefix", false, "Get keys with matching prefix")
+	cmd.Flags().BoolVar(&getFromKey, "from-key", false, "Get keys that are greater than or equal to the given key")
+	cmd.Flags().Int64Var(&getRev, "rev", 0, "Specify the kv revision")
+	cmd.Flags().BoolVar(&getKeysOnly, "keys-only", false, "Get only the keys")
 	return cmd
 }
 

--- a/etcdctl/ctlv3/command/lease_command.go
+++ b/etcdctl/ctlv3/command/lease_command.go
@@ -26,8 +26,8 @@ import (
 // NewLeaseCommand returns the cobra command for "lease".
 func NewLeaseCommand() *cobra.Command {
 	lc := &cobra.Command{
-		Use:   "lease",
-		Short: "lease is used to manage leases.",
+		Use:   "lease <subcommand>",
+		Short: "Lease related commands",
 	}
 
 	lc.AddCommand(NewLeaseGrantCommand())
@@ -41,7 +41,7 @@ func NewLeaseCommand() *cobra.Command {
 func NewLeaseGrantCommand() *cobra.Command {
 	lc := &cobra.Command{
 		Use:   "grant <ttl>",
-		Short: "grant is used to create leases.",
+		Short: "Creates leases",
 
 		Run: leaseGrantCommandFunc,
 	}
@@ -73,7 +73,7 @@ func leaseGrantCommandFunc(cmd *cobra.Command, args []string) {
 func NewLeaseRevokeCommand() *cobra.Command {
 	lc := &cobra.Command{
 		Use:   "revoke <leaseID>",
-		Short: "revoke is used to revoke leases.",
+		Short: "Revokes leases",
 
 		Run: leaseRevokeCommandFunc,
 	}
@@ -105,7 +105,7 @@ func leaseRevokeCommandFunc(cmd *cobra.Command, args []string) {
 func NewLeaseKeepAliveCommand() *cobra.Command {
 	lc := &cobra.Command{
 		Use:   "keep-alive <leaseID>",
-		Short: "keep-alive is used to keep leases alive.",
+		Short: "Keeps leases alive (renew)",
 
 		Run: leaseKeepAliveCommandFunc,
 	}

--- a/etcdctl/ctlv3/command/lock_command.go
+++ b/etcdctl/ctlv3/command/lock_command.go
@@ -29,7 +29,7 @@ import (
 func NewLockCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "lock <lockname>",
-		Short: "lock acquires a named lock",
+		Short: "Acquires a named lock",
 		Run:   lockCommandFunc,
 	}
 	return c

--- a/etcdctl/ctlv3/command/make_mirror_command.go
+++ b/etcdctl/ctlv3/command/make_mirror_command.go
@@ -40,17 +40,17 @@ var (
 func NewMakeMirrorCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "make-mirror [options] <destination>",
-		Short: "make-mirror makes a mirror at the destination etcd cluster",
+		Short: "Makes a mirror at the destination etcd cluster",
 		Run:   makeMirrorCommandFunc,
 	}
 
-	c.Flags().StringVar(&mmprefix, "prefix", "", "the key-value prefix to mirror")
+	c.Flags().StringVar(&mmprefix, "prefix", "", "Key-value prefix to mirror")
 	// TODO: add dest-prefix to mirror a prefix to a different prefix in the destination cluster?
-	c.Flags().StringVar(&mmcert, "dest-cert", "", "identify secure client using this TLS certificate file for the destination cluster")
-	c.Flags().StringVar(&mmkey, "dest-key", "", "identify secure client using this TLS key file")
-	c.Flags().StringVar(&mmcacert, "dest-cacert", "", "verify certificates of TLS enabled secure servers using this CA bundle")
+	c.Flags().StringVar(&mmcert, "dest-cert", "", "Identify secure client using this TLS certificate file for the destination cluster")
+	c.Flags().StringVar(&mmkey, "dest-key", "", "Identify secure client using this TLS key file")
+	c.Flags().StringVar(&mmcacert, "dest-cacert", "", "Verify certificates of TLS enabled secure servers using this CA bundle")
 	// TODO: secure by default when etcd enables secure gRPC by default.
-	c.Flags().BoolVar(&mminsecureTr, "dest-insecure-transport", true, "disable transport security for client connections")
+	c.Flags().BoolVar(&mminsecureTr, "dest-insecure-transport", true, "Disable transport security for client connections")
 
 	return c
 }

--- a/etcdctl/ctlv3/command/member_command.go
+++ b/etcdctl/ctlv3/command/member_command.go
@@ -27,8 +27,8 @@ var memberPeerURLs string
 // NewMemberCommand returns the cobra command for "member".
 func NewMemberCommand() *cobra.Command {
 	mc := &cobra.Command{
-		Use:   "member",
-		Short: "member is used to manage membership in an etcd cluster.",
+		Use:   "member <subcommand>",
+		Short: "Membership related commands",
 	}
 
 	mc.AddCommand(NewMemberAddCommand())
@@ -43,7 +43,7 @@ func NewMemberCommand() *cobra.Command {
 func NewMemberAddCommand() *cobra.Command {
 	cc := &cobra.Command{
 		Use:   "add <memberName>",
-		Short: "add is used to add a member into the cluster",
+		Short: "Adds a member into the cluster",
 
 		Run: memberAddCommandFunc,
 	}
@@ -57,7 +57,7 @@ func NewMemberAddCommand() *cobra.Command {
 func NewMemberRemoveCommand() *cobra.Command {
 	cc := &cobra.Command{
 		Use:   "remove <memberID>",
-		Short: "remove is used to remove a member from the cluster",
+		Short: "Removes a member from the cluster",
 
 		Run: memberRemoveCommandFunc,
 	}
@@ -69,7 +69,7 @@ func NewMemberRemoveCommand() *cobra.Command {
 func NewMemberUpdateCommand() *cobra.Command {
 	cc := &cobra.Command{
 		Use:   "update <memberID>",
-		Short: "update is used to update a member in the cluster",
+		Short: "Updates a member in the cluster",
 
 		Run: memberUpdateCommandFunc,
 	}
@@ -83,7 +83,7 @@ func NewMemberUpdateCommand() *cobra.Command {
 func NewMemberListCommand() *cobra.Command {
 	cc := &cobra.Command{
 		Use:   "list",
-		Short: "list is used to list all members in the cluster",
+		Short: "Lists all members in the cluster",
 		Long: `When --write-out is set to simple, this command prints out comma-separated member lists for each endpoint.
 The items in the lists are ID, Status, Name, Peer Addrs, Client Addrs.
 `,

--- a/etcdctl/ctlv3/command/migrate_command.go
+++ b/etcdctl/ctlv3/command/migrate_command.go
@@ -51,13 +51,13 @@ var (
 func NewMigrateCommand() *cobra.Command {
 	mc := &cobra.Command{
 		Use:   "migrate",
-		Short: "migrates keys in a v2 store to a mvcc store",
+		Short: "Migrates keys in a v2 store to a mvcc store",
 		Run:   migrateCommandFunc,
 	}
 
-	mc.Flags().StringVar(&migrateDatadir, "data-dir", "", "Path to the data directory.")
-	mc.Flags().StringVar(&migrateWALdir, "wal-dir", "", "Path to the WAL directory.")
-	mc.Flags().StringVar(&migrateTransformer, "transformer", "", "Path to the user-provided transformer program.")
+	mc.Flags().StringVar(&migrateDatadir, "data-dir", "", "Path to the data directory")
+	mc.Flags().StringVar(&migrateWALdir, "wal-dir", "", "Path to the WAL directory")
+	mc.Flags().StringVar(&migrateTransformer, "transformer", "", "Path to the user-provided transformer program")
 	return mc
 }
 

--- a/etcdctl/ctlv3/command/put_command.go
+++ b/etcdctl/ctlv3/command/put_command.go
@@ -31,9 +31,9 @@ var (
 func NewPutCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "put [options] <key> <value> (<value> can also be given from stdin)",
-		Short: "Put puts the given key into the store.",
+		Short: "Puts the given key into the store",
 		Long: `
-Put puts the given key into the store.
+Puts the given key into the store.
 
 When <value> begins with '-', <value> is interpreted as a flag.
 Insert '--' for workaround:

--- a/etcdctl/ctlv3/command/role_command.go
+++ b/etcdctl/ctlv3/command/role_command.go
@@ -26,7 +26,7 @@ import (
 func NewRoleCommand() *cobra.Command {
 	ac := &cobra.Command{
 		Use:   "role <subcommand>",
-		Short: "role related command",
+		Short: "Role related commands",
 	}
 
 	ac.AddCommand(newRoleAddCommand())
@@ -42,7 +42,7 @@ func NewRoleCommand() *cobra.Command {
 func newRoleAddCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "add <role name>",
-		Short: "add a new role",
+		Short: "Adds a new role",
 		Run:   roleAddCommandFunc,
 	}
 }
@@ -50,7 +50,7 @@ func newRoleAddCommand() *cobra.Command {
 func newRoleDeleteCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <role name>",
-		Short: "delete a role",
+		Short: "Deletes a role",
 		Run:   roleDeleteCommandFunc,
 	}
 }
@@ -58,7 +58,7 @@ func newRoleDeleteCommand() *cobra.Command {
 func newRoleGetCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <role name>",
-		Short: "get detailed information of a role",
+		Short: "Gets detailed information of a role",
 		Run:   roleGetCommandFunc,
 	}
 }
@@ -66,7 +66,7 @@ func newRoleGetCommand() *cobra.Command {
 func newRoleListCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "list up all roles",
+		Short: "Lists all roles",
 		Run:   roleListCommandFunc,
 	}
 }
@@ -74,7 +74,7 @@ func newRoleListCommand() *cobra.Command {
 func newRoleGrantPermissionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "grant-permission <role name> <permission type> <key> [endkey]",
-		Short: "grant a key to a role",
+		Short: "Grants a key to a role",
 		Run:   roleGrantPermissionCommandFunc,
 	}
 }
@@ -82,7 +82,7 @@ func newRoleGrantPermissionCommand() *cobra.Command {
 func newRoleRevokePermissionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "revoke-permission <role name> <key> [endkey]",
-		Short: "revoke a key from a role",
+		Short: "Revokes a key from a role",
 		Run:   roleRevokePermissionCommandFunc,
 	}
 }

--- a/etcdctl/ctlv3/command/snapshot_command.go
+++ b/etcdctl/ctlv3/command/snapshot_command.go
@@ -58,8 +58,8 @@ var (
 // NewSnapshotCommand returns the cobra command for "snapshot".
 func NewSnapshotCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "snapshot",
-		Short: "snapshot manages etcd node snapshots.",
+		Use:   "snapshot <subcommand>",
+		Short: "Manages etcd node snapshots",
 	}
 	cmd.AddCommand(NewSnapshotSaveCommand())
 	cmd.AddCommand(NewSnapshotRestoreCommand())
@@ -70,7 +70,7 @@ func NewSnapshotCommand() *cobra.Command {
 func NewSnapshotSaveCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "save <filename>",
-		Short: "save stores an etcd node backend snapshot to a given file.",
+		Short: "Stores an etcd node backend snapshot to a given file",
 		Run:   snapshotSaveCommandFunc,
 	}
 }
@@ -78,7 +78,7 @@ func NewSnapshotSaveCommand() *cobra.Command {
 func newSnapshotStatusCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status <filename>",
-		Short: "status gets backend snapshot status of a given file.",
+		Short: "Gets backend snapshot status of a given file",
 		Long: `When --write-out is set to simple, this command prints out comma-separated status lists for each endpoint.
 The items in the lists are hash, revision, total keys, total size.
 `,
@@ -89,15 +89,15 @@ The items in the lists are hash, revision, total keys, total size.
 func NewSnapshotRestoreCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restore <filename>",
-		Short: "restore an etcd member snapshot to an etcd directory",
+		Short: "Restores an etcd member snapshot to an etcd directory",
 		Run:   snapshotRestoreCommandFunc,
 	}
-	cmd.Flags().StringVar(&restoreDataDir, "data-dir", "", "Path to the data directory.")
-	cmd.Flags().StringVar(&restoreCluster, "initial-cluster", initialClusterFromName(defaultName), "Initial cluster configuration for restore bootstrap.")
-	cmd.Flags().StringVar(&restoreClusterToken, "initial-cluster-token", "etcd-cluster", "Initial cluster token for the etcd cluster during restore bootstrap.")
-	cmd.Flags().StringVar(&restorePeerURLs, "initial-advertise-peer-urls", defaultInitialAdvertisePeerURLs, "List of this member's peer URLs to advertise to the rest of the cluster.")
-	cmd.Flags().StringVar(&restoreName, "name", defaultName, "Human-readable name for this member.")
-	cmd.Flags().BoolVar(&skipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory).")
+	cmd.Flags().StringVar(&restoreDataDir, "data-dir", "", "Path to the data directory")
+	cmd.Flags().StringVar(&restoreCluster, "initial-cluster", initialClusterFromName(defaultName), "Initial cluster configuration for restore bootstrap")
+	cmd.Flags().StringVar(&restoreClusterToken, "initial-cluster-token", "etcd-cluster", "Initial cluster token for the etcd cluster during restore bootstrap")
+	cmd.Flags().StringVar(&restorePeerURLs, "initial-advertise-peer-urls", defaultInitialAdvertisePeerURLs, "List of this member's peer URLs to advertise to the rest of the cluster")
+	cmd.Flags().StringVar(&restoreName, "name", defaultName, "Human-readable name for this member")
+	cmd.Flags().BoolVar(&skipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")
 
 	return cmd
 }

--- a/etcdctl/ctlv3/command/txn_command.go
+++ b/etcdctl/ctlv3/command/txn_command.go
@@ -34,10 +34,10 @@ var (
 func NewTxnCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "txn [options]",
-		Short: "Txn processes all the requests in one transaction.",
+		Short: "Txn processes all the requests in one transaction",
 		Run:   txnCommandFunc,
 	}
-	cmd.Flags().BoolVarP(&txnInteractive, "interactive", "i", false, "input transaction in interactive mode")
+	cmd.Flags().BoolVarP(&txnInteractive, "interactive", "i", false, "Input transaction in interactive mode")
 	return cmd
 }
 

--- a/etcdctl/ctlv3/command/user_command.go
+++ b/etcdctl/ctlv3/command/user_command.go
@@ -31,7 +31,7 @@ var (
 func NewUserCommand() *cobra.Command {
 	ac := &cobra.Command{
 		Use:   "user <subcommand>",
-		Short: "user related command",
+		Short: "User related commands",
 	}
 
 	ac.AddCommand(newUserAddCommand())
@@ -52,11 +52,11 @@ var (
 func newUserAddCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "add <user name>",
-		Short: "add a new user",
+		Short: "Adds a new user",
 		Run:   userAddCommandFunc,
 	}
 
-	cmd.Flags().BoolVar(&passwordInteractive, "interactive", true, "read password from stdin instead of interactive terminal")
+	cmd.Flags().BoolVar(&passwordInteractive, "interactive", true, "Read password from stdin instead of interactive terminal")
 
 	return &cmd
 }
@@ -64,7 +64,7 @@ func newUserAddCommand() *cobra.Command {
 func newUserDeleteCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <user name>",
-		Short: "delete a user",
+		Short: "Deletes a user",
 		Run:   userDeleteCommandFunc,
 	}
 }
@@ -72,11 +72,11 @@ func newUserDeleteCommand() *cobra.Command {
 func newUserGetCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "get <user name>",
-		Short: "get detailed information of a user",
+		Short: "Gets detailed information of a user",
 		Run:   userGetCommandFunc,
 	}
 
-	cmd.Flags().BoolVar(&userShowDetail, "detail", false, "show permissions of roles granted to the user")
+	cmd.Flags().BoolVar(&userShowDetail, "detail", false, "Show permissions of roles granted to the user")
 
 	return &cmd
 }
@@ -84,7 +84,7 @@ func newUserGetCommand() *cobra.Command {
 func newUserListCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "list up all users",
+		Short: "Lists all users",
 		Run:   userListCommandFunc,
 	}
 }
@@ -92,11 +92,11 @@ func newUserListCommand() *cobra.Command {
 func newUserChangePasswordCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "passwd <user name>",
-		Short: "change password of user",
+		Short: "Changes password of user",
 		Run:   userChangePasswordCommandFunc,
 	}
 
-	cmd.Flags().BoolVar(&passwordInteractive, "interactive", true, "if true, read password from stdin instead of interactive terminal")
+	cmd.Flags().BoolVar(&passwordInteractive, "interactive", true, "If true, read password from stdin instead of interactive terminal")
 
 	return &cmd
 }
@@ -104,7 +104,7 @@ func newUserChangePasswordCommand() *cobra.Command {
 func newUserGrantRoleCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "grant-role <user name> <role name>",
-		Short: "grant a role to a user",
+		Short: "Grants a role to a user",
 		Run:   userGrantRoleCommandFunc,
 	}
 }
@@ -112,7 +112,7 @@ func newUserGrantRoleCommand() *cobra.Command {
 func newUserRevokeRoleCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "revoke-role <user name> <role name>",
-		Short: "revoke a role from a user",
+		Short: "Revokes a role from a user",
 		Run:   userRevokeRoleCommandFunc,
 	}
 }

--- a/etcdctl/ctlv3/command/version_command.go
+++ b/etcdctl/ctlv3/command/version_command.go
@@ -26,7 +26,7 @@ import (
 func NewVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print the version of etcdctl.",
+		Short: "Prints the version of etcdctl",
 		Run:   versionCommandFunc,
 	}
 }

--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -35,13 +35,13 @@ var (
 func NewWatchCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "watch [options] [key or prefix] [range_end]",
-		Short: "Watch watches events stream on keys or prefixes.",
+		Short: "Watches events stream on keys or prefixes",
 		Run:   watchCommandFunc,
 	}
 
-	cmd.Flags().BoolVarP(&watchInteractive, "interactive", "i", false, "interactive mode")
-	cmd.Flags().BoolVar(&watchPrefix, "prefix", false, "watch on a prefix if prefix is set")
-	cmd.Flags().Int64Var(&watchRev, "rev", 0, "revision to start watching")
+	cmd.Flags().BoolVarP(&watchInteractive, "interactive", "i", false, "Interactive mode")
+	cmd.Flags().BoolVar(&watchPrefix, "prefix", false, "Watch on a prefix if prefix is set")
+	cmd.Flags().Int64Var(&watchRev, "rev", 0, "Revision to start watching")
 
 	return cmd
 }


### PR DESCRIPTION
1. Capitalize first letter
2. Remove period at the end

(followed the pattern in linux coreutil man page)

```diff
diff --git a/a.txt b/a.txt
index 162d3db..8c75d13 100644
--- a/a.txt
+++ b/a.txt
@@ -1,44 +1,43 @@
-COMMANDS:
-	get			Get gets the key or a range of keys.
-	put			Put puts the given key into the store.
-	del			Removes the specified key or range of keys [key, range_end).
-	txn			Txn processes all the requests in one transaction.
-	compaction		Compaction compacts the event history in etcd.
-	alarm disarm		disarm all alarms
-	alarm list		list all alarms
-	defrag			defrag defragments the storage of the etcd members with given endpoints.
-	endpoint health		health checks the healthiness of endpoints specified in `--endpoints` flag
-	endpoint status		status prints out the status of endpoints specified in `--endpoints` flag
-	watch			Watch watches events stream on keys or prefixes.
-	version			Print the version of etcdctl.
-	lease grant		grant is used to create leases.
-	lease revoke		revoke is used to revoke leases.
-	lease keep-alive	keep-alive is used to keep leases alive.
-	member add		add is used to add a member into the cluster
-	member remove		remove is used to remove a member from the cluster
-	member update		update is used to update a member in the cluster
-	member list		list is used to list all members in the cluster
-	snapshot save		save stores an etcd node backend snapshot to a given file.
-	snapshot restore	restore an etcd member snapshot to an etcd directory
-	snapshot status		status gets backend snapshot status of a given file.
-	make-mirror		make-mirror makes a mirror at the destination etcd cluster
-	migrate			migrates keys in a v2 store to a mvcc store
-	lock			lock acquires a named lock
-	elect			elect observes and participates in leader election
-	auth enable		enable authentication
-	auth disable		disable authentication
-	user add		add a new user
-	user delete		delete a user
-	user get		get detailed information of a user
-	user list		list up all users
-	user passwd		change password of user
-	user grant-role		grant a role to a user
-	user revoke-role	revoke a role from a user
-	role add		add a new role
-	role delete		delete a role
-	role get		get detailed information of a role
-	role list		list up all roles
-	role grant-permission	grant a key to a role
-	role revoke-permission	revoke a key from a role
+	get			Gets the key or a range of keys
+	put			Puts the given key into the store
+	del			Removes the specified key or range of keys [key, range_end)
+	txn			Txn processes all the requests in one transaction
+	compaction		Compacts the event history in etcd
+	alarm disarm		Disarms all alarms
+	alarm list		Lists all alarms
+	defrag			Defragments the storage of the etcd members with given endpoints
+	endpoint health		Checks the healthiness of endpoints specified in `--endpoints` flag
+	endpoint status		Prints out the status of endpoints specified in `--endpoints` flag
+	watch			Watches events stream on keys or prefixes
+	version			Prints the version of etcdctl
+	lease grant		Creates leases
+	lease revoke		Revokes leases
+	lease keep-alive	Keeps leases alive (renew)
+	member add		Adds a member into the cluster
+	member remove		Removes a member from the cluster
+	member update		Updates a member in the cluster
+	member list		Lists all members in the cluster
+	snapshot save		Stores an etcd node backend snapshot to a given file
+	snapshot restore	Restores an etcd member snapshot to an etcd directory
+	snapshot status		Gets backend snapshot status of a given file
+	make-mirror		Makes a mirror at the destination etcd cluster
+	migrate			Migrates keys in a v2 store to a mvcc store
+	lock			Acquires a named lock
+	elect			Observes and participates in leader election
+	auth enable		Enables authentication
+	auth disable		Disables authentication
+	user add		Adds a new user
+	user delete		Deletes a user
+	user get		Gets detailed information of a user
+	user list		Lists all users
+	user passwd		Changes password of user
+	user grant-role		Grants a role to a user
+	user revoke-role	Revokes a role from a user
+	role add		Adds a new role
+	role delete		Deletes a role
+	role get		Gets detailed information of a role
+	role list		Lists all roles
+	role grant-permission	Grants a key to a role
+	role revoke-permission	Revokes a key from a role
 	help			Help about any command
 ```