### PR TITLE
raft: implemented TODO for returning an error and handled panic for Term due to IOB

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -220,7 +220,8 @@ func (l *raftLog) term(i uint64) (uint64, error) {
 	// the valid term range is [index of dummy entry, last index]
 	dummyIndex := l.firstIndex() - 1
 	if i < dummyIndex || i > l.lastIndex() {
-		return 0, ErrTermUnavailable
+		// TODO: return an error instead?
+		return 0, nil
 	}
 
 	if t, ok := l.unstable.maybeTerm(i); ok {

--- a/raft/log.go
+++ b/raft/log.go
@@ -220,8 +220,7 @@ func (l *raftLog) term(i uint64) (uint64, error) {
 	// the valid term range is [index of dummy entry, last index]
 	dummyIndex := l.firstIndex() - 1
 	if i < dummyIndex || i > l.lastIndex() {
-		// TODO: return an error instead?
-		return 0, nil
+		return 0, ErrTermUnavailable
 	}
 
 	if t, ok := l.unstable.maybeTerm(i); ok {
@@ -232,7 +231,7 @@ func (l *raftLog) term(i uint64) (uint64, error) {
 	if err == nil {
 		return t, nil
 	}
-	if err == ErrCompacted {
+	if err == ErrCompacted || err == ErrTermUnavailable {
 		return 0, err
 	}
 	panic(err) // TODO(bdarnell)

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -698,22 +698,16 @@ func TestTerm(t *testing.T) {
 	tests := []struct {
 		index uint64
 		w     uint64
-		werr  error
 	}{
-		{offset - 1, 0, ErrTermUnavailable},
-		{offset, 1, nil},
-		{offset + num/2, num / 2, nil},
-		{offset + num - 1, num - 1, nil},
-		{offset + num, 0, ErrTermUnavailable},
+		{offset - 1, 0},
+		{offset, 1},
+		{offset + num/2, num / 2},
+		{offset + num - 1, num - 1},
+		{offset + num, 0},
 	}
 
 	for j, tt := range tests {
-		term, err := l.term(tt.index)
-
-		if err != tt.werr {
-			t.Errorf("#%d: at = %d, got: %d, want %d", j, term, err, tt.werr)
-		}
-
+		term := mustTerm(l.term(tt.index))
 		if term != tt.w {
 			t.Errorf("#%d: at = %d, want %d", j, term, tt.w)
 		}
@@ -732,25 +726,20 @@ func TestTermWithUnstableSnapshot(t *testing.T) {
 	tests := []struct {
 		index uint64
 		w     uint64
-		werr  error
 	}{
 		// cannot get term from storage
-		{storagesnapi, 0, ErrTermUnavailable},
+		{storagesnapi, 0},
 		// cannot get term from the gap between storage ents and unstable snapshot
-		{storagesnapi + 1, 0, ErrTermUnavailable},
-		{unstablesnapi - 1, 0, ErrTermUnavailable},
+		{storagesnapi + 1, 0},
+		{unstablesnapi - 1, 0},
 		// get term from unstable snapshot index
-		{unstablesnapi, 1, nil},
+		{unstablesnapi, 1},
 	}
 
-	for _, tt := range tests {
-		term, err := l.term(tt.index)
-		if err != tt.werr {
-			t.Errorf("#%d: at = %d, got: %d, want %d", tt.index, term, err, tt.werr)
-		}
-
+	for i, tt := range tests {
+		term := mustTerm(l.term(tt.index))
 		if term != tt.w {
-			t.Errorf("#%d: at = %d, want %d", tt.index, term, tt.w)
+			t.Errorf("#%d: at = %d, want %d", i, term, tt.w)
 		}
 	}
 }

--- a/raft/storage.go
+++ b/raft/storage.go
@@ -25,6 +25,10 @@ import (
 // index is unavailable because it predates the last snapshot.
 var ErrCompacted = errors.New("requested index is unavailable due to compaction")
 
+// ErrTermUnavailable is returned by Storage interface when the requested Term
+// is unavailable for the index.
+var ErrTermUnavailable = errors.New("requested term at index is unavailable")
+
 // ErrSnapOutOfDate is returned by Storage.CreateSnapshot when a requested
 // index is older than the existing snapshot.
 var ErrSnapOutOfDate = errors.New("requested index is older than the existing snapshot")
@@ -129,6 +133,9 @@ func (ms *MemoryStorage) Term(i uint64) (uint64, error) {
 	offset := ms.ents[0].Index
 	if i < offset {
 		return 0, ErrCompacted
+	}
+	if int(i-offset) >= len(ms.ents) {
+		return 0, ErrTermUnavailable
 	}
 	return ms.ents[i-offset].Term, nil
 }

--- a/raft/storage_test.go
+++ b/raft/storage_test.go
@@ -35,7 +35,7 @@ func TestStorageTerm(t *testing.T) {
 		{3, nil, 3, false},
 		{4, nil, 4, false},
 		{5, nil, 5, false},
-		{6, nil, 0, true},
+		{6, ErrTermUnavailable, 0, false},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Instead of raising panic, returning an error instead for better handling
and also handled TODO for the index check for invalid index