### PR TITLE
Dockerfile: change cmd to entrypoint

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -6,5 +6,5 @@ RUN mkdir -p /var/etcd/
 
 EXPOSE 2379 2380
 
-# Define default command.
-CMD ["/usr/local/bin/etcd"]
+# Define default entrypoint.
+ENTRYPOINT ["/usr/local/bin/etcd"]


### PR DESCRIPTION
Use ENTRYPOINT so people can specify flags to etcd without providing the
binary.

Fixes #5858 