### PR TITLE
e2e: use a single member cluster in TestCtlV3Migrate

### DIFF
--- a/e2e/ctl_v3_migrate_test.go
+++ b/e2e/ctl_v3_migrate_test.go
@@ -29,7 +29,7 @@ import (
 func TestCtlV3Migrate(t *testing.T) {
 	defer testutil.AfterTest(t)
 
-	epc := setupEtcdctlTest(t, &configNoTLS, true)
+	epc := setupEtcdctlTest(t, &configNoTLS, false)
 	defer func() {
 		if errC := epc.Close(); errC != nil {
 			t.Fatalf("error closing etcd processes (%v)", errC)
@@ -48,10 +48,7 @@ func TestCtlV3Migrate(t *testing.T) {
 		}
 	}
 
-	dataDirs := make([]string, len(epc.procs))
-	for i := range epc.procs {
-		dataDirs[i] = epc.procs[i].cfg.dataDirPath
-	}
+	dataDir := epc.procs[0].cfg.dataDirPath
 	if err := epc.StopAll(); err != nil {
 		t.Fatalf("error closing etcd processes (%v)", err)
 	}
@@ -62,18 +59,13 @@ func TestCtlV3Migrate(t *testing.T) {
 		t:           t,
 		cfg:         configNoTLS,
 		dialTimeout: 7 * time.Second,
-		quorum:      true,
 		epc:         epc,
 	}
-	for i := range dataDirs {
-		if err := ctlV3Migrate(cx, dataDirs[i], ""); err != nil {
-			t.Fatal(err)
-		}
+	if err := ctlV3Migrate(cx, dataDir, ""); err != nil {
+		t.Fatal(err)
 	}
 
-	for i := range epc.procs {
-		epc.procs[i].cfg.keepDataDir = true
-	}
+	epc.procs[0].cfg.keepDataDir = true
 	if err := epc.RestartAll(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Occasionally migrate would fail because a minority node would be missing
v2 keys. Instead, just use a single member cluster.

Fixes #5992`