### PR TITLE
etcdctl: forbid empty user name

### DIFF
--- a/etcdctl/ctlv3/command/user_command.go
+++ b/etcdctl/ctlv3/command/user_command.go
@@ -123,6 +123,10 @@ func userAddCommandFunc(cmd *cobra.Command, args []string) {
 		ExitWithError(ExitBadArgs, fmt.Errorf("user add command requires user name as its argument."))
 	}
 
+	if len(args[0]) == 0 {
+		ExitWithError(ExitBadArgs, fmt.Errorf("empty user name is not allowed."))
+	}
+
 	var password string
 
 	if !passwordInteractive {


### PR DESCRIPTION
Current etcdctl user add command allows an empty user name as its
argument. It must not be allowed.

/cc @johnbazan I saw you reported the problem in https://github.com/coreos/etcd/pull/6669#issuecomment-255460180 but the comment disappeared?
