### PR TITLE
etcdserver/api/v2http, Documentation: fix debug pprof index miss / in end

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -276,7 +276,7 @@ Follow the instructions when using these flags.
 ## Profiling flags
 
 ### --enable-pprof
-+ Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof"
++ Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof/"
 + default: false
 
 [build-cluster]: clustering.md#static

--- a/Documentation/v2/configuration.md
+++ b/Documentation/v2/configuration.md
@@ -266,7 +266,7 @@ Follow the instructions when using these flags.
 ## Profiling flags
 
 ### --enable-pprof
-+ Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof"
++ Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof/"
 + default: false
 
 [build-cluster]: clustering.md#static

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -259,7 +259,7 @@ func NewConfig() *config {
 	fs.IntVar(&cfg.autoCompactionRetention, "auto-compaction-retention", 0, "Auto compaction retention for mvcc key value store in hour. 0 means disable auto compaction.")
 
 	// pprof profiler via HTTP
-	fs.BoolVar(&cfg.enablePprof, "enable-pprof", false, "Enable runtime profiling data via HTTP server. Address is at client URL + \"/debug/pprof\"")
+	fs.BoolVar(&cfg.enablePprof, "enable-pprof", false, "Enable runtime profiling data via HTTP server. Address is at client URL + \"/debug/pprof/\"")
 
 	// ignored
 	for _, f := range cfg.ignored {

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -146,6 +146,6 @@ given by the consensus protocol.
 	
 profiling flags:
 	--enable-pprof 'false'
-		Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof"
+		Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof/"
 `
 )

--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -113,7 +113,7 @@ func NewClientHandler(server *etcdserver.EtcdServer, timeout time.Duration) http
 	if server.IsPprofEnabled() {
 		plog.Infof("pprof is enabled under %s", pprofPrefix)
 
-		mux.HandleFunc(pprofPrefix, pprof.Index)
+		mux.HandleFunc(pprofPrefix+"/", pprof.Index)
 		mux.HandleFunc(pprofPrefix+"/profile", pprof.Profile)
 		mux.HandleFunc(pprofPrefix+"/symbol", pprof.Symbol)
 		mux.HandleFunc(pprofPrefix+"/cmdline", pprof.Cmdline)


### PR DESCRIPTION
File `etcdserver/api/v2http/client.go` url route defined `/debug/pprof` for `pprof.Index`, url not auto redirect to `/debug/pprof/`, and `pprof.Index` generate html links use relative path.

old html like:
```
Index: /debug/pprof
Heap:  /debug/heap
...
```

The correct path like `/debug/pprof/heap`