### PR TITLE
embed: add 'Config' method

### DIFF
--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -135,6 +135,11 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 	return
 }
 
+// Config returns the current configuration.
+func (e *Etcd) Config() Config {
+	return e.cfg
+}
+
 func (e *Etcd) Close() {
 	for _, sctx := range e.sctxs {
 		sctx.cancel()


### PR DESCRIPTION
Currently we are only passing values of `embed.Config`. So function call results of `transport.SelfCert` on the `TLSInfo` only stays inside `embed` package. To use auto client TLS from embedded etcd server, one needs to manually `TLSInfo` struct to create client.

With this method, we can simplify as below:

```go
nc := c.GetConfig()
cfg = &nc // overwrite the embed.Config

tlsConfig, err := cfg.ClientTLSInfo.ClientConfig()

cli, err := clientv3.New(clientv3.Config{
	Endpoints:   []string{cfg.LCUrls[0].Host},
	TLS:         tlsConfig,
})
```

/cc @xiang90 @heyitsanthony 

