### PR TITLE
proxy/grpcproxy: fix nil-map assign to 'singles'

### DIFF
--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -49,8 +49,9 @@ func (wp *watchProxy) Watch(stream pb.Watch_WatchServer) (err error) {
 	wp.mu.Unlock()
 
 	sws := serverWatchStream{
-		cw:     wp.cw,
-		groups: &wp.wgs,
+		cw:      wp.cw,
+		groups:  &wp.wgs,
+		singles: make(map[int64]*watcherSingle),
 
 		id:         wp.nextStreamID,
 		gRPCStream: stream,


### PR DESCRIPTION
Otherwise it fails when run `PASSES=grpcproxy ./test`:

```
=== RUN   TestBarrierSingleNode
panic: assignment to entry in nil map

goroutine 28917 [running]:
panic(0x108dbe0, 0xc42aaf3a70)
	/usr/local/go/src/runtime/panic.go:500 +0x1ae
github.com/coreos/etcd/proxy/grpcproxy.(*serverWatchStream).addDedicatedWatcher(0xc42aabcfc0, 0x0, 0xc42aaf3750, 0xc, 0x0, 0x0, 0x0, 0x16f7e70, 0x0, 0x0, ...)
	/home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:180 +0x551
github.com/coreos/etcd/proxy/grpcproxy.(*serverWatchStream).recvLoop(0xc42aabcfc0, 0x0, 0x0)
	/home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:122 +0x467
created by github.com/coreos/etcd/proxy/grpcproxy.(*watchProxy).Watch
	/home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:62 +0x243
exit status 2
```

/cc @heyitsanthony @xiang90 