### PR TITLE
tools/functional-tester: fix limiter

### DIFF
--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -33,7 +33,7 @@ func main() {
 	stressKeySuffixRange := flag.Uint("stress-key-count", 250000, "the count of key range written into etcd.")
 	stressKeyRangeLimit := flag.Uint("stress-range-limit", 50, "maximum number of keys to range or delete.")
 	limit := flag.Int("limit", -1, "the limit of rounds to run failure set (-1 to run without limits).")
-	stressQPS := flag.Int("stress-qps", 10000, "maximum number of stresser requests per second.")
+	stressQPS := flag.Int("stress-qps", 3000, "maximum number of stresser requests per second.")
 	schedCases := flag.String("schedule-cases", "", "test case schedule")
 	consistencyCheck := flag.Bool("consistency-check", true, "true to check consistency (revision, hash)")
 	isV2Only := flag.Bool("v2-only", false, "'true' to run V2 only tester.")

--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -179,7 +179,7 @@ func (s *stresser) Stress() error {
 	s.conn = conn
 	s.cancel = cancel
 	s.wg = wg
-	s.rateLimiter = rate.NewLimiter(rate.Every(time.Second), s.qps)
+	s.rateLimiter = rate.NewLimiter(rate.Limit(s.qps), s.qps)
 	s.mu.Unlock()
 
 	kvc := pb.NewKVClient(conn)


### PR DESCRIPTION
@gyuho 

The limiter was set incorrectly. It was set 1 event per second, which a burst equal to QPS. It means that we can only do one op per second across all stressers with an initial max set to QPS. You might want to read https://en.wikipedia.org/wiki/Token_bucket to understand what is burst.

See https://godoc.org/golang.org/x/time/rate#Every and https://godoc.org/golang.org/x/time/rate#NewLimiter.

Probably you also want to write a small go program to verify what limiter does exactly with different rate and b.



