### PR TITLE
integration: improve TestTransferLeader

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -702,13 +702,13 @@ func (m *member) Stop(t *testing.T) {
 	plog.Printf("stopped %s (%s)", m.Name, m.grpcAddr)
 }
 
-// StopWithAutoLeaderTransfer stops the member with auto leader transfer.
-func (m *member) StopWithAutoLeaderTransfer(t *testing.T) {
-	plog.Printf("stopping %s (%s)", m.Name, m.grpcAddr)
-	m.s.TransferLeadership()
-	m.Close()
-	m.hss = nil
-	plog.Printf("stopped %s (%s)", m.Name, m.grpcAddr)
+// checkLeaderTransition waits for leader transition, returning the new leader ID.
+func checkLeaderTransition(t *testing.T, m *member, oldLead uint64) uint64 {
+	interval := time.Duration(m.s.Cfg.TickMs) * time.Millisecond
+	for m.s.Lead() == 0 || (m.s.Lead() == oldLead) {
+		time.Sleep(interval)
+	}
+	return m.s.Lead()
 }
 
 // StopNotify unblocks when a member stop completes


### PR DESCRIPTION
```
go test -timeout 10m -v --race -tags cluster_proxy -cpu 1,2,4 -run TestTransferLeaderStopTrigger
=== RUN   TestTransferLeaderStopTrigger
took: 11.684917ms
--- FAIL: TestTransferLeaderStopTrigger (0.67s)
	cluster_test.go:499: context deadline exceeded
=== RUN   TestTransferLeaderStopTrigger
took: 7.895174ms
--- PASS: TestTransferLeaderStopTrigger (0.37s)
=== RUN   TestTransferLeaderStopTrigger
took: 8.614713ms
--- PASS: TestTransferLeaderStopTrigger (0.33s)
```

We need more timeout when run in proxy + `--race` flag

/cc @heyitsanthony @xiang90 