### PR TITLE
e2e: Update binary path with binDir

### DIFF
--- a/e2e/ctl_v2_test.go
+++ b/e2e/ctl_v2_test.go
@@ -427,7 +427,7 @@ func etcdctlBackup(clus *etcdProcessCluster, dataDir, backupDir string) error {
 }
 
 func mustEtcdctl(t *testing.T) {
-	if !fileutil.Exist("../bin/etcdctl") {
+	if !fileutil.Exist(binDir + "/etcdctl") {
 		t.Fatalf("could not find etcdctl binary")
 	}
 }

--- a/e2e/etcd_release_upgrade_test.go
+++ b/e2e/etcd_release_upgrade_test.go
@@ -27,7 +27,7 @@ import (
 // TestReleaseUpgrade ensures that changes to master branch does not affect
 // upgrade from latest etcd releases.
 func TestReleaseUpgrade(t *testing.T) {
-	lastReleaseBinary := "../bin/etcd-last-release"
+	lastReleaseBinary := binDir + "/etcd-last-release"
 	if !fileutil.Exist(lastReleaseBinary) {
 		t.Skipf("%q does not exist", lastReleaseBinary)
 	}
@@ -72,7 +72,7 @@ func TestReleaseUpgrade(t *testing.T) {
 		if err := epc.procs[i].Stop(); err != nil {
 			t.Fatalf("#%d: error closing etcd process (%v)", i, err)
 		}
-		epc.procs[i].cfg.execPath = "../bin/etcd"
+		epc.procs[i].cfg.execPath = binDir + "/etcd"
 		epc.procs[i].cfg.keepDataDir = true
 
 		if err := epc.procs[i].Restart(); err != nil {


### PR DESCRIPTION
Miss some hard code binary path in the code in last commit. So update it.