### PR TITLE
clientv3: use correct context in toErr (lease)

### DIFF
--- a/clientv3/lease.go
+++ b/clientv3/lease.go
@@ -141,7 +141,7 @@ func (l *lessor) Grant(ctx context.Context, ttl int64) (*LeaseGrantResponse, err
 			return gresp, nil
 		}
 		if isHaltErr(cctx, err) {
-			return nil, toErr(ctx, err)
+			return nil, toErr(cctx, err)
 		}
 		if nerr := l.newStream(); nerr != nil {
 			return nil, nerr


### PR DESCRIPTION
/cc @heyitsanthony @xiang90 

Based on Anthony's comment https://github.com/coreos/etcd/pull/6321/commits/b2338dba3e322f03e5f572b0d8e3b1942aa41334#r77893050
