### PR TITLE
backend: Close the boltdb on exit

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -186,6 +186,7 @@ func (b *backend) Size() int64 {
 }
 
 func (b *backend) run() {
+	defer b.db.Close()
 	defer close(b.donec)
 	t := time.NewTimer(b.batchInterval)
 	defer t.Stop()


### PR DESCRIPTION
It seems like we need a 'defer b.db.Close()' in backend.run() so that the boltdb is closed properly when  backend.run() exits.
