### PR TITLE
pkg/transport: bump wait time in TestReadWriteTimeoutDialer for write deadline

### DIFF
--- a/pkg/transport/timeout_dialer_test.go
+++ b/pkg/transport/timeout_dialer_test.go
@@ -50,8 +50,9 @@ func TestReadWriteTimeoutDialer(t *testing.T) {
 
 	select {
 	case <-done:
-	// It waits 1s more to avoid delay in low-end system.
-	case <-time.After(d.wtimeoutd*10 + time.Second):
+	// Wait 5s more than timeout to avoid delay in low-end systems;
+	// the slack was 1s extra, but that wasn't enough for CI.
+	case <-time.After(d.wtimeoutd*10 + 5*time.Second):
 		t.Fatal("wait timeout")
 	}
 


### PR DESCRIPTION
Was able to get 2s wait times with 500 concurrent requests on a fast machine;
a slower machine could possibly see similar delays with a single connection.

Fixes #6220