### PR TITLE
docs: link directly to github procfile

### DIFF
--- a/Documentation/v2/proxy.md
+++ b/Documentation/v2/proxy.md
@@ -149,5 +149,5 @@ If an error occurs, check the [add member troubleshooting doc][runtime-configura
 
 [discovery-service]: clustering.md#discovery
 [goreman]: https://github.com/mattn/goreman
-[procfile]: /Procfile
+[procfile]: https://github.com/coreos/etcd/blob/master/Procfile
 [runtime-configuration]: runtime-configuration.md#error-cases-when-adding-members


### PR DESCRIPTION
This is in response to https://github.com/coreos/docs/issues/822
Unfortunately because of how the doc sync works there has to be
a direct link here.