### PR TITLE
etcdserver: document DeleteRangeRequest prefixes

### DIFF
--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -436,6 +436,8 @@ message DeleteRangeRequest {
   bytes key = 1;
   // range_end is the key following the last key to delete for the range [key, range_end).
   // If range_end is not given, the range is defined to contain only the key argument.
+  // If range_end is one bit larger than the given key, then the range is all
+  // the all keys with the prefix (the given key).
   // If range_end is '\0', the range is all keys greater than or equal to the key argument.
   bytes range_end = 2;
 


### PR DESCRIPTION
There was missing info about deleting prefixes in the proto docs for
DeleteRangeRequest.

Closes #6641.