### PR TITLE
raft: hide Campaign rules on applying all entries

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -136,21 +136,7 @@ type Node interface {
 	// However, as an optimization, the application may call Advance while it is applying the
 	// commands. For example. when the last Ready contains a snapshot, the application might take
 	// a long time to apply the snapshot data. To continue receiving Ready without blocking raft
-	// progress, it can call Advance before finishing applying the last ready. To make this optimization
-	// work safely, when the application receives a Ready with softState.RaftState equal to Candidate
-	// it MUST apply all pending configuration changes if there is any.
-	//
-	// Here is a simple solution that waiting for ALL pending entries to get applied.
-	// ```
-	// ...
-	// rd := <-n.Ready()
-	// go apply(rd.CommittedEntries) // optimization to apply asynchronously in FIFO order.
-	// if rd.SoftState.RaftState == StateCandidate {
-	//     waitAllApplied()
-	// }
-	// n.Advance()
-	// ...
-	//```
+	// progress, it can call Advance before finishing applying the last ready.
 	Advance()
 	// ApplyConfChange applies config change to the local node.
 	// Returns an opaque ConfState protobuf which must be recorded

--- a/raft/rawnode.go
+++ b/raft/rawnode.go
@@ -103,9 +103,14 @@ func NewRawNode(config *Config, peers []Peer) (*RawNode, error) {
 			r.addNode(peer.ID)
 		}
 	}
+
 	// Set the initial hard and soft states after performing all initialization.
 	rn.prevSoftSt = r.softState()
-	rn.prevHardSt = r.hardState()
+	if lastIndex == 0 {
+		rn.prevHardSt = emptyState
+	} else {
+		rn.prevHardSt = r.hardState()
+	}
 
 	return rn, nil
 }

--- a/raft/rawnode_test.go
+++ b/raft/rawnode_test.go
@@ -53,12 +53,18 @@ func TestRawNodeProposeAndConfChange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	rd := rawNode.Ready()
+	s.Append(rd.Entries)
+	rawNode.Advance(rd)
+
 	rawNode.Campaign()
 	proposed := false
-	var lastIndex uint64
-	var ccdata []byte
+	var (
+		lastIndex uint64
+		ccdata    []byte
+	)
 	for {
-		rd := rawNode.Ready()
+		rd = rawNode.Ready()
 		s.Append(rd.Entries)
 		// Once we are the leader, propose a command and a ConfChange.
 		if !proposed && rd.SoftState.Lead == rawNode.raft.id {
@@ -124,15 +130,12 @@ func TestRawNodeStart(t *testing.T) {
 	}
 	wants := []Ready{
 		{
-			SoftState: &SoftState{Lead: 1, RaftState: StateLeader},
-			HardState: raftpb.HardState{Term: 2, Commit: 2, Vote: 1},
+			HardState: raftpb.HardState{Term: 1, Commit: 1, Vote: 0},
 			Entries: []raftpb.Entry{
 				{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: ccdata},
-				{Term: 2, Index: 2},
 			},
 			CommittedEntries: []raftpb.Entry{
 				{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: ccdata},
-				{Term: 2, Index: 2},
 			},
 		},
 		{
@@ -147,7 +150,6 @@ func TestRawNodeStart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rawNode.Campaign()
 	rd := rawNode.Ready()
 	t.Logf("rd %v", rd)
 	if !reflect.DeepEqual(rd, wants[0]) {
@@ -156,6 +158,13 @@ func TestRawNodeStart(t *testing.T) {
 		storage.Append(rd.Entries)
 		rawNode.Advance(rd)
 	}
+	storage.Append(rd.Entries)
+	rawNode.Advance(rd)
+
+	rawNode.Campaign()
+	rd = rawNode.Ready()
+	storage.Append(rd.Entries)
+	rawNode.Advance(rd)
 
 	rawNode.Propose([]byte("foo"))
 	if rd = rawNode.Ready(); !reflect.DeepEqual(rd, wants[1]) {


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6013.

@LK4D4 can you please give this a try?

Previously we have some rules about when there are configuration changes. It is actually a little bit hard to follow for applications. Now we try to handle it internally inside raft.

