### PR TITLE
Obey the usual rules of SSL server name verification when using a private PKI

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"math/big"
 	"net"
 	"os"
@@ -235,9 +234,6 @@ func (info TLSInfo) ClientConfig() (*tls.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		// if given a CA, trust any host with a cert signed by the CA
-		log.Println("warning: ignoring ServerName for user-provided CA for backwards compatibility is deprecated")
-		cfg.ServerName = ""
 	}
 
 	if info.selfCert {


### PR DESCRIPTION
This line does not do what it thinks it does. If it did do what it thinks it does, then it would be insecure. As it is, it's pretty damn insecure. Actually it's all pretty insecure.

The intended behaviour would not verify the server name when a private PKI is being used. Actually, that's not true, it would not verify any PKI, private or not, if the root certs are being explicitly provided. This means that the TLS does not protect against MITMs if you have any certificate from the PKI (basically removing the P from PKI and making it a rather clumsy shared secret).

The current behaviour of setting ServerName to an empty string causes the ssl to be verified against the Host passed to the transport (as far as I can tell). This is exactly what #6084 is meant to solve. But this breaks it. Here's etcdctl connecting to a cluster where the certs are signed with the SRV domain record, but not the individual records:

```
▶ etcdctl -D etcd-test.XX.com --key-file ./etcd-test-key.pem --cert-file ./etcd.pem -ca-file ./ca.pem  ls /
Error:  client: etcd cluster is unavailable or misconfigured; error #0: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-0.stg.eu.YY.com.
; error #1: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-4.stg.eu.YY.com.
; error #2: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-2.stg.eu.YY.com.
; error #3: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-3.stg.eu.YY.com.
; error #4: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-1.stg.eu.YY.com.

error #0: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-0.stg.eu.YY.com.
error #1: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-4.stg.eu.YY.com.
error #2: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-2.stg.eu.YY.com.
error #3: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-3.stg.eu.YY.com.
error #4: x509: certificate is valid for etcd-staging.XX.com, etcd-test.XX.com, not etcd-1.stg.eu.YY.com.
```

Where there is a SRV record `etcd-test.XX.com` pointing to `etcd-[0-4].stg.eu.YY.com`
