### PR TITLE
integration: fix race in TestDoubleBarrierFailover

### DIFF
--- a/integration/v3_double_barrier_test.go
+++ b/integration/v3_double_barrier_test.go
@@ -114,8 +114,8 @@ func TestDoubleBarrierFailover(t *testing.T) {
 	// sacrificial barrier holder; lease will be revoked
 	go func() {
 		b := recipe.NewDoubleBarrier(s0, "test-barrier", waiters)
-		if err = b.Enter(); err != nil {
-			t.Fatalf("could not enter on barrier (%v)", err)
+		if berr := b.Enter(); berr != nil {
+			t.Fatalf("could not enter on barrier (%v)", berr)
 		}
 		donec <- struct{}{}
 	}()
@@ -123,8 +123,8 @@ func TestDoubleBarrierFailover(t *testing.T) {
 	for i := 0; i < waiters-1; i++ {
 		go func() {
 			b := recipe.NewDoubleBarrier(s1, "test-barrier", waiters)
-			if err = b.Enter(); err != nil {
-				t.Fatalf("could not enter on barrier (%v)", err)
+			if berr := b.Enter(); berr != nil {
+				t.Fatalf("could not enter on barrier (%v)", berr)
 			}
 			donec <- struct{}{}
 			b.Leave()


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c420a596d0 by goroutine 404:
  github.com/coreos/etcd/integration.TestDoubleBarrierFailover.func1()
      /home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/integration/v3_double_barrier_test.go:117 +0x186

Previous write at 0x00c420a596d0 by goroutine 1012:
  github.com/coreos/etcd/integration.TestDoubleBarrierFailover.func2()
      /home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/integration/v3_double_barrier_test.go:126 +0x186

Goroutine 404 (running) created at:
  github.com/coreos/etcd/integration.TestDoubleBarrierFailover()
      /home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/integration/v3_double_barrier_test.go:121 +0x3ff
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:610 +0xc9

Goroutine 1012 (running) created at:
  github.com/coreos/etcd/integration.TestDoubleBarrierFailover()
      /home/gyuho/go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/integration/v3_double_barrier_test.go:132 +0x45b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:610 +0xc9
==================
```

It was writing to the same `err` var (found in `grpcproxy` tests).

/cc @heyitsanthony @xiang90 