### PR TITLE
pkg/pbutil: corrected the package name in logger in pbutil.go

### DIFF
--- a/pkg/pbutil/pbutil.go
+++ b/pkg/pbutil/pbutil.go
@@ -18,7 +18,7 @@ package pbutil
 import "github.com/coreos/pkg/capnslog"
 
 var (
-	plog = capnslog.NewPackageLogger("github.com/coreos/etcd/pkg", "flags")
+	plog = capnslog.NewPackageLogger("github.com/coreos/etcd/pkg", "pbutil")
 )
 
 type Marshaler interface {


### PR DESCRIPTION
corrected the package name in logger in pbutil.go from "flags" to "pbutil"