### PR TITLE
etcd-tester: request with grpc.FailFast true

### DIFF
--- a/tools/functional-tester/etcd-tester/stresser.go
+++ b/tools/functional-tester/etcd-tester/stresser.go
@@ -76,7 +76,7 @@ func newStressPut(kvc pb.KVClient, keySuffixRange, keySize int) stressFunc {
 		_, err := kvc.Put(ctx, &pb.PutRequest{
 			Key:   []byte(fmt.Sprintf("foo%016x", rand.Intn(keySuffixRange))),
 			Value: randBytes(keySize),
-		}, grpc.FailFast(false))
+		})
 		return err
 	}
 }
@@ -85,7 +85,7 @@ func newStressRange(kvc pb.KVClient, keySuffixRange int) stressFunc {
 	return func(ctx context.Context) error {
 		_, err := kvc.Range(ctx, &pb.RangeRequest{
 			Key: []byte(fmt.Sprintf("foo%016x", rand.Intn(keySuffixRange))),
-		}, grpc.FailFast(false))
+		})
 		return err
 	}
 }
@@ -97,7 +97,7 @@ func newStressRangeInterval(kvc pb.KVClient, keySuffixRange int) stressFunc {
 		_, err := kvc.Range(ctx, &pb.RangeRequest{
 			Key:      []byte(fmt.Sprintf("foo%016x", start)),
 			RangeEnd: []byte(fmt.Sprintf("foo%016x", end)),
-		}, grpc.FailFast(false))
+		})
 		return err
 	}
 }
@@ -106,7 +106,7 @@ func newStressDelete(kvc pb.KVClient, keySuffixRange int) stressFunc {
 	return func(ctx context.Context) error {
 		_, err := kvc.DeleteRange(ctx, &pb.DeleteRangeRequest{
 			Key: []byte(fmt.Sprintf("foo%016x", rand.Intn(keySuffixRange))),
-		}, grpc.FailFast(false))
+		})
 		return err
 	}
 }
@@ -118,7 +118,7 @@ func newStressDeleteInterval(kvc pb.KVClient, keySuffixRange int) stressFunc {
 		_, err := kvc.DeleteRange(ctx, &pb.DeleteRangeRequest{
 			Key:      []byte(fmt.Sprintf("foo%016x", start)),
 			RangeEnd: []byte(fmt.Sprintf("foo%016x", end)),
-		}, grpc.FailFast(false))
+		})
 		return err
 	}
 }


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6221.

Since we close the grpc connection, FailFast false
will block.

When we cancel stresser, we close grpc connection (https://github.com/coreos/etcd/blob/master/tools/functional-tester/etcd-tester/stresser.go#L281). This will cause `errConnClosing` in grpc side (https://github.com/grpc/grpc-go/blob/master/call.go#L173), hanging with grpc FailFast false.

We should use grpc FailFast true as in clientv3.
