### PR TITLE
embed: use actual listen urls, not advertised urls

### DIFF
--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -96,8 +96,8 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 
 	srvcfg := &etcdserver.ServerConfig{
 		Name:                    cfg.Name,
-		ClientURLs:              cfg.ACUrls,
-		PeerURLs:                cfg.APUrls,
+		ClientURLs:              cfg.LCUrls,
+		PeerURLs:                cfg.LPUrls,
 		DataDir:                 cfg.Dir,
 		DedicatedWALDir:         cfg.WalDir,
 		SnapCount:               cfg.SnapCount,


### PR DESCRIPTION
I think a small copy+paste mistake was made, and it is more accurate that these be the listen URLS, not the advertise URLs.