### PR TITLE
rafthttp: log stream stopped message before closing channel

### DIFF
--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -320,8 +320,8 @@ func (cr *streamReader) run() {
 		// overhead when retry.
 		case <-time.After(100 * time.Millisecond):
 		case <-cr.stopc:
-			close(cr.done)
 			plog.Infof("stopped streaming with peer %s (%s reader)", cr.peerID, t)
+			close(cr.done)
 			return
 		}
 	}


### PR DESCRIPTION
Cf. https://semaphoreci.com/coreos/etcd/branches/master/builds/909