### PR TITLE
v3rpc: don't elide next progress notification on progress notification

### DIFF
--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -487,7 +487,7 @@ func testWatchWithProgressNotify(t *testing.T, watchOnPut bool) {
 		} else if len(resp.Events) != 0 { // wait for notification otherwise
 			t.Fatalf("expected no events, but got %+v", resp.Events)
 		}
-	case <-time.After(2 * pi):
+	case <-time.After(time.Duration(1.5 * float64(pi))):
 		t.Fatalf("watch response expected in %v, but timed out", pi)
 	}
 }

--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -295,7 +295,8 @@ func (sws *serverWatchStream) sendLoop() {
 			}
 
 			sws.mu.Lock()
-			if _, ok := sws.progress[wresp.WatchID]; ok {
+			if len(evs) > 0 && sws.progress[wresp.WatchID] {
+				// elide next progress update if sent a key update
 				sws.progress[wresp.WatchID] = false
 			}
 			sws.mu.Unlock()

--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -971,7 +971,7 @@ func TestWatchWithProgressNotify(t *testing.T) {
 	}
 
 	// no more notification
-	rok, resp := waitResponse(wStream, testInterval+time.Second)
+	rok, resp := waitResponse(wStream, time.Second)
 	if !rok {
 		t.Errorf("unexpected pb.WatchResponse is received %+v", resp)
 	}


### PR DESCRIPTION
Fixes #5878 

Clocked parts of the failing test, noticed the wait time was about 6s instead of 3s.