### PR TITLE
rafthttp: add v3.x to supported streams

### DIFF
--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -49,6 +49,8 @@ var (
 		"2.1.0": {streamTypeMsgAppV2, streamTypeMessage},
 		"2.2.0": {streamTypeMsgAppV2, streamTypeMessage},
 		"2.3.0": {streamTypeMsgAppV2, streamTypeMessage},
+		"3.0.0": {streamTypeMsgAppV2, streamTypeMessage},
+		"3.1.0": {streamTypeMsgAppV2, streamTypeMessage},
 	}
 )
 


### PR DESCRIPTION
Fix `TestReleaseUpgrade*`.

It was hanging in https://github.com/coreos/etcd/blob/master/rafthttp/stream.go#L445-L446.

We now found this because we have had `3.0.0` in master branch, which is always less than `3.0.x` of recent releases.
