### PR TITLE
test: test with v3.0 (preparation for v3.1)

### DIFF
--- a/test
+++ b/test
@@ -89,12 +89,13 @@ function grpcproxy_pass {
 }
 
 function release_pass {
-	UPGRADE_VER=$(git tag -l | tail -1)
+	# to grab latest patch release; bump this up for every minor release
+	UPGRADE_VER=$(git tag -l | grep v3.0 | tail -1)
 	if [ -n "$MANUAL_VER" ]; then
 		# in case, we need to test against different version
 		UPGRADE_VER=$MANUAL_VER
 	fi
-	echo "Running release upgrade tests with" etcd $UPGRADE_VER
+	echo "Downloading" etcd $UPGRADE_VER
 	curl -L https://github.com/coreos/etcd/releases/download/$UPGRADE_VER/etcd-$UPGRADE_VER-linux-amd64.tar.gz -o /tmp/etcd-$UPGRADE_VER-linux-amd64.tar.gz
 	tar xzvf /tmp/etcd-$UPGRADE_VER-linux-amd64.tar.gz -C /tmp/ --strip-components=1
 	mv /tmp/etcd ./bin/etcd-last-release


### PR DESCRIPTION
For https://github.com/coreos/etcd/pull/6309#issuecomment-243523255.

Confirmed that this fails without Xiang's patch

```
2016-08-30 16:47:58.995114 C | etcdmain: database file (/tmp/testname1.etcd397787835/member/snap/db index 0) does not match with snapshot (index 16).
2016-08-30 16:47:58.998345 C | etcdmain: database file (/tmp/testname2.etcd766704350/member/snap/db index 0) does not match with snapshot (index 16).
2016-08-30 16:47:59.000010 C | etcdmain: database file (/tmp/testname0.etcd443864012/member/snap/db index 0) does not match with snapshot (index 16).
```

/cc @xiang90 @heyitsanthony 