### PR TITLE
auth: cheap bcrypt for tests

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -52,6 +52,9 @@ var (
 	ErrRoleNotGranted       = errors.New("auth: role is not granted to the user")
 	ErrPermissionNotGranted = errors.New("auth: permission is not granted to the role")
 	ErrAuthNotEnabled       = errors.New("auth: authentication is not enabled")
+
+	// BcryptCost is the algorithm cost / strength for hashing auth passwords
+	BcryptCost = bcrypt.DefaultCost
 )
 
 const (
@@ -240,7 +243,7 @@ func (as *authStore) Recover(be backend.Backend) {
 }
 
 func (as *authStore) UserAdd(r *pb.AuthUserAddRequest) (*pb.AuthUserAddResponse, error) {
-	hashed, err := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
+	hashed, err := bcrypt.GenerateFromPassword([]byte(r.Password), BcryptCost)
 	if err != nil {
 		plog.Errorf("failed to hash password: %s", err)
 		return nil, err
@@ -287,7 +290,7 @@ func (as *authStore) UserDelete(r *pb.AuthUserDeleteRequest) (*pb.AuthUserDelete
 func (as *authStore) UserChangePassword(r *pb.AuthUserChangePasswordRequest) (*pb.AuthUserChangePasswordResponse, error) {
 	// TODO(mitake): measure the cost of bcrypt.GenerateFromPassword()
 	// If the cost is too high, we should move the encryption to outside of the raft
-	hashed, err := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
+	hashed, err := bcrypt.GenerateFromPassword([]byte(r.Password), BcryptCost)
 	if err != nil {
 		plog.Errorf("failed to hash password: %s", err)
 		return nil, err

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -20,8 +20,11 @@ import (
 
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/mvcc/backend"
+	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/net/context"
 )
+
+func init() { BcryptCost = bcrypt.MinCost }
 
 func TestUserAdd(t *testing.T) {
 	b, tPath := backend.NewDefaultTmpBackend()

--- a/clientv3/example_auth_test.go
+++ b/clientv3/example_auth_test.go
@@ -32,13 +32,11 @@ func ExampleAuth() {
 	}
 	defer cli.Close()
 
-	authapi := clientv3.NewAuth(cli)
-
-	if _, err = authapi.RoleAdd(context.TODO(), "root"); err != nil {
+	if _, err = cli.RoleAdd(context.TODO(), "root"); err != nil {
 		log.Fatal(err)
 	}
 
-	if _, err = authapi.RoleGrantPermission(
+	if _, err = cli.RoleGrantPermission(
 		context.TODO(),
 		"root", // role name
 		"foo",  // key
@@ -47,16 +45,13 @@ func ExampleAuth() {
 	); err != nil {
 		log.Fatal(err)
 	}
-
-	if _, err = authapi.UserAdd(context.TODO(), "root", "123"); err != nil {
+	if _, err = cli.UserAdd(context.TODO(), "root", "123"); err != nil {
 		log.Fatal(err)
 	}
-
-	if _, err = authapi.UserGrantRole(context.TODO(), "root", "root"); err != nil {
+	if _, err = cli.UserGrantRole(context.TODO(), "root", "root"); err != nil {
 		log.Fatal(err)
 	}
-
-	if _, err = authapi.AuthEnable(context.TODO()); err != nil {
+	if _, err = cli.AuthEnable(context.TODO()); err != nil {
 		log.Fatal(err)
 	}
 
@@ -71,12 +66,11 @@ func ExampleAuth() {
 	}
 	defer cliAuth.Close()
 
-	kv := clientv3.NewKV(cliAuth)
-	if _, err = kv.Put(context.TODO(), "foo1", "bar"); err != nil {
+	if _, err = cliAuth.Put(context.TODO(), "foo1", "bar"); err != nil {
 		log.Fatal(err)
 	}
 
-	_, err = kv.Txn(context.TODO()).
+	_, err = cliAuth.Txn(context.TODO()).
 		If(clientv3.Compare(clientv3.Value("zoo1"), ">", "abc")).
 		Then(clientv3.OpPut("zoo1", "XYZ")).
 		Else(clientv3.OpPut("zoo1", "ABC")).
@@ -84,14 +78,13 @@ func ExampleAuth() {
 	fmt.Println(err)
 
 	// now check the permission
-	authapi2 := clientv3.NewAuth(cliAuth)
-	resp, err := authapi2.RoleGet(context.TODO(), "root")
+	resp, err := cliAuth.RoleGet(context.TODO(), "root")
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("root user permission: key %q, range end %q\n", resp.Perm[0].Key, resp.Perm[0].RangeEnd)
 
-	if _, err = authapi2.AuthDisable(context.TODO()); err != nil {
+	if _, err = cliAuth.AuthDisable(context.TODO()); err != nil {
 		log.Fatal(err)
 	}
 	// Output: etcdserver: permission denied

--- a/clientv3/main_test.go
+++ b/clientv3/main_test.go
@@ -20,9 +20,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/coreos/etcd/auth"
 	"github.com/coreos/etcd/integration"
 	"github.com/coreos/etcd/pkg/testutil"
+	"golang.org/x/crypto/bcrypt"
 )
+
+func init() { auth.BcryptCost = bcrypt.MinCost }
 
 // TestMain sets up an etcd cluster if running the examples.
 func TestMain(m *testing.M) {


### PR DESCRIPTION
turns out bcrypt takes a lot of time with DefaultCost when using `--race  --cpu=1,2,4` flags

/cc @mitake 
