### PR TITLE
Add some test flags for e2e test

### DIFF
--- a/e2e/ctl_v2_test.go
+++ b/e2e/ctl_v2_test.go
@@ -323,7 +323,7 @@ func etcdctlPrefixArgs(clus *etcdProcessCluster) []string {
 		}
 		endpoints = strings.Join(es, ",")
 	}
-	cmdArgs := []string{defaultCtlBinPath, "--endpoints", endpoints}
+	cmdArgs := []string{ctlBinPath, "--endpoints", endpoints}
 	if clus.cfg.clientTLS == clientTLS {
 		cmdArgs = append(cmdArgs, "--ca-file", caPath, "--cert-file", certPath, "--key-file", privateKeyPath)
 	}

--- a/e2e/ctl_v3_test.go
+++ b/e2e/ctl_v3_test.go
@@ -148,7 +148,7 @@ func (cx *ctlCtx) PrefixArgs() []string {
 		}
 		endpoints = strings.Join(es, ",")
 	}
-	cmdArgs := []string{defaultCtlBinPath, "--endpoints", endpoints, "--dial-timeout", cx.dialTimeout.String()}
+	cmdArgs := []string{ctlBinPath, "--endpoints", endpoints, "--dial-timeout", cx.dialTimeout.String()}
 	if cx.epc.cfg.clientTLS == clientTLS {
 		if cx.epc.cfg.isClientAutoTLS {
 			cmdArgs = append(cmdArgs, "--insecure-transport=false", "--insecure-skip-tls-verify")

--- a/e2e/etcd_test.go
+++ b/e2e/etcd_test.go
@@ -26,16 +26,14 @@ import (
 	"github.com/coreos/etcd/pkg/fileutil"
 )
 
-const (
-	etcdProcessBasePort = 20000
-	certPath            = "../integration/fixtures/server.crt"
-	privateKeyPath      = "../integration/fixtures/server.key.insecure"
-	caPath              = "../integration/fixtures/ca.crt"
-)
+const etcdProcessBasePort = 20000
 
 var (
-	binPath    string
-	ctlBinPath string
+	binPath        string
+	ctlBinPath     string
+	certPath       string
+	privateKeyPath string
+	caPath         string
 )
 
 type clientConnType int
@@ -207,6 +205,9 @@ func newEtcdProcess(cfg *etcdProcessConfig) (*etcdProcess, error) {
 func (cfg *etcdProcessClusterConfig) etcdProcessConfigs() []*etcdProcessConfig {
 	binPath = binDir + "/etcd"
 	ctlBinPath = binDir + "/etcdctl"
+	certPath = certDir + "/server.crt"
+	privateKeyPath = certDir + "/server.key.insecure"
+	caPath = certDir + "/ca.crt"
 
 	if cfg.basePort == 0 {
 		cfg.basePort = etcdProcessBasePort

--- a/e2e/etcd_test.go
+++ b/e2e/etcd_test.go
@@ -31,8 +31,11 @@ const (
 	certPath            = "../integration/fixtures/server.crt"
 	privateKeyPath      = "../integration/fixtures/server.key.insecure"
 	caPath              = "../integration/fixtures/ca.crt"
-	defaultBinPath      = "../bin/etcd"
-	defaultCtlBinPath   = "../bin/etcdctl"
+)
+
+var (
+	binPath    string
+	ctlBinPath string
 )
 
 type clientConnType int
@@ -202,12 +205,15 @@ func newEtcdProcess(cfg *etcdProcessConfig) (*etcdProcess, error) {
 }
 
 func (cfg *etcdProcessClusterConfig) etcdProcessConfigs() []*etcdProcessConfig {
+	binPath = binDir + "/etcd"
+	ctlBinPath = binDir + "/etcdctl"
+
 	if cfg.basePort == 0 {
 		cfg.basePort = etcdProcessBasePort
 	}
 
 	if cfg.execPath == "" {
-		cfg.execPath = defaultBinPath
+		cfg.execPath = binPath
 	}
 	if cfg.snapCount == 0 {
 		cfg.snapCount = etcdserver.DefaultSnapCount

--- a/e2e/gateway_test.go
+++ b/e2e/gateway_test.go
@@ -41,14 +41,14 @@ func TestGateway(t *testing.T) {
 	os.Setenv("ETCDCTL_API", "3")
 	defer os.Unsetenv("ETCDCTL_API")
 
-	err = spawnWithExpect([]string{defaultCtlBinPath, "--endpoints=" + defaultGatewayEndpoint, "put", "foo", "bar"}, "OK\r\n")
+	err = spawnWithExpect([]string{ctlBinPath, "--endpoints=" + defaultGatewayEndpoint, "put", "foo", "bar"}, "OK\r\n")
 	if err != nil {
 		t.Errorf("failed to finish put request through gateway: %v", err)
 	}
 }
 
 func startGateway(t *testing.T, endpoints string) *expect.ExpectProcess {
-	p, err := expect.NewExpect(defaultBinPath, "gateway", "--endpoints="+endpoints, "start")
+	p, err := expect.NewExpect(binPath, "gateway", "--endpoints="+endpoints, "start")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -5,6 +5,7 @@
 package e2e
 
 import (
+	"flag"
 	"os"
 	"runtime"
 	"testing"
@@ -12,8 +13,14 @@ import (
 	"github.com/coreos/etcd/pkg/testutil"
 )
 
+var binDir string
+
 func TestMain(m *testing.M) {
 	os.Setenv("ETCD_UNSUPPORTED_ARCH", runtime.GOARCH)
+
+	flag.StringVar(&binDir, "bin-dir", "../bin", "The directory for store etcd and etcdctl binaries.")
+	flag.Parse()
+
 	v := m.Run()
 	if v == 0 && testutil.CheckLeakedGoroutine() {
 		os.Exit(1)

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 var binDir string
+var certDir string
 
 func TestMain(m *testing.M) {
 	os.Setenv("ETCD_UNSUPPORTED_ARCH", runtime.GOARCH)
 
 	flag.StringVar(&binDir, "bin-dir", "../bin", "The directory for store etcd and etcdctl binaries.")
+	flag.StringVar(&certDir, "cert-dir", "../integration/fixtures", "The directory for store certificate files.")
 	flag.Parse()
 
 	v := m.Run()


### PR DESCRIPTION
In this pullreq, mainly doing one thing by add a command line flags.
1. Run e2e test with an existing or old version of etcd and etcdctl.
The flag name is 'bin-dir' and it is default value is "../bin" as it is in the original code.


Example command line(run under e2e directory):
 go test -timeout 10m -v -bin-dir /usr/bin
