### PR TITLE
Lease: Add lease errors to togRPCError()

### DIFF
--- a/etcdserver/api/v3rpc/lease.go
+++ b/etcdserver/api/v3rpc/lease.go
@@ -18,7 +18,6 @@ import (
 	"io"
 
 	"github.com/coreos/etcd/etcdserver"
-	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/lease"
 	"golang.org/x/net/context"
@@ -35,20 +34,18 @@ func NewLeaseServer(s *etcdserver.EtcdServer) pb.LeaseServer {
 
 func (ls *LeaseServer) LeaseGrant(ctx context.Context, cr *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error) {
 	resp, err := ls.le.LeaseGrant(ctx, cr)
-	if err == lease.ErrLeaseExists {
-		return nil, rpctypes.ErrGRPCLeaseExist
-	}
+
 	if err != nil {
-		return nil, err
+		return nil, togRPCError(err)
 	}
 	ls.hdr.fill(resp.Header)
-	return resp, err
+	return resp, nil
 }
 
 func (ls *LeaseServer) LeaseRevoke(ctx context.Context, rr *pb.LeaseRevokeRequest) (*pb.LeaseRevokeResponse, error) {
 	resp, err := ls.le.LeaseRevoke(ctx, rr)
 	if err != nil {
-		return nil, rpctypes.ErrGRPCLeaseNotFound
+		return nil, togRPCError(err)
 	}
 	ls.hdr.fill(resp.Header)
 	return resp, nil
@@ -57,7 +54,7 @@ func (ls *LeaseServer) LeaseRevoke(ctx context.Context, rr *pb.LeaseRevokeReques
 func (ls *LeaseServer) LeaseTimeToLive(ctx context.Context, rr *pb.LeaseTimeToLiveRequest) (*pb.LeaseTimeToLiveResponse, error) {
 	resp, err := ls.le.LeaseTimeToLive(ctx, rr)
 	if err != nil {
-		return nil, rpctypes.ErrGRPCLeaseNotFound
+		return nil, togRPCError(err)
 	}
 	ls.hdr.fill(resp.Header)
 	return resp, nil

--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -60,6 +60,11 @@ func togRPCError(err error) error {
 	case etcdserver.ErrUnhealthy:
 		return rpctypes.ErrGRPCUnhealthy
 
+	case lease.ErrLeaseNotFound:
+		return rpctypes.ErrGRPCLeaseNotFound
+	case lease.ErrLeaseExists:
+		return rpctypes.ErrGRPCLeaseExist
+
 	case auth.ErrRootUserNotExist:
 		return rpctypes.ErrGRPCRootUserNotExist
 	case auth.ErrRootRoleNotExist:


### PR DESCRIPTION
This allows lease's function to convert lease error to appropriate GRPC errors