### PR TITLE
etcdctlv3: Readme.md updated

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -33,9 +33,10 @@ The protobuf encoding of the PUT [RPC response][etcdrpc].
 #### Examples
 
 ``` bash
-./etcdctl PUT foo bar --lease=0x1234abcd
+./etcdctl put foo bar --lease=1234abcd
 OK
-./etcdctl range foo
+./etcdctl get foo
+foo
 bar
 ```
 


### PR DESCRIPTION
1. Under PUT example the put command was mentioned in capital which will
give the below error:
Error: unknown command "PUT" for "etcdctl"
Hence corrected the same.
2. The lease id is mentioned with 0x to denote hex but since its an
example, copy pasting the command will give the below error:
Error: bad lease ID (strconv.ParseInt: parsing "0x1234abcd": invalid
syntax), expecting ID in Hex
Hence modified the same to a sample correct value so that a user new to
etcd does not get confused.
3. The command ./etcdctl range foo does not work and gives the below
error:
Error: unknown command "range" for "etcdctl"
Hence corrected the same

#6372