### PR TITLE
embed: fix go 1.7 http issue

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -208,6 +208,9 @@ func (info TLSInfo) ServerConfig() (*tls.Config, error) {
 		cfg.ClientCAs = cp
 	}
 
+	// "h2" NextProtos is necessary for enabling HTTP2 for go's HTTP server
+	cfg.NextProtos = []string{"h2"}
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
go 1.7 introduces HTTP2 compatibility issue. Now we
need to explicitly enable HTTP2 when TLS is set.

Fix #6455. @gyuho