### PR TITLE
clientv3: drop Config.Logger field

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -18,8 +18,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"net"
 	"net/url"
 	"strings"
@@ -317,12 +315,6 @@ func newClient(cfg *Config) (*Client, error) {
 	client.Watcher = NewWatcher(client)
 	client.Auth = NewAuth(client)
 	client.Maintenance = NewMaintenance(client)
-	if cfg.Logger != nil {
-		logger.Set(cfg.Logger)
-	} else {
-		// disable client side grpc by default
-		logger.Set(log.New(ioutil.Discard, "", 0))
-	}
 
 	go client.autoSync()
 	return client, nil

--- a/clientv3/config.go
+++ b/clientv3/config.go
@@ -38,9 +38,6 @@ type Config struct {
 	// TLS holds the client secure credentials, if any.
 	TLS *tls.Config
 
-	// Logger is the logger used by client library.
-	Logger Logger
-
 	// Username is a username for authentication
 	Username string
 

--- a/clientv3/example_test.go
+++ b/clientv3/example_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
+	"github.com/coreos/pkg/capnslog"
 	"golang.org/x/net/context"
 )
 
@@ -30,6 +31,9 @@ var (
 )
 
 func Example() {
+	var plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "clientv3")
+	clientv3.SetLogger(plog)
+
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:   endpoints,
 		DialTimeout: dialTimeout,


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6603.

Instead adds 'SetLogger' to set global logger interface
to avoid unnecessary logger updates.

/cc @heyitsanthony @xiang90 @chzyer 