### PR TITLE
embed: support unix sockets

### DIFF
--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -225,7 +225,7 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 	for _, u := range cfg.LCUrls {
 		sctx := newServeCtx()
 
-		if u.Scheme == "http" {
+		if u.Scheme == "http" || u.Scheme == "unix" {
 			if !cfg.ClientTLSInfo.Empty() {
 				plog.Warningf("The scheme of client url %s is HTTP while peer key/cert files are presented. Ignored key/cert files.", u.String())
 			}
@@ -233,11 +233,16 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 				plog.Warningf("The scheme of client url %s is HTTP while client cert auth (--client-cert-auth) is enabled. Ignored client cert auth for this url.", u.String())
 			}
 		}
-		if u.Scheme == "https" && cfg.ClientTLSInfo.Empty() {
+		if (u.Scheme == "https" || u.Scheme == "unixs") && cfg.ClientTLSInfo.Empty() {
 			return nil, fmt.Errorf("TLS key/cert (--cert-file, --key-file) must be provided for client url %s with HTTPs scheme", u.String())
 		}
 
-		sctx.secure = u.Scheme == "https"
+		proto := "tcp"
+		if u.Scheme == "unix" || u.Scheme == "unixs" {
+			proto = "unix"
+		}
+
+		sctx.secure = u.Scheme == "https" || u.Scheme == "unixs"
 		sctx.insecure = !sctx.secure
 		if oldctx := sctxs[u.Host]; oldctx != nil {
 			oldctx.secure = oldctx.secure || sctx.secure
@@ -245,7 +250,7 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 			continue
 		}
 
-		if sctx.l, err = net.Listen("tcp", u.Host); err != nil {
+		if sctx.l, err = net.Listen(proto, u.Host); err != nil {
 			return nil, err
 		}
 
@@ -256,8 +261,10 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 			sctx.l = transport.LimitListener(sctx.l, int(fdLimit-reservedInternalFDNum))
 		}
 
-		if sctx.l, err = transport.NewKeepAliveListener(sctx.l, "tcp", nil); err != nil {
-			return nil, err
+		if proto == "tcp" {
+			if sctx.l, err = transport.NewKeepAliveListener(sctx.l, "tcp", nil); err != nil {
+				return nil, err
+			}
 		}
 
 		plog.Info("listening for client requests on ", u.Host)

--- a/integration/embed_test.go
+++ b/integration/embed_test.go
@@ -88,15 +88,11 @@ func TestEmbedEtcd(t *testing.T) {
 	}
 }
 
-// 4000x so no conflict with e2e tests
-var embedBasePort = 40000
-
 func newEmbedURLs(n int) (urls []url.URL) {
 	for i := 0; i < n; i++ {
-		u, _ := url.Parse(fmt.Sprintf("http://localhost:%d", embedBasePort+i))
+		u, _ := url.Parse(fmt.Sprintf("unix://localhost:%d.%d.sock", os.Getpid(), i))
 		urls = append(urls, *u)
 	}
-	embedBasePort += n
 	return
 }
 


### PR DESCRIPTION
In response to unpredictable port conflicts in semaphore.

Fixes #5953 