### PR TITLE
raftexample: implement Raft snapshot

### DIFF
--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"log"
 	"sync"
 )
@@ -76,4 +77,21 @@ func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {
 	if err, ok := <-errorC; ok {
 		log.Fatal(err)
 	}
+}
+
+func (s *kvstore) getSnapshot() ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return json.Marshal(s.kvStore)
+}
+
+func (s *kvstore) recoverFromSnapshot(snapshot []byte) error {
+	var store map[string]string
+	if err := json.Unmarshal(snapshot, &store); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.kvStore = store
+	s.mu.Unlock()
+	return nil
 }

--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -20,13 +20,16 @@ import (
 	"encoding/json"
 	"log"
 	"sync"
+
+	"github.com/coreos/etcd/snap"
 )
 
 // a key-value store backed by raft
 type kvstore struct {
-	proposeC chan<- string // channel for proposing updates
-	mu       sync.RWMutex
-	kvStore  map[string]string // current committed key-value pairs
+	proposeC    chan<- string // channel for proposing updates
+	mu          sync.RWMutex
+	kvStore     map[string]string // current committed key-value pairs
+	snapshotter *snap.Snapshotter
 }
 
 type kv struct {
@@ -34,8 +37,8 @@ type kv struct {
 	Val string
 }
 
-func newKVStore(proposeC chan<- string, commitC <-chan *string, errorC <-chan error) *kvstore {
-	s := &kvstore{proposeC: proposeC, kvStore: make(map[string]string)}
+func newKVStore(snapshotter *snap.Snapshotter, proposeC chan<- string, commitC <-chan *string, errorC <-chan error) *kvstore {
+	s := &kvstore{proposeC: proposeC, kvStore: make(map[string]string), snapshotter: snapshotter}
 	// replay log into key-value map
 	s.readCommits(commitC, errorC)
 	// read commits from raft into kvStore map until error
@@ -62,7 +65,18 @@ func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {
 	for data := range commitC {
 		if data == nil {
 			// done replaying log; new data incoming
-			return
+			// OR signaled to load snapshot
+			snapshot, err := s.snapshotter.Load()
+			if err == snap.ErrNoSnapshot {
+				return
+			}
+			if err != nil && err != snap.ErrNoSnapshot {
+				log.Panic(err)
+			}
+			log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)
+			if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
+				log.Panic(err)
+			}
 		}
 
 		var dataKv kv

--- a/contrib/raftexample/kvstore_test.go
+++ b/contrib/raftexample/kvstore_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_kvstore_snapshot(t *testing.T) {
+	tm := map[string]string{"foo": "bar"}
+	s := &kvstore{kvStore: tm}
+
+	v, _ := s.Lookup("foo")
+	if v != "bar" {
+		t.Fatalf("foo has unexpected value, got %s", v)
+	}
+
+	data, err := s.getSnapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.kvStore = nil
+
+	if err := s.recoverFromSnapshot(data); err != nil {
+		t.Fatal(err)
+	}
+	v, _ = s.Lookup("foo")
+	if v != "bar" {
+		t.Fatalf("foo has unexpected value, got %s", v)
+	}
+	if !reflect.DeepEqual(s.kvStore, tm) {
+		t.Fatalf("store expected %+v, got %+v", tm, s.kvStore)
+	}
+}

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -34,8 +34,12 @@ func main() {
 	defer close(confChangeC)
 
 	// raft provides a commit stream for the proposals from the http api
-	commitC, errorC := newRaftNode(*id, strings.Split(*cluster, ","), *join, proposeC, confChangeC)
+	var kvs *kvstore
+	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
+	commitC, errorC, snapshotterReady := newRaftNode(*id, strings.Split(*cluster, ","), *join, getSnapshot, proposeC, confChangeC)
+
+	kvs = newKVStore(<-snapshotterReady, proposeC, commitC, errorC)
 
 	// the key-value http handler will propose updates to raft
-	serveHttpKVAPI(*kvport, proposeC, confChangeC, commitC, errorC)
+	serveHttpKVAPI(kvs, *kvport, confChangeC, errorC)
 }

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -50,7 +50,7 @@ func newCluster(n int) *cluster {
 		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", i+1))
 		clus.proposeC[i] = make(chan string, 1)
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
-		clus.commitC[i], clus.errorC[i] = newRaftNode(i+1, clus.peers, false, clus.proposeC[i], clus.confChangeC[i])
+		clus.commitC[i], clus.errorC[i], _ = newRaftNode(i+1, clus.peers, false, nil, clus.proposeC[i], clus.confChangeC[i])
 	}
 
 	return clus

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -47,6 +47,7 @@ func newCluster(n int) *cluster {
 
 	for i := range clus.peers {
 		os.RemoveAll(fmt.Sprintf("raftexample-%d", i+1))
+		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", i+1))
 		clus.proposeC[i] = make(chan string, 1)
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
 		clus.commitC[i], clus.errorC[i] = newRaftNode(i+1, clus.peers, false, clus.proposeC[i], clus.confChangeC[i])
@@ -79,6 +80,7 @@ func (clus *cluster) Close() (err error) {
 		}
 		// clean intermediates
 		os.RemoveAll(fmt.Sprintf("raftexample-%d", i+1))
+		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", i+1))
 	}
 	return err
 }


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/4019.

Tried to make it work like etcdserver snapshot, with simple storage backend.
Tests became a bit messy when `raftNode` embeds `kvstore`, though.

Please review. Thanks.
/cc @heyitsanthony @xiang90 
