### PR TITLE
raft: handled panic for Term due to IOB

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -232,7 +232,7 @@ func (l *raftLog) term(i uint64) (uint64, error) {
 	if err == nil {
 		return t, nil
 	}
-	if err == ErrCompacted {
+	if err == ErrCompacted || err == ErrUnavailable {
 		return 0, err
 	}
 	panic(err) // TODO(bdarnell)

--- a/raft/storage.go
+++ b/raft/storage.go
@@ -130,6 +130,9 @@ func (ms *MemoryStorage) Term(i uint64) (uint64, error) {
 	if i < offset {
 		return 0, ErrCompacted
 	}
+	if int(i-offset) >= len(ms.ents) {
+		return 0, ErrUnavailable
+	}
 	return ms.ents[i-offset].Term, nil
 }
 

--- a/raft/storage_test.go
+++ b/raft/storage_test.go
@@ -35,7 +35,7 @@ func TestStorageTerm(t *testing.T) {
 		{3, nil, 3, false},
 		{4, nil, 4, false},
 		{5, nil, 5, false},
-		{6, nil, 0, true},
+		{6, ErrUnavailable, 0, false},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Instead of raising panic, returning an error instead for better handling

#6215