### PR TITLE
*: fix build script, bump up version

### DIFF
--- a/build
+++ b/build
@@ -5,15 +5,15 @@ ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/etcd"
 export GO15VENDOREXPERIMENT="1"
 
-# Set GO_LDFLAGS="" for building with all symbols for debugging.
-if [ -z "${GO_LDFLAGS+x}" ]; then GO_LDFLAGS="-s"; fi
-GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/cmd/vendor/${REPO_PATH}/version.GitSHA=${GIT_SHA}"
-
 eval $(go env)
 GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
 if [ ! -z "$FAILPOINTS" ]; then
 	GIT_SHA="$GIT_SHA"-FAILPOINTS
 fi
+
+# Set GO_LDFLAGS="" for building with all symbols for debugging.
+if [ -z "${GO_LDFLAGS+x}" ]; then GO_LDFLAGS="-s"; fi
+GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/cmd/vendor/${REPO_PATH}/version.GitSHA=${GIT_SHA}"
 
 # enable/disable failpoints
 toggle_failpoints() {

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
-	Version           = "3.1.0-alpha.1+git"
+	Version           = "3.1.0-rc.0"
 
 	// Git SHA Value will be set during build
 	GitSHA = "Not provided (use ./build instead of go build)"

--- a/version/version.go
+++ b/version/version.go
@@ -24,7 +24,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
-	Version           = "v3.1.0-rc.0"
+	Version           = "3.1.0-alpha.1+git"
 
 	// Git SHA Value will be set during build
 	GitSHA = "Not provided (use ./build instead of go build)"


### PR DESCRIPTION
https://github.com/coreos/etcd/commit/9ac2c8072aa387f023842a0bd0580fc5a9462116 broke our GitSHA grep, so GitSHA in release binary was empty.

@xiang90 @sinsharat