### PR TITLE
WIP clientv3/integration: WaitLeader before request

### DIFF
--- a/clientv3/integration/txn_test.go
+++ b/clientv3/integration/txn_test.go
@@ -77,6 +77,7 @@ func TestTxnWriteFail(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatalf("timed out waiting for txn fail")
 		case <-txnc:
+			clus.WaitLeader(t) // in case leader was stopped
 		}
 		// and ensure the put didn't take
 		gresp, gerr := clus.Client(1).Get(context.TODO(), "foo")


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6238.

Reproduce

1. `Stop` kills the leader
2. `clus.Client(1).Get` is started before leader election is finished
3. `clus.Client(1).Get` returns `grpc: the client connection is closing` error

```
2016-08-24 20:48:21.922497 I | rafthttp: stopped streaming with peer 61524ab52b09c4e7 (writer)
2016-08-24 20:48:21.922519 I | rafthttp: stopped HTTP pipelining with peer 61524ab52b09c4e7
2016-08-24 20:48:21.922535 I | rafthttp: stopped streaming with peer 61524ab52b09c4e7 (stream MsgApp v2 reader)
2016-08-24 20:48:21.922546 I | rafthttp: stopped streaming with peer 61524ab52b09c4e7 (stream Message reader)
2016-08-24 20:48:21.922553 I | rafthttp: stopped peer 61524ab52b09c4e7
2016-08-24 20:48:21.922559 I | rafthttp: stopping peer b189be73f73333b2...
2016-08-24 20:48:21.922815 I | rafthttp: closed the TCP streaming connection with peer b189be73f73333b2 (stream MsgApp v2 writer)
2016-08-24 20:48:21.922825 I | rafthttp: stopped streaming with peer b189be73f73333b2 (writer)
2016-08-24 20:48:21.923088 I | rafthttp: closed the TCP streaming connection with peer b189be73f73333b2 (stream Message writer)
2016-08-24 20:48:21.923101 I | rafthttp: stopped streaming with peer b189be73f73333b2 (writer)
2016-08-24 20:48:21.923125 I | rafthttp: stopped HTTP pipelining with peer b189be73f73333b2
2016-08-24 20:48:21.923142 I | rafthttp: stopped streaming with peer b189be73f73333b2 (stream MsgApp v2 reader)
2016-08-24 20:48:21.923152 I | rafthttp: stopped streaming with peer b189be73f73333b2 (stream Message reader)
2016-08-24 20:48:21.923159 I | rafthttp: stopped peer b189be73f73333b2
2016-08-24 20:48:21.925606 I | integration: terminated node4823273917992247466 (unix://localhost:node4823273917992247466.sock.bridge)
--- PASS: TestTxnWriteFail (1.16s)
PASS
ok      github.com/coreos/etcd/clientv3/integration     2.661s
=== RUN   TestTxnWriteFail
2016-08-24 20:48:33.920420 I | integration: launching node8494747037266658263 (unix://localhost:node8494747037266658263.sock.bridge)
2016-08-24 20:48:33.925421 I | integration: launching node5227339968745439129 (unix://localhost:node5227339968745439129.sock.bridge)
2016-08-24 20:48:33.929685 I | integration: launching node8156548762872175943 (unix://localhost:node8156548762872175943.sock.bridge)
2016-08-24 20:48:33.945714 I | etcdserver: name = node8494747037266658263
2016-08-24 20:48:33.945801 I | etcdserver: data dir = /tmp/etcd221205717
2016-08-24 20:48:33.945841 I | etcdserver: member dir = /tmp/etcd221205717/member
2016-08-24 20:48:33.945874 I | etcdserver: heartbeat = 10ms
2016-08-24 20:48:33.945905 I | etcdserver: election = 100ms
2016-08-24 20:48:33.945937 I | etcdserver: snapshot count = 0
2016-08-24 20:48:33.945987 I | etcdserver: advertise client URLs = unix://127.0.0.1:21006.25176.sock
2016-08-24 20:48:33.946030 I | etcdserver: initial advertise peer URLs = unix://127.0.0.1:21005.25176.sock
2016-08-24 20:48:33.946119 I | etcdserver: initial cluster = node5227339968745439129=unix://127.0.0.1:21001.25176.sock,node8156548762872175943=unix://127.0.0.1:21003.25176.sock,node8494747037266658263=unix://127.0.0.1:21005.25176.sock
2016-08-24 20:48:33.950059 I | etcdserver: name = node5227339968745439129
2016-08-24 20:48:33.950157 I | etcdserver: data dir = /tmp/etcd078817131
2016-08-24 20:48:33.950202 I | etcdserver: member dir = /tmp/etcd078817131/member
2016-08-24 20:48:33.950249 I | etcdserver: heartbeat = 10ms
2016-08-24 20:48:33.950303 I | etcdserver: election = 100ms
2016-08-24 20:48:33.950339 I | etcdserver: snapshot count = 0
2016-08-24 20:48:33.950382 I | etcdserver: advertise client URLs = unix://127.0.0.1:21002.25176.sock
2016-08-24 20:48:33.950420 I | etcdserver: initial advertise peer URLs = unix://127.0.0.1:21001.25176.sock
2016-08-24 20:48:33.950511 I | etcdserver: initial cluster = node5227339968745439129=unix://127.0.0.1:21001.25176.sock,node8156548762872175943=unix://127.0.0.1:21003.25176.sock,node8494747037266658263=unix://127.0.0.1:21005.25176.sock
2016-08-24 20:48:33.952472 I | etcdserver: starting member f3fb46502e44e344 in cluster e5bf372c41a7c846
2016-08-24 20:48:33.952602 I | raft: f3fb46502e44e344 became follower at term 0
2016-08-24 20:48:33.952673 I | raft: newRaft f3fb46502e44e344 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
2016-08-24 20:48:33.952717 I | raft: f3fb46502e44e344 became follower at term 1
2016-08-24 20:48:33.954012 I | etcdserver: name = node8156548762872175943
2016-08-24 20:48:33.954379 I | etcdserver: data dir = /tmp/etcd862358990
2016-08-24 20:48:33.954427 I | etcdserver: member dir = /tmp/etcd862358990/member
2016-08-24 20:48:33.954514 I | etcdserver: heartbeat = 10ms
2016-08-24 20:48:33.954559 I | etcdserver: election = 100ms
2016-08-24 20:48:33.954590 I | etcdserver: snapshot count = 0
2016-08-24 20:48:33.954633 I | etcdserver: advertise client URLs = unix://127.0.0.1:21004.25176.sock
2016-08-24 20:48:33.954672 I | etcdserver: initial advertise peer URLs = unix://127.0.0.1:21003.25176.sock
2016-08-24 20:48:33.954745 I | etcdserver: initial cluster = node5227339968745439129=unix://127.0.0.1:21001.25176.sock,node8156548762872175943=unix://127.0.0.1:21003.25176.sock,node8494747037266658263=unix://127.0.0.1:21005.25176.sock
2016-08-24 20:48:33.967165 I | etcdserver: starting member c9ee48a5685b13a3 in cluster e5bf372c41a7c846
2016-08-24 20:48:33.967329 I | raft: c9ee48a5685b13a3 became follower at term 0
2016-08-24 20:48:33.967456 I | raft: newRaft c9ee48a5685b13a3 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
2016-08-24 20:48:33.967523 I | raft: c9ee48a5685b13a3 became follower at term 1
2016-08-24 20:48:33.976180 I | etcdserver: starting member b7214340cedb2d51 in cluster e5bf372c41a7c846
2016-08-24 20:48:33.976320 I | raft: b7214340cedb2d51 became follower at term 0
2016-08-24 20:48:33.976385 I | raft: newRaft b7214340cedb2d51 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
2016-08-24 20:48:33.976425 I | raft: b7214340cedb2d51 became follower at term 1
2016-08-24 20:48:33.989232 I | rafthttp: starting peer c9ee48a5685b13a3...
2016-08-24 20:48:33.989709 I | rafthttp: started HTTP pipelining with peer c9ee48a5685b13a3
2016-08-24 20:48:34.006072 I | rafthttp: started streaming with peer c9ee48a5685b13a3 (writer)
2016-08-24 20:48:34.011822 I | rafthttp: starting peer b7214340cedb2d51...
2016-08-24 20:48:34.012263 I | rafthttp: started HTTP pipelining with peer b7214340cedb2d51
2016-08-24 20:48:34.020148 I | rafthttp: started peer b7214340cedb2d51
2016-08-24 20:48:34.020421 I | rafthttp: added peer b7214340cedb2d51
2016-08-24 20:48:34.020498 I | rafthttp: starting peer c9ee48a5685b13a3...
2016-08-24 20:48:34.020927 I | rafthttp: started HTTP pipelining with peer c9ee48a5685b13a3
2016-08-24 20:48:34.045510 I | rafthttp: started streaming with peer c9ee48a5685b13a3 (writer)
2016-08-24 20:48:34.045763 I | rafthttp: started streaming with peer b7214340cedb2d51 (writer)
2016-08-24 20:48:34.045875 I | rafthttp: started streaming with peer b7214340cedb2d51 (writer)
2016-08-24 20:48:34.045954 I | rafthttp: started streaming with peer b7214340cedb2d51 (stream Message reader)
2016-08-24 20:48:34.046896 I | rafthttp: started streaming with peer b7214340cedb2d51 (stream MsgApp v2 reader)
2016-08-24 20:48:34.057336 I | rafthttp: starting peer b7214340cedb2d51...
2016-08-24 20:48:34.057822 I | rafthttp: started HTTP pipelining with peer b7214340cedb2d51
2016-08-24 20:48:34.073617 I | rafthttp: started peer b7214340cedb2d51
2016-08-24 20:48:34.073912 I | rafthttp: added peer b7214340cedb2d51
2016-08-24 20:48:34.073983 I | rafthttp: starting peer f3fb46502e44e344...
2016-08-24 20:48:34.074369 I | rafthttp: started HTTP pipelining with peer f3fb46502e44e344
2016-08-24 20:48:34.079995 I | rafthttp: started peer c9ee48a5685b13a3
2016-08-24 20:48:34.080236 I | rafthttp: added peer c9ee48a5685b13a3
2016-08-24 20:48:34.080306 I | rafthttp: starting peer f3fb46502e44e344...
2016-08-24 20:48:34.080835 I | rafthttp: started HTTP pipelining with peer f3fb46502e44e344
2016-08-24 20:48:34.094026 I | rafthttp: started peer f3fb46502e44e344
2016-08-24 20:48:34.094330 I | rafthttp: added peer f3fb46502e44e344
2016-08-24 20:48:34.094395 I | etcdserver: set snapshot count to default 10000
2016-08-24 20:48:34.094450 I | etcdserver: starting server... [version: 3.0.0+git, cluster version: to_be_decided]
2016-08-24 20:48:34.128397 I | rafthttp: started peer c9ee48a5685b13a3
2016-08-24 20:48:34.128714 I | rafthttp: added peer c9ee48a5685b13a3
2016-08-24 20:48:34.128793 I | etcdserver: set snapshot count to default 10000
2016-08-24 20:48:34.128846 I | etcdserver: starting server... [version: 3.0.0+git, cluster version: to_be_decided]
2016-08-24 20:48:34.142746 I | rafthttp: started streaming with peer b7214340cedb2d51 (writer)
2016-08-24 20:48:34.145668 I | rafthttp: started streaming with peer b7214340cedb2d51 (writer)
2016-08-24 20:48:34.145940 I | rafthttp: started streaming with peer b7214340cedb2d51 (stream MsgApp v2 reader)
2016-08-24 20:48:34.146693 I | rafthttp: started streaming with peer b7214340cedb2d51 (stream Message reader)
2016-08-24 20:48:34.148411 I | rafthttp: started streaming with peer c9ee48a5685b13a3 (stream MsgApp v2 reader)
2016-08-24 20:48:34.166101 I | rafthttp: started streaming with peer c9ee48a5685b13a3 (stream Message reader)
2016-08-24 20:48:34.166582 I | rafthttp: started streaming with peer f3fb46502e44e344 (writer)
2016-08-24 20:48:34.166656 I | rafthttp: started streaming with peer f3fb46502e44e344 (writer)
2016-08-24 20:48:34.166717 I | rafthttp: started streaming with peer f3fb46502e44e344 (stream MsgApp v2 reader)
2016-08-24 20:48:34.168237 I | rafthttp: started streaming with peer f3fb46502e44e344 (stream Message reader)
2016-08-24 20:48:34.170163 I | rafthttp: started streaming with peer c9ee48a5685b13a3 (writer)
2016-08-24 20:48:34.170227 I | rafthttp: started streaming with peer c9ee48a5685b13a3 (writer)
2016-08-24 20:48:34.170321 I | rafthttp: started streaming with peer c9ee48a5685b13a3 (stream Message reader)
2016-08-24 20:48:34.170592 I | rafthttp: started streaming with peer c9ee48a5685b13a3 (stream MsgApp v2 reader)
2016-08-24 20:48:34.172343 I | rafthttp: started streaming with peer f3fb46502e44e344 (writer)
2016-08-24 20:48:34.172869 I | rafthttp: started streaming with peer f3fb46502e44e344 (writer)
2016-08-24 20:48:34.175344 I | rafthttp: peer f3fb46502e44e344 became active
2016-08-24 20:48:34.175431 I | rafthttp: established a TCP streaming connection with peer f3fb46502e44e344 (stream MsgApp v2 writer)
2016-08-24 20:48:34.177850 I | rafthttp: established a TCP streaming connection with peer f3fb46502e44e344 (stream Message writer)
2016-08-24 20:48:34.178531 W | raft: f3fb46502e44e344 cannot campaign at term 1 since there are still 3 pending configuration changes to apply
2016-08-24 20:48:34.180655 I | integration: launched node8494747037266658263 (unix://localhost:node8494747037266658263.sock.bridge)
2016-08-24 20:48:34.181091 I | membership: added member b7214340cedb2d51 [unix://127.0.0.1:21001.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.183611 I | membership: added member c9ee48a5685b13a3 [unix://127.0.0.1:21003.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.184151 I | membership: added member f3fb46502e44e344 [unix://127.0.0.1:21005.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.184658 I | membership: added member b7214340cedb2d51 [unix://127.0.0.1:21001.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.185154 I | membership: added member c9ee48a5685b13a3 [unix://127.0.0.1:21003.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.185634 I | membership: added member f3fb46502e44e344 [unix://127.0.0.1:21005.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.186792 I | rafthttp: started peer f3fb46502e44e344
2016-08-24 20:48:34.187040 I | rafthttp: added peer f3fb46502e44e344
2016-08-24 20:48:34.187095 I | etcdserver: set snapshot count to default 10000
2016-08-24 20:48:34.187137 I | etcdserver: starting server... [version: 3.0.0+git, cluster version: to_be_decided]
2016-08-24 20:48:34.189013 I | rafthttp: started streaming with peer f3fb46502e44e344 (stream MsgApp v2 reader)
2016-08-24 20:48:34.189299 I | rafthttp: started streaming with peer f3fb46502e44e344 (stream Message reader)
2016-08-24 20:48:34.193256 I | rafthttp: peer c9ee48a5685b13a3 became active
2016-08-24 20:48:34.193318 I | rafthttp: established a TCP streaming connection with peer c9ee48a5685b13a3 (stream MsgApp v2 writer)
2016-08-24 20:48:34.198352 I | rafthttp: peer f3fb46502e44e344 became active
2016-08-24 20:48:34.198408 I | rafthttp: established a TCP streaming connection with peer f3fb46502e44e344 (stream Message writer)
2016-08-24 20:48:34.199237 I | integration: launched node5227339968745439129 (unix://localhost:node5227339968745439129.sock.bridge)
2016-08-24 20:48:34.199311 I | rafthttp: peer b7214340cedb2d51 became active
2016-08-24 20:48:34.199358 I | rafthttp: established a TCP streaming connection with peer b7214340cedb2d51 (stream Message writer)
2016-08-24 20:48:34.217482 I | rafthttp: peer b7214340cedb2d51 became active
2016-08-24 20:48:34.217586 I | rafthttp: established a TCP streaming connection with peer b7214340cedb2d51 (stream Message writer)
2016-08-24 20:48:34.219599 I | rafthttp: established a TCP streaming connection with peer f3fb46502e44e344 (stream MsgApp v2 writer)
2016-08-24 20:48:34.221503 I | rafthttp: established a TCP streaming connection with peer b7214340cedb2d51 (stream MsgApp v2 writer)
2016-08-24 20:48:34.222522 I | membership: added member b7214340cedb2d51 [unix://127.0.0.1:21001.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.223062 I | membership: added member c9ee48a5685b13a3 [unix://127.0.0.1:21003.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.223616 I | membership: added member f3fb46502e44e344 [unix://127.0.0.1:21005.25176.sock] to cluster e5bf372c41a7c846
2016-08-24 20:48:34.224336 I | integration: launched node8156548762872175943 (unix://localhost:node8156548762872175943.sock.bridge)
2016-08-24 20:48:34.225709 I | rafthttp: established a TCP streaming connection with peer b7214340cedb2d51 (stream Message reader)
2016-08-24 20:48:34.225965 I | rafthttp: established a TCP streaming connection with peer b7214340cedb2d51 (stream MsgApp v2 reader)
2016-08-24 20:48:34.228850 I | rafthttp: peer c9ee48a5685b13a3 became active
2016-08-24 20:48:34.228925 I | rafthttp: established a TCP streaming connection with peer c9ee48a5685b13a3 (stream Message writer)
2016-08-24 20:48:34.229627 I | rafthttp: established a TCP streaming connection with peer b7214340cedb2d51 (stream MsgApp v2 reader)
2016-08-24 20:48:34.232034 I | rafthttp: established a TCP streaming connection with peer c9ee48a5685b13a3 (stream Message reader)
2016-08-24 20:48:34.232262 I | rafthttp: established a TCP streaming connection with peer c9ee48a5685b13a3 (stream MsgApp v2 reader)
2016-08-24 20:48:34.242417 I | rafthttp: established a TCP streaming connection with peer b7214340cedb2d51 (stream MsgApp v2 writer)
2016-08-24 20:48:34.249535 I | rafthttp: established a TCP streaming connection with peer c9ee48a5685b13a3 (stream Message writer)
2016-08-24 20:48:34.258714 I | rafthttp: established a TCP streaming connection with peer f3fb46502e44e344 (stream Message reader)
2016-08-24 20:48:34.261666 I | rafthttp: established a TCP streaming connection with peer c9ee48a5685b13a3 (stream MsgApp v2 reader)
2016-08-24 20:48:34.266707 I | rafthttp: established a TCP streaming connection with peer c9ee48a5685b13a3 (stream Message reader)
2016-08-24 20:48:34.280255 I | rafthttp: established a TCP streaming connection with peer c9ee48a5685b13a3 (stream MsgApp v2 writer)
2016-08-24 20:48:34.281814 I | rafthttp: established a TCP streaming connection with peer f3fb46502e44e344 (stream Message reader)
2016-08-24 20:48:34.282064 I | rafthttp: established a TCP streaming connection with peer f3fb46502e44e344 (stream MsgApp v2 reader)
2016-08-24 20:48:34.284305 I | rafthttp: established a TCP streaming connection with peer f3fb46502e44e344 (stream MsgApp v2 reader)
2016-08-24 20:48:34.290582 I | rafthttp: established a TCP streaming connection with peer b7214340cedb2d51 (stream Message reader)
2016-08-24 20:48:34.337366 I | raft: b7214340cedb2d51 is starting a new election at term 1
2016-08-24 20:48:34.337470 I | raft: b7214340cedb2d51 became candidate at term 2
2016-08-24 20:48:34.337517 I | raft: b7214340cedb2d51 received vote from b7214340cedb2d51 at term 2
2016-08-24 20:48:34.337571 I | raft: b7214340cedb2d51 [logterm: 1, index: 3] sent vote request to c9ee48a5685b13a3 at term 2
2016-08-24 20:48:34.337627 I | raft: b7214340cedb2d51 [logterm: 1, index: 3] sent vote request to f3fb46502e44e344 at term 2
2016-08-24 20:48:34.338032 I | raft: c9ee48a5685b13a3 is starting a new election at term 1
2016-08-24 20:48:34.338128 I | raft: c9ee48a5685b13a3 became candidate at term 2
2016-08-24 20:48:34.338178 I | raft: c9ee48a5685b13a3 received vote from c9ee48a5685b13a3 at term 2
2016-08-24 20:48:34.338235 I | raft: c9ee48a5685b13a3 [logterm: 1, index: 3] sent vote request to b7214340cedb2d51 at term 2
2016-08-24 20:48:34.338295 I | raft: c9ee48a5685b13a3 [logterm: 1, index: 3] sent vote request to f3fb46502e44e344 at term 2
2016-08-24 20:48:34.344839 I | raft: f3fb46502e44e344 [logterm: 1, index: 3, vote: 0] ignored vote from c9ee48a5685b13a3 [logterm: 1, index: 3] at term 1: lease is not expired (remaining ticks: 1)
2016-08-24 20:48:34.345054 I | raft: c9ee48a5685b13a3 [logterm: 1, index: 3, vote: c9ee48a5685b13a3] rejected vote from b7214340cedb2d51 [logterm: 1, index: 3] at term 2
2016-08-24 20:48:34.346310 I | raft: f3fb46502e44e344 [logterm: 1, index: 3, vote: 0] ignored vote from b7214340cedb2d51 [logterm: 1, index: 3] at term 1: lease is not expired (remaining ticks: 1)
2016-08-24 20:48:34.346406 I | raft: b7214340cedb2d51 [logterm: 1, index: 3, vote: b7214340cedb2d51] rejected vote from c9ee48a5685b13a3 [logterm: 1, index: 3] at term 2
2016-08-24 20:48:34.346794 I | raft: c9ee48a5685b13a3 received vote rejection from b7214340cedb2d51 at term 2
2016-08-24 20:48:34.346859 I | raft: c9ee48a5685b13a3 [quorum:2] has received 1 votes and 1 vote rejections
2016-08-24 20:48:34.346942 I | raft: b7214340cedb2d51 received vote rejection from c9ee48a5685b13a3 at term 2
2016-08-24 20:48:34.347010 I | raft: b7214340cedb2d51 [quorum:2] has received 1 votes and 1 vote rejections
2016-08-24 20:48:34.363817 I | raft: f3fb46502e44e344 is starting a new election at term 1
2016-08-24 20:48:34.363943 I | raft: f3fb46502e44e344 became candidate at term 2
2016-08-24 20:48:34.363995 I | raft: f3fb46502e44e344 received vote from f3fb46502e44e344 at term 2
2016-08-24 20:48:34.364075 I | raft: f3fb46502e44e344 [logterm: 1, index: 3] sent vote request to b7214340cedb2d51 at term 2
2016-08-24 20:48:34.364145 I | raft: f3fb46502e44e344 [logterm: 1, index: 3] sent vote request to c9ee48a5685b13a3 at term 2
2016-08-24 20:48:34.365565 I | raft: b7214340cedb2d51 [logterm: 1, index: 3, vote: b7214340cedb2d51] rejected vote from f3fb46502e44e344 [logterm: 1, index: 3] at term 2
2016-08-24 20:48:34.365889 I | raft: f3fb46502e44e344 received vote rejection from b7214340cedb2d51 at term 2
2016-08-24 20:48:34.365950 I | raft: f3fb46502e44e344 [quorum:2] has received 1 votes and 1 vote rejections
2016-08-24 20:48:34.366151 I | raft: c9ee48a5685b13a3 [logterm: 1, index: 3, vote: c9ee48a5685b13a3] rejected vote from f3fb46502e44e344 [logterm: 1, index: 3] at term 2
2016-08-24 20:48:34.366461 I | raft: f3fb46502e44e344 received vote rejection from c9ee48a5685b13a3 at term 2
2016-08-24 20:48:34.366511 I | raft: f3fb46502e44e344 [quorum:2] has received 1 votes and 2 vote rejections
2016-08-24 20:48:34.366593 I | raft: f3fb46502e44e344 became follower at term 2
2016-08-24 20:48:34.446989 I | raft: b7214340cedb2d51 is starting a new election at term 2
2016-08-24 20:48:34.447098 I | raft: b7214340cedb2d51 became candidate at term 3
2016-08-24 20:48:34.447143 I | raft: b7214340cedb2d51 received vote from b7214340cedb2d51 at term 3
2016-08-24 20:48:34.447204 I | raft: b7214340cedb2d51 [logterm: 1, index: 3] sent vote request to c9ee48a5685b13a3 at term 3
2016-08-24 20:48:34.447261 I | raft: b7214340cedb2d51 [logterm: 1, index: 3] sent vote request to f3fb46502e44e344 at term 3
2016-08-24 20:48:34.448967 I | raft: c9ee48a5685b13a3 [term: 2] received a MsgVote message with higher term from b7214340cedb2d51 [term: 3]
2016-08-24 20:48:34.449072 I | raft: c9ee48a5685b13a3 became follower at term 3
2016-08-24 20:48:34.449136 I | raft: c9ee48a5685b13a3 [logterm: 1, index: 3, vote: 0] voted for b7214340cedb2d51 [logterm: 1, index: 3] at term 3
2016-08-24 20:48:34.449588 I | raft: f3fb46502e44e344 [logterm: 1, index: 3, vote: f3fb46502e44e344] ignored vote from b7214340cedb2d51 [logterm: 1, index: 3] at term 2: lease is not expired (remaining ticks: 2)
2016-08-24 20:48:34.450375 I | raft: b7214340cedb2d51 received vote from c9ee48a5685b13a3 at term 3
2016-08-24 20:48:34.450429 I | raft: b7214340cedb2d51 [quorum:2] has received 2 votes and 0 vote rejections
2016-08-24 20:48:34.450507 I | raft: b7214340cedb2d51 became leader at term 3
2016-08-24 20:48:34.450571 I | raft: raft.node: b7214340cedb2d51 elected leader b7214340cedb2d51 at term 3
2016-08-24 20:48:34.452225 I | raft: raft.node: c9ee48a5685b13a3 elected leader b7214340cedb2d51 at term 3
2016-08-24 20:48:34.452726 I | raft: f3fb46502e44e344 [term: 2] received a MsgApp message with higher term from b7214340cedb2d51 [term: 3]
2016-08-24 20:48:34.452830 I | raft: f3fb46502e44e344 became follower at term 3
2016-08-24 20:48:34.452894 I | raft: raft.node: f3fb46502e44e344 elected leader b7214340cedb2d51 at term 3
2016-08-24 20:48:34.470503 I | etcdserver: published {Name:node5227339968745439129 ClientURLs:[unix://127.0.0.1:21002.25176.sock]} to cluster e5bf372c41a7c846
2016-08-24 20:48:34.471939 I | etcdserver: published {Name:node8156548762872175943 ClientURLs:[unix://127.0.0.1:21004.25176.sock]} to cluster e5bf372c41a7c846
2016-08-24 20:48:34.475016 I | etcdserver: setting up the initial cluster version to 3.0
2016-08-24 20:48:34.477031 I | etcdserver: published {Name:node8494747037266658263 ClientURLs:[unix://127.0.0.1:21006.25176.sock]} to cluster e5bf372c41a7c846
2016-08-24 20:48:34.485810 N | membership: set the initial cluster version to 3.0
2016-08-24 20:48:34.486047 I | api: enabled capabilities for version 3.0
2016-08-24 20:48:34.486660 N | membership: set the initial cluster version to 3.0
2016-08-24 20:48:34.487748 N | membership: set the initial cluster version to 3.0
2016-08-24 20:48:34.499354388 [BEFORE] Stop b7214340cedb2d51
2016-08-24 20:48:34.499404 I | integration: stopping node5227339968745439129 (unix://localhost:node5227339968745439129.sock.bridge)
2016-08-24 20:48:34.500387 I | rafthttp: stopping peer c9ee48a5685b13a3...
2016-08-24 20:48:34.503377 I | rafthttp: closed the TCP streaming connection with peer c9ee48a5685b13a3 (stream MsgApp v2 writer)
2016-08-24 20:48:34.503431 I | rafthttp: stopped streaming with peer c9ee48a5685b13a3 (writer)
2016-08-24 20:48:34.505556 I | rafthttp: closed the TCP streaming connection with peer c9ee48a5685b13a3 (stream Message writer)
2016-08-24 20:48:34.505609 I | rafthttp: stopped streaming with peer c9ee48a5685b13a3 (writer)
2016-08-24 20:48:34.505783 I | rafthttp: stopped HTTP pipelining with peer c9ee48a5685b13a3
2016-08-24 20:48:34.506163 W | rafthttp: lost the TCP streaming connection with peer c9ee48a5685b13a3 (stream MsgApp v2 reader)
2016-08-24 20:48:34.506228 E | rafthttp: failed to read c9ee48a5685b13a3 on stream MsgApp v2 (net/http: request canceled)
2016-08-24 20:48:34.506263 I | rafthttp: peer c9ee48a5685b13a3 became inactive
2016-08-24 20:48:34.506328 I | rafthttp: stopped streaming with peer c9ee48a5685b13a3 (stream MsgApp v2 reader)
2016-08-24 20:48:34.506533 W | rafthttp: lost the TCP streaming connection with peer c9ee48a5685b13a3 (stream Message reader)
2016-08-24 20:48:34.506603 I | rafthttp: stopped streaming with peer c9ee48a5685b13a3 (stream Message reader)
2016-08-24 20:48:34.506683 I | rafthttp: stopped peer c9ee48a5685b13a3
2016-08-24 20:48:34.506723 I | rafthttp: stopping peer f3fb46502e44e344...
2016-08-24 20:48:34.508928 I | rafthttp: closed the TCP streaming connection with peer f3fb46502e44e344 (stream MsgApp v2 writer)
2016-08-24 20:48:34.508986 I | rafthttp: stopped streaming with peer f3fb46502e44e344 (writer)
2016-08-24 20:48:34.511124 I | rafthttp: closed the TCP streaming connection with peer f3fb46502e44e344 (stream Message writer)
2016-08-24 20:48:34.511176 I | rafthttp: stopped streaming with peer f3fb46502e44e344 (writer)
2016-08-24 20:48:34.511418 I | rafthttp: stopped HTTP pipelining with peer f3fb46502e44e344
2016-08-24 20:48:34.511592 W | rafthttp: lost the TCP streaming connection with peer f3fb46502e44e344 (stream MsgApp v2 reader)
2016-08-24 20:48:34.511647 I | rafthttp: stopped streaming with peer f3fb46502e44e344 (stream MsgApp v2 reader)
2016-08-24 20:48:34.511800 W | rafthttp: lost the TCP streaming connection with peer f3fb46502e44e344 (stream Message reader)
2016-08-24 20:48:34.511853 E | rafthttp: failed to read f3fb46502e44e344 on stream Message (net/http: request canceled)
2016-08-24 20:48:34.511885 I | rafthttp: peer f3fb46502e44e344 became inactive
2016-08-24 20:48:34.511930 I | rafthttp: stopped streaming with peer f3fb46502e44e344 (stream Message reader)
2016-08-24 20:48:34.511980 I | rafthttp: stopped peer f3fb46502e44e344
2016-08-24 20:48:34.515888 I | integration: stopped node5227339968745439129 (unix://localhost:node5227339968745439129.sock.bridge)
2016-08-24 20:48:34.515927407 [AFTER] Stop b7214340cedb2d51
2016-08-24 20:48:34.516151017 [BEFORE] Txn request to b7214340cedb2d51
2016-08-24 20:48:34.516634 I | v3rpc/grpc: transport: http2Client.notifyError got notified that the client transport was broken write unix @->localhost:node5227339968745439129.sock.bridge: write: broken pipe.
2016-08-24 20:48:34.516856095 [AFTER] Txn request to b7214340cedb2d51 (rpc error: code = 13 desc = transport: write unix @->localhost:node5227339968745439129.sock.bridge: write: broken pipe)
2016-08-24 20:48:34.516893144 [BEFORE] close(txnc)
2016-08-24 20:48:34.516916528 [AFTER] close(txnc)
2016-08-24 20:48:34.517450 I | v3rpc/grpc: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial unix localhost:node5227339968745439129.sock.bridge: connect: no such file or directory"; Reconnecting to {"localhost:node5227339968745439129.sock.bridge" <nil>}
2016-08-24 20:48:34.517694014 [AFTER] <-txnc
2016-08-24 20:48:34.517713687 [BEFORE] GET request to c9ee48a5685b13a3
2016-08-24 20:48:34.519918 W | rafthttp: lost the TCP streaming connection with peer b7214340cedb2d51 (stream Message reader)
2016-08-24 20:48:34.520002 W | rafthttp: lost the TCP streaming connection with peer b7214340cedb2d51 (stream MsgApp v2 reader)
2016-08-24 20:48:34.522761 W | rafthttp: lost the TCP streaming connection with peer b7214340cedb2d51 (stream Message reader)
2016-08-24 20:48:34.522829 W | rafthttp: lost the TCP streaming connection with peer b7214340cedb2d51 (stream MsgApp v2 reader)
2016-08-24 20:48:34.613125 I | raft: f3fb46502e44e344 is starting a new election at term 3
2016-08-24 20:48:34.613272 I | raft: f3fb46502e44e344 became candidate at term 4
2016-08-24 20:48:34.613318 I | raft: f3fb46502e44e344 received vote from f3fb46502e44e344 at term 4
2016-08-24 20:48:34.613378 I | raft: f3fb46502e44e344 [logterm: 3, index: 8] sent vote request to b7214340cedb2d51 at term 4
2016-08-24 20:48:34.613464 I | raft: f3fb46502e44e344 [logterm: 3, index: 8] sent vote request to c9ee48a5685b13a3 at term 4
2016-08-24 20:48:34.613557 I | raft: raft.node: f3fb46502e44e344 lost leader b7214340cedb2d51 at term 4
2016-08-24 20:48:34.615394 I | raft: c9ee48a5685b13a3 [term: 3] received a MsgVote message with higher term from f3fb46502e44e344 [term: 4]
2016-08-24 20:48:34.615484 I | raft: c9ee48a5685b13a3 became follower at term 4
2016-08-24 20:48:34.615549 I | raft: c9ee48a5685b13a3 [logterm: 3, index: 8, vote: 0] voted for f3fb46502e44e344 [logterm: 3, index: 8] at term 4
2016-08-24 20:48:34.615592 I | raft: raft.node: c9ee48a5685b13a3 lost leader b7214340cedb2d51 at term 4
2016-08-24 20:48:34.616628 I | raft: f3fb46502e44e344 received vote from c9ee48a5685b13a3 at term 4
2016-08-24 20:48:34.616705 I | raft: f3fb46502e44e344 [quorum:2] has received 2 votes and 0 vote rejections
2016-08-24 20:48:34.616813 I | raft: f3fb46502e44e344 became leader at term 4
2016-08-24 20:48:34.616877 I | raft: raft.node: f3fb46502e44e344 elected leader f3fb46502e44e344 at term 4
2016-08-24 20:48:34.617885 I | raft: raft.node: c9ee48a5685b13a3 elected leader f3fb46502e44e344 at term 4
2016-08-24 20:48:34.619624 W | etcdserver: failed to reach the peerURL(unix://127.0.0.1:21001.25176.sock) of member b7214340cedb2d51 (Get http://127.0.0.1:21001.25176.sock/version: dial unix 127.0.0.1:21001.25176.sock: connect: no such file or directory)
2016-08-24 20:48:34.619683 W | etcdserver: cannot get the version of member b7214340cedb2d51 (Get http://127.0.0.1:21001.25176.sock/version: dial unix 127.0.0.1:21001.25176.sock: connect: no such file or directory)
2016-08-24 20:48:34.621057 E | rafthttp: failed to dial b7214340cedb2d51 on stream Message (dial unix 127.0.0.1:21001.25176.sock: connect: no such file or directory)
2016-08-24 20:48:34.621109 I | rafthttp: peer b7214340cedb2d51 became inactive
2016-08-24 20:48:34.623603 E | rafthttp: failed to dial b7214340cedb2d51 on stream MsgApp v2 (dial unix 127.0.0.1:21001.25176.sock: connect: no such file or directory)
2016-08-24 20:48:34.623654 I | rafthttp: peer b7214340cedb2d51 became inactive
2016-08-24 20:48:34.635638 W | rafthttp: lost the TCP streaming connection with peer b7214340cedb2d51 (stream Message writer)
2016-08-24 20:48:35.132984 W | rafthttp: lost the TCP streaming connection with peer b7214340cedb2d51 (stream MsgApp v2 writer)
2016-08-24 20:48:35.517659 I | v3rpc/grpc: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial unix localhost:node5227339968745439129.sock.bridge: connect: no such file or directory"; Reconnecting to {"localhost:node5227339968745439129.sock.bridge" <nil>}
2016-08-24 20:48:37.156609 I | v3rpc/grpc: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial unix localhost:node5227339968745439129.sock.bridge: connect: no such file or directory"; Reconnecting to {"localhost:node5227339968745439129.sock.bridge" <nil>}
2016-08-24 20:48:37.482325 W | rafthttp: lost the TCP streaming connection with peer b7214340cedb2d51 (stream Message writer)
2016-08-24 20:48:37.494785 W | etcdserver: failed to send out heartbeat on time (exceeded the 10ms timeout for 1.503481ms)
2016-08-24 20:48:37.494859 W | etcdserver: server is likely overloaded
2016-08-24 20:48:37.494923 W | etcdserver: failed to send out heartbeat on time (exceeded the 10ms timeout for 1.691118ms)
2016-08-24 20:48:37.494965 W | etcdserver: server is likely overloaded
2016-08-24 20:48:37.517136 W | etcdserver: failed to send out heartbeat on time (exceeded the 10ms timeout for 2.393647ms)
2016-08-24 20:48:37.517213 W | etcdserver: server is likely overloaded
2016-08-24 20:48:37.517262 W | etcdserver: failed to send out heartbeat on time (exceeded the 10ms timeout for 2.338676ms)
2016-08-24 20:48:37.517305 W | etcdserver: server is likely overloaded
2016-08-24 20:48:37.541562 W | etcdserver: failed to send out heartbeat on time (exceeded the 10ms timeout for 4.417416ms)
2016-08-24 20:48:37.541633 W | etcdserver: server is likely overloaded
2016-08-24 20:48:37.541676 W | etcdserver: failed to send out heartbeat on time (exceeded the 10ms timeout for 4.418841ms)
2016-08-24 20:48:37.541707 W | etcdserver: server is likely overloaded
2016-08-24 20:48:38.622749 W | etcdserver: failed to reach the peerURL(unix://127.0.0.1:21001.25176.sock) of member b7214340cedb2d51 (Get http://127.0.0.1:21001.25176.sock/version: dial unix 127.0.0.1:21001.25176.sock: connect: no such file or directory)
2016-08-24 20:48:38.622842 W | etcdserver: cannot get the version of member b7214340cedb2d51 (Get http://127.0.0.1:21001.25176.sock/version: dial unix 127.0.0.1:21001.25176.sock: connect: no such file or directory)
2016-08-24 20:48:39.046936 W | rafthttp: health check for peer b7214340cedb2d51 could not connect: dial unix 127.0.0.1:21001.25176.sock: connect: no such file or directory
2016-08-24 20:48:39.143889 W | rafthttp: lost the TCP streaming connection with peer b7214340cedb2d51 (stream MsgApp v2 writer)
2016-08-24 20:48:39.148139 W | rafthttp: health check for peer b7214340cedb2d51 could not connect: dial unix 127.0.0.1:21001.25176.sock: connect: no such file or directory
2016-08-24 20:48:39.516792 I | integration: terminating node5227339968745439129 (unix://localhost:node5227339968745439129.sock.bridge)
2016-08-24 20:48:39.517190 I | integration: terminated node5227339968745439129 (unix://localhost:node5227339968745439129.sock.bridge)
2016-08-24 20:48:39.517254 I | integration: terminating node8156548762872175943 (unix://localhost:node8156548762872175943.sock.bridge)
2016-08-24 20:48:39.517702 I | v3rpc/grpc: grpc: addrConn.transportMonitor exits due to: context canceled
2016-08-24 20:48:39.518359671 [AFTER] GET request to c9ee48a5685b13a3 (grpc: the client connection is closing)
2016-08-24 20:48:39.519048 I | v3rpc/grpc: transport: http2Server.HandleStreams failed to read frame: read unix localhost:node8156548762872175943.sock->@: use of closed network connection
2016-08-24 20:48:39.519565 I | v3rpc/grpc: grpc: Server.processUnaryRPC failed to write status: connection error: desc = "transport: write unix localhost:node8156548762872175943.sock->@: use of closed network connection"
2016-08-24 20:48:39.519861 I | rafthttp: stopping peer b7214340cedb2d51...
2016-08-24 20:48:39.519973 I | rafthttp: stopped streaming with peer b7214340cedb2d51 (writer)
2016-08-24 20:48:39.520049 I | rafthttp: stopped streaming with peer b7214340cedb2d51 (writer)
2016-08-24 20:48:39.520172 I | rafthttp: stopped HTTP pipelining with peer b7214340cedb2d51
2016-08-24 20:48:39.520247 I | rafthttp: stopped streaming with peer b7214340cedb2d51 (stream MsgApp v2 reader)
2016-08-24 20:48:39.520343 I | rafthttp: stopped streaming with peer b7214340cedb2d51 (stream Message reader)
2016-08-24 20:48:39.520400 I | rafthttp: stopped peer b7214340cedb2d51
2016-08-24 20:48:39.520435 I | rafthttp: stopping peer f3fb46502e44e344...
2016-08-24 20:48:39.521589 I | rafthttp: closed the TCP streaming connection with peer f3fb46502e44e344 (stream MsgApp v2 writer)
2016-08-24 20:48:39.521639 I | rafthttp: stopped streaming with peer f3fb46502e44e344 (writer)
2016-08-24 20:48:39.522783 I | rafthttp: closed the TCP streaming connection with peer f3fb46502e44e344 (stream Message writer)
2016-08-24 20:48:39.522827 I | rafthttp: stopped streaming with peer f3fb46502e44e344 (writer)
2016-08-24 20:48:39.523070 I | rafthttp: stopped HTTP pipelining with peer f3fb46502e44e344
2016-08-24 20:48:39.523257 W | rafthttp: lost the TCP streaming connection with peer f3fb46502e44e344 (stream MsgApp v2 reader)
2016-08-24 20:48:39.523307 E | rafthttp: failed to read f3fb46502e44e344 on stream MsgApp v2 (net/http: request canceled)
2016-08-24 20:48:39.523340 I | rafthttp: peer f3fb46502e44e344 became inactive
2016-08-24 20:48:39.523392 I | rafthttp: stopped streaming with peer f3fb46502e44e344 (stream MsgApp v2 reader)
2016-08-24 20:48:39.523567 W | rafthttp: lost the TCP streaming connection with peer f3fb46502e44e344 (stream Message reader)
2016-08-24 20:48:39.523619 I | rafthttp: stopped streaming with peer f3fb46502e44e344 (stream Message reader)
2016-08-24 20:48:39.523660 I | rafthttp: stopped peer f3fb46502e44e344
2016-08-24 20:48:39.527781 I | integration: terminated node8156548762872175943 (unix://localhost:node8156548762872175943.sock.bridge)
2016-08-24 20:48:39.527834 I | integration: terminating node8494747037266658263 (unix://localhost:node8494747037266658263.sock.bridge)
2016-08-24 20:48:39.528196 I | v3rpc/grpc: transport: http2Server.HandleStreams failed to read frame: read unix localhost:node8494747037266658263.sock->@: use of closed network connection
2016-08-24 20:48:39.528677 I | rafthttp: stopping peer b7214340cedb2d51...
2016-08-24 20:48:39.528809 I | rafthttp: stopped streaming with peer b7214340cedb2d51 (writer)
2016-08-24 20:48:39.528887 I | rafthttp: stopped streaming with peer b7214340cedb2d51 (writer)
2016-08-24 20:48:39.529025 I | rafthttp: stopped HTTP pipelining with peer b7214340cedb2d51
2016-08-24 20:48:39.529092 I | rafthttp: stopped streaming with peer b7214340cedb2d51 (stream MsgApp v2 reader)
2016-08-24 20:48:39.529166 I | rafthttp: stopped streaming with peer b7214340cedb2d51 (stream Message reader)
2016-08-24 20:48:39.529218 I | rafthttp: stopped peer b7214340cedb2d51
2016-08-24 20:48:39.529258 I | rafthttp: stopping peer c9ee48a5685b13a3...
2016-08-24 20:48:39.530400 I | rafthttp: closed the TCP streaming connection with peer c9ee48a5685b13a3 (stream MsgApp v2 writer)
2016-08-24 20:48:39.530449 I | rafthttp: stopped streaming with peer c9ee48a5685b13a3 (writer)
2016-08-24 20:48:39.531591 I | rafthttp: closed the TCP streaming connection with peer c9ee48a5685b13a3 (stream Message writer)
2016-08-24 20:48:39.531635 I | rafthttp: stopped streaming with peer c9ee48a5685b13a3 (writer)
2016-08-24 20:48:39.532105 I | rafthttp: stopped HTTP pipelining with peer c9ee48a5685b13a3
2016-08-24 20:48:39.532527 W | rafthttp: lost the TCP streaming connection with peer c9ee48a5685b13a3 (stream MsgApp v2 reader)
2016-08-24 20:48:39.532586 I | rafthttp: stopped streaming with peer c9ee48a5685b13a3 (stream MsgApp v2 reader)
2016-08-24 20:48:39.532991 W | rafthttp: lost the TCP streaming connection with peer c9ee48a5685b13a3 (stream Message reader)
2016-08-24 20:48:39.533048 I | rafthttp: stopped streaming with peer c9ee48a5685b13a3 (stream Message reader)
2016-08-24 20:48:39.533107 I | rafthttp: stopped peer c9ee48a5685b13a3
2016-08-24 20:48:39.537496 I | integration: terminated node8494747037266658263 (unix://localhost:node8494747037266658263.sock.bridge)
==================
WARNING: DATA RACE
Read at 0x00c4202444c3 by goroutine 56:
  testing.tRunner.func1()
      /usr/local/go/src/testing/testing.go:573 +0x16c
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:479 +0x4b
  testing.(*common).Fatalf()
      /usr/local/go/src/testing/testing.go:496 +0x94
  github.com/coreos/etcd/clientv3/integration.TestTxnWriteFail()
      /home/gyuho/go/src/github.com/coreos/etcd/clientv3/integration/txn_test.go:105 +0x9ff
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:610 +0xc9

Previous write at 0x00c4202444c3 by goroutine 31:
  [failed to restore the stack]

Goroutine 56 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:646 +0x52f
  testing.RunTests.func1()
      /usr/local/go/src/testing/testing.go:793 +0xb9
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:610 +0xc9
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:799 +0x4ba
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:743 +0x12f
  github.com/coreos/etcd/clientv3/integration.TestMain()
      /home/gyuho/go/src/github.com/coreos/etcd/clientv3/integration/main_test.go:15 +0x38
  main.main()
      github.com/coreos/etcd/clientv3/integration/_test/_testmain.go:170 +0x1b5

Goroutine 31 (finished) created at:
  github.com/coreos/etcd/clientv3/integration.TestTxnWriteFail()
      /home/gyuho/go/src/github.com/coreos/etcd/clientv3/integration/txn_test.go:101 +0x928
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:610 +0xc9
==================
--- FAIL: TestTxnWriteFail (5.67s)
        txn_test.go:105: timed out waiting for get
        txn_test.go:93: grpc: the client connection is closing
```