### PR TITLE
etcd-tester: fix tester for 5-node cluster

### DIFF
--- a/tools/functional-tester/etcd-tester/cluster.go
+++ b/tools/functional-tester/etcd-tester/cluster.go
@@ -41,7 +41,6 @@ type cluster struct {
 	stressQPS            int
 	stressKeySize        int
 	stressKeySuffixRange int
-	stressKeyRangeLimit  int
 
 	Size      int
 	Stressers []Stresser
@@ -114,7 +113,6 @@ func (c *cluster) bootstrap(agentEndpoints []string) error {
 				Endpoint:       m.grpcAddr(),
 				keySize:        c.stressKeySize,
 				keySuffixRange: c.stressKeySuffixRange,
-				keyRangeLimit:  c.stressKeyRangeLimit,
 				N:              stressN,
 				rateLimiter:    limiter,
 			}

--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -31,7 +31,6 @@ func main() {
 	datadir := flag.String("data-dir", "agent.etcd", "etcd data directory location on agent machine.")
 	stressKeySize := flag.Uint("stress-key-size", 100, "the size of each key written into etcd.")
 	stressKeySuffixRange := flag.Uint("stress-key-count", 250000, "the count of key range written into etcd.")
-	stressKeyRangeLimit := flag.Uint("stress-range-limit", 50, "maximum number of keys to range or delete.")
 	limit := flag.Int("limit", -1, "the limit of rounds to run failure set (-1 to run without limits).")
 	stressQPS := flag.Int("stress-qps", 10000, "maximum number of stresser requests per second.")
 	schedCases := flag.String("schedule-cases", "", "test case schedule")
@@ -45,7 +44,6 @@ func main() {
 		stressQPS:            *stressQPS,
 		stressKeySize:        int(*stressKeySize),
 		stressKeySuffixRange: int(*stressKeySuffixRange),
-		stressKeyRangeLimit:  int(*stressKeyRangeLimit),
 	}
 	if err := c.bootstrap(strings.Split(*endpointStr, ",")); err != nil {
 		plog.Fatal(err)

--- a/tools/functional-tester/etcd-tester/member.go
+++ b/tools/functional-tester/etcd-tester/member.go
@@ -123,7 +123,8 @@ func (m *member) SetHealthKeyV3() error {
 		return fmt.Errorf("%v (%s)", err, m.ClientURL)
 	}
 	defer cli.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// give enough time-out in case expensive requests (range/delete) are pending
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	_, err = cli.Put(ctx, "health", "good")
 	cancel()
 	if err != nil {

--- a/tools/functional-tester/etcd-tester/tester.go
+++ b/tools/functional-tester/etcd-tester/tester.go
@@ -52,6 +52,8 @@ func (tt *tester) runLoop() {
 			}
 			continue
 		}
+		// -1 so that logPrefix doesn't print out 'case'
+		tt.status.setCase(-1)
 
 		revToCompact := max(0, tt.currentRevision-10000)
 		compactN := revToCompact - prevCompactRev
@@ -80,9 +82,6 @@ func (tt *tester) runLoop() {
 }
 
 func (tt *tester) doRound(round int) (bool, error) {
-	// -1 so that logPrefix doesn't print out 'case'
-	defer tt.status.setCase(-1)
-
 	for j, f := range tt.failures {
 		caseTotalCounter.WithLabelValues(f.Desc()).Inc()
 		tt.status.setCase(j)


### PR DESCRIPTION
1. fix failure case counting
2. match ErrClientConnClosing in stresser
3. longer timeout for set-health-key
4. fixed range for range/delete stresser