### PR TITLE
Dockerfile: use 'ENTRYPOINT' instead of 'CMD'

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -6,5 +6,5 @@ RUN mkdir -p /var/etcd/
 
 EXPOSE 2379 2380
 
-# Define default command.
-CMD ["/usr/local/bin/etcd"]
+# Define default entrypoint.
+ENTRYPOINT ["/usr/local/bin/etcd"]


### PR DESCRIPTION
use entrypoint, so people can specify flags to etcd
without providing the binary.

Signed-off-by: Secret <haichuang221@163.com>

Replacing https://github.com/coreos/etcd/pull/5859.

Fix https://github.com/coreos/etcd/issues/5858.

Let's get this merged, so that we can ship this in the next release this week.

/cc @sctlee @xiang90 