### PR TITLE
clientv3/integration: fix race in TestWatchCompactRevision

### DIFF
--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -400,7 +400,7 @@ func TestWatchResumeCompacted(t *testing.T) {
 func TestWatchCompactRevision(t *testing.T) {
 	defer testutil.AfterTest(t)
 
-	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
 	// set some keys


### PR DESCRIPTION
Fix #5982 

Reduce the cluster size to 1 for this test. It is not necessary to have a 3 member cluster for this test at the first place.

If we use a 3 member cluster, the watch request might arrive before the compaction propagates to that member. Then watch with rev 2 will succeed.

