### PR TITLE
etcdctl: fix migrate in outputing client.Node to json

### DIFF
--- a/etcdctl/ctlv3/command/migrate_command.go
+++ b/etcdctl/ctlv3/command/migrate_command.go
@@ -220,7 +220,7 @@ func writeKeys(w io.Writer, n *store.NodeExtern) uint64 {
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
-	fmt.Fprintf(w, string(b))
+	fmt.Fprint(w, string(b))
 	for _, nn := range nodes {
 		max := writeKeys(w, nn)
 		if max > maxIndex {


### PR DESCRIPTION
We should use print/println instead of printf.