### PR TITLE
etcd-tester: pause before compaction, fix races

### DIFF
--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -32,7 +32,7 @@ func main() {
 	stressKeySize := flag.Int("stress-key-size", 100, "the size of each key written into etcd.")
 	stressKeySuffixRange := flag.Int("stress-key-count", 250000, "the count of key range written into etcd.")
 	limit := flag.Int("limit", -1, "the limit of rounds to run failure set (-1 to run without limits).")
-	stressQPS := flag.Int("stress-qps", 5000, "maximum number of stresser requests per second.")
+	stressQPS := flag.Int("stress-qps", 10000, "maximum number of stresser requests per second.")
 	schedCases := flag.String("schedule-cases", "", "test case schedule")
 	consistencyCheck := flag.Bool("consistency-check", true, "true to check consistency (revision, hash)")
 	isV2Only := flag.Bool("v2-only", false, "'true' to run V2 only tester.")

--- a/tools/functional-tester/etcd-tester/tester.go
+++ b/tools/functional-tester/etcd-tester/tester.go
@@ -149,15 +149,14 @@ func (tt *tester) checkConsistency() (failed bool, err error) {
 	var (
 		revs   map[string]int64
 		hashes map[string]int64
-		rerr   error
 		ok     bool
 	)
 	for i := 0; i < 7; i++ {
 		time.Sleep(time.Second)
 
-		revs, hashes, rerr = tt.cluster.getRevisionHash()
-		if rerr != nil {
-			plog.Printf("%s #%d failed to get current revisions (%v)", tt.logPrefix(), i, rerr)
+		revs, hashes, err = tt.cluster.getRevisionHash()
+		if err != nil {
+			plog.Printf("%s #%d failed to get current revisions (%v)", tt.logPrefix(), i, err)
 			continue
 		}
 		if tt.currentRevision, ok = getSameValue(revs); ok {
@@ -168,10 +167,9 @@ func (tt *tester) checkConsistency() (failed bool, err error) {
 	}
 	plog.Printf("%s updated current revisions with %d", tt.logPrefix(), tt.currentRevision)
 
-	if !ok || rerr != nil {
+	if !ok || err != nil {
 		plog.Printf("%s checking current revisions failed [revisions: %v]", tt.logPrefix(), revs)
 		failed = true
-		err = tt.cleanup()
 		return
 	}
 	plog.Printf("%s all members are consistent with current revisions [revisions: %v]", tt.logPrefix(), revs)
@@ -180,7 +178,6 @@ func (tt *tester) checkConsistency() (failed bool, err error) {
 	if _, ok = getSameValue(hashes); !ok {
 		plog.Printf("%s checking current storage hashes failed [hashes: %v]", tt.logPrefix(), hashes)
 		failed = true
-		err = tt.cleanup()
 		return
 	}
 	plog.Printf("%s all members are consistent with storage hashes", tt.logPrefix())
@@ -188,6 +185,9 @@ func (tt *tester) checkConsistency() (failed bool, err error) {
 }
 
 func (tt *tester) compact(rev int64, timeout time.Duration) error {
+	tt.cancelStressers()
+	defer tt.startStressers()
+
 	plog.Printf("%s compacting storage (current revision %d, compact revision %d)", tt.logPrefix(), tt.currentRevision, rev)
 	if err := tt.cluster.compactKV(rev, timeout); err != nil {
 		return err


### PR DESCRIPTION
- increase default qps
- fix race condition between stresser cancel, start
- pause before doing compaction
- remove duplicate cleanup calls
- add additional atomic canceled check

For example,

```
2016-07-13 18:23:53.576937 I | etcd-tester: [round#2 case#38] starting the stressers...
2016-07-13 18:23:53.576954 I | etcd-tester: [round#2 case#38] started stressers
2016-07-13 18:23:53.576965 I | etcd-tester: [round#2 case#38] succeed!
2016-07-13 18:23:53.576980 I | etcd-tester: [round#2] compacting 642280 entries (timeout 22s)
2016-07-13 18:23:53.576991 I | etcd-tester: [round#2] canceling the stressers...
2016-07-13 18:23:53.577003 I | etcd-tester: "10.240.0.19:2379" canceled
2016-07-13 18:23:53.577011 I | etcd-tester: "10.240.0.20:2379" canceled
2016-07-13 18:23:53.577021 I | etcd-tester: "10.240.0.22:2379" canceled
2016-07-13 18:23:53.577031 I | etcd-tester: [round#2] canceled stressers
2016-07-13 18:23:53.577041 I | etcd-tester: [round#2] compacting storage (current revision 1939051, compact revision 1929051)
2016-07-13 18:23:53.577078 I | etcd-tester: [compact kv #0] starting (endpoint http://10.240.0.19:2379)
2016-07-13 18:23:53.577117 I | etcd-tester: stresser to "10.240.0.20:2379" started
2016-07-13 18:23:53.577134 I | etcd-tester: stresser to "10.240.0.19:2379" started
2016-07-13 18:23:53.577228 I | etcd-tester: stresser to "10.240.0.22:2379" started
```