### PR TITLE
e2e: close process if spawnWithExpects fails

### DIFF
--- a/e2e/etcd_test.go
+++ b/e2e/etcd_test.go
@@ -510,6 +510,7 @@ func spawnWithExpects(args []string, xs ...string) error {
 		for {
 			l, err := proc.ExpectFunc(lineFunc)
 			if err != nil {
+				proc.Close()
 				return fmt.Errorf("%v (expected %q, got %q)", err, txt, lines)
 			}
 			lines = append(lines, l)


### PR DESCRIPTION
Was causing a process leak in TestCtlV3Alarm