### PR TITLE
auth: correct range checking

### DIFF
--- a/auth/range_perm_cache.go
+++ b/auth/range_perm_cache.go
@@ -32,9 +32,9 @@ func isSubset(a, b *rangePerm) bool {
 		// b is a key, a is a range
 		return false
 	case len(a.end) == 0:
-		return 0 <= bytes.Compare(a.begin, b.begin) && bytes.Compare(a.begin, b.end) <= 0
+		return 0 <= bytes.Compare(a.begin, b.begin) && bytes.Compare(a.begin, b.end) < 0
 	default:
-		return 0 <= bytes.Compare(a.begin, b.begin) && bytes.Compare(a.end, b.end) <= 0
+		return 0 <= bytes.Compare(a.begin, b.begin) && bytes.Compare(a.end, b.end) < 0
 	}
 }
 


### PR DESCRIPTION

Current permission checking allows access to a key b if a user has a
role that is granted to a range [a, b). The range shouldn't include
the end key so this commit let the checking logic excludes it.

/cc @soyking