### PR TITLE
etcd-tester: fix peer-port parsing bug with localhost url

### DIFF
--- a/tools/functional-tester/etcd-tester/member.go
+++ b/tools/functional-tester/etcd-tester/member.go
@@ -168,7 +168,11 @@ func (m *member) grpcAddr() string {
 }
 
 func (m *member) peerPort() (port int) {
-	_, portStr, err := net.SplitHostPort(m.PeerURL)
+	u, err := url.Parse(m.PeerURL)
+	if err != nil {
+		panic(err)
+	}
+	_, portStr, err := net.SplitHostPort(u.Host)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Contributing guidelines

Please read our [contribution workflow][contributing] before submitting a pull request.

[contributing]: ../CONTRIBUTING.md#contribution-flow

The following format "http://localhost:1234" causes existing port parser to fail. Add new logic to parse the host name first then extract port.

Fixes #6409