### PR TITLE
mvcc: add BenchmarkWatchableStoreTxnPut benchmark

### DIFF
--- a/mvcc/watchable_store_bench_test.go
+++ b/mvcc/watchable_store_bench_test.go
@@ -34,8 +34,34 @@ func BenchmarkWatchableStorePut(b *testing.B) {
 	vals := createBytesSlice(bytesN, b.N)
 
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		s.Put(keys[i], vals[i], lease.NoLease)
+	}
+}
+
+// BenchmarkWatchableStoreTxnPut benchmarks the Put operation
+// with transaction begin and end, where transaction involves
+// some synchronization operations, such as mutex locking.
+func BenchmarkWatchableStoreTxnPut(b *testing.B) {
+	var i fakeConsistentIndex
+	be, tmpPath := backend.NewDefaultTmpBackend()
+	s := New(be, &lease.FakeLessor{}, &i)
+	defer cleanup(s, be, tmpPath)
+
+	// arbitrary number of bytes
+	bytesN := 64
+	keys := createBytesSlice(bytesN, b.N)
+	vals := createBytesSlice(bytesN, b.N)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		id := s.TxnBegin()
+		if _, err := s.TxnPut(id, keys[i], vals[i], lease.NoLease); err != nil {
+			plog.Fatalf("txn put error: %v", err)
+		}
+		s.TxnEnd(id)
 	}
 }
 


### PR DESCRIPTION
Add benchmark similar to `BenchmarkWatchableStorePut` but using `TxnBegin`/`TxnEnd`.