### PR TITLE
build: add option to enable binaries stripping

### DIFF
--- a/build
+++ b/build
@@ -11,8 +11,7 @@ if [ ! -z "$FAILPOINTS" ]; then
 	GIT_SHA="$GIT_SHA"-FAILPOINTS
 fi
 
-# Set GO_LDFLAGS="" for building with all symbols for debugging.
-if [ -z "${GO_LDFLAGS+x}" ]; then GO_LDFLAGS="-s"; fi
+# Set GO_LDFLAGS="-s" for building without symbols for debugging.
 GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/cmd/vendor/${REPO_PATH}/version.GitSHA=${GIT_SHA}"
 
 # enable/disable failpoints


### PR DESCRIPTION
As suggested in #6664 adding command line option to enable binaries stripping from symbols.

I don't feel very good about this change, now we have a mix of env and command line arguments governing script behavior. What do you think?
