### PR TITLE
functional-tester: decouple stresser from tester

### DIFF
--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -48,6 +48,7 @@ func main() {
 	schedCases := flag.String("schedule-cases", "", "test case schedule")
 	consistencyCheck := flag.Bool("consistency-check", true, "true to check consistency (revision, hash)")
 	isV2Only := flag.Bool("v2-only", false, "'true' to run V2 only tester.")
+	stresserType := flag.String("stresser", "default", "specify stresser (\"default\" or \"nop\").")
 	flag.Parse()
 
 	eps := strings.Split(*endpointStr, ",")
@@ -63,13 +64,18 @@ func main() {
 		agents[i].datadir = *datadir
 	}
 
+	sConfig := &stressConfig{
+		qps:            *stressQPS,
+		keyLargeSize:   int(*stressKeyLargeSize),
+		keySize:        int(*stressKeySize),
+		keySuffixRange: int(*stressKeySuffixRange),
+		v2:             *isV2Only,
+	}
+
 	c := &cluster{
-		agents:               agents,
-		v2Only:               *isV2Only,
-		stressQPS:            *stressQPS,
-		stressKeyLargeSize:   int(*stressKeyLargeSize),
-		stressKeySize:        int(*stressKeySize),
-		stressKeySuffixRange: int(*stressKeySuffixRange),
+		agents:        agents,
+		v2Only:        *isV2Only,
+		stressBuilder: newStressBuilder(*stresserType, sConfig),
 	}
 
 	if err := c.bootstrap(); err != nil {


### PR DESCRIPTION

This commit decouples stresser from the tester of
functional-tester. For doing it, this commit adds a new option
--stresser to etcd-tester. The option accepts two types of stresser:
"default" and "nop". If the option is "default", etcd-tester stresses
its etcd cluster with the existing stresser. If the option is "nop",
etcd-tester does nothing for stressing.

Partially fixes https://github.com/coreos/etcd/issues/6446

/cc @heyitsanthony 