### PR TITLE
Fixed:  TODO: remove the 2nd check when we fix GetClusterFromRemotePeers

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -258,14 +258,9 @@ func startProxy(cfg *config) error {
 	clientURLs := []string{}
 	uf := func() []string {
 		gcls, gerr := etcdserver.GetClusterFromRemotePeers(peerURLs, tr)
-		// TODO: remove the 2nd check when we fix GetClusterFromRemotePeers
-		// GetClusterFromRemotePeers should not return nil error with an invalid empty cluster
 		if gerr != nil {
 			plog.Warningf("proxy: %v", gerr)
 			return []string{}
-		}
-		if len(gcls.Members()) == 0 {
-			return clientURLs
 		}
 		clientURLs = gcls.ClientURLs()
 

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -87,6 +87,12 @@ func getClusterFromRemotePeers(urls []string, timeout time.Duration, logerr bool
 			}
 			continue
 		}
+		if len(membs) == 0 {
+			if logerr {
+				plog.Warningf("no members found in url %v", u)
+			}
+			continue
+		}
 		id, err := types.IDFromString(resp.Header.Get("X-Etcd-Cluster-ID"))
 		if err != nil {
 			if logerr {


### PR DESCRIPTION
# Contributing guidelines

Please read our [contribution workflow][contributing] before submitting a pull request.

[contributing]: ../CONTRIBUTING.md#contribution-flow

        GetClusterFromRemotePeers should not return nil error with an invalid empty cluster