### PR TITLE
acbuild: add symlinks to /usr/local/bin/etcd*

### DIFF
--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -43,23 +43,31 @@ DF
 
 acbuild --debug set-name coreos.com/etcd
 
-acbuild --debug copy --to-dir $BINARYDIR/etcd $BINARYDIR/etcdctl /
-acbuild --debug copy README.md /README.md
-acbuild --debug copy etcdctl/README.md /README-etcdctl.md
-acbuild --debug copy etcdctl/READMEv2.md /READMEv2-etcdctl.md
-acbuild --debug copy --to-dir Documentation /
+acbuild --debug copy $BINARYDIR/etcd /usr/local/bin/etcd
+acbuild --debug copy $BINARYDIR/etcdctl /usr/local/bin/etcdctl
 
-acbuild --debug environment add ETCD_DATA_DIR /data-dir
+acbuild --debug copy README.md README.md
+acbuild --debug copy etcdctl/README.md README-etcdctl.md
+acbuild --debug copy etcdctl/READMEv2.md READMEv2-etcdctl.md
+acbuild --debug copy-to-dir Documentation .
+
+acbuild --debug environment add ETCD_DATA_DIR /var/lib/etcd
+acbuild --debug mount add data-dir /var/lib/etcd
 
 acbuild --debug label add version "$VERSION"
 
-acbuild --debug set-exec -- /etcd
-
-acbuild --debug mount add data-dir /data-dir
+acbuild --debug set-exec -- /usr/local/bin/etcd
 
 acbuild --debug port add client tcp 2379
 acbuild --debug port add peer tcp 2380
 
 acbuild --debug copy "$TMPHOSTS" /etc/hosts
+
+# mkdir default data-dir
+mkdir -p .acbuild/currentaci/rootfs/var/lib/etcd
+
+# symlinks for backward-compatibility
+ln -s ./usr/local/bin/etcd .acbuild/currentaci/rootfs/etcd
+ln -s ./usr/local/bin/etcdctl .acbuild/currentaci/rootfs/etcdctl
 
 acbuild --debug write --overwrite $BUILDDIR/etcd-${1}-linux-amd64.aci


### PR DESCRIPTION
And uses latest acbuild (v0.4.0, --to-dir flag is deprecated).

For https://github.com/coreos/etcd/issues/6057.

/cc @steveeJ @jonboulle @xiang90 

