### PR TITLE
etcdctlv2: windows compatibility issue fix for etcd v3.0.1

### DIFF
--- a/etcdctl/ctlv2/ctl.go
+++ b/etcdctl/ctlv2/ctl.go
@@ -47,7 +47,7 @@ func Start() {
 		cli.StringFlag{Name: "key-file", Value: "", Usage: "identify HTTPS client using this SSL key file"},
 		cli.StringFlag{Name: "ca-file", Value: "", Usage: "verify certificates of HTTPS-enabled servers using this CA bundle"},
 		cli.StringFlag{Name: "username, u", Value: "", Usage: "provide username[:password] and prompt if password is not supplied."},
-		cli.DurationFlag{Name: "timeout", Value: time.Second, Usage: "connection timeout per request"},
+		cli.DurationFlag{Name: "timeout", Value: 2 * time.Second, Usage: "connection timeout per request"},
 		cli.DurationFlag{Name: "total-timeout", Value: 5 * time.Second, Usage: "timeout for the command execution (except watch)"},
 	}
 	app.Commands = []cli.Command{


### PR DESCRIPTION
This fixes the issue of failing of etcdctl v2 commands when the commands are executed without the endpoint flag specified.

#5882

@xiang90 Regarding logging issue with wrong url: It exists at a lot of places, need to analyze more to find ideal solution to it, so that it can be done in an optimum manner. Will analyze that in detail and once fixed will raise in next PR.

