### PR TITLE
hack/tls-setup minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /hack/insta-discovery/.env
 *.test
 tools/functional-tester/docker/bin
+hack/tls-setup/certs

--- a/hack/tls-setup/Makefile
+++ b/hack/tls-setup/Makefile
@@ -8,6 +8,7 @@ all: cfssl ca req
 cfssl:
 	go get -u -tags nopkcs11 github.com/cloudflare/cfssl/cmd/cfssl
 	go get -u github.com/cloudflare/cfssl/cmd/cfssljson
+	go get -u github.com/mattn/goreman
 
 ca:
 	mkdir -p certs


### PR DESCRIPTION
Minor tweaks to `hack/tls-setup` example:

1. install `goreman` since the example references and uses it
2. add generated `certs` directory to gitignore