### PR TITLE
etcdctl: Add support for formating output of key related commands

### DIFF
--- a/etcdctl/ctlv2/command/mkdir_command.go
+++ b/etcdctl/ctlv2/command/mkdir_command.go
@@ -48,9 +48,12 @@ func mkdirCommandFunc(c *cli.Context, ki client.KeysAPI, prevExist client.PrevEx
 	ttl := c.Int("ttl")
 
 	ctx, cancel := contextWithTotalTimeout(c)
-	_, err := ki.Set(ctx, key, "", &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: prevExist})
+	resp, err := ki.Set(ctx, key, "", &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: prevExist})
 	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
+	}
+	if c.GlobalString("output") != "simple" {
+		printResponseKey(resp, c.GlobalString("output"))
 	}
 }

--- a/etcdctl/ctlv2/command/rm_command.go
+++ b/etcdctl/ctlv2/command/rm_command.go
@@ -57,8 +57,7 @@ func rmCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	if err != nil {
 		handleError(ExitServerError, err)
 	}
-
-	if !resp.Node.Dir {
+	if !resp.Node.Dir || c.GlobalString("output") != "simple" {
 		printResponseKey(resp, c.GlobalString("output"))
 	}
 }

--- a/etcdctl/ctlv2/command/rmdir_command.go
+++ b/etcdctl/ctlv2/command/rmdir_command.go
@@ -48,7 +48,7 @@ func rmdirCommandFunc(c *cli.Context, ki client.KeysAPI) {
 		handleError(ExitServerError, err)
 	}
 
-	if !resp.Node.Dir {
+	if !resp.Node.Dir || c.GlobalString("output") != "simple" {
 		printResponseKey(resp, c.GlobalString("output"))
 	}
 }

--- a/etcdctl/ctlv2/command/update_dir_command.go
+++ b/etcdctl/ctlv2/command/update_dir_command.go
@@ -46,9 +46,12 @@ func updatedirCommandFunc(c *cli.Context, ki client.KeysAPI) {
 	key := c.Args()[0]
 	ttl := c.Int("ttl")
 	ctx, cancel := contextWithTotalTimeout(c)
-	_, err := ki.Set(ctx, key, "", &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: client.PrevExist})
+	resp, err := ki.Set(ctx, key, "", &client.SetOptions{TTL: time.Duration(ttl) * time.Second, Dir: true, PrevExist: client.PrevExist})
 	cancel()
 	if err != nil {
 		handleError(ExitServerError, err)
+	}
+	if c.GlobalString("output") != "simple" {
+		printResponseKey(resp, c.GlobalString("output"))
 	}
 }


### PR DESCRIPTION
This is hopefully a welcomed followup to #5993

This change adds support for honoring the global format option for the remaining (v2) key and directory commands that were previously ignoring it. If the option was not specified via the `--output` option, the output will continue to be the same as it was. 

For example, `rm` _without_ `--output` will _continue_ to have no output:

`etcdctl rm --dir myDir`

But, `rm ` _with_ `--output json` for example, will now output json like the user wanted:

`etcdctl --output json rm --dir myDir`
`{"action":"delete","node":{"key":"/myDir","dir":true,"modifiedIndex":9,"createdIndex":5},"prevNode":{"key":"/myDir","dir":true,"modifiedIndex":5,"createdIndex":5}}`

Same behavior with mkdir, rmdir, and updatedir.