### PR TITLE
documentation: fix typo in build commands

### DIFF
--- a/Documentation/dl_build.md
+++ b/Documentation/dl_build.md
@@ -28,7 +28,7 @@ $ echo $GOPATH
 
 $ mkdir -p $GOPATH/src/github.com/coreos
 $ cd $GOPATH/src/github.com/coreos
-$ git clone github.com:coreos/etcd.git
+$ git clone git@github.com:coreos/etcd.git
 $ cd etcd
 $ ./build
 $ ./bin/etcd


### PR DESCRIPTION
documentation: fix typo in build commands

In the documentation for building etcd, there is a typo in the `git clone` command. Fixed by switching `git clone github.com:coreos/etcd.git` to `git clone git@github.com:coreos/etcd.git`.
