### PR TITLE
*: separate 'capnslog' log level setting

### DIFF
--- a/clientv3/integration/logger_test.go
+++ b/clientv3/integration/logger_test.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import "github.com/coreos/pkg/capnslog"
+
+func init() {
+	capnslog.SetGlobalLogLevel(capnslog.INFO)
+}

--- a/integration/logger_test.go
+++ b/integration/logger_test.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import "github.com/coreos/pkg/capnslog"
+
+func init() {
+	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
+}

--- a/integration/v2_http_kv_test.go
+++ b/integration/v2_http_kv_test.go
@@ -28,12 +28,7 @@ import (
 
 	"github.com/coreos/etcd/pkg/testutil"
 	"github.com/coreos/etcd/pkg/transport"
-	"github.com/coreos/pkg/capnslog"
 )
-
-func init() {
-	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
-}
 
 func TestV2Set(t *testing.T) {
 	defer testutil.AfterTest(t)


### PR DESCRIPTION
Default level is `INFO`. And sometimes it's useful to turn on/off `capnslog` for debugging.

/cc @xiang90  @heyitsanthony 
