### PR TITLE
raft: fix minor grammar, remove TODO

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -136,7 +136,7 @@ type Node interface {
 	// However, as an optimization, the application may call Advance while it is applying the
 	// commands. For example. when the last Ready contains a snapshot, the application might take
 	// a long time to apply the snapshot data. To continue receiving Ready without blocking raft
-	// progress, it can call Advance before finish applying the last ready. To make this optimization
+	// progress, it can call Advance before finishing applying the last ready. To make this optimization
 	// work safely, when the application receives a Ready with softState.RaftState equal to Candidate
 	// it MUST apply all pending configuration changes if there is any.
 	//

--- a/raft/storage_test.go
+++ b/raft/storage_test.go
@@ -22,31 +22,42 @@ import (
 	pb "github.com/coreos/etcd/raft/raftpb"
 )
 
-// TODO(xiangli): Test panic cases
-
 func TestStorageTerm(t *testing.T) {
 	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
 	tests := []struct {
 		i uint64
 
-		werr  error
-		wterm uint64
+		werr   error
+		wterm  uint64
+		wpanic bool
 	}{
-		{2, ErrCompacted, 0},
-		{3, nil, 3},
-		{4, nil, 4},
-		{5, nil, 5},
+		{2, ErrCompacted, 0, false},
+		{3, nil, 3, false},
+		{4, nil, 4, false},
+		{5, nil, 5, false},
+		{6, nil, 0, true},
 	}
 
 	for i, tt := range tests {
 		s := &MemoryStorage{ents: ents}
-		term, err := s.Term(tt.i)
-		if err != tt.werr {
-			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
-		}
-		if term != tt.wterm {
-			t.Errorf("#%d: term = %d, want %d", i, term, tt.wterm)
-		}
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.wpanic {
+						t.Errorf("%d: panic = %v, want %v", i, true, tt.wpanic)
+					}
+				}
+			}()
+
+			term, err := s.Term(tt.i)
+			if err != tt.werr {
+				t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
+			}
+			if term != tt.wterm {
+				t.Errorf("#%d: term = %d, want %d", i, term, tt.wterm)
+			}
+		}()
 	}
 }
 


### PR DESCRIPTION
- test 'Term' panic cases (remove TODO)
- fix minor grammar in 'Node' godoc