### PR TITLE
grpcproxy: respect {min,max}{create,mod} revision

### DIFF
--- a/proxy/grpcproxy/kv.go
+++ b/proxy/grpcproxy/kv.go
@@ -135,6 +135,10 @@ func RangeRequestToOp(r *pb.RangeRequest) clientv3.Op {
 		clientv3.SortTarget(r.SortTarget),
 		clientv3.SortOrder(r.SortOrder)),
 	)
+	opts = append(opts, clientv3.WithMaxCreateRev(r.MaxCreateRevision))
+	opts = append(opts, clientv3.WithMinCreateRev(r.MinCreateRevision))
+	opts = append(opts, clientv3.WithMaxModRev(r.MaxModRevision))
+	opts = append(opts, clientv3.WithMinModRev(r.MinModRevision))
 
 	if r.Serializable {
 		opts = append(opts, clientv3.WithSerializable())


### PR DESCRIPTION
Mutexes were breaking in proxy integration tests.