### PR TITLE
raft: do not change RecentActive when resetState for progress

### DIFF
--- a/raft/progress.go
+++ b/raft/progress.go
@@ -75,7 +75,6 @@ type Progress struct {
 
 func (pr *Progress) resetState(state ProgressStateType) {
 	pr.Paused = false
-	pr.RecentActive = false
 	pr.PendingSnapshot = 0
 	pr.State = state
 	pr.ins.reset()


### PR DESCRIPTION
Fix #5879. 

This reset is completely unnecessary. Most of time it is also wrong, since the state is usually changed when leader receives a message from follower, which indicates the follower is actually active.

