### PR TITLE
auth, etcdserver: apply Authenticate() in an asynchronous manner

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -146,9 +146,6 @@ type AuthStore interface {
 
 	// Revision gets current revision of authStore
 	Revision() uint64
-
-	// CheckPassword checks a given pair of username and password is correct
-	CheckPassword(username, password string) (uint64, error)
 }
 
 type authStore struct {
@@ -235,29 +232,16 @@ func (as *authStore) Authenticate(ctx context.Context, username, password string
 		return nil, ErrAuthFailed
 	}
 
+	if bcrypt.CompareHashAndPassword(user.Password, []byte(password)) != nil {
+		plog.Noticef("authentication failed, invalid password for user %s", username)
+		return &pb.AuthenticateResponse{}, ErrAuthFailed
+	}
+
 	token := fmt.Sprintf("%s.%d", simpleToken, index)
 	as.assignSimpleTokenToUser(username, token)
 
 	plog.Infof("authorized %s, token is %s", username, token)
 	return &pb.AuthenticateResponse{Token: token}, nil
-}
-
-func (as *authStore) CheckPassword(username, password string) (uint64, error) {
-	tx := as.be.BatchTx()
-	tx.Lock()
-	defer tx.Unlock()
-
-	user := getUser(tx, username)
-	if user == nil {
-		return 0, ErrAuthFailed
-	}
-
-	if bcrypt.CompareHashAndPassword(user.Password, []byte(password)) != nil {
-		plog.Noticef("authentication failed, invalid password for user %s", username)
-		return 0, ErrAuthFailed
-	}
-
-	return getRevision(tx), nil
 }
 
 func (as *authStore) Recover(be backend.Backend) {

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -20,6 +20,7 @@ import (
 
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/mvcc/backend"
+	"github.com/coreos/etcd/pkg/wait"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/net/context"
 )
@@ -33,7 +34,7 @@ func TestUserAdd(t *testing.T) {
 		os.Remove(tPath)
 	}()
 
-	as := NewAuthStore(b)
+	as := NewAuthStore(b, wait.NewTimeList())
 	ua := &pb.AuthUserAddRequest{Name: "foo"}
 	_, err := as.UserAdd(ua) // add a non-existing user
 	if err != nil {
@@ -74,7 +75,7 @@ func TestAuthenticate(t *testing.T) {
 		os.Remove(tPath)
 	}()
 
-	as := NewAuthStore(b)
+	as := NewAuthStore(b, wait.NewTimeList())
 	err := enableAuthAndCreateRoot(as)
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +132,7 @@ func TestUserDelete(t *testing.T) {
 		os.Remove(tPath)
 	}()
 
-	as := NewAuthStore(b)
+	as := NewAuthStore(b, wait.NewTimeList())
 	err := enableAuthAndCreateRoot(as)
 	if err != nil {
 		t.Fatal(err)
@@ -167,7 +168,7 @@ func TestUserChangePassword(t *testing.T) {
 		os.Remove(tPath)
 	}()
 
-	as := NewAuthStore(b)
+	as := NewAuthStore(b, wait.NewTimeList())
 	err := enableAuthAndCreateRoot(as)
 	if err != nil {
 		t.Fatal(err)
@@ -216,7 +217,7 @@ func TestRoleAdd(t *testing.T) {
 		os.Remove(tPath)
 	}()
 
-	as := NewAuthStore(b)
+	as := NewAuthStore(b, wait.NewTimeList())
 	err := enableAuthAndCreateRoot(as)
 	if err != nil {
 		t.Fatal(err)
@@ -236,7 +237,7 @@ func TestUserGrant(t *testing.T) {
 		os.Remove(tPath)
 	}()
 
-	as := NewAuthStore(b)
+	as := NewAuthStore(b, wait.NewTimeList())
 	err := enableAuthAndCreateRoot(as)
 	if err != nil {
 		t.Fatal(err)

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -67,7 +67,7 @@ func enableAuthAndCreateRoot(as *authStore) error {
 	return as.AuthEnable()
 }
 
-func TestCheckPassword(t *testing.T) {
+func TestAuthenticate(t *testing.T) {
 	b, tPath := backend.NewDefaultTmpBackend()
 	defer func() {
 		b.Close()
@@ -87,7 +87,8 @@ func TestCheckPassword(t *testing.T) {
 	}
 
 	// auth a non-existing user
-	_, err = as.CheckPassword("foo-test", "bar")
+	ctx1 := context.WithValue(context.WithValue(context.TODO(), "index", uint64(1)), "simpleToken", "dummy")
+	_, err = as.Authenticate(ctx1, "foo-test", "bar")
 	if err == nil {
 		t.Fatalf("expected %v, got %v", ErrAuthFailed, err)
 	}
@@ -96,13 +97,15 @@ func TestCheckPassword(t *testing.T) {
 	}
 
 	// auth an existing user with correct password
-	_, err = as.CheckPassword("foo", "bar")
+	ctx2 := context.WithValue(context.WithValue(context.TODO(), "index", uint64(2)), "simpleToken", "dummy")
+	_, err = as.Authenticate(ctx2, "foo", "bar")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// auth an existing user but with wrong password
-	_, err = as.CheckPassword("foo", "")
+	ctx3 := context.WithValue(context.WithValue(context.TODO(), "index", uint64(3)), "simpleToken", "dummy")
+	_, err = as.Authenticate(ctx3, "foo", "")
 	if err == nil {
 		t.Fatalf("expected %v, got %v", ErrAuthFailed, err)
 	}

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -88,7 +88,7 @@ func TestAuthenticate(t *testing.T) {
 
 	// auth a non-existing user
 	ctx1 := context.WithValue(context.WithValue(context.TODO(), "index", uint64(1)), "simpleToken", "dummy")
-	_, err = as.Authenticate(ctx1, "foo-test", "bar")
+	_, err = as.AsyncAuthenticateParam(ctx1, "foo-test", "bar")
 	if err == nil {
 		t.Fatalf("expected %v, got %v", ErrAuthFailed, err)
 	}
@@ -96,16 +96,26 @@ func TestAuthenticate(t *testing.T) {
 		t.Fatalf("expected %v, got %v", ErrAuthFailed, err)
 	}
 
+	var params interface{}
+
 	// auth an existing user with correct password
 	ctx2 := context.WithValue(context.WithValue(context.TODO(), "index", uint64(2)), "simpleToken", "dummy")
-	_, err = as.Authenticate(ctx2, "foo", "bar")
+	params, err = as.AsyncAuthenticateParam(ctx2, "foo", "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = as.AsyncAuthenticate(params)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// auth an existing user but with wrong password
 	ctx3 := context.WithValue(context.WithValue(context.TODO(), "index", uint64(3)), "simpleToken", "dummy")
-	_, err = as.Authenticate(ctx3, "foo", "")
+	params, err = as.AsyncAuthenticateParam(ctx3, "foo", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = as.AsyncAuthenticate(params)
 	if err == nil {
 		t.Fatalf("expected %v, got %v", ErrAuthFailed, err)
 	}
@@ -168,11 +178,14 @@ func TestUserChangePassword(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var params interface{}
+
 	ctx1 := context.WithValue(context.WithValue(context.TODO(), "index", uint64(1)), "simpleToken", "dummy")
-	_, err = as.Authenticate(ctx1, "foo", "")
+	params, err = as.AsyncAuthenticateParam(ctx1, "foo", "")
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = as.AsyncAuthenticate(params)
 
 	_, err = as.UserChangePassword(&pb.AuthUserChangePasswordRequest{Name: "foo", Password: "bar"})
 	if err != nil {
@@ -180,10 +193,11 @@ func TestUserChangePassword(t *testing.T) {
 	}
 
 	ctx2 := context.WithValue(context.WithValue(context.TODO(), "index", uint64(2)), "simpleToken", "dummy")
-	_, err = as.Authenticate(ctx2, "foo", "bar")
+	params, err = as.AsyncAuthenticateParam(ctx2, "foo", "bar")
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = as.AsyncAuthenticate(params)
 
 	// change a non-existing user
 	_, err = as.UserChangePassword(&pb.AuthUserChangePasswordRequest{Name: "foo-test", Password: "bar"})

--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -50,6 +50,8 @@ type applyResult struct {
 type asyncApplyer struct {
 	params interface{}
 	f      func(interface{}) *applyResult
+	id     uint64
+	index  uint64
 }
 
 func (aa *asyncApplyer) AsyncApply() *applyResult {

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -594,7 +594,7 @@ func (s *EtcdServer) isValidSimpleToken(token string) bool {
 	}
 
 	select {
-	case <-s.applyWait.Wait(uint64(index)):
+	case <-s.authApplyWait.Wait(uint64(index)):
 		return true
 	case <-s.stop:
 		return true

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -419,42 +419,24 @@ func (s *EtcdServer) AuthDisable(ctx context.Context, r *pb.AuthDisableRequest) 
 }
 
 func (s *EtcdServer) Authenticate(ctx context.Context, r *pb.AuthenticateRequest) (*pb.AuthenticateResponse, error) {
-	var result *applyResult
-
-	for {
-		checkedRevision, err := s.AuthStore().CheckPassword(r.Name, r.Password)
-		if err != nil {
-			plog.Errorf("invalid authentication request to user %s was issued", r.Name)
-			return nil, err
-		}
-
-		st, err := s.AuthStore().GenSimpleToken()
-		if err != nil {
-			return nil, err
-		}
-
-		internalReq := &pb.InternalAuthenticateRequest{
-			Name:        r.Name,
-			Password:    r.Password,
-			SimpleToken: st,
-		}
-
-		result, err = s.processInternalRaftRequestOnce(ctx, pb.InternalRaftRequest{Authenticate: internalReq})
-		if err != nil {
-			return nil, err
-		}
-		if result.err != nil {
-			return nil, result.err
-		}
-
-		if checkedRevision != s.AuthStore().Revision() {
-			plog.Infof("revision when password checked is obsolete, retrying")
-			continue
-		}
-
-		break
+	st, err := s.AuthStore().GenSimpleToken()
+	if err != nil {
+		return nil, err
 	}
 
+	internalReq := &pb.InternalAuthenticateRequest{
+		Name:        r.Name,
+		Password:    r.Password,
+		SimpleToken: st,
+	}
+
+	result, err := s.processInternalRaftRequestOnce(ctx, pb.InternalRaftRequest{Authenticate: internalReq})
+	if err != nil {
+		return nil, err
+	}
+	if result.err != nil {
+		return nil, result.err
+	}
 	return result.resp.(*pb.AuthenticateResponse), nil
 }
 


### PR DESCRIPTION
Because of the high cost of bcrypt password checking, the checking
mechanism was moved to the API layer once. However, the modification
produced a corner case that can involve inconsistent state of the auth
store [1].

This commit moves the checking mechanism to the apply layer of state
machine again. For doing this, Authenticate() is now deconstructed
into two part: AsyncAuthenticateParam() and
AsyncAuthenticate(). AsyncAuthenticateParam() is called in the apply
loop like other commands and it obtains all parameters that are
required for doing auth. AsyncAuthenticate() does actual checking
based on the params obtained by
AsyncAuthenticateParam(). AsyncAuthenticate() can take long time
because of the bcrypt cost, but it is executed in its own goroutine
and does not block the apply loop. They are invoked with a new
function AsyncApplyBuilder() of applierV3.

[1] https://github.com/coreos/etcd/issues/6675#issuecomment-255006389

Fixes https://github.com/coreos/etcd/issues/6675 and https://github.com/coreos/etcd/issues/6683
