### PR TITLE
pkg/httputil: simplify RequestCanceler args

### DIFF
--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 )
 
-func RequestCanceler(rt http.RoundTripper, req *http.Request) func() {
+func RequestCanceler(req *http.Request) func() {
 	ch := make(chan struct{})
 	req.Cancel = ch
 

--- a/proxy/httpproxy/reverse.go
+++ b/proxy/httpproxy/reverse.go
@@ -110,7 +110,7 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 	var requestClosed int32
 	completeCh := make(chan bool, 1)
 	closeNotifier, ok := rw.(http.CloseNotifier)
-	cancel := httputil.RequestCanceler(p.transport, proxyreq)
+	cancel := httputil.RequestCanceler(proxyreq)
 	if ok {
 		closeCh := closeNotifier.CloseNotify()
 		go func() {

--- a/rafthttp/pipeline.go
+++ b/rafthttp/pipeline.go
@@ -117,7 +117,7 @@ func (p *pipeline) post(data []byte) (err error) {
 	req := createPostRequest(u, RaftPrefix, bytes.NewBuffer(data), "application/protobuf", p.tr.URLs, p.tr.ID, p.tr.ClusterID)
 
 	done := make(chan struct{}, 1)
-	cancel := httputil.RequestCanceler(p.tr.pipelineRt, req)
+	cancel := httputil.RequestCanceler(req)
 	go func() {
 		select {
 		case <-done:

--- a/rafthttp/snapshot_sender.go
+++ b/rafthttp/snapshot_sender.go
@@ -103,7 +103,7 @@ func (s *snapshotSender) send(merged snap.Message) {
 // post posts the given request.
 // It returns nil when request is sent out and processed successfully.
 func (s *snapshotSender) post(req *http.Request) (err error) {
-	cancel := httputil.RequestCanceler(s.tr.pipelineRt, req)
+	cancel := httputil.RequestCanceler(req)
 
 	type responseAndError struct {
 		resp *http.Response

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -413,7 +413,7 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("stream reader is stopped")
 	default:
 	}
-	cr.cancel = httputil.RequestCanceler(cr.tr.streamRt, req)
+	cr.cancel = httputil.RequestCanceler(req)
 	cr.mu.Unlock()
 
 	resp, err := cr.tr.streamRt.RoundTrip(req)


### PR DESCRIPTION
`http.RoundTripper` is not used. Later, we can just use `WithContext` https://github.com/golang/go/blob/15db3654b8e9fda6d41f4389879c8cd370f71a7e/src/net/http/request.go#L253-L255.