### PR TITLE
build: allow to build outside the etcd directory

### DIFF
--- a/build
+++ b/build
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+CDIR=$(cd `dirname "$0"` && pwd)
+cd "$CDIR"
+
 # set some environment variables
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/etcd"
@@ -35,7 +38,15 @@ etcd_build() {
 	CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "-s" -o ${out}/etcdctl ${REPO_PATH}/cmd/etcdctl
 }
 
+etcd_setup_gopath() {
+	export GOPATH=${CDIR}/gopath
+	rm -f $GOPATH/src
+	mkdir -p $GOPATH
+	ln -s ${CDIR}/cmd/vendor $GOPATH/src
+}
+
 toggle_failpoints
+etcd_setup_gopath
 
 # don't build when sourced
 (echo "$0" | grep "/build$" > /dev/null) && etcd_build || true

--- a/test
+++ b/test
@@ -220,12 +220,6 @@ function build_pass {
 	GO_BUILD_FLAGS="-a -v" etcd_build
 }
 
-# Set up gopath so tests use vendored dependencies
-export GOPATH=${PWD}/gopath
-rm -f $GOPATH/src
-mkdir -p $GOPATH
-ln -s ${PWD}/cmd/vendor $GOPATH/src
-
 for pass in $PASSES; do
 	${pass}_pass
 done


### PR DESCRIPTION
And added gopath hack which allows to build without setting any GOPATH
env. Just run the build script when you have installed golang. As it is implemented in [fleet](https://github.com/coreos/fleet/).