### PR TITLE
Add support for formating output of ls command in json or extended fo…

### DIFF
--- a/etcdctl/ctlv2/command/ls_command.go
+++ b/etcdctl/ctlv2/command/ls_command.go
@@ -63,11 +63,16 @@ func lsCommandFunc(c *cli.Context, ki client.KeysAPI) {
 // printLs writes a response out in a manner similar to the `ls` command in unix.
 // Non-empty directories list their contents and files list their name.
 func printLs(c *cli.Context, resp *client.Response) {
-	if !resp.Node.Dir {
-		fmt.Println(resp.Node.Key)
-	}
-	for _, node := range resp.Node.Nodes {
-		rPrint(c, node)
+	if c.GlobalString("output") == "simple" {
+		if !resp.Node.Dir {
+			fmt.Println(resp.Node.Key)
+		}
+		for _, node := range resp.Node.Nodes {
+			rPrint(c, node)
+		}
+	} else {
+		// user wants JSON or extended output
+		printResponseKey(resp, c.GlobalString("output"))
 	}
 }
 


### PR DESCRIPTION
This change keeps the existing formatting for the default case and defers to [printResponseKey](https://github.com/coreos/etcd/blob/66e5e4f298e66bdd72307336935e192aa66097c0/etcdctl/ctlv2/command/format.go#L26) when the user has explicitly specified something else via `--output` global option for `ls`.

Fixes #5993

I also could do something similar with `mkdir` and and `rmdir` where they'd continue to behave the same as they do today unless the user has explicitly indicated otherwise with `--output`.