### PR TITLE
etcdctlv3: Readme.md updated

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -12,7 +12,7 @@ PUT assigns the specified value with the specified key. If key already holds a v
 
 #### Options
 
-- lease -- lease ID (in hexadecimal) to attach to the key.
+- lease -- lease ID (in hexadecimal) to attach to the key. Refer '### LEASE GRANT \<ttl\>' section about creaing the lease before it can be attached to the key.
 
 #### Return value
 
@@ -33,10 +33,8 @@ The protobuf encoding of the PUT [RPC response][etcdrpc].
 #### Examples
 
 ``` bash
-./etcdctl PUT foo bar --lease=0x1234abcd
+./etcdctl put foo bar --lease=1234abcd
 OK
-./etcdctl range foo
-bar
 ```
 
 #### Notes


### PR DESCRIPTION
1. Under PUT example the put command was mentioned in capital which will
give the below error:
Error:  unknown command "PUT" for "etcdctl"
Hence corrected the same.
2. The lease id is mentioned with 0x to denote hex but since its an
example, copy pasting the command will give the below error:
Error:  bad lease ID (strconv.ParseInt: parsing "0x1234abcd": invalid
syntax), expecting ID in Hex
Hence modified the same to a sample correct value so that a user new to
etcd does not get confused.
3. A user new to etcd may not know that the lease will need to be
generated first before attaching it to the key and may get error as
specified below:
Error:  etcdserver: requested lease not found
Hence added a refernce to lease grant for a new user to refer it under
the OPTIONS section.
4. The command ./etcdctl range foo does not work and gives the below
error:
Error: unknown command "range" for "etcdctl"
Hence corrected the same