### PR TITLE
e2e: run e2e tests on unsupported architectures

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -6,12 +6,14 @@ package e2e
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/coreos/etcd/pkg/testutil"
 )
 
 func TestMain(m *testing.M) {
+	os.Setenv("ETCD_UNSUPPORTED_ARCH", runtime.GOARCH)
 	v := m.Run()
 	if v == 0 && testutil.CheckLeakedGoroutine() {
 		os.Exit(1)


### PR DESCRIPTION
for arch bringup