### PR TITLE
functional-tester: decoupling functionalities of etcd-tester

### DIFF
--- a/tools/functional-tester/etcd-tester/failure.go
+++ b/tools/functional-tester/etcd-tester/failure.go
@@ -172,3 +172,8 @@ func killMap(size int, seed int) map[int]bool {
 		}
 	}
 }
+
+type failureNop failureByFunc
+
+func (f *failureNop) Inject(c *cluster, round int) error  { return nil }
+func (f *failureNop) Recover(c *cluster, round int) error { return nil }

--- a/tools/functional-tester/etcd-tester/failure_agent.go
+++ b/tools/functional-tester/etcd-tester/failure_agent.go
@@ -139,3 +139,9 @@ func newFailureSlowNetworkAll() failure {
 		recoverMember: recoverLatency,
 	}
 }
+
+func newFailureNop() failure {
+	return &failureNop{
+		description: "no failure",
+	}
+}


### PR DESCRIPTION
This PR decouples the functionalities of etcd-tester.

- The first commit adds a new flag for turning on/off of failures.
- The second commit adds a new flag for keeping etcd cluster alive after testing.
- The third commit adds a new command etcd-checker for independent consistency checking.

/cc @heyitsanthony @gyuho 