### PR TITLE
clientv3: fix race on watch initial revision

### DIFF
--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -573,7 +573,6 @@ func (w *watchGrpcStream) serveSubstream(ws *watcherStream, resumec chan struct{
 		if !resuming {
 			ws.closing = true
 		}
-		ws.initReq.rev = nextRev
 		close(ws.donec)
 		if !resuming {
 			w.closingc <- ws
@@ -619,6 +618,7 @@ func (w *watchGrpcStream) serveSubstream(ws *watcherStream, resumec chan struct{
 			if len(wr.Events) > 0 {
 				nextRev = wr.Events[len(wr.Events)-1].Kv.ModRevision + 1
 			}
+			ws.initReq.rev = nextRev
 		case <-ws.initReq.ctx.Done():
 			return
 		case <-resumec:


### PR DESCRIPTION
The initial revision was being updated in the substream goroutine defer;
this was racing with the resume path fetching the initial revision when
the substream closes during resume. Instead, update the initial revision
whenever the substream processes a new watch response. Since the substream
cannot receive a watch response while it is resuming, the write to the
initial revision is ordered to always happen after the resume read.

Fixes #6586