### PR TITLE
grpcproxy: fix race on watcher revision

### DIFF
--- a/proxy/grpcproxy/watcher_group.go
+++ b/proxy/grpcproxy/watcher_group.go
@@ -68,10 +68,14 @@ func (wg *watcherGroup) broadcast(wr clientv3.WatchResponse) {
 }
 
 // add adds the watcher into the group with given ID.
-// The current revision of the watcherGroup is returned.
+// The current revision of the watcherGroup is returned or -1
+// if the watcher is at a revision prior to the watcher group.
 func (wg *watcherGroup) add(rid receiverID, w watcher) int64 {
 	wg.mu.Lock()
 	defer wg.mu.Unlock()
+	if wg.rev > w.rev {
+		return -1
+	}
 	wg.receivers[rid] = w
 	return wg.rev
 }

--- a/proxy/grpcproxy/watcher_groups.go
+++ b/proxy/grpcproxy/watcher_groups.go
@@ -102,11 +102,7 @@ func (wgs *watchergroups) maybeJoinWatcherSingle(rid receiverID, ws watcherSingl
 
 	group, ok := wgs.groups[ws.w.wr]
 	if ok {
-		if ws.w.rev >= group.rev {
-			group.add(receiverID{streamID: ws.sws.id, watcherID: ws.w.id}, ws.w)
-			return true
-		}
-		return false
+		return group.add(receiverID{streamID: ws.sws.id, watcherID: ws.w.id}, ws.w) != -1
 	}
 
 	if ws.canPromote() {


### PR DESCRIPTION
Was racing between broadcast setting the watchgroup revision
and joining single watchers.

```
WARNING: DATA RACE
Read at 0x00c421a433c8 by goroutine 339:
  github.com/coreos/etcd/proxy/grpcproxy.(*watchergroups).maybeJoinWatcherSingle()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watcher_groups.go:105 +0x4fd
  github.com/coreos/etcd/proxy/grpcproxy.(*serverWatchStream).maybeCoalesceWatcher()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:221 +0x153
  github.com/coreos/etcd/proxy/grpcproxy.watcherSingle.run()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watcher_single.go:58 +0x1bc

Previous write at 0x00c421a433c8 by goroutine 154:
  github.com/coreos/etcd/proxy/grpcproxy.(*watcherGroup).broadcast()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watcher_group.go:64 +0xbc
  github.com/coreos/etcd/proxy/grpcproxy.(*watcherGroup).run()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watcher_group.go:56 +0x19c

Goroutine 339 (running) created at:
  github.com/coreos/etcd/proxy/grpcproxy.(*serverWatchStream).addDedicatedWatcher()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:209 +0x5ac
  github.com/coreos/etcd/proxy/grpcproxy.(*serverWatchStream).recvLoop()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:155 +0x466

Goroutine 154 (running) created at:
  github.com/coreos/etcd/proxy/grpcproxy.(*watchergroups).maybeJoinWatcherSingle()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watcher_groups.go:116 +0x3fe
  github.com/coreos/etcd/proxy/grpcproxy.(*serverWatchStream).maybeCoalesceWatcher()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watch.go:221 +0x153
  github.com/coreos/etcd/proxy/grpcproxy.watcherSingle.run()
      /Users/anthony/go/src/github.com/coreos/etcd/proxy/grpcproxy/watcher_single.go:58 +0x1bc
```