### PR TITLE
compactor/compactor.go : corrected the capnslog package name

### DIFF
--- a/compactor/compactor.go
+++ b/compactor/compactor.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "etcdserver")
+	plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "compactor")
 )
 
 const (


### PR DESCRIPTION
corrected the package name in the logger

from :  "github.com/coreos/etcd", "etcdserver"
to : "github.com/coreos/etcd", "compactor"