### PR TITLE
etcdctl: improve printing of role get for prefix permission

### DIFF
--- a/clientv3/auth.go
+++ b/clientv3/auth.go
@@ -43,6 +43,7 @@ type (
 	AuthRoleListResponse             pb.AuthRoleListResponse
 
 	PermissionType authpb.Permission_Type
+	Permission     authpb.Permission
 )
 
 const (


### PR DESCRIPTION

This commit improves printing of role get command for prefix
permission. If a range permission corresponds to a prefix permission,
it is explicitly printed for a user. Below is an example of the new
printing:

$ ETCDCTL_API=3 bin/etcdctl --user root:p role get r1
Role r1
KV Read:
        [/dir/, /dir0) (prefix /dir/)
        [k1, k5)
KV Write:
        [/dir/, /dir0) (prefix /dir/)
        [k1, k5)