### PR TITLE
wal: release wal locks before renaming directory on init

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -129,15 +129,22 @@ func Create(dirpath string, metadata []byte) (*WAL, error) {
 		return nil, err
 	}
 
-	if err := os.RemoveAll(dirpath); err != nil {
-		return nil, err
-	}
+	// rename of directory with locked files doesn't work on windows; close
+	// the WAL to release the locks so the directory can be renamed
+	w.Close()
 	if err := os.Rename(tmpdirpath, dirpath); err != nil {
 		return nil, err
 	}
-
-	w.fp = newFilePipeline(w.dir, segmentSizeBytes)
-	return w, nil
+	// reopen and relock
+	newWAL, oerr := Open(dirpath, walpb.Snapshot{})
+	if oerr != nil {
+		return nil, oerr
+	}
+	if _, _, _, err := newWAL.ReadAll(); err != nil {
+		newWAL.Close()
+		return nil, err
+	}
+	return newWAL, nil
 }
 
 // Open opens the WAL at the given snap.


### PR DESCRIPTION
Brokenness of master on windows confirmed; works with patch.

Fixes #5852

/cc @xiang90 @MartyMacGyver