### PR TITLE
Correct security configuration for peers in sample config file.

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -111,16 +111,16 @@ peer-transport-security:
   ca-file:
 
   # Path to the peer server TLS cert file.
-  peer-cert-file: 
+  cert-file: 
 
   # Path to the peer server TLS key file.
-  peer-key-file: 
+  key-file: 
 
   # Enable peer client cert authentication.
-  peer-client-cert-auth: false
+  client-cert-auth: false
 
   # Path to the peer server TLS trusted CA key file.
-  peer-trusted-ca-file: 
+  trusted-ca-file: 
 
   # Peer TLS using generated certificates.
   auto-tls: false


### PR DESCRIPTION
Using a leading "peer-" prefix on the config file entries does not work.  Both security configuration yaml blocks take the same options (which differs from the cmdline args).