### PR TITLE
etcdserver: skip range requests in txn if the result is needless

### DIFF
--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -788,3 +788,21 @@ func isGteRange(rangeEnd []byte) bool {
 func noSideEffect(r *pb.InternalRaftRequest) bool {
 	return r.Range != nil || r.AuthUserGet != nil || r.AuthRoleGet != nil
 }
+
+func removeNeedlessRangeReqs(txn *pb.TxnRequest) {
+	f := func(ops []*pb.RequestOp) []*pb.RequestOp {
+		j := 0
+		for i := 0; i < len(ops); i++ {
+			if _, ok := ops[i].Request.(*pb.RequestOp_RequestRange); ok {
+				continue
+			}
+			ops[j] = ops[i]
+			j++
+		}
+
+		return ops[:j]
+	}
+
+	txn.Success = f(txn.Success)
+	txn.Failure = f(txn.Failure)
+}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1080,7 +1080,11 @@ func (s *EtcdServer) applyEntryNormal(e *raftpb.Entry) {
 	}
 
 	var ar *applyResult
-	if s.w.IsRegistered(id) || !noSideEffect(&raftReq) {
+	needResult := s.w.IsRegistered(id)
+	if needResult || !noSideEffect(&raftReq) {
+		if !needResult && raftReq.Txn != nil {
+			removeNeedlessRangeReqs(raftReq.Txn)
+		}
 		ar = s.applyV3.Apply(&raftReq)
 	}
 


### PR DESCRIPTION
If a server isn't serving txn requests from a client, the server
doesn't need the result of range requests in the txn.

This is a succeeding commit of
https://github.com/coreos/etcd/pull/5689

/cc @xiang90 