### PR TITLE
Revert "Dockerfile: use 'ENTRYPOINT' instead of 'CMD'"

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -6,5 +6,5 @@ RUN mkdir -p /var/etcd/
 
 EXPOSE 2379 2380
 
-# Define default entrypoint.
-ENTRYPOINT ["/usr/local/bin/etcd"]
+# Define default command.
+CMD ["/usr/local/bin/etcd"]


### PR DESCRIPTION
Reverts coreos/etcd#5876

Sorry, just found out

'ENTRYPOINT' does not allow other entry points, like

```
sudo docker run --name etcd quay.io/coreos/etcd:v3.0.2 -e "ETCDCTL_API=3" /usr/local/bin/etcdctl version

2016-07-14 01:30:18.199422 E | etcdmain: error verifying flags, '/usr/local/bin/etcdctl' is not a valid flag. See 'etcd --help'.
```

And change the default data directory to '/var/lib/etcd/'

This one works for both

```
sudo docker run --name etcd etcd_test /usr/local/bin/etcd

sudo docker exec etcd /bin/sh -c "/usr/local/bin/etcd --version"
sudo docker exec etcd /bin/sh -c "/usr/local/bin/etcdctl --version"
```
