### PR TITLE
etcdserver: commit before sending snapshot

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1170,8 +1170,7 @@ func (s *EtcdServer) snapshot(snapi uint64, confState raftpb.ConfState) {
 			}
 			plog.Panicf("unexpected create snapshot error %v", err)
 		}
-		// commit v3 storage because WAL file before snapshot index
-		// could be removed after SaveSnap.
+		// commit kv to write metadata (for example: consistent index) to disk.
 		s.KV().Commit()
 		// SaveSnap saves the snapshot and releases the locked wal files
 		// to the snapshot index.

--- a/etcdserver/snapshot_merge.go
+++ b/etcdserver/snapshot_merge.go
@@ -39,6 +39,8 @@ func (s *EtcdServer) createMergedSnapshotMessage(m raftpb.Message, snapi uint64,
 		plog.Panicf("store save should never fail: %v", err)
 	}
 
+	// commit kv to write metadata(for example: consistent index).
+	s.KV().Commit()
 	dbsnap := s.be.Snapshot()
 	// get a snapshot of v3 KV as readCloser
 	rc := newSnapshotReaderCloser(dbsnap)


### PR DESCRIPTION
Fix #5857.

Reproduce:

1. write some v2 keys to force a snapshot
2. remove a member
3. add the member back
4. kill the added member immediately before a new snapshot is triggered or consistent index is ever updated.

Then the newly added member will not be able to restart anymore.

This pr fixes it. 
