### PR TITLE
scripts: Don't erase gopath.proto after genproto.sh

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -76,8 +76,6 @@ protoc -I. \
     --swagger_out=logtostderr=true:./Documentation/dev-guide/apispec/swagger/. \
     ./etcdserver/etcdserverpb/rpc.proto
 
-rm -rf ${PWD}/gopath.proto
-
 # TODO: change this whenever we add more swagger API
 mv \
 	Documentation/dev-guide/apispec/swagger/etcdserver/etcdserverpb/rpc.swagger.json \
@@ -112,4 +110,3 @@ if [ "$1" = "-g" ]; then
 else
 	echo "skipping grpc API reference document auto-generation..."
 fi
-


### PR DESCRIPTION
Wiping gopath.proto after a successful run does nothing but slow down
the next run unnecessarily as it downloads everything again.