### PR TITLE
etcd-tester: handle error in RevHash

### DIFF
--- a/tools/functional-tester/etcd-tester/member.go
+++ b/tools/functional-tester/etcd-tester/member.go
@@ -95,6 +95,11 @@ func (m *member) RevHash() (int64, int64, error) {
 	resp, err := mt.Hash(ctx, &pb.HashRequest{})
 	cancel()
 	conn.Close()
+
+	if err != nil {
+		return 0, 0, err
+	}
+
 	return resp.Header.Revision, int64(resp.Hash), nil
 }
 


### PR DESCRIPTION
I got this error

```
c = "transport: dial tcp 10.240.0.15:2379: getsockopt: connection refused"; Reconnecting to {"10.240.0.15:2379" <nil>}
2016-06-30 00:21:59.097687 I | etcd-tester: grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing
2016-06-30 00:21:59.098177 I | etcd-tester: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 10.240.0.16:2379: getsockopt: connection refused"; Reconnecting to {"10.240.0.16:2379" <nil>}
2016-06-30 00:21:59.098191 I | etcd-tester: grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing
2016-06-30 00:21:59.098557 I | etcd-tester: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 10.240.0.17:2379: getsockopt: connection refused"; Reconnecting to {"10.240.0.17:2379" <nil>}
2016-06-30 00:21:59.098573 I | etcd-tester: grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x406e6a]

goroutine 1 [running]:
panic(0xaccd40, 0xc4200100d0)
        /home/gyuho/go-master/src/runtime/panic.go:500 +0x1a1
main.(*member).RevHash(0xc4201634f0, 0xc420d92900, 0xc420163480, 0xc420f196a0, 0x0)
        /home/gyuho/go/src/github.com/coreos/etcd/tools/functional-tester/etcd-tester/member.go:98 +0x15a
main.(*cluster).getRevisionHash(0xc420170300, 0xbcc62e, 0x20, 0xc420691788, 0x1)
        /home/gyuho/go/src/github.com/coreos/etcd/tools/functional-tester/etcd-tester/cluster.go:233 +0xc9
main.(*tester).checkConsistency(0xc4202141e0, 0xbc4400, 0x0, 0x0)
        /home/gyuho/go/src/github.com/coreos/etcd/tools/functional-tester/etcd-tester/tester.go:158 +0x1c1
main.(*tester).doRound(0xc4202141e0, 0x3, 0x1010b87200, 0x0, 0x0)
        /home/gyuho/go/src/github.com/coreos/etcd/tools/functional-tester/etcd-tester/tester.go:122 +0x6d9
main.(*tester).runLoop(0xc4202141e0)
        /home/gyuho/go/src/github.com/coreos/etcd/tools/functional-tester/etcd-tester/tester.go:49 +0x1e2
main.main()
        /home/gyuho/go/src/github.com/coreos/etcd/tools/functional-tester/etcd-tester/main.go:87 +0xbd6
```
