### PR TITLE
*: fix spell errors from go report card

### DIFF
--- a/etcdctl/ctlv3/command/del_command.go
+++ b/etcdctl/ctlv3/command/del_command.go
@@ -60,7 +60,7 @@ func getDelOp(cmd *cobra.Command, args []string) (string, []clientv3.OpOption) {
 	key := args[0]
 	if len(args) > 1 {
 		if delPrefix {
-			ExitWithError(ExitBadArgs, fmt.Errorf("too many arguments, only accept one arguement when `--prefix` is set."))
+			ExitWithError(ExitBadArgs, fmt.Errorf("too many arguments, only accept one argument when `--prefix` is set."))
 		}
 		opts = append(opts, clientv3.WithRange(args[1]))
 	}

--- a/etcdctl/ctlv3/command/get_command.go
+++ b/etcdctl/ctlv3/command/get_command.go
@@ -86,7 +86,7 @@ func getGetOp(cmd *cobra.Command, args []string) (string, []clientv3.OpOption) {
 	key := args[0]
 	if len(args) > 1 {
 		if getPrefix || getFromKey {
-			ExitWithError(ExitBadArgs, fmt.Errorf("too many arguments, only accept one arguement when `--prefix` or `--from-key` is set."))
+			ExitWithError(ExitBadArgs, fmt.Errorf("too many arguments, only accept one argument when `--prefix` or `--from-key` is set."))
 		}
 		opts = append(opts, clientv3.WithRange(args[1]))
 	}

--- a/etcdctl/ctlv3/command/lock_command.go
+++ b/etcdctl/ctlv3/command/lock_command.go
@@ -37,7 +37,7 @@ func NewLockCommand() *cobra.Command {
 
 func lockCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		ExitWithError(ExitBadArgs, errors.New("lock takes one lock name arguement."))
+		ExitWithError(ExitBadArgs, errors.New("lock takes one lock name argument."))
 	}
 	c := mustClientFromCmd(cmd)
 	if err := lockUntilSignal(c, args[0]); err != nil {

--- a/etcdctl/ctlv3/command/put_command.go
+++ b/etcdctl/ctlv3/command/put_command.go
@@ -42,7 +42,7 @@ Insert '--' for workaround:
 $ put <key> -- <value>
 $ put -- <key> <value>
 
-If <value> isn't given as command line arguement, this command tries to read the value from standard input.
+If <value> isn't given as command line argument, this command tries to read the value from standard input.
 For example,
 $ cat file | put <key>
 will store the content of the file to <key>.

--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -92,7 +92,7 @@ type serverWatchStream struct {
 	mu sync.Mutex
 	// progress tracks the watchID that stream might need to send
 	// progress to.
-	// TOOD: combine progress and prevKV into a single struct?
+	// TODO: combine progress and prevKV into a single struct?
 	progress map[mvcc.WatchID]bool
 	prevKV   map[mvcc.WatchID]bool
 

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -39,7 +39,7 @@ const (
 	maxV3RequestTimeout = 5 * time.Second
 
 	// In the health case, there might be a small gap (10s of entries) between
-	// the applied index and commited index.
+	// the applied index and committed index.
 	// However, if the committed entries are very heavy to apply, the gap might grow.
 	// We should stop accepting new proposals if the gap growing to a certain point.
 	maxGapBetweenApplyAndCommitIndex = 1000

--- a/proxy/grpcproxy/watcher_groups.go
+++ b/proxy/grpcproxy/watcher_groups.go
@@ -72,10 +72,10 @@ func (wgs *watchergroups) maybeJoinWatcherSingle(rid receiverID, ws watcherSingl
 	wgs.mu.Lock()
 	defer wgs.mu.Unlock()
 
-	gropu, ok := wgs.groups[ws.w.wr]
+	group, ok := wgs.groups[ws.w.wr]
 	if ok {
-		if ws.w.rev >= gropu.rev {
-			gropu.add(receiverID{streamID: ws.sws.id, watcherID: ws.w.id}, ws.w)
+		if ws.w.rev >= group.rev {
+			group.add(receiverID{streamID: ws.sws.id, watcherID: ws.w.id}, ws.w)
 			return true
 		}
 		return false


### PR DESCRIPTION
https://goreportcard.com/report/github.com/coreos/etcd#misspell