### PR TITLE
etcdctl: an option for granting permission with key prefix

### DIFF
--- a/e2e/ctl_v3_role_test.go
+++ b/e2e/ctl_v3_role_test.go
@@ -101,6 +101,9 @@ func ctlV3Role(cx ctlCtx, args []string, expStr string) error {
 
 func ctlV3RoleGrantPermission(cx ctlCtx, rolename string, perm grantingPerm) error {
 	cmdArgs := append(cx.PrefixArgs(), "role", "grant-permission")
+	if perm.prefix {
+		cmdArgs = append(cmdArgs, "--prefix")
+	}
 	cmdArgs = append(cmdArgs, rolename)
 	cmdArgs = append(cmdArgs, grantingPermToArgs(perm)...)
 
@@ -137,6 +140,7 @@ type grantingPerm struct {
 	write    bool
 	key      string
 	rangeEnd string
+	prefix   bool
 }
 
 func grantingPermToArgs(perm grantingPerm) []string {


### PR DESCRIPTION

This commit adds a new option --prefix to "role grant-permission"
command. If the option is passed, the command interprets the key as a
prefix of range permission.

Example of usage:
$ ETCDCTL_API=3 bin/etcdctl --user root:p role grant-permission --prefix r1 readwrite /dir/
Role r1 updated
$ ETCDCTL_API=3 bin/etcdctl --user root:p role get r1
Role r1
KV Read:
        [/dir/, /dir0)
        [k1, k5)
KV Write:
        [/dir/, /dir0)
        [k1, k5)
$ ETCDCTL_API=3 bin/etcdctl --user u1:p put /dir/key val
OK

/cc @glycerine 