### PR TITLE
etcdserver: fix a node panic bug caused LeaseTimeToLive call on a nonexistent lease

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -308,17 +308,15 @@ func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveR
 		return nil, err
 	}
 
-	var lresp *pb.LeaseTimeToLiveResponse
 	for _, url := range leader.PeerURLs {
 		lurl := url + leasehttp.LeaseInternalPrefix
 		var iresp *leasepb.LeaseInternalResponse
 		iresp, err = leasehttp.TimeToLiveHTTP(ctx, lease.LeaseID(r.ID), r.Keys, lurl, s.peerRt)
 		if err == nil {
-			lresp = iresp.LeaseTimeToLiveResponse
-			break
+			return iresp.LeaseTimeToLiveResponse, nil
 		}
 	}
-	return lresp, nil
+	return nil, err
 }
 
 func (s *EtcdServer) waitLeader() (*membership.Member, error) {


### PR DESCRIPTION


When the non Leader etcd server receives a LeaseTimeToLive on a nonexistent lease, it responds with a nil resp and a nil error The invoking function parses the nil resp and results a segmentation fault.
I fix the bug by making sure the lease not found error is returned so that the invoking function parses the the error message instead.

fix #6537