### PR TITLE
WIP etcd-tester: retry for ErrTooManyRequests

### DIFF
--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -237,6 +237,10 @@ func (s *stresser) run(ctx context.Context) {
 				// to the new leader.
 				shouldContinue = true
 
+			case etcdserver.ErrTooManyRequests.Error():
+				// applier fell behind
+				shouldContinue = true
+
 			case etcdserver.ErrStopped.Error():
 				// one of the etcd nodes stopped from failure injection
 				shouldContinue = true


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6017.

When applier falls behind, it rejects stresser requests with ErrTooManyRequests, which then exits the stresser routine. We should retry.