### PR TITLE
etcdserver, api, v2http, client: Added support for semicolons

### DIFF
--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -761,6 +761,10 @@ func trimErrorPrefix(err error, prefix string) error {
 
 func unmarshalRequest(r *http.Request, req json.Unmarshaler, w http.ResponseWriter) bool {
 	ctype := r.Header.Get("Content-Type")
+	semicolonPosition := strings.Index(ctype, ";")
+	if semicolonPosition != -1 {
+		ctype = strings.TrimSpace(strings.ToLower(ctype[0:semicolonPosition]))
+	}
 	if ctype != "application/json" {
 		writeError(w, r, httptypes.NewHTTPError(http.StatusUnsupportedMediaType, fmt.Sprintf("Bad Content-Type %s, accept application/json", ctype)))
 		return false


### PR DESCRIPTION
Added support into the v2 API to fix an issue (6433) where if there is a semicolon and fields after it the API would return an "invalid Content-type" message even if the content type was actually correct