### PR TITLE
[WIP]proxy: update cache througt watch

### DIFF
--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -34,6 +34,7 @@ import (
 	"github.com/coreos/etcd/etcdserver/api/v2http/httptypes"
 	"github.com/coreos/etcd/etcdserver/auth"
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
+	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/etcdserver/membership"
 	"github.com/coreos/etcd/etcdserver/stats"
 	"github.com/coreos/etcd/pkg/types"

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -103,6 +103,13 @@ type Response struct {
 	err     error
 }
 
+func NewResponse(event *store.Event, err error) *Response {
+	return &Response{
+		Event: event,
+		err:   err,
+	}
+}
+
 type Server interface {
 	// Start performs any initialization of the Server necessary for it to
 	// begin serving requests. It must be called before Do or Process.

--- a/proxy/httpproxy/cache/cache_server.go
+++ b/proxy/httpproxy/cache/cache_server.go
@@ -1,0 +1,174 @@
+package cache
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+
+	"github.com/coreos/etcd/client"
+	"github.com/coreos/etcd/etcdserver"
+	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/pkg/capnslog"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/coreos/etcd/store"
+	"golang.org/x/net/context"
+)
+
+const defaultV2KeysPrefix = "/v2/keys"
+
+const plog = capnslog.NewPackageLogger("github.com/coreos/etcd/proxy/httpproxy/cache", "v2proxy")
+
+type CacheServer struct {
+	client client.KeysAPI
+	cache  *threadSafeMap
+	usable sync.RWMutex
+	//TODO:add a watchhub here, or in cache
+}
+
+func (s *CacheServer) Do(ctx context.Context, r pb.Request) (etcdserver.Response, error) {
+	if r.Method == "GET" && r.Quorum {
+		r.Method = "QGET"
+	}
+
+	switch r.Method {
+	case "POST":
+		return s.client.Create(ctx, r.Path, r.Val)
+	case "PUT":
+		return s.client.Set(ctx, r.Path, r.Val)
+	case "DELETE":
+		return s.client.Delete(ctx, r.Path, r.Dir, r.Recursive)
+	case "QGET":
+		return s.client.Get(ctx, r.Path, &client.GetOptions{Quorum: true, Sort: r.Sorted})
+	case "GET":
+		if r.Wait {
+			//TODO:implement watch
+			panic("not implemented")
+		}
+		s.usable.RLock()
+		s.usable.RUnlock()
+		event, err := s.cache.Get(ctx, r.Path, r.Recursive, r.Sorted)
+		return etcdserver.NewResponse(event, err)
+	case "HEAD":
+		//TODO:implement haed by forwarding
+		panic("not implemented")
+	}
+	return etcdserver.Response{}, etcdserver.ErrUnknownMethod
+}
+
+func NewCacheServer(client client.KeysAPI) *CacheServer {
+	s := &CacheServer{
+		client: client,
+		cache:  NewStore(),
+	}
+
+	s.usable.Unlock()
+
+	// update local cache by watch
+	go func() {
+		ctx := context.TODO()
+		for {
+			resp, err := s.client.Get(ctx, defaultV2KeysPrefix+"/", &client.GetOptions{Recursive: true})
+			if err != nil {
+				continue
+			}
+			//TODO: close all watchers when invalidate the whole cache
+			s.cache.InvalidateAll()
+			s.AddNode(resp.Node)
+			s.usable.Unlock()
+
+			idx := resp.Index
+			func() {
+				defer s.usable.Lock()
+				for {
+					watcher := s.client.Watcher(ctx, defaultV2KeysPrefix+"/", &client.WatcherOptions{AfterIndex: idx, Recursive: true})
+					resp, err := watcher.Next(ctx)
+					if err != nil {
+						break
+					}
+					s.UpdateCache(resp)
+				}
+			}()
+		}
+	}()
+
+	return s
+}
+
+func (s *CacheServer) AddNode(node client.Node) {
+	if node.Dir && len(node.Nodes) != 0 {
+		for node := range node.Nodes {
+			s.AddNode(node)
+		}
+	}
+	s.cache.Add(node.Key, node.Value)
+}
+
+func (s *CacheServer) DeleteNode(node client.Node) {
+	if node.Dir && len(node.Nodes) != 0 {
+		for node := range node.Nodes {
+			s.DeleteNode(node)
+		}
+	}
+	s.cache.Delete(node.Key)
+}
+
+func (s *CacheServer) UpdateCache(resp client.Response) {
+	switch resp.Action {
+	case store.Create:
+		s.AddNode(resp.Node)
+	case store.Update:
+		s.AddNode(resp.Node)
+	case store.Delete:
+		s.DeleteNode(resp.Node.Key)
+	case store.CompareAndDelete:
+		s.DeleteNode(resp.Node.Key)
+	case store.CompareAndSwap:
+		s.AddNode(resp.Node.Key)
+	case store.Expire:
+		s.DeleteNode(resp.Node)
+	default:
+		plog.Errorf("unexpected event type: %v", resp.Action)
+	}
+}
+
+type KeysHandler struct {
+	Server *CacheServer
+}
+
+func (h *KeysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r.Method, "HEAD", "GET", "PUT", "POST", "DELETE") {
+		return
+	}
+
+	// TODO: write "X-Etcd-Cluster-ID", "X-Raft-Term", and "X-Raft-Index" header
+	//w.Header().Set("X-Etcd-Cluster-ID", h.cluster.ID().String())
+
+	ctx := context.TODO()
+	clock := clockwork.NewRealClock()
+	rr, err := parseKeyRequest(r, clock)
+	if err != nil {
+		writeKeyError(w, err)
+		return
+	}
+
+	resp, err := h.Server.Do(ctx, rr)
+	if err != nil {
+		err = trimErrorPrefix(err, etcdserver.StoreKeysPrefix)
+		writeKeyError(w, err)
+		return
+	}
+	switch {
+	case resp.Event != nil:
+		//if err := writeKeyEvent(w, resp.Event, h.timer); err != nil {
+		if err := writeKeyEvent(w, resp.Event); err != nil {
+			// Should never be reached
+			plog.Errorf("error writing event (%v)", err)
+		}
+	case resp.Watcher != nil:
+		//TODO:implement watch
+		panic("not implemented")
+	default:
+		writeKeyError(w, errors.New("received response with no Event/Watcher!"))
+	}
+}

