### PR TITLE
build: Windows build cleanup

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,9 +1,14 @@
 $ORG_PATH="github.com/coreos"
 $REPO_PATH="$ORG_PATH/etcd"
 $PWD = $((Get-Item -Path ".\" -Verbose).FullName)
+$FSROOT = $((Get-Location).Drive.Name+":")
+$FSYS = $((Get-WMIObject win32_logicaldisk -filter "DeviceID = '$FSROOT'").filesystem)
 $GO_LDFLAGS="-s"
 
-echo "Building etcd"
+if ($FSYS.StartsWith("FAT","CurrentCultureIgnoreCase")) {
+	echo "Error: Cannot build etcd using the $FSYS filesystem (use NTFS instead)"
+	exit 1
+}
 
 # Set $Env:GO_LDFLAGS=" "(space) for building with all symbols for debugging.
 if ($Env:GO_LDFLAGS.length -gt 0) {
@@ -12,10 +17,7 @@ if ($Env:GO_LDFLAGS.length -gt 0) {
 $GO_LDFLAGS="$GO_LDFLAGS -X $REPO_PATH/cmd/vendor/$REPO_PATH/version.GitSHA=$GIT_SHA"
 
 # rebuild symlinks
-echo ""
-echo "Re-creating symlinks"
 git ls-files -s cmd | select-string -pattern 120000 | ForEach {
-	echo ""	
 	$l = $_.ToString()
 	$lnkname = $l.Split('	')[1]
 	$target = "$(git log -p HEAD -- $lnkname | select -last 2 | select -first 1)"
@@ -32,75 +34,52 @@ git ls-files -s cmd | select-string -pattern 120000 | ForEach {
 		if (Test-Path "$lnkname") {
 			if ((Get-Item "$lnkname") -is [System.IO.DirectoryInfo]) {
 				# rd so deleting junction doesn't take files with it
-				echo  "rd `"$lnkname`""
 				cmd /c rd  "$lnkname"
 			}
 		}
 		if (Test-Path "$lnkname") {
 			if (!((Get-Item "$lnkname") -is [System.IO.DirectoryInfo])) {
-				echo  "del /A /F `"$lnkname`""
 				cmd /c del /A /F  "$lnkname"
 			}
 		}
-		echo  "mklink /J `"$lnkname`" `"$targetAbs`""
-		cmd /c mklink /J  "$lnkname"   "$targetAbs"
+		cmd /c mklink /J  "$lnkname"   "$targetAbs"  ">NUL"
 	} else {
 		# Remove file with symlink data (first run)
 		if (Test-Path "$lnkname") {
-			echo  "del /A /F `"$lnkname`""
 			cmd /c del /A /F  "$lnkname"
 		}
-		echo  "mklink /H `"$lnkname`" `"$targetAbs`""
-		cmd /c mklink /H  "$lnkname"   "$targetAbs"
+		cmd /c mklink /H  "$lnkname"   "$targetAbs"  ">NUL"
 	}
 }
 
 if (-not $env:GOPATH) {
-	echo ""
-	echo "Setting up GOPATH"
 	$orgpath="$PWD\gopath\src\" + $ORG_PATH.Replace("/", "\")
-	echo ""
-	echo "Remove and create junction to $orgpath\etcd"
 	if (Test-Path "$orgpath\etcd") {
 		if ((Get-Item "$orgpath\etcd") -is [System.IO.DirectoryInfo]) {
 			# rd so deleting junction doesn't take files with it
-			echo  "rd `"$orgpath\etcd`""
 			cmd /c rd  "$orgpath\etcd"
 		}
 	}
 	if (Test-Path "$orgpath") {
 		if ((Get-Item "$orgpath") -is [System.IO.DirectoryInfo]) {
 			# rd so deleting junction doesn't take files with it
-			echo  "rd `"$orgpath`""
 			cmd /c rd  "$orgpath"
 		}
 	}
 	if (Test-Path "$orgpath") {
 		if (!((Get-Item "$orgpath") -is [System.IO.DirectoryInfo])) {
 			# Remove file with symlink data (first run)
-			echo  "del /A /F `"$orgpath`""
 			cmd /c del /A /F  "$orgpath"
 		}
 	}
-	echo  "mkdir `"$orgpath`""
 	cmd /c mkdir  "$orgpath"
-	echo  "mklink /J `"$orgpath\etcd`" `"$PWD`""
-	cmd /c mklink /J  "$orgpath\etcd"   "$PWD"
+	cmd /c mklink /J  "$orgpath\etcd"   "$PWD"  ">NUL"
 	$env:GOPATH = "$PWD\gopath"
 }
 
-echo ""
-echo "GOPATH = $env:GOPATH"
-
 # Static compilation is useful when etcd is run in a container
-echo ""
-echo "Building statically linked artifacts"
 $env:CGO_ENABLED = 0
 $env:GO15VENDOREXPERIMENT = 1
 $GIT_SHA="$(git rev-parse --short HEAD)"
 go build -a -installsuffix cgo -ldflags $GO_LDFLAGS -o bin\etcd.exe "$REPO_PATH\cmd\etcd"
 go build -a -installsuffix cgo -ldflags $GO_LDFLAGS -o bin\etcdctl.exe "$REPO_PATH\cmd\etcdctl"
-
-echo ""
-echo "Build complete"
-echo "Build artifacts available at `"$PWD\bin`""

--- a/build.ps1
+++ b/build.ps1
@@ -3,6 +3,8 @@ $REPO_PATH="$ORG_PATH/etcd"
 $PWD = $((Get-Item -Path ".\" -Verbose).FullName)
 $GO_LDFLAGS="-s"
 
+echo "Building etcd"
+
 # Set $Env:GO_LDFLAGS=" "(space) for building with all symbols for debugging.
 if ($Env:GO_LDFLAGS.length -gt 0) {
 	$GO_LDFLAGS=$Env:GO_LDFLAGS
@@ -10,8 +12,10 @@ if ($Env:GO_LDFLAGS.length -gt 0) {
 $GO_LDFLAGS="$GO_LDFLAGS -X $REPO_PATH/cmd/vendor/$REPO_PATH/version.GitSHA=$GIT_SHA"
 
 # rebuild symlinks
-echo "Rebuilding symlinks"
+echo ""
+echo "Re-creating symlinks"
 git ls-files -s cmd | select-string -pattern 120000 | ForEach {
+	echo ""	
 	$l = $_.ToString()
 	$lnkname = $l.Split('	')[1]
 	$target = "$(git log -p HEAD -- $lnkname | select -last 2 | select -first 1)"
@@ -20,33 +24,83 @@ git ls-files -s cmd | select-string -pattern 120000 | ForEach {
 
 	$terms = $lnkname.Split("\")
 	$dirname = $terms[0..($terms.length-2)] -join "\"
-	
 	$lnkname = "$PWD\$lnkname"
 	$targetAbs = "$((Get-Item -Path "$dirname\$target").FullName)"
 	$targetAbs = $targetAbs.Replace("/", "\")
+
 	if (test-path -pathtype container "$targetAbs") {
-		# rd so deleting junction doesn't take files with it
-		cmd /c rd "$lnkname"
-		cmd /c del /A /F "$lnkname"
-		cmd /c mklink /J "$lnkname" "$targetAbs"
+		if (Test-Path "$lnkname") {
+			if ((Get-Item "$lnkname") -is [System.IO.DirectoryInfo]) {
+				# rd so deleting junction doesn't take files with it
+				echo  "rd `"$lnkname`""
+				cmd /c rd  "$lnkname"
+			}
+		}
+		if (Test-Path "$lnkname") {
+			if (!((Get-Item "$lnkname") -is [System.IO.DirectoryInfo])) {
+				echo  "del /A /F `"$lnkname`""
+				cmd /c del /A /F  "$lnkname"
+			}
+		}
+		echo  "mklink /J `"$lnkname`" `"$targetAbs`""
+		cmd /c mklink /J  "$lnkname"   "$targetAbs"
 	} else {
-		cmd /c del /A /F "$lnkname"
-		cmd /c mklink /H "$lnkname" "$targetAbs"
+		# Remove file with symlink data (first run)
+		if (Test-Path "$lnkname") {
+			echo  "del /A /F `"$lnkname`""
+			cmd /c del /A /F  "$lnkname"
+		}
+		echo  "mklink /H `"$lnkname`" `"$targetAbs`""
+		cmd /c mklink /H  "$lnkname"   "$targetAbs"
 	}
 }
 
 if (-not $env:GOPATH) {
+	echo ""
+	echo "Setting up GOPATH"
 	$orgpath="$PWD\gopath\src\" + $ORG_PATH.Replace("/", "\")
-	cmd /c rd "$orgpath\etcd"
-	cmd /c del "$orgpath"
-	cmd /c mkdir "$orgpath"
-	cmd /c mklink /J "$orgpath\etcd" "$PWD"
+	echo ""
+	echo "Remove and create junction to $orgpath\etcd"
+	if (Test-Path "$orgpath\etcd") {
+		if ((Get-Item "$orgpath\etcd") -is [System.IO.DirectoryInfo]) {
+			# rd so deleting junction doesn't take files with it
+			echo  "rd `"$orgpath\etcd`""
+			cmd /c rd  "$orgpath\etcd"
+		}
+	}
+	if (Test-Path "$orgpath") {
+		if ((Get-Item "$orgpath") -is [System.IO.DirectoryInfo]) {
+			# rd so deleting junction doesn't take files with it
+			echo  "rd `"$orgpath`""
+			cmd /c rd  "$orgpath"
+		}
+	}
+	if (Test-Path "$orgpath") {
+		if (!((Get-Item "$orgpath") -is [System.IO.DirectoryInfo])) {
+			# Remove file with symlink data (first run)
+			echo  "del /A /F `"$orgpath`""
+			cmd /c del /A /F  "$orgpath"
+		}
+	}
+	echo  "mkdir `"$orgpath`""
+	cmd /c mkdir  "$orgpath"
+	echo  "mklink /J `"$orgpath\etcd`" `"$PWD`""
+	cmd /c mklink /J  "$orgpath\etcd"   "$PWD"
 	$env:GOPATH = "$PWD\gopath"
 }
 
+echo ""
+echo "GOPATH = $env:GOPATH"
+
 # Static compilation is useful when etcd is run in a container
+echo ""
+echo "Building statically linked artifacts"
 $env:CGO_ENABLED = 0
 $env:GO15VENDOREXPERIMENT = 1
 $GIT_SHA="$(git rev-parse --short HEAD)"
 go build -a -installsuffix cgo -ldflags $GO_LDFLAGS -o bin\etcd.exe "$REPO_PATH\cmd\etcd"
 go build -a -installsuffix cgo -ldflags $GO_LDFLAGS -o bin\etcdctl.exe "$REPO_PATH\cmd\etcdctl"
+
+echo ""
+echo "Build complete"
+echo "Build artifacts available at `"$PWD\bin`""


### PR DESCRIPTION
Remove spurious warnings and prompts; make output more informative

Fixes #5866