### PR TITLE
etcdctl: allow to add a user within one command line

### DIFF
--- a/e2e/ctl_v3_user_test.go
+++ b/e2e/ctl_v3_user_test.go
@@ -39,6 +39,18 @@ func userAddTest(cx ctlCtx) {
 			expectedStr: "User username created",
 			stdIn:       []string{"password"},
 		},
+		// Adds a user name using the usertest:password syntax.
+		{
+			args:        []string{"add", "usertest:password"},
+			expectedStr: "User usertest created",
+			stdIn:       []string{},
+		},
+		// Tries to add a user with empty username.
+		{
+			args:        []string{"add", ":password"},
+			expectedStr: "empty user name is not allowed.",
+			stdIn:       []string{},
+		},
 		// Tries to add a user name that already exists.
 		{
 			args:        []string{"add", "username", "--interactive=false"},

--- a/etcdctl/ctlv3/command/user_command.go
+++ b/etcdctl/ctlv3/command/user_command.go
@@ -124,19 +124,30 @@ func userAddCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	var password string
+	var user string
 
-	if !passwordInteractive {
-		fmt.Scanf("%s", &password)
+	splitted := strings.SplitN(args[0], ":", 2)
+	if len(splitted) < 2 {
+		user = args[0]
+		if !passwordInteractive {
+			fmt.Scanf("%s", &password)
+		} else {
+			password = readPasswordInteractive(args[0])
+		}
 	} else {
-		password = readPasswordInteractive(args[0])
+		user = splitted[0]
+		password = splitted[1]
+		if len(user) == 0 {
+			ExitWithError(ExitBadArgs, fmt.Errorf("empty user name is not allowed."))
+		}
 	}
 
-	_, err := mustClientFromCmd(cmd).Auth.UserAdd(context.TODO(), args[0], password)
+	_, err := mustClientFromCmd(cmd).Auth.UserAdd(context.TODO(), user, password)
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
 
-	fmt.Printf("User %s created\n", args[0])
+	fmt.Printf("User %s created\n", user)
 }
 
 // userDeleteCommandFunc executes the "user delete" command.


### PR DESCRIPTION
This makes the "user add usr:pwd" feature available for ctlv3
without asking for the password in a new prompt.

Also forbids adding an empty username.
