### PR TITLE
store: removed duplicate method call for the same method

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -141,8 +141,6 @@ func (s *store) Get(nodePath string, recursive, sorted bool) (*Event, error) {
 		}
 	}()
 
-	nodePath = path.Clean(path.Join("/", nodePath))
-
 	n, err := s.internalGet(nodePath)
 	if err != nil {
 		return nil, err

--- a/wal/doc.go
+++ b/wal/doc.go
@@ -25,7 +25,7 @@ to it with the Save method:
 	...
 	err := w.Save(s, ents)
 
-After saving an raft snapshot to disk, SaveSnapshot method should be called to
+After saving a raft snapshot to disk, SaveSnapshot method should be called to
 record it. So WAL can match with the saved snapshot when restarting.
 
 	err := w.SaveSnapshot(walpb.Snapshot{Index: 10, Term: 2})


### PR DESCRIPTION
the get func was calling path's Join and clean method which is already
being in internalGet(nodePath) func. Hence the func was getting called
unnecessarily twice which is not needed.