### PR TITLE
adt: fast path Stab in empty interval tree

### DIFF
--- a/pkg/adt/interval_tree.go
+++ b/pkg/adt/interval_tree.go
@@ -447,6 +447,9 @@ func (ivt *IntervalTree) Contains(iv Interval) bool {
 
 // Stab returns a slice with all elements in the tree intersecting the interval.
 func (ivt *IntervalTree) Stab(iv Interval) (ivs []*IntervalValue) {
+	if ivt.count == 0 {
+		return nil
+	}
 	f := func(n *IntervalValue) bool { ivs = append(ivs, n); return true }
 	ivt.Visit(iv, f)
 	return ivs


### PR DESCRIPTION
Check if there are any intervals in the tree before going slow path. This avoids extra calls/allocations in empty tree (if there are no range watches in etcd).
