### PR TITLE
release: fix Dockerfile etcd binary paths

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
-ADD bin/etcd /usr/local/bin/
-ADD bin/etcdctl /usr/local/bin/
+ADD etcd /usr/local/bin/
+ADD etcdctl /usr/local/bin/
 RUN mkdir -p /var/etcd/
 
 EXPOSE 2379 2380


### PR DESCRIPTION
release script uses binary files in 'release/image-docker',
not the ones in "bin/". Tested with v3.0.0 release.

Had no time to fix it in release-3.0 branch, but the docker image was built correctly with this Dockerfile. Will backport for next releases.