### PR TITLE
etcdmain: correctly check return values from SdNotify()

### DIFF
--- a/cmd/Godeps/Godeps.json
+++ b/cmd/Godeps/Godeps.json
@@ -38,18 +38,18 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/daemon",
-			"Comment": "v3-6-gcea488b",
-			"Rev": "cea488b4e6855fee89b6c22a811e3c5baca861b6"
+			"Comment": "v10-13-gd6c05a1d",
+			"Rev": "d6c05a1dcbb5ac02b7653da4d99e5db340c20778"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/journal",
-			"Comment": "v3-6-gcea488b",
-			"Rev": "cea488b4e6855fee89b6c22a811e3c5baca861b6"
+			"Comment": "v10-13-gd6c05a1d",
+			"Rev": "d6c05a1dcbb5ac02b7653da4d99e5db340c20778"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/util",
-			"Comment": "v3-6-gcea488b",
-			"Rev": "cea488b4e6855fee89b6c22a811e3c5baca861b6"
+			"Comment": "v10-13-gd6c05a1d",
+			"Rev": "d6c05a1dcbb5ac02b7653da4d99e5db340c20778"
 		},
 		{
 			"ImportPath": "github.com/coreos/pkg/capnslog",

--- a/cmd/vendor/github.com/coreos/go-systemd/daemon/sdnotify.go
+++ b/cmd/vendor/github.com/coreos/go-systemd/daemon/sdnotify.go
@@ -2,30 +2,37 @@
 package daemon
 
 import (
-	"errors"
 	"net"
 	"os"
 )
 
-var SdNotifyNoSocket = errors.New("No socket")
-
 // SdNotify sends a message to the init daemon. It is common to ignore the error.
-func SdNotify(state string) error {
+// It returns one of the following:
+// (false, nil) - notification not supported (i.e. NOTIFY_SOCKET is unset)
+// (false, err) - notification supported, but failure happened (e.g. error connecting to NOTIFY_SOCKET or while sending data)
+// (true, nil) - notification supported, data has been sent
+func SdNotify(state string) (sent bool, err error) {
 	socketAddr := &net.UnixAddr{
 		Name: os.Getenv("NOTIFY_SOCKET"),
 		Net:  "unixgram",
 	}
 
+	// NOTIFY_SOCKET not set
 	if socketAddr.Name == "" {
-		return SdNotifyNoSocket
+		return false, nil
 	}
 
 	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)
+	// Error connecting to NOTIFY_SOCKET
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer conn.Close()
 
 	_, err = conn.Write([]byte(state))
-	return err
+	// Error sending the message
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/cmd/vendor/github.com/coreos/go-systemd/journal/journal.go
+++ b/cmd/vendor/github.com/coreos/go-systemd/journal/journal.go
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package journal provides write bindings to the systemd journal
+// Package journal provides write bindings to the local systemd journal.
+// It is implemented in pure Go and connects to the journal directly over its
+// unix socket.
+//
+// To read from the journal, see the "sdjournal" package, which wraps the
+// sd-journal a C API.
+//
+// http://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
 package journal
 
 import (
@@ -53,14 +60,14 @@ func init() {
 	}
 }
 
-// Enabled returns true iff the systemd journal is available for logging
+// Enabled returns true if the local systemd journal is available for logging
 func Enabled() bool {
 	return conn != nil
 }
 
-// Send a message to the systemd journal. vars is a map of journald fields to
-// values.  Fields must be composed of uppercase letters, numbers, and
-// underscores, but must not start with an underscore. Within these
+// Send a message to the local systemd journal. vars is a map of journald
+// fields to values.  Fields must be composed of uppercase letters, numbers,
+// and underscores, but must not start with an underscore. Within these
 // restrictions, any arbitrary field name may be used.  Some names have special
 // significance: see the journalctl documentation
 // (http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html)
@@ -83,6 +90,7 @@ func Send(message string, priority Priority, vars map[string]string) error {
 		if err != nil {
 			return journalError(err.Error())
 		}
+		defer file.Close()
 		_, err = io.Copy(file, data)
 		if err != nil {
 			return journalError(err.Error())
@@ -100,6 +108,11 @@ func Send(message string, priority Priority, vars map[string]string) error {
 		return journalError(err.Error())
 	}
 	return nil
+}
+
+// Print prints a message to the local systemd journal using Send().
+func Print(priority Priority, format string, a ...interface{}) error {
+	return Send(fmt.Sprintf(format, a...), priority, nil)
 }
 
 func appendVariable(w io.Writer, name, value string) {

--- a/cmd/vendor/github.com/coreos/go-systemd/util/util.go
+++ b/cmd/vendor/github.com/coreos/go-systemd/util/util.go
@@ -13,15 +13,66 @@
 // limitations under the License.
 
 // Package util contains utility functions related to systemd that applications
-// can use to check things like whether systemd is running.
+// can use to check things like whether systemd is running.  Note that some of
+// these functions attempt to manually load systemd libraries at runtime rather
+// than linking against them.
 package util
 
+// #include <stdlib.h>
+// #include <sys/types.h>
+// #include <unistd.h>
+//
+// int
+// my_sd_pid_get_owner_uid(void *f, pid_t pid, uid_t *uid)
+// {
+//   int (*sd_pid_get_owner_uid)(pid_t, uid_t *);
+//
+//   sd_pid_get_owner_uid = (int (*)(pid_t, uid_t *))f;
+//   return sd_pid_get_owner_uid(pid, uid);
+// }
+//
+// int
+// my_sd_pid_get_unit(void *f, pid_t pid, char **unit)
+// {
+//   int (*sd_pid_get_unit)(pid_t, char **);
+//
+//   sd_pid_get_unit = (int (*)(pid_t, char **))f;
+//   return sd_pid_get_unit(pid, unit);
+// }
+//
+// int
+// my_sd_pid_get_slice(void *f, pid_t pid, char **slice)
+// {
+//   int (*sd_pid_get_slice)(pid_t, char **);
+//
+//   sd_pid_get_slice = (int (*)(pid_t, char **))f;
+//   return sd_pid_get_slice(pid, slice);
+// }
+//
+// int
+// am_session_leader()
+// {
+//   return (getsid(0) == getpid());
+// }
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 )
 
+var libsystemdNames = []string{
+	// systemd < 209
+	"libsystemd-login.so.0",
+	"libsystemd-login.so",
+
+	// systemd >= 209 merged libsystemd-login into libsystemd proper
+	"libsystemd.so.0",
+	"libsystemd.so",
+}
+
 // IsRunningSystemd checks whether the host was booted with systemd as its init
-// system. This functions similar to systemd's `sd_booted(3)`: internally, it
+// system. This functions similarly to systemd's `sd_booted(3)`: internally, it
 // checks whether /run/systemd/system/ exists and is a directory.
 // http://www.freedesktop.org/software/systemd/man/sd_booted.html
 func IsRunningSystemd() bool {
@@ -30,4 +81,16 @@ func IsRunningSystemd() bool {
 		return false
 	}
 	return fi.IsDir()
+}
+
+// GetMachineID returns a host's 128-bit machine ID as a string. This functions
+// similarly to systemd's `sd_id128_get_machine`: internally, it simply reads
+// the contents of /etc/machine-id
+// http://www.freedesktop.org/software/systemd/man/sd_id128_get_machine.html
+func GetMachineID() (string, error) {
+	machineID, err := ioutil.ReadFile("/etc/machine-id")
+	if err != nil {
+		return "", fmt.Errorf("failed to read /etc/machine-id: %v", err)
+	}
+	return strings.TrimSpace(string(machineID)), nil
 }

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -160,12 +160,12 @@ func startEtcdOrProxyV2() {
 		// for accepting connections. The etcd instance should be
 		// joined with the cluster and ready to serve incoming
 		// connections.
-		err := daemon.SdNotify("READY=1")
+		sent, err := daemon.SdNotify("READY=1")
 		if err != nil {
 			plog.Errorf("failed to notify systemd for readiness: %v", err)
-			if err == daemon.SdNotifyNoSocket {
-				plog.Errorf("forgot to set Type=notify in systemd service file?")
-			}
+		}
+		if !sent {
+			plog.Errorf("forgot to set Type=notify in systemd service file?")
 		}
 	}
 


### PR DESCRIPTION
Since https://github.com/coreos/go-systemd/commit/0d7fccc155921b2b4023b0acfd60981d4a27b3da, ``SdNotify()`` in ``go-systemd`` started to return 2 values, sent and err. So ``startEtcdOrProxyV2()`` in etcd needs to check the 2 return values correctly. As the 2 values are independent of each other, error checking logic needs to be slightly updated too. ``SdNotifyNoSocket``, which was previously provided by ``go-systemd``, does not exist any more. In that case ``(false, nil)`` will be returned instead.

This was a direct reason of a travis-ci failure in fleet like this: https://travis-ci.org/coreos/fleet/builds/146093283. Although fleet has nothing to do with this API change, travis always fetches the most recent master branch for each git repo.