### PR TITLE
compactor: wait for After() in TestPeriodic

### DIFF
--- a/compactor/compactor_test.go
+++ b/compactor/compactor_test.go
@@ -47,7 +47,10 @@ func TestPeriodic(t *testing.T) {
 			fc.Advance(checkCompactionInterval)
 			rg.Wait(1)
 		}
-		// ready to acknowledge hour "i"; unblock clock
+		// ready to acknowledge hour "i"
+		// block until compactor calls clock.After()
+		fc.BlockUntil(1)
+		// unblock the After()
 		fc.Advance(checkCompactionInterval)
 		a, err := compactable.Wait(1)
 		if err != nil {


### PR DESCRIPTION
If the test calls clock.Advance() after the compactor checks clock.Now()
but before the compactor calls clock.After(), the compactor will wait
forever on clock.After() expecting the lost clock.Advance().

Reproduced failure by putting a Sleep() in the clock.Now() continue path.

Fixes #6060 (again)