### PR TITLE
etcdserver: Error handling for invalid empty raft cluster

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -258,15 +258,12 @@ func startProxy(cfg *config) error {
 	clientURLs := []string{}
 	uf := func() []string {
 		gcls, gerr := etcdserver.GetClusterFromRemotePeers(peerURLs, tr)
-		// TODO: remove the 2nd check when we fix GetClusterFromRemotePeers
-		// GetClusterFromRemotePeers should not return nil error with an invalid empty cluster
+
 		if gerr != nil {
 			plog.Warningf("proxy: %v", gerr)
 			return []string{}
 		}
-		if len(gcls.Members()) == 0 {
-			return clientURLs
-		}
+
 		clientURLs = gcls.ClientURLs()
 
 		urls := struct{ PeerURLs []string }{gcls.PeerURLs()}

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -94,7 +94,16 @@ func getClusterFromRemotePeers(urls []string, timeout time.Duration, logerr bool
 			}
 			continue
 		}
-		return membership.NewClusterFromMembers("", id, membs), nil
+
+		// check the length of membership members
+		// if the membership members are present then prepare and return raft cluster
+		// if membership members are not present then the raft cluster formed will be
+		// an invalid empty cluster hence return failed to get raft cluster member(s) from the given urls error
+		if len(membs) > 0 {
+			return membership.NewClusterFromMembers("", id, membs), nil
+		}
+
+		return nil, fmt.Errorf("failed to get raft cluster member(s) from the given urls.")
 	}
 	return nil, fmt.Errorf("could not retrieve cluster information from the given urls")
 }


### PR DESCRIPTION

TODO implemented for GetClusterFromRemotePeers should not return nil
error with an invalid empty cluster

#6137