### PR TITLE
clientv3: clarify scheme needs to be stripped

### DIFF
--- a/clientv3/config.go
+++ b/clientv3/config.go
@@ -25,7 +25,8 @@ import (
 )
 
 type Config struct {
-	// Endpoints is a list of URLs
+	// Endpoints is a list of URLs.
+	// Make sure to strip scheme:// prefixes since grpc dials by host.
 	Endpoints []string
 
 	// AutoSyncInterval is the interval to update endpoints with its latest members.


### PR DESCRIPTION
We already strip schemas for balancer.
For the initial endpoint, we should do the same thing.