### PR TITLE
lease: add TTL() method

### DIFF
--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -508,7 +508,7 @@ func (a *applierV3backend) LeaseGrant(lc *pb.LeaseGrantRequest) (*pb.LeaseGrantR
 	resp := &pb.LeaseGrantResponse{}
 	if err == nil {
 		resp.ID = int64(l.ID)
-		resp.TTL = l.TTL
+		resp.TTL = l.TTL()
 		resp.Header = &pb.ResponseHeader{Revision: a.s.KV().Rev()}
 	}
 

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -338,7 +338,7 @@ func (s *EtcdServer) LeaseTimeToLive(ctx context.Context, r *pb.LeaseTimeToLiveR
 			return nil, lease.ErrLeaseNotFound
 		}
 		// TODO: fill out ResponseHeader
-		resp := &pb.LeaseTimeToLiveResponse{Header: &pb.ResponseHeader{}, ID: r.ID, TTL: int64(le.Remaining().Seconds()), GrantedTTL: le.TTL}
+		resp := &pb.LeaseTimeToLiveResponse{Header: &pb.ResponseHeader{}, ID: r.ID, TTL: int64(le.Remaining().Seconds()), GrantedTTL: le.TTL()}
 		if r.Keys {
 			ks := le.Keys()
 			kbs := make([][]byte, len(ks))

--- a/lease/leasehttp/http.go
+++ b/lease/leasehttp/http.go
@@ -96,7 +96,7 @@ func (h *leaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Header:     &pb.ResponseHeader{},
 				ID:         lreq.LeaseTimeToLiveRequest.ID,
 				TTL:        int64(l.Remaining().Seconds()),
-				GrantedTTL: l.TTL,
+				GrantedTTL: l.TTL(),
 			},
 		}
 		if lreq.LeaseTimeToLiveRequest.Keys {

--- a/lease/lessor_test.go
+++ b/lease/lessor_test.go
@@ -140,13 +140,15 @@ func TestLessorRenew(t *testing.T) {
 	}
 
 	// manually change the ttl field
-	l.TTL = 10
+	le.mu.Lock()
+	l.ttl = 10
+	le.mu.Unlock()
 	ttl, err := le.Renew(l.ID)
 	if err != nil {
 		t.Fatalf("failed to renew lease (%v)", err)
 	}
-	if ttl != l.TTL {
-		t.Errorf("ttl = %d, want %d", ttl, l.TTL)
+	if ttl != l.ttl {
+		t.Errorf("ttl = %d, want %d", ttl, l.ttl)
 	}
 
 	l = le.Lookup(l.ID)
@@ -211,13 +213,13 @@ func TestLessorRecover(t *testing.T) {
 	// Create a new lessor with the same backend
 	nle := newLessor(be, minLeaseTTL)
 	nl1 := nle.Lookup(l1.ID)
-	if nl1 == nil || nl1.TTL != l1.TTL {
-		t.Errorf("nl1 = %v, want nl1.TTL= %d", nl1.TTL, l1.TTL)
+	if nl1 == nil || nl1.ttl != l1.ttl {
+		t.Errorf("nl1 = %v, want nl1.ttl= %d", nl1.ttl, l1.ttl)
 	}
 
 	nl2 := nle.Lookup(l2.ID)
-	if nl2 == nil || nl2.TTL != l2.TTL {
-		t.Errorf("nl2 = %v, want nl2.TTL= %d", nl2.TTL, l2.TTL)
+	if nl2 == nil || nl2.ttl != l2.ttl {
+		t.Errorf("nl2 = %v, want nl2.ttl= %d", nl2.ttl, l2.ttl)
 	}
 }
 


### PR DESCRIPTION
`Lease` is an exported type, so is TTL field. So anybody can modify `*lease.Lease`.

`lease` package internally has `refresh` method accessing this `TTL` field, so it can cause race conditions with external packages that use `*lease.Lease`.

Fix https://github.com/coreos/etcd/issues/6595.

/cc @xiang90 @heyitsanthony 