### PR TITLE
mvcc: fix count

### DIFF
--- a/mvcc/kv_test.go
+++ b/mvcc/kv_test.go
@@ -245,6 +245,9 @@ func testKVRangeLimit(t *testing.T, f rangeFunc) {
 		if r.Rev != wrev {
 			t.Errorf("#%d: rev = %d, want %d", i, r.Rev, wrev)
 		}
+		if r.Count != len(kvs) {
+			t.Errorf("#%d: count = %d, want %d", i, r.Count, len(kvs))
+		}
 	}
 }
 

--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -498,7 +498,7 @@ func (s *store) rangeKeys(key, end []byte, limit, rangeRev int64, countOnly bool
 			break
 		}
 	}
-	return kvs, len(kvs), curRev, nil
+	return kvs, len(revpairs), curRev, nil
 }
 
 func (s *store) put(key, value []byte, leaseID lease.LeaseID) {


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6145.

/cc @shyamradhakrishnan

In your example, count should be 4 not 5. Range query does not include the end key.
