### PR TITLE
store: removed duplicate method call for the same method

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -141,8 +141,6 @@ func (s *store) Get(nodePath string, recursive, sorted bool) (*Event, error) {
 		}
 	}()
 
-	nodePath = path.Clean(path.Join("/", nodePath))
-
 	n, err := s.internalGet(nodePath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
the get func was calling path's Join and clean method which is already
being in internalGet(nodePath) func. Hence the func was getting called
unnecessarily twice which is not needed.

#6295