### PR TITLE
tools: add --user for auth in benchmarks

### DIFF
--- a/tools/benchmark/cmd/root.go
+++ b/tools/benchmark/cmd/root.go
@@ -46,6 +46,8 @@ var (
 
 	cpuProfPath string
 	memProfPath string
+
+	user string
 )
 
 func init() {
@@ -57,4 +59,6 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&tls.CertFile, "cert", "", "identify HTTPS client using this SSL certificate file")
 	RootCmd.PersistentFlags().StringVar(&tls.KeyFile, "key", "", "identify HTTPS client using this SSL key file")
 	RootCmd.PersistentFlags().StringVar(&tls.CAFile, "cacert", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+
+	RootCmd.PersistentFlags().StringVar(&user, "user", "", "specify username and password in username:password format")
 }

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/coreos/etcd/clientv3"
 )
@@ -39,6 +40,17 @@ func mustCreateConn() *clientv3.Client {
 			os.Exit(1)
 		}
 		cfg.TLS = cfgtls
+	}
+
+	if len(user) != 0 {
+		splitted := strings.SplitN(user, ":", 2)
+		if len(splitted) != 2 {
+			fmt.Fprintf(os.Stderr, "bad user information: %s\n", user)
+			os.Exit(1)
+		}
+
+		cfg.Username = splitted[0]
+		cfg.Password = splitted[1]
 	}
 
 	client, err := clientv3.New(cfg)


### PR DESCRIPTION

This commit adds --user for auth in benchmarks. Its purpose is
measuring overhead of authentication of v3 API. Of course the given
user must be granted permission of target keys before benchmarking.

Example of a case with no authentication:
% ./benchmark range k1
bench with linearizable range
 10000 / 10000 Booooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00%2m10s

Summary:
  Total:        130.1850 secs.
  Slowest:      0.4071 secs.
  Fastest:      0.0064 secs.
  Average:      0.0130 secs.
  Stddev:       0.0079 secs.
  Requests/sec: 76.8138

Response time histogram:
  0.006 [1]     |
  0.046 [9990]  |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.087 [3]     |
  0.127 [0]     |
  0.167 [3]     |
  0.207 [2]     |
  0.247 [0]     |
  0.287 [0]     |
  0.327 [0]     |
  0.367 [0]     |
  0.407 [1]     |

Latency distribution:
  10% in 0.0076 secs.
  25% in 0.0086 secs.
  50% in 0.0113 secs.
  75% in 0.0146 secs.
  90% in 0.0209 secs.
  95% in 0.0272 secs.
  99% in 0.0344 secs.

Example of a case with authentication:
% ./benchmark --user=u1:p range k1
bench with linearizable range
 10000 / 10000 Booooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00%2m11s

Summary:
  Total:        131.4923 secs.
  Slowest:      0.1637 secs.
  Fastest:      0.0065 secs.
  Average:      0.0131 secs.
  Stddev:       0.0070 secs.
  Requests/sec: 76.0501

Response time histogram:
  0.006 [1]     |
  0.022 [9075]  |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.038 [875]   |∎∎∎
  0.054 [36]    |
  0.069 [5]     |
  0.085 [1]     |
  0.101 [1]     |
  0.117 [0]     |
  0.132 [0]     |
  0.148 [5]     |
  0.164 [1]     |

Latency distribution:
  10% in 0.0076 secs.
  25% in 0.0087 secs.
  50% in 0.0114 secs.
  75% in 0.0150 secs.
  90% in 0.0215 secs.
  95% in 0.0272 secs.
  99% in 0.0347 secs.

It seems that current auth mechanism does not introduce visible overhead.