### PR TITLE
scripts, doc: remove actool references

### DIFF
--- a/Documentation/dev-internal/release.md
+++ b/Documentation/dev-internal/release.md
@@ -47,7 +47,7 @@ All releases version numbers follow the format of [semantic versioning 2.0.0](ht
 
 ## Build release binaries and images
 
-- Ensure `actool` is available, or installing it through `go get github.com/appc/spec/actool`.
+- Ensure `acbuild` is available.
 - Ensure `docker` is available.
 
 Run release script in root directory:

--- a/Documentation/v2/dev/release.md
+++ b/Documentation/v2/dev/release.md
@@ -48,7 +48,7 @@ All releases version numbers follow the format of [semantic versioning 2.0.0](ht
 
 ## Build Release Binaries and Images
 
-- Ensure `actool` is available, or installing it through `go get github.com/appc/spec/actool`.
+- Ensure `acbuild` is available.
 - Ensure `docker` is available.
 
 Run release script in root directory:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,11 +11,8 @@ if [ -z "${VERSION}" ]; then
 	exit 255
 fi
 
-# A non-installed actool can be used, for example:
-# ACTOOL=../../appc/spec/bin/actool
-ACTOOL=${ACTOOL:-actool}
-if ! command -v $ACTOOL >/dev/null; then
-    echo "cannot find actool ($ACTOOL)"
+if ! command -v acbuild >/dev/null; then
+    echo "cannot find acbuild"
     exit 1
 fi
 


### PR DESCRIPTION
Since c597d591b56a2a9ed355c57a717d1b2ed4c31aa9 the release script uses
acbuild instead of actool, so purge all the references and have the
release script check for acbuild's presence instead.