### PR TITLE
test: grep versions with --sort

### DIFF
--- a/test
+++ b/test
@@ -90,7 +90,7 @@ function grpcproxy_pass {
 
 function release_pass {
 	# to grab latest patch release; bump this up for every minor release
-	UPGRADE_VER=$(git tag -l | grep v3.0 | tail -1)
+	UPGRADE_VER=$(git tag -l --sort=-version:refname "v3.0.*" | head -1)
 	if [ -n "$MANUAL_VER" ]; then
 		# in case, we need to test against different version
 		UPGRADE_VER=$MANUAL_VER


### PR DESCRIPTION
/cc @heyitsanthony @xiang90 

Otherwise, it only `grep`s `v3.0.9`