### PR TITLE
functional-tester: put large keys

### DIFF
--- a/tools/functional-tester/etcd-tester/cluster.go
+++ b/tools/functional-tester/etcd-tester/cluster.go
@@ -39,6 +39,7 @@ type cluster struct {
 
 	datadir              string
 	stressQPS            int
+	stressKeyLargeSize   int
 	stressKeySize        int
 	stressKeySuffixRange int
 
@@ -111,6 +112,7 @@ func (c *cluster) bootstrap(agentEndpoints []string) error {
 		} else {
 			c.Stressers[i] = &stresser{
 				Endpoint:       m.grpcAddr(),
+				keyLargeSize:   c.stressKeyLargeSize,
 				keySize:        c.stressKeySize,
 				keySuffixRange: c.stressKeySuffixRange,
 				N:              stressN,

--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -29,7 +29,8 @@ var plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "etcd-tester")
 func main() {
 	endpointStr := flag.String("agent-endpoints", "localhost:9027", "HTTP RPC endpoints of agents. Do not specify the schema.")
 	datadir := flag.String("data-dir", "agent.etcd", "etcd data directory location on agent machine.")
-	stressKeySize := flag.Uint("stress-key-size", 100, "the size of each key written into etcd.")
+	stressKeyLargeSize := flag.Uint("stress-key-large-size", 32*1024+1, "the size of each large key written into etcd.")
+	stressKeySize := flag.Uint("stress-key-size", 100, "the size of each small key written into etcd.")
 	stressKeySuffixRange := flag.Uint("stress-key-count", 250000, "the count of key range written into etcd.")
 	limit := flag.Int("limit", -1, "the limit of rounds to run failure set (-1 to run without limits).")
 	stressQPS := flag.Int("stress-qps", 10000, "maximum number of stresser requests per second.")
@@ -42,6 +43,7 @@ func main() {
 		v2Only:               *isV2Only,
 		datadir:              *datadir,
 		stressQPS:            *stressQPS,
+		stressKeyLargeSize:   int(*stressKeyLargeSize),
 		stressKeySize:        int(*stressKeySize),
 		stressKeySuffixRange: int(*stressKeySuffixRange),
 	}

--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -135,6 +135,7 @@ type Stresser interface {
 type stresser struct {
 	Endpoint string
 
+	keyLargeSize   int
 	keySize        int
 	keySuffixRange int
 
@@ -179,6 +180,10 @@ func (s *stresser) Stress() error {
 
 	var stressEntries = []stressEntry{
 		{weight: 0.7, f: newStressPut(kvc, s.keySuffixRange, s.keySize)},
+		{
+			weight: 0.7 * float32(s.keySize) / float32(s.keyLargeSize),
+			f:      newStressPut(kvc, s.keySuffixRange, s.keyLargeSize),
+		},
 		{weight: 0.07, f: newStressRange(kvc, s.keySuffixRange)},
 		{weight: 0.07, f: newStressRangeInterval(kvc, s.keySuffixRange)},
 		{weight: 0.07, f: newStressDelete(kvc, s.keySuffixRange)},


### PR DESCRIPTION
For testing writes that must span multiple pages. (Cf. #6191)