### PR TITLE
integration: write to leader group first, or wait

### DIFF
--- a/integration/network_partition_test.go
+++ b/integration/network_partition_test.go
@@ -50,7 +50,9 @@ func TestNetworkPartition5MembersLeaderInMinority(t *testing.T) {
 
 	// recover network partition (bi-directional)
 	recoverPartition(t, minorityMembers, majorityMembers)
-	clusterMustProgress(t, clus.Members)
+
+	// write to majority first
+	clusterMustProgress(t, append(majorityMembers, minorityMembers...))
 }
 
 func TestNetworkPartition5MembersLeaderInMajority(t *testing.T) {
@@ -86,7 +88,9 @@ func TestNetworkPartition5MembersLeaderInMajority(t *testing.T) {
 
 	// recover network partition (bi-directional)
 	recoverPartition(t, majorityMembers, minorityMembers)
-	clusterMustProgress(t, clus.Members)
+
+	// write to majority first
+	clusterMustProgress(t, append(majorityMembers, minorityMembers...))
 }
 
 func TestNetworkPartition4Members(t *testing.T) {
@@ -112,6 +116,10 @@ func TestNetworkPartition4Members(t *testing.T) {
 
 	// recover network partition (bi-directional)
 	recoverPartition(t, leaderPartition, followerPartition)
+
+	// need to wait since it recovered with no leader
+	clus.WaitLeader(t)
+
 	clusterMustProgress(t, clus.Members)
 }
 


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6176.

The issue is that [`clusterMustProgress`](https://github.com/coreos/etcd/blob/master/integration/cluster_test.go#L445) tries to write to the first member in `clus.Members` slice. And if `clus.Members[0]` happens to be the member in minority members that lost the leader, it needs some time to acknowledge the leader after network partition recovery.

Can reproduce by commenting out `recoverPartition`.

/cc @heyitsanthony @xiang90 