### PR TITLE
build: build cross-compiled binaries in bin/ by default

### DIFF
--- a/build
+++ b/build
@@ -27,11 +27,8 @@ toggle_failpoints() {
 }
 
 etcd_build() {
-	if [ -z "${GOARCH}" ] || [ "${GOARCH}" = "$(go env GOHOSTARCH)" ]; then
-		out="bin"
-	else
-		out="bin/${GOARCH}"
-	fi
+	out="bin"
+	if [ -n "${BINDIR}" ]; then out="${BINDIR}"; fi
 	toggle_failpoints
 	# Static compilation is useful when etcd is run in a container
 	CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "-s -X ${REPO_PATH}/cmd/vendor/${REPO_PATH}/version.GitSHA=${GIT_SHA}" -o ${out}/etcd ${REPO_PATH}/cmd


### PR DESCRIPTION
Otherwise GOARCH=386 PASSES="build integration" ./test fail on amd64
because the e2e tests can't find the binaries. Added a BINDIR option
for writing the build output to somewhere else, in case it's needed.

/cc @glevand