### PR TITLE
Adding ppc64le to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
    - TARGET=arm64
    - TARGET=arm
    - TARGET=386
+   - TARGET=ppc64le
 
 matrix:
   fast_finish: true
@@ -27,6 +28,8 @@ matrix:
     env: TARGET=arm64
   - go: tip
     env: TARGET=386
+  - go: tip
+    env: TARGET=ppc64le
 
 addons:
   apt:


### PR DESCRIPTION
Hi,

This adds ppc64le to travis again. I was able to build etcd on local ppc64le machine, and I ran ./test to check the result. Here is the output:

```
# ./test 
Checking gofmt...
Checking govet...
Checking 'go tool vet -shadow'...
which: no goword in (/go/src/go.googlesource.com/go/bin/:/opt/at9.0/sbin/:/opt/at9.0/bin:/opt/at9.0/sbin:/opt/at9.0/bin:/opt/at9.0/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin)
Skipping goword...
which: no gosimple in (/go/src/go.googlesource.com/go/bin/:/opt/at9.0/sbin/:/opt/at9.0/bin:/opt/at9.0/sbin:/opt/at9.0/bin:/opt/at9.0/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin)
Skipping gosimple...
which: no unused in (/go/src/go.googlesource.com/go/bin/:/opt/at9.0/sbin/:/opt/at9.0/bin:/opt/at9.0/sbin:/opt/at9.0/bin:/opt/at9.0/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin)
Skipping unused...
Checking for license header...
Checking commit titles...
Checking package dependencies...
Checking build...
github.com/golang/protobuf/proto
github.com/coreos/etcd/auth/authpb
golang.org/x/net/context
golang.org/x/net/http2/hpack
golang.org/x/net/http2
golang.org/x/net/internal/timeseries
golang.org/x/net/trace
google.golang.org/grpc/codes
google.golang.org/grpc/credentials
google.golang.org/grpc/grpclog
google.golang.org/grpc/internal
google.golang.org/grpc/metadata
google.golang.org/grpc/naming
google.golang.org/grpc/peer
google.golang.org/grpc/transport
google.golang.org/grpc
github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes
github.com/coreos/etcd/mvcc/mvccpb
github.com/golang/protobuf/jsonpb
github.com/grpc-ecosystem/grpc-gateway/runtime/internal
github.com/grpc-ecosystem/grpc-gateway/utilities
github.com/grpc-ecosystem/grpc-gateway/runtime
github.com/coreos/etcd/etcdserver/etcdserverpb
github.com/coreos/etcd/pkg/tlsutil
gopkg.in/yaml.v2
github.com/ghodss/yaml
github.com/coreos/etcd/clientv3
github.com/coreos/etcd/clientv3/concurrency
github.com/coreos/etcd/lease/leasepb
github.com/boltdb/bolt
github.com/coreos/go-systemd/journal
github.com/coreos/pkg/capnslog
github.com/beorn7/perks/quantile
github.com/prometheus/client_model/go
bitbucket.org/ww/goautoneg
github.com/matttproud/golang_protobuf_extensions/pbutil
github.com/prometheus/common/model
github.com/prometheus/common/expfmt
github.com/prometheus/procfs
github.com/prometheus/client_golang/prometheus
github.com/coreos/etcd/mvcc/backend
github.com/coreos/etcd/lease
github.com/coreos/etcd/pkg/adt
github.com/coreos/etcd/pkg/schedule
github.com/google/btree
github.com/coreos/etcd/mvcc
github.com/coreos/etcd/pkg/fileutil
github.com/coreos/etcd/pkg/transport
github.com/shurcooL/sanitized_anchor_name
github.com/russross/blackfriday
github.com/cpuguy83/go-md2man/md2man
github.com/inconshreveable/mousetrap
github.com/spf13/pflag
github.com/spf13/cobra
gopkg.in/cheggaaa/pb.v1
github.com/coreos/etcd/tools/benchmark/cmd
_/root/etcd/tools/benchmark
_/root/etcd/tools/benchmark/cmd
github.com/coreos/etcd/pkg/pbutil
github.com/coreos/etcd/pkg/types
github.com/coreos/etcd/raft/raftpb
github.com/coreos/etcd/pkg/ioutil
github.com/coreos/etcd/raft
github.com/coreos/etcd/snap/snappb
github.com/coreos/etcd/snap
github.com/coreos/etcd/pkg/crc
github.com/coreos/etcd/wal/walpb
github.com/coreos/etcd/wal
_/root/etcd/tools/etcd-dump-logs
github.com/akrennmair/gopcap
# github.com/akrennmair/gopcap
gopath/src/github.com/akrennmair/gopcap/pcap.go:12:18: fatal error: pcap.h: No such file or directory
compilation terminated.
github.com/golang/glog
github.com/spacejam/loghisto
github.com/coreos/etcd/pkg/netutil
github.com/coreos/etcd/tools/functional-tester/etcd-agent/client
_/root/etcd/tools/functional-tester/etcd-agent
_/root/etcd/tools/functional-tester/etcd-agent/client
_/root/etcd/tools/functional-tester/etcd-runner
github.com/coreos/etcd/pkg/pathutil
github.com/ugorji/go/codec
github.com/coreos/etcd/client
github.com/coreos/etcd/alarm
golang.org/x/crypto/blowfish
golang.org/x/crypto/bcrypt
github.com/coreos/etcd/auth
github.com/jonboulle/clockwork
github.com/coreos/etcd/compactor
github.com/coreos/etcd/discovery
github.com/coreos/etcd/etcdserver/api/v2http/httptypes
github.com/coreos/etcd/error
github.com/coreos/etcd/store
github.com/coreos/etcd/version
github.com/coreos/go-semver/semver
github.com/coreos/etcd/etcdserver/membership
github.com/coreos/etcd/etcdserver/stats
github.com/coreos/etcd/lease/leasehttp
github.com/coreos/etcd/pkg/contention
github.com/coreos/etcd/pkg/httputil
github.com/coreos/etcd/pkg/idutil
github.com/coreos/etcd/pkg/runtime
github.com/coreos/etcd/pkg/wait
github.com/coreos/etcd/pkg/logutil
github.com/xiang90/probing
github.com/coreos/etcd/rafthttp
github.com/gogo/protobuf/proto
github.com/coreos/etcd/etcdserver
golang.org/x/time/rate
_/root/etcd/tools/functional-tester/etcd-tester
_/root/etcd/tools/local-tester/bridge
```

I would be maintaining the code for ppc64le if required. Please let me know, if there is anything else/resource you require.