### PR TITLE
rafthttp: fix TestPipelineExceedMaximumServing

### DIFF
--- a/rafthttp/pipeline_test.go
+++ b/rafthttp/pipeline_test.go
@@ -67,9 +67,9 @@ func TestPipelineKeepSendingWhenPostError(t *testing.T) {
 }
 
 func TestPipelineExceedMaximumServing(t *testing.T) {
-	tr := newRoundTripperBlocker()
+	rt := newRoundTripperBlocker()
 	picker := mustNewURLPicker(t, []string{"http://localhost:2380"})
-	tp := &Transport{pipelineRt: tr}
+	tp := &Transport{pipelineRt: rt}
 	p := startTestPipeline(tp, picker)
 	defer p.stop()
 
@@ -91,12 +91,12 @@ func TestPipelineExceedMaximumServing(t *testing.T) {
 	}
 
 	// unblock the senders and force them to send out the data
-	tr.unblock()
+	rt.unblock()
 
 	// It could send new data after previous ones succeed
 	select {
 	case p.msgc <- raftpb.Message{}:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Errorf("failed to send out message")
 	}
 }


### PR DESCRIPTION
Fix #6398 

The timeout is too short. It might take more than 10ms to send
request over a blocking chan (buffer is full). Changing the timeout
to 1 second can fix this issue.

/cc @heyitsanthony 

There is no race. The only problem is the short timeout.