### PR TITLE
mvcc: force commit and hash should be atomic for getting hash

### DIFF
--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -323,10 +323,9 @@ func (s *store) Compact(rev int64) (<-chan struct{}, error) {
 }
 
 func (s *store) Hash() (uint32, int64, error) {
-	s.b.ForceCommit()
-
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.b.ForceCommit()
 
 	// ignore hash consistent index field for now.
 	// consistent index might be changed due to v2 internal sync, which


### PR DESCRIPTION
Fix #6272 

I examined the db file and wal files. The state are actually consistent. However agent1 returns a hash of a previous KV state. This is because:

we force commit revision -> 5884913671
... there are more ops going into the mvcc

we acquire lock
we get the in mem rev -> 5884913683
we get the hash of the force committed state at 5884913671
we release lock

thus we end up with a rev = 5884913683 with a hash state of rev 5884913671

This is confirmed by log, wal and db. So I am sure this is what happened.

