### PR TITLE
benchmark: submit keepalive requests concurrently with report.Run()

### DIFF
--- a/tools/benchmark/cmd/lease.go
+++ b/tools/benchmark/cmd/lease.go
@@ -68,10 +68,14 @@ func leaseKeepaliveFunc(cmd *cobra.Command, args []string) {
 		}(clients[i])
 	}
 
-	for i := 0; i < leaseKeepaliveTotal; i++ {
-		requests <- struct{}{}
-	}
-	close(requests)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < leaseKeepaliveTotal; i++ {
+			requests <- struct{}{}
+		}
+		close(requests)
+	}()
 
 	rc := r.Run()
 	wg.Wait()


### PR DESCRIPTION
Otherwise report won't consume the results and the benchmark hangs.