### PR TITLE
etcdserver: fix TestSnap

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -845,7 +845,7 @@ func TestSnapshot(t *testing.T) {
 	s := raft.NewMemoryStorage()
 	s.Append([]raftpb.Entry{{Index: 1}})
 	st := mockstore.NewRecorder()
-	p := mockstorage.NewStorageRecorder("")
+	p := mockstorage.NewStorageRecorderStream("")
 	srv := &EtcdServer{
 		Cfg: &ServerConfig{},
 		r: raftNode{
@@ -869,7 +869,7 @@ func TestSnapshot(t *testing.T) {
 	if !reflect.DeepEqual(gaction[1], testutil.Action{Name: "SaveNoCopy"}) {
 		t.Errorf("action = %s, want SaveNoCopy", gaction[1])
 	}
-	gaction = p.Action()
+	gaction, _ = p.Wait(1)
 	if len(gaction) != 1 {
 		t.Fatalf("len(action) = %d, want 1", len(gaction))
 	}


### PR DESCRIPTION
Fix #5797.

We introduce the kv.commit call in the snapshot path, which slows down the go routine. Using wait to reliably wait for the actual snap event to happen.

