### PR TITLE
e2e: use unix port for release tests

### DIFF
--- a/e2e/etcd_release_upgrade_test.go
+++ b/e2e/etcd_release_upgrade_test.go
@@ -37,6 +37,7 @@ func TestReleaseUpgrade(t *testing.T) {
 	copiedCfg := configNoTLS
 	copiedCfg.execPath = lastReleaseBinary
 	copiedCfg.snapCount = 3
+	copiedCfg.baseScheme = "unix" // to avoid port conflict
 
 	epc, err := newEtcdProcessCluster(&copiedCfg)
 	if err != nil {


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/5947.

When we restart, the previous port could have been still bind
by the OS. Use Unix port to avoid such rebind cases.