### PR TITLE
etcdctlv3: updated options for TIMETOLIVE

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -328,9 +328,13 @@ LEASE REVOKE destroys a given lease, deleting all attached keys.
 ```
 
 
-### LEASE TIMETOLIVE \<leaseID\>
+### LEASE TIMETOLIVE \<leaseID\> [options]
 
 LEASE TIMETOLIVE retrieves the lease information with the given lease ID.
+
+#### Options
+
+- keys -- Get keys attached to this lease
 
 #### Return value
 

--- a/etcdctl/ctlv3/command/lease_command.go
+++ b/etcdctl/ctlv3/command/lease_command.go
@@ -103,7 +103,7 @@ var timeToLiveKeys bool
 // NewLeaseTimeToLiveCommand returns the cobra command for "lease timetolive".
 func NewLeaseTimeToLiveCommand() *cobra.Command {
 	lc := &cobra.Command{
-		Use:   "timetolive <leaseID>",
+		Use:   "timetolive <leaseID> [options]",
 		Short: "Get lease information",
 
 		Run: leaseTimeToLiveCommandFunc,


### PR DESCRIPTION
1. updated missing option section for timetolive which is present in the code to make the Readme.md uniform.
2. Updated the usage for help in lease_command.go 

