### PR TITLE
proxy/grpcproxy: fix data race in watch close

### DIFF
--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -86,10 +86,12 @@ type serverWatchStream struct {
 func (sws *serverWatchStream) close() {
 	close(sws.watchCh)
 	close(sws.ctrlCh)
+	sws.mu.Lock()
 	for _, ws := range sws.singles {
 		ws.stop()
 	}
 	sws.groups.stop()
+	sws.mu.Unlock()
 }
 
 func (sws *serverWatchStream) recvLoop() error {


### PR DESCRIPTION
From local run `PASSES=grpcproxy ./test`

```
==================
WARNING: DATA RACE
Read at 0x00c422558630 by goroutine 72:
  runtime.mapiterinit()
      /usr/local/go/src/runtime/hashmap.go:620 +0x0
  github.com/coreos/etcd/proxy/grpcproxy.(*serverWatchStream).close()
      /home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:89 +0xf8
  github.com/coreos/etcd/proxy/grpcproxy.(*serverWatchStream).recvLoop()
      /home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:104 +0x617
```

/cc @heyitsanthony @xiang90 
