### PR TITLE
rafthttp: fix misprint in readBytesLimit value

### DIFF
--- a/rafthttp/msg_codec.go
+++ b/rafthttp/msg_codec.go
@@ -43,7 +43,7 @@ type messageDecoder struct {
 }
 
 var (
-	readBytesLimit     uint64 = 512 * 1024 // 512 MB
+	readBytesLimit     uint64 = 512 * 1024 * 1024 // 512 MB
 	ErrExceedSizeLimit        = errors.New("rafthttp: error limit exceeded")
 )
 

--- a/rafthttp/msg_codec_test.go
+++ b/rafthttp/msg_codec_test.go
@@ -23,6 +23,12 @@ import (
 )
 
 func TestMessage(t *testing.T) {
+	// Lower readBytesLimit to make test pass in restricted resources environment
+	originalLimit := readBytesLimit
+	readBytesLimit = 1000
+	defer func() {
+		readBytesLimit = originalLimit
+	}()
 	tests := []struct {
 		msg       raftpb.Message
 		encodeErr error


### PR DESCRIPTION
Simple fix for miscalculated value in readBytesLimit