### PR TITLE
raft: minor updates and clean up in log.go

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -74,8 +74,8 @@ func (l *raftLog) String() string {
 // maybeAppend returns (0, false) if the entries cannot be appended. Otherwise,
 // it returns (last index of new entries, true).
 func (l *raftLog) maybeAppend(index, logTerm, committed uint64, ents ...pb.Entry) (lastnewi uint64, ok bool) {
-	lastnewi = index + uint64(len(ents))
 	if l.matchTerm(index, logTerm) {
+		lastnewi = index + uint64(len(ents))
 		ci := l.findConflict(ents)
 		switch {
 		case ci == 0:

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -29,7 +29,6 @@ func TestFindConflict(t *testing.T) {
 	}{
 		// no conflict, empty ent
 		{[]pb.Entry{}, 0},
-		{[]pb.Entry{}, 0},
 		// no conflict
 		{[]pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}}, 0},
 		{[]pb.Entry{{Index: 2, Term: 2}, {Index: 3, Term: 3}}, 0},
@@ -73,7 +72,7 @@ func TestIsUpToDate(t *testing.T) {
 		{raftLog.lastIndex() - 1, 2, false},
 		{raftLog.lastIndex(), 2, false},
 		{raftLog.lastIndex() + 1, 2, false},
-		// equal term, lager lastIndex wins
+		// equal term, equal or lager lastIndex wins
 		{raftLog.lastIndex() - 1, 3, false},
 		{raftLog.lastIndex(), 3, true},
 		{raftLog.lastIndex() + 1, 3, true},


### PR DESCRIPTION
- remove redundant test case in log_test.go
- fix test case comment ('equal or larger')
- lastnewi after matching index and term