### PR TITLE
functional-tester: move checker logic to cluster

### DIFF
--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -74,9 +74,10 @@ func main() {
 	}
 
 	c := &cluster{
-		agents:        agents,
-		v2Only:        *isV2Only,
-		stressBuilder: newStressBuilder(*stresserType, sConfig),
+		agents:           agents,
+		v2Only:           *isV2Only,
+		stressBuilder:    newStressBuilder(*stresserType, sConfig),
+		consistencyCheck: *consistencyCheck,
 	}
 
 	if err := c.bootstrap(); err != nil {
@@ -116,11 +117,6 @@ func main() {
 		failures: schedule,
 		cluster:  c,
 		limit:    *limit,
-		checker:  newNoChecker(),
-	}
-
-	if *consistencyCheck && !c.v2Only {
-		t.checker = newHashChecker(t)
 	}
 
 	sh := statusHandler{status: &t.status}

--- a/tools/functional-tester/etcd-tester/tester.go
+++ b/tools/functional-tester/etcd-tester/tester.go
@@ -20,11 +20,9 @@ import (
 )
 
 type tester struct {
-	failures []failure
-	cluster  *cluster
-	limit    int
-	checker  Checker
-
+	failures        []failure
+	cluster         *cluster
+	limit           int
 	status          Status
 	currentRevision int64
 }
@@ -146,7 +144,7 @@ func (tt *tester) checkConsistency() (err error) {
 		}
 		err = tt.startStressers()
 	}()
-	if err = tt.checker.Check(); err != nil {
+	if err = tt.cluster.Checker.Check(); err != nil {
 		plog.Printf("%s %v", tt.logPrefix(), err)
 	}
 	return err


### PR DESCRIPTION
I move the checker logic from tester to cluster so that stressers and checkers can be initialized at the same time.
this is useful because some checker depends on stressers.