### PR TITLE
e2e: remove server testing in etcdctl test

### DIFF
--- a/e2e/ctl_v3_member_test.go
+++ b/e2e/ctl_v3_member_test.go
@@ -84,20 +84,11 @@ func memberRemoveTest(cx ctlCtx) {
 	}
 
 	var (
-		n2            = n1 - 1
 		memIDToRemove = fmt.Sprintf("%x", resp.Header.MemberId)
 		cluserID      = fmt.Sprintf("%x", resp.Header.ClusterId)
 	)
 	if err = ctlV3MemberRemove(cx, memIDToRemove, cluserID); err != nil {
 		cx.t.Fatal(err)
-	}
-
-	resp, err = getMemberList(cx)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
-	if n2 != len(resp.Members) {
-		cx.t.Fatalf("expected %d, got %d", n2, len(resp.Members))
 	}
 }
 
@@ -112,27 +103,6 @@ func memberAddTest(cx ctlCtx) {
 	if err := spawnWithExpect(cmdArgs, " added to cluster "); err != nil {
 		cx.t.Fatal(err)
 	}
-
-	mresp, err := getMemberList(cx)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
-	if len(mresp.Members) != 2 {
-		cx.t.Fatalf("expected 2, got %d", len(mresp.Members))
-	}
-
-	found := false
-	for _, mem := range mresp.Members {
-		for _, v := range mem.PeerURLs {
-			if v == peerURL {
-				found = true
-				break
-			}
-		}
-	}
-	if !found {
-		cx.t.Fatalf("expected %s in PeerURLs, got %+v", peerURL, mresp.Members)
-	}
 }
 
 func memberUpdateTest(cx ctlCtx) {
@@ -145,17 +115,5 @@ func memberUpdateTest(cx ctlCtx) {
 	cmdArgs := append(cx.PrefixArgs(), "member", "update", fmt.Sprintf("%x", mr.Members[0].ID), fmt.Sprintf("--peer-urls=%s", peerURL))
 	if err = spawnWithExpect(cmdArgs, " updated in cluster "); err != nil {
 		cx.t.Fatal(err)
-	}
-
-	mresp, err := getMemberList(cx)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
-	if len(mresp.Members) != 1 {
-		cx.t.Fatalf("expected 1, got %d", len(mresp.Members))
-	}
-
-	if mresp.Members[0].PeerURLs[0] != peerURL {
-		cx.t.Fatalf("expected %s in PeerURLs, got %+v", peerURL, mresp.Members)
 	}
 }


### PR DESCRIPTION
Fix #6192 

I played around with etcdctl, and try to make memberlist reliable.

But after I gave a close look at the testing code, I figured out what we are testing here is not necessary.

We want to test etcdctl behaviors correctly by sending correct thing to the server.

Once server responded with `member is added` or `member is updated`, we know etcdctl works. We should not try to verify the server does the correct thing by adding a member to its list. These are already covered by server side testing.
