### PR TITLE
Optimize updating key by storing lease in lessor

### DIFF
--- a/mvcc/kvstore_bench_test.go
+++ b/mvcc/kvstore_bench_test.go
@@ -45,6 +45,23 @@ func BenchmarkStorePut(b *testing.B) {
 	}
 }
 
+// BenchmarkStoreTxnPutUpdate is same as above, but instead updates single key
+func BenchmarkStorePutUpdate(b *testing.B) {
+	var i fakeConsistentIndex
+	be, tmpPath := backend.NewDefaultTmpBackend()
+	s := NewStore(be, &lease.FakeLessor{}, &i)
+	defer cleanup(s, be, tmpPath)
+
+	// arbitrary number of bytes
+	keys := createBytesSlice(64, 1)
+	vals := createBytesSlice(1024, 1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Put(keys[0], vals[0], lease.NoLease)
+	}
+}
+
 // BenchmarkStoreTxnPut benchmarks the Put operation
 // with transaction begin and end, where transaction involves
 // some synchronization operations, such as mutex locking.

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -144,7 +144,6 @@ func TestStorePut(t *testing.T) {
 
 		if tt.rr != nil {
 			wact = []testutil.Action{
-				{"range", []interface{}{keyBucketName, newTestKeyBytes(tt.r.rev, false), []byte(nil), int64(0)}},
 				{"seqput", []interface{}{keyBucketName, tt.wkey, data}},
 			}
 		}
@@ -306,7 +305,6 @@ func TestStoreDeleteRange(t *testing.T) {
 		}
 		wact := []testutil.Action{
 			{"seqput", []interface{}{keyBucketName, tt.wkey, data}},
-			{"range", []interface{}{keyBucketName, newTestKeyBytes(revision{2, 0}, false), []byte(nil), int64(0)}},
 		}
 		if g := b.tx.Action(); !reflect.DeepEqual(g, wact) {
 			t.Errorf("#%d: tx action = %+v, want %+v", i, g, wact)


### PR DESCRIPTION
This is a first attempt to avoid looking up `KeyValue` in storage and unmarshalling protobuf  mentioned in #6615. Also optimized `delete`, which had to do the same.
Here is somewhat strange `mvcc` package benchmark comparison (do not look at timings, run benchmarks on my laptop):
```
benchmark                                   old ns/op     new ns/op      delta
BenchmarkIndexRestore-4                     7795          7809           +0.18%
BenchmarkStorePut-4                         42041         42061          +0.05%
BenchmarkStorePutUpdate-4                   61554         42147          -31.53%
BenchmarkStoreTxnPut-4                      43972         44419          +1.02%
BenchmarkWatchableStorePut-4                42125         41386          -1.75%
BenchmarkWatchableStoreTxnPut-4             49307         53009          +7.51%
BenchmarkWatchableStoreWatchSyncPut-4       7520          7376           -1.91%
BenchmarkWatchableStoreUnsyncedCancel-4     908           1792           +97.36%
BenchmarkWatchableStoreSyncedCancel-4       0.82          1187249426     +144786515265.85%
BenchmarkKVWatcherMemoryUsage-4             24495         23046          -5.92%

benchmark                                   old allocs     new allocs     delta
BenchmarkIndexRestore-4                     3              3              +0.00%
BenchmarkStorePut-4                         12             12             +0.00%
BenchmarkStorePutUpdate-4                   18             12             -33.33%
BenchmarkStoreTxnPut-4                      12             12             +0.00%
BenchmarkWatchableStorePut-4                11             11             +0.00%
BenchmarkWatchableStoreTxnPut-4             14             14             +0.00%
BenchmarkWatchableStoreWatchSyncPut-4       2              2              +0.00%
BenchmarkWatchableStoreUnsyncedCancel-4     0              0              +0.00%
BenchmarkWatchableStoreSyncedCancel-4       0              37             +Inf%
BenchmarkKVWatcherMemoryUsage-4             9              9              +0.00%

benchmark                                   old bytes     new bytes     delta
BenchmarkIndexRestore-4                     178           178           +0.00%
BenchmarkStorePut-4                         1541          1524          -1.10%
BenchmarkStorePutUpdate-4                   5148          3752          -27.12%
BenchmarkStoreTxnPut-4                      1545          1557          +0.78%
BenchmarkWatchableStorePut-4                1289          1262          -2.09%
BenchmarkWatchableStoreTxnPut-4             1333          1307          -1.95%
BenchmarkWatchableStoreWatchSyncPut-4       207           203           -1.93%
BenchmarkWatchableStoreUnsyncedCancel-4     0             0             +0.00%
BenchmarkWatchableStoreSyncedCancel-4       0             2352          +Inf%
BenchmarkKVWatcherMemoryUsage-4             547           545           -0.37%

```
Not quite sure why `BenchmarkWatchableStoreSyncedCancel` brings such results.