### PR TITLE
Dockerfile-release: add '/var/lib/etcd/'

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -3,6 +3,7 @@ FROM alpine:latest
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/
 RUN mkdir -p /var/etcd/
+RUN mkdir -p /var/lib/etcd/
 
 EXPOSE 2379 2380
 


### PR DESCRIPTION
We have '/var/etcd/' in Dockerfile for historical reason.
Most cases, user store data in `/var/lib/etcd/`.

I think I put `/var/etcd/` in 3.0 release. Since we have in old versions, we should just keep `/var/etcd`.

/cc @xiang90 