### PR TITLE
etcdserver: make WaitGroup.Add sync with Wait

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -939,8 +939,8 @@ func TestTriggerSnap(t *testing.T) {
 		srv.Do(context.Background(), pb.Request{Method: "PUT"})
 	}
 
-	srv.Stop()
 	<-donec
+	srv.Stop()
 }
 
 // TestConcurrentApplyAndSnapshotV3 will send out snapshots concurrently with


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6534.

After stopping the cluster, I think it's ok to drop other remaining goroutines

i.e., we might drop goroutines here https://github.com/coreos/etcd/blob/master/etcdserver/server.go#L1503-L1510 when it misses to receive from `<-s.stopping`

/cc @xiang90 @heyitsanthony 

Any feedback?
