### PR TITLE
etcdctl/ctlv3: support del all keys with '--prefix'

### DIFF
--- a/e2e/ctl_v3_kv_test.go
+++ b/e2e/ctl_v3_kv_test.go
@@ -180,6 +180,16 @@ func delTest(cx ctlCtx) {
 
 		deletedNum int
 	}{
+		{ // delete all keys
+			[]kv{{"foo1", "bar"}, {"foo2", "bar"}, {"foo3", "bar"}},
+			[]string{"", "--prefix"},
+			3,
+		},
+		{ // delete all keys
+			[]kv{{"foo1", "bar"}, {"foo2", "bar"}, {"foo3", "bar"}},
+			[]string{"", "--from-key"},
+			3,
+		},
 		{
 			[]kv{{"this", "value"}},
 			[]string{"that"},

--- a/etcdctl/ctlv3/command/del_command.go
+++ b/etcdctl/ctlv3/command/del_command.go
@@ -72,7 +72,12 @@ func getDelOp(cmd *cobra.Command, args []string) (string, []clientv3.OpOption) {
 	}
 
 	if delPrefix {
-		opts = append(opts, clientv3.WithPrefix())
+		if len(key) == 0 {
+			key = "\x00"
+			opts = append(opts, clientv3.WithFromKey())
+		} else {
+			opts = append(opts, clientv3.WithPrefix())
+		}
 	}
 	if delPrevKV {
 		opts = append(opts, clientv3.WithPrevKV())


### PR DESCRIPTION
Reference https://github.com/coreos/etcd/pull/5351.

Currently `etcdctl del "" --from-key` works, but `etcdctl del "" --prefix` doesn't work,
while `etcdctl get "" --from-key`, `etcdctl get "" --prefix` work.

This makes `del` command consistent with `get` command.

/cc @xiang90 @heyitsanthony 
