### PR TITLE
functional-tester: share limiter among stresser

### DIFF
--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -33,7 +33,7 @@ func main() {
 	stressKeySuffixRange := flag.Uint("stress-key-count", 250000, "the count of key range written into etcd.")
 	stressKeyRangeLimit := flag.Uint("stress-range-limit", 50, "maximum number of keys to range or delete.")
 	limit := flag.Int("limit", -1, "the limit of rounds to run failure set (-1 to run without limits).")
-	stressQPS := flag.Int("stress-qps", 3000, "maximum number of stresser requests per second.")
+	stressQPS := flag.Int("stress-qps", 10000, "maximum number of stresser requests per second.")
 	schedCases := flag.String("schedule-cases", "", "test case schedule")
 	consistencyCheck := flag.Bool("consistency-check", true, "true to check consistency (revision, hash)")
 	isV2Only := flag.Bool("v2-only", false, "'true' to run V2 only tester.")

--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -148,8 +148,7 @@ type stresser struct {
 	keySuffixRange int
 	keyRangeLimit  int
 
-	qps int
-	N   int
+	N int
 
 	mu sync.Mutex
 	wg *sync.WaitGroup
@@ -166,6 +165,10 @@ type stresser struct {
 }
 
 func (s *stresser) Stress() error {
+	if s.rateLimiter == nil {
+		panic("expect rateLimiter to be set")
+	}
+
 	// TODO: add backoff option
 	conn, err := grpc.Dial(s.Endpoint, grpc.WithInsecure())
 	if err != nil {
@@ -180,7 +183,6 @@ func (s *stresser) Stress() error {
 	s.conn = conn
 	s.cancel = cancel
 	s.wg = wg
-	s.rateLimiter = rate.NewLimiter(rate.Limit(s.qps), s.qps)
 	s.mu.Unlock()
 
 	kvc := pb.NewKVClient(conn)


### PR DESCRIPTION
Otherwise, adding more members stresses the cluster with more ops.

/cc @xiang90 @gyuho 