### PR TITLE
Easy 32bit patches

### DIFF
--- a/cmd/vendor/github.com/prometheus/client_golang/prometheus/histogram.go
+++ b/cmd/vendor/github.com/prometheus/client_golang/prometheus/histogram.go
@@ -217,11 +217,12 @@ func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogr
 
 type histogram struct {
 	// sumBits contains the bits of the float64 representing the sum of all
-	// observations. sumBits and count have to go first in the struct to
-	// guarantee alignment for atomic operations.
+	// observations. sumBits, count, and counts have to go first in the struct
+	// to guarantee alignment for atomic operations.
 	// http://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	sumBits uint64
 	count   uint64
+	counts  []uint64
 
 	SelfCollector
 	// Note that there is no mutex required.
@@ -229,7 +230,6 @@ type histogram struct {
 	desc *Desc
 
 	upperBounds []float64
-	counts      []uint64
 
 	labelPairs []*dto.LabelPair
 }

--- a/raft/node.go
+++ b/raft/node.go
@@ -38,6 +38,8 @@ var (
 // SoftState provides state that is useful for logging and debugging.
 // The state is volatile and does not need to be persisted to the WAL.
 type SoftState struct {
+	// The Lead field must be the first element to keep 64-bit alignment for
+	// atomic access.
 	Lead      uint64
 	RaftState StateType
 }


### PR DESCRIPTION
This is a series of easy fixes for the atomic access alignment issues that plague 32bit architecture builds.

I'm motivated to have 32bit ARM work.  With my patches it seems to work just fine so I'm going to try to upstream them.

I audited use of sync/atomic and only found a few issues.  Mostly it looks as though there is no mechanism to find regressions.  The codebase, including the 3rd party vendored code, is full of comments stating the need to keep some items 64bit aligned, but others seemed to slip through the cracks.  I patch those that do here.

Interesting I only found one issue in the 3rd party code.  I've already submitted a pull request for the upstream prometheus client code.