### PR TITLE
Log TLS error in health checking

### DIFF
--- a/cmd/Godeps/Godeps.json
+++ b/cmd/Godeps/Godeps.json
@@ -197,7 +197,7 @@
 		},
 		{
 			"ImportPath": "github.com/xiang90/probing",
-			"Rev": "6a0cc1ae81b4cc11db5e491e030e4b98fba79c19"
+			"Rev": "95bd620af35406ab93d7f5bf320dba4b4667982e"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/bcrypt",

--- a/cmd/vendor/github.com/xiang90/probing/prober.go
+++ b/cmd/vendor/github.com/xiang90/probing/prober.go
@@ -61,7 +61,7 @@ func (p *prober) AddHTTP(id string, probingInterval time.Duration, endpoints []s
 				}
 				resp, err := p.tr.RoundTrip(req)
 				if err != nil {
-					s.recordFailure()
+					s.recordFailure(err)
 					pinned = (pinned + 1) % len(endpoints)
 					continue
 				}
@@ -71,7 +71,7 @@ func (p *prober) AddHTTP(id string, probingInterval time.Duration, endpoints []s
 				err = d.Decode(&hh)
 				resp.Body.Close()
 				if err != nil || !hh.OK {
-					s.recordFailure()
+					s.recordFailure(err)
 					pinned = (pinned + 1) % len(endpoints)
 					continue
 				}

--- a/cmd/vendor/github.com/xiang90/probing/status.go
+++ b/cmd/vendor/github.com/xiang90/probing/status.go
@@ -14,6 +14,7 @@ type Status interface {
 	Total() int64
 	Loss() int64
 	Health() bool
+	Err() error
 	// Estimated smoothed round trip time
 	SRTT() time.Duration
 	// Estimated clock difference
@@ -27,6 +28,7 @@ type status struct {
 	total     int64
 	loss      int64
 	health    bool
+	err       error
 	clockdiff time.Duration
 	stopC     chan struct{}
 }
@@ -56,6 +58,12 @@ func (s *status) Health() bool {
 	return s.health
 }
 
+func (s *status) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
 func (s *status) ClockDiff() time.Duration {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -74,15 +82,17 @@ func (s *status) record(rtt time.Duration, when time.Time) {
 	s.health = true
 	s.srtt = time.Duration((1-α)*float64(s.srtt) + α*float64(rtt))
 	s.clockdiff = time.Now().Sub(when) - s.srtt/2
+	s.err = nil
 }
 
-func (s *status) recordFailure() {
+func (s *status) recordFailure(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.total++
 	s.health = false
 	s.loss += 1
+	s.err = err
 }
 
 func (s *status) reset() {
@@ -93,4 +103,5 @@ func (s *status) reset() {
 	s.total = 0
 	s.health = false
 	s.clockdiff = 0
+	s.err = nil
 }

--- a/rafthttp/probing_status.go
+++ b/rafthttp/probing_status.go
@@ -25,6 +25,7 @@ var (
 	// Or the connection will time-out.
 	proberInterval           = ConnReadTimeout - time.Second
 	statusMonitoringInterval = 30 * time.Second
+	statusErrorInterval      = 5 * time.Second
 )
 
 func addPeerToProber(p probing.Prober, id string, us []string) {
@@ -44,11 +45,16 @@ func addPeerToProber(p probing.Prober, id string, us []string) {
 }
 
 func monitorProbingStatus(s probing.Status, id string) {
+	// set the first interval short to log error early.
+	interval := statusErrorInterval
 	for {
 		select {
-		case <-time.After(statusMonitoringInterval):
+		case <-time.After(interval):
 			if !s.Health() {
-				plog.Warningf("health check for peer %s could not connect", id)
+				plog.Warningf("health check for peer %s could not connect: %v", id, s.Err())
+				interval = statusErrorInterval
+			} else {
+				interval = statusMonitoringInterval
 			}
 			if s.ClockDiff() > time.Second {
 				plog.Warningf("the clock difference against peer %s is too high [%v > %v]", id, s.ClockDiff(), time.Second)


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6018

/cc @heyitsanthony @discordianfish

Example:
```
18:25:33 etcd3 | 2016-07-31 18:25:33.692952 I | raft: d6ee1f0cd942d91a [logterm: 1, index: 3] sent vote request to ac6d821297fe37e6 at term 131
18:25:33 etcd3 | 2016-07-31 18:25:33.692968 I | raft: d6ee1f0cd942d91a [logterm: 1, index: 3] sent vote request to 6bf2f0d9786cdbb at term 131
18:25:34 etcd3 | 2016-07-31 18:25:34.430867 W | rafthttp: health check for peer 6bf2f0d9786cdbb could not connect: x509: certificate is valid for etcd, not localhost
18:25:34 etcd3 | 2016-07-31 18:25:34.441369 W | rafthttp: health check for peer ac6d821297fe37e6 could not connect: x509: certificate is valid for etcd, not localhost
18:25:34 etcd2 | 2016-07-31 18:25:34.471851 W | rafthttp: health check for peer ac6d821297fe37e6 could not connect: x509: certificate is valid for etcd, not localhost
18:25:34 etcd2 | 2016-07-31 18:25:34.486670 W | rafthttp: health check for peer d6ee1f0cd942d91a could not connect: x509: certificate is valid for etcd, not localhost
18:25:34 etcd1 | 2016-07-31 18:25:34.490560 W | rafthttp: health check for peer 6bf2f0d9786cdbb could not connect: x509: certificate is valid for etcd, not localhost
18:25:34 etcd1 | 2016-07-31 18:25:34.502922 W | rafthttp: health check for peer d6ee1f0cd942d91a could not connect: x509: certificate is valid for etcd, not localhost
18:25:34 etcd3 | 2016-07-31 18:25:34.792758 I | raft: d6ee1f0cd942d91a is starting a new election at term 131
18:25:34 etcd3 | 2016-07-31 18:25:34.792805 I | raft: d6ee1f0cd942d91a became candidate at term 132
```