--- a/proxy/httpproxy/cache/store.go
+++ b/proxy/httpproxy/cache/store.go
@@ -1,0 +1,51 @@
+package cache
+
+import "sync"
+
+type threadSafeMap struct {
+	lock  sync.RWMutex
+	items map[string]interface{}
+}
+
+func NewStore() *threadSafeMap {
+	return &threadSafeMap{}
+}
+
+func (c *threadSafeMap) Add(key string, obj interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.items[key] = obj
+}
+
+func (c *threadSafeMap) Update(key string, obj interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.items[key] = obj
+}
+
+func (c *threadSafeMap) Delete(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if _, exists := c.items[key]; exists {
+		delete(c.items, key)
+	}
+}
+
+func (c *threadSafeMap) Get(key string) (item interface{}, exists bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	item, exists = c.items[key]
+	return item, exists
+}
+
+func (c *threadSafeMap) Replace(items map[string]interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.items = items
+}
+
+func (c *threadSafeMap) InvalidateAll() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.items = map[string]interface{}{}
+}

--- a/proxy/httpproxy/cache/utils.go
+++ b/proxy/httpproxy/cache/utils.go
@@ -1,0 +1,318 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	etcdErr "github.com/coreos/etcd/error"
+	"github.com/coreos/etcd/etcdserver"
+	"github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/etcd/pkg/logutil"
+	"github.com/coreos/etcd/store"
+	"github.com/coreos/pkg/capnslog"
+	"github.com/jonboulle/clockwork"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	keysPrefix = "/v2/keys"
+	plog       = capnslog.NewPackageLogger("github.com/coreos/etcd/proxy/httpproxy/cache", "v2proxy")
+	mlog       = logutil.NewMergeLogger(plog)
+)
+
+// allowMethod verifies that the given method is one of the allowed methods,
+// and if not, it writes an error to w.  A boolean is returned indicating
+// whether or not the method is allowed.
+func allowMethod(w http.ResponseWriter, m string, ms ...string) bool {
+	for _, meth := range ms {
+		if m == meth {
+			return true
+		}
+	}
+	w.Header().Set("Allow", strings.Join(ms, ","))
+	http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	return false
+}
+
+// parseKeyRequest converts a received http.Request on keysPrefix to
+// a server Request, performing validation of supplied fields as appropriate.
+// If any validation fails, an empty Request and non-nil error is returned.
+func parseKeyRequest(r *http.Request, clock clockwork.Clock) (etcdserverpb.Request, error) {
+	emptyReq := etcdserverpb.Request{}
+
+	err := r.ParseForm()
+	if err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidForm,
+			err.Error(),
+		)
+	}
+
+	if !strings.HasPrefix(r.URL.Path, keysPrefix) {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidForm,
+			"incorrect key prefix",
+		)
+	}
+	p := path.Join(etcdserver.StoreKeysPrefix, r.URL.Path[len(keysPrefix):])
+
+	var pIdx, wIdx uint64
+	if pIdx, err = getUint64(r.Form, "prevIndex"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeIndexNaN,
+			`invalid value for "prevIndex"`,
+		)
+	}
+	if wIdx, err = getUint64(r.Form, "waitIndex"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeIndexNaN,
+			`invalid value for "waitIndex"`,
+		)
+	}
+
+	var rec, sort, wait, dir, quorum, stream bool
+	if rec, err = getBool(r.Form, "recursive"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`invalid value for "recursive"`,
+		)
+	}
+	if sort, err = getBool(r.Form, "sorted"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`invalid value for "sorted"`,
+		)
+	}
+	if wait, err = getBool(r.Form, "wait"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`invalid value for "wait"`,
+		)
+	}
+	// TODO(jonboulle): define what parameters dir is/isn't compatible with?
+	if dir, err = getBool(r.Form, "dir"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`invalid value for "dir"`,
+		)
+	}
+	if quorum, err = getBool(r.Form, "quorum"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`invalid value for "quorum"`,
+		)
+	}
+	if stream, err = getBool(r.Form, "stream"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`invalid value for "stream"`,
+		)
+	}
+
+	if wait && r.Method != "GET" {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`"wait" can only be used with GET requests`,
+		)
+	}
+
+	pV := r.FormValue("prevValue")
+	if _, ok := r.Form["prevValue"]; ok && pV == "" {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodePrevValueRequired,
+			`"prevValue" cannot be empty`,
+		)
+	}
+
+	// TTL is nullable, so leave it null if not specified
+	// or an empty string
+	var ttl *uint64
+	if len(r.FormValue("ttl")) > 0 {
+		i, err := getUint64(r.Form, "ttl")
+		if err != nil {
+			return emptyReq, etcdErr.NewRequestError(
+				etcdErr.EcodeTTLNaN,
+				`invalid value for "ttl"`,
+			)
+		}
+		ttl = &i
+	}
+
+	// prevExist is nullable, so leave it null if not specified
+	var pe *bool
+	if _, ok := r.Form["prevExist"]; ok {
+		bv, err := getBool(r.Form, "prevExist")
+		if err != nil {
+			return emptyReq, etcdErr.NewRequestError(
+				etcdErr.EcodeInvalidField,
+				"invalid value for prevExist",
+			)
+		}
+		pe = &bv
+	}
+
+	// refresh is nullable, so leave it null if not specified
+	var refresh *bool
+	if _, ok := r.Form["refresh"]; ok {
+		bv, err := getBool(r.Form, "refresh")
+		if err != nil {
+			return emptyReq, etcdErr.NewRequestError(
+				etcdErr.EcodeInvalidField,
+				"invalid value for refresh",
+			)
+		}
+		refresh = &bv
+		if refresh != nil && *refresh {
+			val := r.FormValue("value")
+			if _, ok := r.Form["value"]; ok && val != "" {
+				return emptyReq, etcdErr.NewRequestError(
+					etcdErr.EcodeRefreshValue,
+					`A value was provided on a refresh`,
+				)
+			}
+			if ttl == nil {
+				return emptyReq, etcdErr.NewRequestError(
+					etcdErr.EcodeRefreshTTLRequired,
+					`No TTL value set`,
+				)
+			}
+		}
+	}
+
+	rr := etcdserverpb.Request{
+		Method:    r.Method,
+		Path:      p,
+		Val:       r.FormValue("value"),
+		Dir:       dir,
+		PrevValue: pV,
+		PrevIndex: pIdx,
+		PrevExist: pe,
+		Wait:      wait,
+		Since:     wIdx,
+		Recursive: rec,
+		Sorted:    sort,
+		Quorum:    quorum,
+		Stream:    stream,
+	}
+
+	if pe != nil {
+		rr.PrevExist = pe
+	}
+
+	if refresh != nil {
+		rr.Refresh = refresh
+	}
+
+	// Null TTL is equivalent to unset Expiration
+	if ttl != nil {
+		expr := time.Duration(*ttl) * time.Second
+		rr.Expiration = clock.Now().Add(expr).UnixNano()
+	}
+
+	return rr, nil
+}
+
+// getUint64 extracts a uint64 by the given key from a Form. If the key does
+// not exist in the form, 0 is returned. If the key exists but the value is
+// badly formed, an error is returned. If multiple values are present only the
+// first is considered.
+func getUint64(form url.Values, key string) (i uint64, err error) {
+	if vals, ok := form[key]; ok {
+		i, err = strconv.ParseUint(vals[0], 10, 64)
+	}
+	return
+}
+
+// getBool extracts a bool by the given key from a Form. If the key does not
+// exist in the form, false is returned. If the key exists but the value is
+// badly formed, an error is returned. If multiple values are present only the
+// first is considered.
+func getBool(form url.Values, key string) (b bool, err error) {
+	if vals, ok := form[key]; ok {
+		b, err = strconv.ParseBool(vals[0])
+	}
+	return
+}
+
+// trimPrefix removes a given prefix and any slash following the prefix
+// e.g.: trimPrefix("foo", "foo") == trimPrefix("foo/", "foo") == ""
+func trimPrefix(p, prefix string) (s string) {
+	s = strings.TrimPrefix(p, prefix)
+	s = strings.TrimPrefix(s, "/")
+	return
+}
+
+// writeKeyError logs and writes the given Error to the ResponseWriter.
+// If Error is not an etcdErr, the error will be converted to an etcd error.
+func writeKeyError(w http.ResponseWriter, err error) {
+	if err == nil {
+		return
+	}
+	switch e := err.(type) {
+	case *etcdErr.Error:
+		e.WriteTo(w)
+	default:
+		switch err {
+		case etcdserver.ErrTimeoutDueToLeaderFail, etcdserver.ErrTimeoutDueToConnectionLost:
+			mlog.MergeError(err)
+		default:
+			mlog.MergeErrorf("got unexpected response error (%v)", err)
+		}
+		ee := etcdErr.NewError(etcdErr.EcodeRaftInternal, err.Error(), 0)
+		ee.WriteTo(w)
+	}
+}
+
+func trimEventPrefix(ev *store.Event, prefix string) *store.Event {
+	if ev == nil {
+		return nil
+	}
+	// Since the *Event may reference one in the store history
+	// history, we must copy it before modifying
+	e := ev.Clone()
+	trimNodeExternPrefix(e.Node, prefix)
+	trimNodeExternPrefix(e.PrevNode, prefix)
+	return e
+}
+
+func trimNodeExternPrefix(n *store.NodeExtern, prefix string) {
+	if n == nil {
+		return
+	}
+	n.Key = strings.TrimPrefix(n.Key, prefix)
+	for _, nn := range n.Nodes {
+		trimNodeExternPrefix(nn, prefix)
+	}
+}
+
+func trimErrorPrefix(err error, prefix string) error {
+	if e, ok := err.(*etcdErr.Error); ok {
+		e.Cause = strings.TrimPrefix(e.Cause, prefix)
+	}
+	return err
+}
+
+// writeKeyEvent trims the prefix of key path in a single Event under
+// StoreKeysPrefix, serializes it and writes the resulting JSON to the given
+// ResponseWriter, along with the appropriate headers.
+func writeKeyEvent(w http.ResponseWriter, ev *store.Event) error {
+	if ev == nil {
+		return errors.New("cannot write empty Event!")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Etcd-Index", fmt.Sprint(ev.EtcdIndex))
+	//w.Header().Set("X-Raft-Index", fmt.Sprint(rt.Index()))
+	//w.Header().Set("X-Raft-Term", fmt.Sprint(rt.Term()))
+
+	if ev.IsCreated() {
+		w.WriteHeader(http.StatusCreated)
+	}
+
+	ev = trimEventPrefix(ev, etcdserver.StoreKeysPrefix)
+	return json.NewEncoder(w).Encode(ev)
+}


### PR DESCRIPTION
This is a WIP implementation of cache in v2proxy. Send for comments to ensure I am going in the right direction.

TODO:
* funcs in utils.go are almost copied from `etcdserver/api/v2http/client.go`, remove the duplication
* implement watch and HEAD
* write "X-Etcd-Cluster-ID", "X-Raft-Term", and "X-Raft-Index" header?  

@xiang @gyuho 

cc @jerryzh168
