### PR TITLE
grpcproxy: return interface

### DIFF
--- a/proxy/grpcproxy/kv.go
+++ b/proxy/grpcproxy/kv.go
@@ -27,7 +27,7 @@ type kvProxy struct {
 	cache  cache.Cache
 }
 
-func NewKvProxy(c *clientv3.Client) *kvProxy {
+func NewKvProxy(c *clientv3.Client) pb.KVServer {
 	return &kvProxy{
 		client: c,
 		cache:  cache.NewCache(cache.DefaultMaxEntries),
@@ -100,10 +100,6 @@ func (p *kvProxy) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.Com
 	}
 
 	return (*pb.CompactionResponse)(resp), err
-}
-
-func (p *kvProxy) Close() error {
-	return p.client.Close()
 }
 
 func requestOpToOp(union *pb.RequestOp) clientv3.Op {

--- a/proxy/grpcproxy/kv_test.go
+++ b/proxy/grpcproxy/kv_test.go
@@ -50,10 +50,11 @@ func TestKVProxyRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
+	client.Close()
 }
 
 type kvproxyTestServer struct {
-	kp     *kvProxy
+	kp     pb.KVServer
 	server *grpc.Server
 	l      net.Listener
 }
@@ -61,7 +62,6 @@ type kvproxyTestServer struct {
 func (kts *kvproxyTestServer) close() {
 	kts.server.Stop()
 	kts.l.Close()
-	kts.kp.Close()
 }
 
 func newKVProxyServer(endpoints []string, t *testing.T) *kvproxyTestServer {

--- a/proxy/grpcproxy/lease.go
+++ b/proxy/grpcproxy/lease.go
@@ -25,7 +25,7 @@ type leaseProxy struct {
 	client *clientv3.Client
 }
 
-func NewLeaseProxy(c *clientv3.Client) *leaseProxy {
+func NewLeaseProxy(c *clientv3.Client) pb.LeaseServer {
 	return &leaseProxy{
 		client: c,
 	}

--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -32,7 +32,7 @@ type watchProxy struct {
 	nextStreamID int64
 }
 
-func NewWatchProxy(c *clientv3.Client) *watchProxy {
+func NewWatchProxy(c *clientv3.Client) pb.WatchServer {
 	return &watchProxy{
 		c: c,
 		wgs: watchergroups{


### PR DESCRIPTION
We now can ensure the implementation actually satisfy the interface.

