### PR TITLE
Support for "charset" in the header "Conntent-type"

### DIFF
--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -761,6 +761,9 @@ func trimErrorPrefix(err error, prefix string) error {
 
 func unmarshalRequest(r *http.Request, req json.Unmarshaler, w http.ResponseWriter) bool {
 	ctype := r.Header.Get("Content-Type")
+	if strings.Contains(ctype, ";") {
+		ctype = strings.Split(ctype, ";")[0]
+	}
 	if ctype != "application/json" {
 		writeError(w, r, httptypes.NewHTTPError(http.StatusUnsupportedMediaType, fmt.Sprintf("Bad Content-Type %s, accept application/json", ctype)))
 		return false

--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -761,9 +761,6 @@ func trimErrorPrefix(err error, prefix string) error {
 
 func unmarshalRequest(r *http.Request, req json.Unmarshaler, w http.ResponseWriter) bool {
 	ctype := r.Header.Get("Content-Type")
-	if strings.Contains(ctype, ";") {
-		ctype = strings.Split(ctype, ";")[0]
-	}
 	if ctype != "application/json" {
 		writeError(w, r, httptypes.NewHTTPError(http.StatusUnsupportedMediaType, fmt.Sprintf("Bad Content-Type %s, accept application/json", ctype)))
 		return false


### PR DESCRIPTION
Implemented changes required to fix issue 6433 where the API would return an error message if the "Content-type" header add extra fields in it other than just the content type