### PR TITLE
version: bump to 3.1.0-alpha.0+git

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
-	Version           = "3.1.0-alpha.0"
+	Version           = "3.1.0-alpha.0+git"
 
 	// Git SHA Value will be set during build
 	GitSHA = "Not provided (use ./build instead of go build)"


### PR DESCRIPTION
to merge following 3.1.0-alpha.0 release
