### PR TITLE
ctlv2: allow to add a user within one command line

### DIFF
--- a/etcdctl/ctlv2/command/user_commands.go
+++ b/etcdctl/ctlv2/command/user_commands.go
@@ -111,18 +111,20 @@ func actionUserAdd(c *cli.Context) error {
 	api, userarg := mustUserAPIAndName(c)
 	ctx, cancel := contextWithTotalTimeout(c)
 	defer cancel()
-	user, _, _ := getUsernamePassword("", userarg+":")
+
+	user, pass, err := getUsernamePassword("New password: ", userarg)
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error reading user/password:", err)
+		os.Exit(1)
+	}
 	currentUser, err := api.GetUser(ctx, user)
+
 	if currentUser != nil {
 		fmt.Fprintf(os.Stderr, "User %s already exists\n", user)
 		os.Exit(1)
 	}
 
-	_, pass, err := getUsernamePassword("New password: ", userarg)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error reading password:", err)
-		os.Exit(1)
-	}
 	err = api.AddUser(ctx, user, pass)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/etcdctl/ctlv2/command/util.go
+++ b/etcdctl/ctlv2/command/util.go
@@ -199,6 +199,10 @@ func getUsernamePassword(prompt, usernameFlag string) (username string, password
 		if err != nil {
 			return "", "", err
 		}
+	} else if colon == 0 {
+		// Empty username
+		fmt.Fprintln(os.Stderr, "Invalid username")
+		os.Exit(1)
 	} else {
 		username = usernameFlag[:colon]
 		password = usernameFlag[colon+1:]


### PR DESCRIPTION
This makes the "user add usr:pwd" feature available for ctlv2
without asking for the password in a new prompt.

Fixes #6668