### PR TITLE
v2http: use guest access in non-TLS mode

### DIFF
--- a/etcdserver/api/v2http/client_auth.go
+++ b/etcdserver/api/v2http/client_auth.go
@@ -116,10 +116,11 @@ func hasKeyPrefixAccess(sec auth.Store, r *http.Request, key string, recursive, 
 	}
 
 	var user *auth.User
-	if r.Header.Get("Authorization") == "" && clientCertAuthEnabled {
-		user = userFromClientCertificate(sec, r)
+	if r.Header.Get("Authorization") == "" {
+		if clientCertAuthEnabled {
+			user = userFromClientCertificate(sec, r)
+		}
 		if user == nil {
-			plog.Warningf("auth: no authorization provided, checking guest access")
 			return hasGuestAccess(sec, r, key)
 		}
 	} else {

--- a/etcdserver/api/v2http/client_auth_test.go
+++ b/etcdserver/api/v2http/client_auth_test.go
@@ -717,6 +717,36 @@ func TestPrefixAccess(t *testing.T) {
 			hasKeyPrefixAccess: false,
 			hasRecursiveAccess: false,
 		},
+		{ // guest access in non-TLS mode
+			key: "/foo",
+			req: (func() *http.Request {
+				return mustJSONRequest(t, "GET", "somepath", "")
+			})(),
+			store: &mockAuthStore{
+				enabled: true,
+				users: map[string]*auth.User{
+					"root": {
+						User:     "root",
+						Password: goodPassword,
+						Roles:    []string{"root"},
+					},
+				},
+				roles: map[string]*auth.Role{
+					"guest": {
+						Role: "guest",
+						Permissions: auth.Permissions{
+							KV: auth.RWPermission{
+								Read:  []string{"/foo*"},
+								Write: []string{"/foo*"},
+							},
+						},
+					},
+				},
+			},
+			hasRoot:            false,
+			hasKeyPrefixAccess: true,
+			hasRecursiveAccess: true,
+		},
 	}
 
 	for i, tt := range table {


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6075.

/cc @xiang90 @shyamradhakrishnan