### PR TITLE
integration: NewClusterV3() should launch cluster before creating clients

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -837,6 +837,7 @@ func NewClusterV3(t *testing.T, cfg *ClusterConfig) *ClusterV3 {
 	clus := &ClusterV3{
 		cluster: NewClusterByConfig(t, cfg),
 	}
+	clus.Launch(t)
 	for _, m := range clus.Members {
 		client, err := NewClientV3(m)
 		if err != nil {
@@ -844,7 +845,6 @@ func NewClusterV3(t *testing.T, cfg *ClusterConfig) *ClusterV3 {
 		}
 		clus.clients = append(clus.clients, client)
 	}
-	clus.Launch(t)
 
 	return clus
 }


### PR DESCRIPTION
What?
It changes NewClusterV3() to launch the cluster before creating clients.

Why?
Previously, NewClientV3() didn't have client connections established but kept retrying. If we have TLS handshake, it failed because it would block and return error.