### PR TITLE
e2e: add gateway test

### DIFF
--- a/e2e/ctl_v2_test.go
+++ b/e2e/ctl_v2_test.go
@@ -323,7 +323,7 @@ func etcdctlPrefixArgs(clus *etcdProcessCluster) []string {
 		}
 		endpoints = strings.Join(es, ",")
 	}
-	cmdArgs := []string{"../bin/etcdctl", "--endpoints", endpoints}
+	cmdArgs := []string{defaultCtlBinPath, "--endpoints", endpoints}
 	if clus.cfg.clientTLS == clientTLS {
 		cmdArgs = append(cmdArgs, "--ca-file", caPath, "--cert-file", certPath, "--key-file", privateKeyPath)
 	}

--- a/e2e/ctl_v3_test.go
+++ b/e2e/ctl_v3_test.go
@@ -148,7 +148,7 @@ func (cx *ctlCtx) PrefixArgs() []string {
 		}
 		endpoints = strings.Join(es, ",")
 	}
-	cmdArgs := []string{"../bin/etcdctl", "--endpoints", endpoints, "--dial-timeout", cx.dialTimeout.String()}
+	cmdArgs := []string{defaultCtlBinPath, "--endpoints", endpoints, "--dial-timeout", cx.dialTimeout.String()}
 	if cx.epc.cfg.clientTLS == clientTLS {
 		if cx.epc.cfg.isClientAutoTLS {
 			cmdArgs = append(cmdArgs, "--insecure-transport=false", "--insecure-skip-tls-verify")

--- a/e2e/etcd_test.go
+++ b/e2e/etcd_test.go
@@ -31,6 +31,8 @@ const (
 	certPath            = "../integration/fixtures/server.crt"
 	privateKeyPath      = "../integration/fixtures/server.key.insecure"
 	caPath              = "../integration/fixtures/ca.crt"
+	defaultBinPath      = "../bin/etcd"
+	defaultCtlBinPath   = "../bin/etcdctl"
 )
 
 type clientConnType int
@@ -205,7 +207,7 @@ func (cfg *etcdProcessClusterConfig) etcdProcessConfigs() []*etcdProcessConfig {
 	}
 
 	if cfg.execPath == "" {
-		cfg.execPath = "../bin/etcd"
+		cfg.execPath = defaultBinPath
 	}
 	if cfg.snapCount == 0 {
 		cfg.snapCount = etcdserver.DefaultSnapCount

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -1,0 +1,60 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/coreos/etcd/pkg/expect"
+)
+
+var (
+	defaultGatewayEndpoint = "127.0.0.1:23790"
+)
+
+func TestGateway(t *testing.T) {
+	ec, err := newEtcdProcessCluster(&configNoTLS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ec.StopAll()
+
+	eps := strings.Join(ec.grpcEndpoints(), ",")
+
+	p := startGateway(t, eps)
+	defer p.Stop()
+
+	os.Setenv("ETCDCTL_API", "3")
+	defer os.Unsetenv("ETCDCTL_API")
+
+	err = spawnWithExpect([]string{defaultCtlBinPath, "--endpoints=" + defaultGatewayEndpoint, "put", "foo", "bar"}, "OK\r\n")
+	if err != nil {
+		t.Errorf("failed to finish put request through gateway: %v", err)
+	}
+}
+
+func startGateway(t *testing.T, endpoints string) *expect.ExpectProcess {
+	p, err := expect.NewExpect(defaultBinPath, "gateway", "--endpoints="+endpoints, "start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = p.Expect("tcpproxy: ready to proxy client requests to")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/5408

gateway is just a simple tcp proxy. testing one command would be good enough. we might want to test how it handles etcd failures in the future though.

/cc @heyitsanthony @gyuho 
