### PR TITLE
build: support building out of path when GOPATH is not set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,6 @@ script:
         ;;
       *)
         # test building out of gopath
-        GO_BUILD_FLAGS="-a -v" GOPATH=/bad-go-path GOARCH="${TARGET}" ./build
+        GO_BUILD_FLAGS="-a -v" GOPATH="" GOARCH="${TARGET}" ./build
         ;;
     esac

--- a/build
+++ b/build
@@ -40,7 +40,10 @@ etcd_setup_gopath() {
 	cd "$CDIR"
 	etcdGOPATH=${CDIR}/gopath
 	# preserve old gopath to support building with unvendored tooling deps (e.g., gofail)
-	export GOPATH=${etcdGOPATH}:$GOPATH
+	if [ -n "$GOPATH" ]; then
+		GOPATH=":$GOPATH"
+	fi
+	export GOPATH=${etcdGOPATH}$GOPATH
 	rm -f ${etcdGOPATH}/src
 	mkdir -p ${etcdGOPATH}
 	ln -s ${CDIR}/cmd/vendor ${etcdGOPATH}/src


### PR DESCRIPTION
Otherwise gets "go: GOPATH entry is relative; must be absolute path: ""."