### PR TITLE
wal/wal.go : improved coverage by testing WAL.Save which causes a WAL…

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -563,7 +563,6 @@ func (w *WAL) Save(st raftpb.HardState, ents []raftpb.Entry) error {
 		return nil
 	}
 
-	// TODO: add a test for this code path when refactoring the tests
 	return w.cut()
 }
 


### PR DESCRIPTION
completed the TODO:

wal/wal.go // TODO: add a test for this code path when refactoring the tests

files modified:
wal/wal.go : removed the TODO
wal/wal_test.go : added test case TestSaveWithCut

this solves the above TODO

Updated @xiang90 comments in the PR https://github.com/coreos/etcd/pull/6469
