### PR TITLE
wal/wal.go: optimized WAL.SaveSnapshot to do Marshal outside the mutex lock

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -567,10 +567,11 @@ func (w *WAL) Save(st raftpb.HardState, ents []raftpb.Entry) error {
 }
 
 func (w *WAL) SaveSnapshot(e walpb.Snapshot) error {
+	b := pbutil.MustMarshal(&e)
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	b := pbutil.MustMarshal(&e)
 	rec := &walpb.Record{Type: snapshotType, Data: b}
 	if err := w.encoder.encode(rec); err != nil {
 		return err


### PR DESCRIPTION
modified :
- wal/wal.go
  modified WAL.SaveSnapshot  to do the Marshal before aquiring the mutex
