### PR TITLE
rafthttp: fix race between streamReader.stop() and connection closer

### DIFF
--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -332,7 +332,16 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 	default:
 		plog.Panicf("unhandled stream type %s", t)
 	}
-	cr.closer = rc
+	select {
+	case <-cr.stopc:
+		cr.mu.Unlock()
+		if err := rc.Close(); err != nil {
+			return err
+		}
+		return io.EOF
+	default:
+		cr.closer = rc
+	}
 	cr.mu.Unlock()
 
 	for {


### PR DESCRIPTION
probably caused transport leaks