### PR TITLE
etcd.service: order after network.target

### DIFF
--- a/contrib/systemd/etcd.service
+++ b/contrib/systemd/etcd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=etcd key-value store
 Documentation=https://github.com/coreos/etcd
+After=network.target
 
 [Service]
 User=etcd


### PR DESCRIPTION
From [systemd NetworkTarget description](https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/):

> [...]since the shutdown ordering of units in systemd is the reverse of the startup ordering, any unit that is order After=network.target can be sure that it is stopped before the network is shut down if the system is powered off. This allows services to cleanly terminate connections before going down, instead of abruptly losing connectivity for ongoing connections, leaving them in an undefined state.[...]
