### PR TITLE
integration: l-read before Put in TestWatchReconnRequest

### DIFF
--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -211,6 +211,14 @@ func testWatchReconnRequest(t *testing.T, wctx *watchctx) {
 	stopc <- struct{}{}
 	<-donec
 
+	// spinning on dropping connections may trigger a leader election
+	// due to resource starvation; l-read to ensure the cluster is stable
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	if _, err := wctx.kv.Get(ctx, "_"); err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+
 	// ensure watcher works
 	putAndWatch(t, wctx, "a", "a")
 }


### PR DESCRIPTION
TestWatchReconnRequest occasionally triggers elections because it spins on
drop connections, eating up CPU. In case there's an election, submit an
l-read to wait for the cluster to settle down.

Fixes #6314

/cc @xiang90