### PR TITLE
etcd-tester: compact every X entries

### DIFF
--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -93,6 +93,8 @@ func main() {
 		cluster:          c,
 		limit:            *limit,
 		consistencyCheck: *consistencyCheck,
+		compactQPS:       50000,
+		compactCount:     100000,
 	}
 
 	sh := statusHandler{status: &t.status}


### PR DESCRIPTION
Fail points has longer rounds, more entries to compact.
We want to compact more often so that we don't compact
like 5-million entries after rounds.

/cc @xiang90 @heyitsanthony 