### PR TITLE
build: don't override gopath by default, demote old gopath on override

### DIFF
--- a/build
+++ b/build
@@ -39,14 +39,15 @@ etcd_build() {
 }
 
 etcd_setup_gopath() {
-	export GOPATH=${CDIR}/gopath
-	rm -f $GOPATH/src
-	mkdir -p $GOPATH
-	ln -s ${CDIR}/cmd/vendor $GOPATH/src
+	etcdGOPATH=${CDIR}/gopath
+	# preserve old gopath to support building with unvendored tooling deps (e.g., gofail)
+	export GOPATH=${etcdGOPATH}:$GOPATH
+	rm -f ${etcdGOPATH}/src
+	mkdir -p ${etcdGOPATH}
+	ln -s ${CDIR}/cmd/vendor ${etcdGOPATH}/src
 }
 
 toggle_failpoints
-etcd_setup_gopath
 
 # don't build when sourced
 (echo "$0" | grep "/build$" > /dev/null) && etcd_build || true

--- a/test
+++ b/test
@@ -12,6 +12,9 @@ set -e
 
 source ./build
 
+# build tests with vendored dependencies
+etcd_setup_gopath
+
 if [ -z "$PASSES" ]; then
 	PASSES="fmt dep compile build unit"
 fi


### PR DESCRIPTION
Builds already vendor through cmd/ so there's no reason to set the GOPATH; it
was also breaking gofail builds. For builds that need to override GOPATH, also
include the old GOPATH as a fallback for dependencies outside cmd/vendor/.

/cc @gyuho