### PR TITLE
e2e: rename 'backends' to 'processes'

### DIFF
--- a/e2e/ctl_v2_test.go
+++ b/e2e/ctl_v2_test.go
@@ -316,9 +316,9 @@ func etcdctlPrefixArgs(clus *etcdProcessCluster) []string {
 	endpoints := ""
 	if proxies := clus.proxies(); len(proxies) != 0 {
 		endpoints = proxies[0].cfg.acurl
-	} else if backends := clus.backends(); len(backends) != 0 {
+	} else if processes := clus.processes(); len(processes) != 0 {
 		es := []string{}
-		for _, b := range backends {
+		for _, b := range processes {
 			es = append(es, b.cfg.acurl)
 		}
 		endpoints = strings.Join(es, ",")

--- a/e2e/ctl_v3_snapshot_test.go
+++ b/e2e/ctl_v3_snapshot_test.go
@@ -167,7 +167,7 @@ func TestIssue6361(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = epc.backends()[0].Stop(); err != nil {
+	if err = epc.processes()[0].Stop(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -187,7 +187,7 @@ func TestIssue6361(t *testing.T) {
 			epc.procs[0].cfg.args[i+1] = newDataDir
 		}
 	}
-	if err = epc.backends()[0].Restart(); err != nil {
+	if err = epc.processes()[0].Restart(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/e2e/etcd_test.go
+++ b/e2e/etcd_test.go
@@ -528,13 +528,13 @@ func (epc *etcdProcessCluster) proxies() []*etcdProcess {
 	return epc.procs[epc.cfg.clusterSize:]
 }
 
-func (epc *etcdProcessCluster) backends() []*etcdProcess {
+func (epc *etcdProcessCluster) processes() []*etcdProcess {
 	return epc.procs[:epc.cfg.clusterSize]
 }
 
 func (epc *etcdProcessCluster) endpoints() []string {
 	eps := make([]string, epc.cfg.clusterSize)
-	for i, ep := range epc.backends() {
+	for i, ep := range epc.processes() {
 		eps[i] = ep.cfg.acurl
 	}
 	return eps
@@ -542,7 +542,7 @@ func (epc *etcdProcessCluster) endpoints() []string {
 
 func (epc *etcdProcessCluster) grpcEndpoints() []string {
 	eps := make([]string, epc.cfg.clusterSize)
-	for i, ep := range epc.backends() {
+	for i, ep := range epc.processes() {
 		eps[i] = ep.cfg.acurlHost
 	}
 	return eps


### PR DESCRIPTION
Address https://github.com/coreos/etcd/pull/6428#r78876569.