### PR TITLE
grpcproxy: define 'watchergroups' in pointer

### DIFF
--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -50,7 +50,7 @@ func (wp *watchProxy) Watch(stream pb.Watch_WatchServer) (err error) {
 
 	sws := serverWatchStream{
 		c:      wp.c,
-		groups: wp.wgs,
+		groups: &wp.wgs,
 
 		id:         wp.nextStreamID,
 		gRPCStream: stream,
@@ -71,7 +71,7 @@ type serverWatchStream struct {
 	c  *clientv3.Client
 
 	mu      sync.Mutex // make sure any access of groups and singles is atomic
-	groups  watchergroups
+	groups  *watchergroups
 	singles map[int64]*watcherSingle
 
 	gRPCStream pb.Watch_WatchServer


### PR DESCRIPTION
With Go tip, go vet complains

   gopath/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:53:
   literal copies lock value from wp.wgs: grpcproxy.watchergroups contains sync.Mutex
