### PR TITLE
embed: load config defaults before loading from file

### DIFF
--- a/e2e/etcd_config_test.go
+++ b/e2e/etcd_config_test.go
@@ -1,0 +1,34 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+)
+
+const exampleConfigFile = "../etcd.conf.yml.sample"
+
+func TestEtcdExampleConfig(t *testing.T) {
+	proc, err := spawnCmd([]string{binDir + "/etcd", "--config-file", exampleConfigFile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = waitReadyExpectProc(proc, false); err != nil {
+		t.Fatal(err)
+	}
+	if err = proc.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/e2e/etcd_test.go
+++ b/e2e/etcd_test.go
@@ -446,8 +446,13 @@ func (ep *etcdProcess) Stop() error {
 }
 
 func (ep *etcdProcess) waitReady() error {
+	defer close(ep.donec)
+	return waitReadyExpectProc(ep.proc, ep.cfg.isProxy)
+}
+
+func waitReadyExpectProc(exproc *expect.ExpectProcess, isProxy bool) error {
 	readyStrs := []string{"enabled capabilities for version", "published"}
-	if ep.cfg.isProxy {
+	if isProxy {
 		readyStrs = []string{"httpproxy: endpoints found"}
 	}
 	c := 0
@@ -460,8 +465,7 @@ func (ep *etcdProcess) waitReady() error {
 		}
 		return c == len(readyStrs)
 	}
-	_, err := ep.proc.ExpectFunc(matchSet)
-	close(ep.donec)
+	_, err := exproc.ExpectFunc(matchSet)
 	return err
 }
 

--- a/embed/config.go
+++ b/embed/config.go
@@ -160,7 +160,7 @@ func NewConfig() *Config {
 }
 
 func ConfigFromFile(path string) (*Config, error) {
-	cfg := &configYAML{}
+	cfg := &configYAML{Config: *NewConfig()}
 	if err := cfg.configFromFile(path); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Was crashing on `etcd --config-file etcd.conf.yml.sample`:
```
goroutine 1 [running]:
panic(0xba0be0, 0xc82000e0d0)
	/usr/local/Cellar/go/1.6/libexec/src/runtime/panic.go:464 +0x3e6
github.com/coreos/etcd/pkg/cors.(*CORSInfo).String(0x0, 0x0, 0x0)
	/Users/anthony/go/src/github.com/coreos/etcd/pkg/cors/cors.go:50 +0x79
github.com/coreos/etcd/embed.(*Etcd).serve(0xc820224500, 0x0, 0x0)
	/Users/anthony/go/src/github.com/coreos/etcd/embed/etcd.go:295 +0x256
github.com/coreos/etcd/embed.StartEtcd(0xc82023c000, 0xc820224500, 0x0, 0x0)
	/Users/anthony/go/src/github.com/coreos/etcd/embed/etcd.go:130 +0xa38
github.com/coreos/etcd/etcdmain.startEtcd(0xc82023c000, 0x6, 0xd55a18, 0x0, 0x0)
	/Users/anthony/go/src/github.com/coreos/etcd/etcdmain/etcd.go:187 +0x31
github.com/coreos/etcd/etcdmain.startEtcdOrProxyV2()
	/Users/anthony/go/src/github.com/coreos/etcd/etcdmain/etcd.go:100 +0x2399
github.com/coreos/etcd/etcdmain.Main()
	/Users/anthony/go/src/github.com/coreos/etcd/etcdmain/main.go:36 +0x26d
main.main()
	/Users/anthony/go/src/github.com/coreos/etcd/main.go:28 +0x14
```

Found when investigating #6144 