### PR TITLE
etcdctl: add ttl unit to flag description

### DIFF
--- a/etcdctl/ctlv2/command/mk_command.go
+++ b/etcdctl/ctlv2/command/mk_command.go
@@ -31,7 +31,7 @@ func NewMakeCommand() cli.Command {
 		ArgsUsage: "<key> <value>",
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "in-order", Usage: "create in-order key under directory <key>"},
-			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live"},
+			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live in seconds"},
 		},
 		Action: func(c *cli.Context) error {
 			mkCommandFunc(c, mustNewKeyAPI(c))

--- a/etcdctl/ctlv2/command/mkdir_command.go
+++ b/etcdctl/ctlv2/command/mkdir_command.go
@@ -29,7 +29,7 @@ func NewMakeDirCommand() cli.Command {
 		Usage:     "make a new directory",
 		ArgsUsage: "<key>",
 		Flags: []cli.Flag{
-			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live"},
+			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live in seconds"},
 		},
 		Action: func(c *cli.Context) error {
 			mkdirCommandFunc(c, mustNewKeyAPI(c), client.PrevNoExist)

--- a/etcdctl/ctlv2/command/set_command.go
+++ b/etcdctl/ctlv2/command/set_command.go
@@ -36,7 +36,7 @@ func NewSetCommand() cli.Command {
 
    $ set -- <key> <value>`,
 		Flags: []cli.Flag{
-			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live"},
+			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live in seconds"},
 			cli.StringFlag{Name: "swap-with-value", Value: "", Usage: "previous value"},
 			cli.IntFlag{Name: "swap-with-index", Value: 0, Usage: "previous index"},
 		},

--- a/etcdctl/ctlv2/command/set_dir_command.go
+++ b/etcdctl/ctlv2/command/set_dir_command.go
@@ -26,7 +26,7 @@ func NewSetDirCommand() cli.Command {
 		Usage:     "create a new directory or update an existing directory TTL",
 		ArgsUsage: "<key>",
 		Flags: []cli.Flag{
-			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live"},
+			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live in seconds"},
 		},
 		Action: func(c *cli.Context) error {
 			mkdirCommandFunc(c, mustNewKeyAPI(c), client.PrevIgnore)

--- a/etcdctl/ctlv2/command/update_command.go
+++ b/etcdctl/ctlv2/command/update_command.go
@@ -30,7 +30,7 @@ func NewUpdateCommand() cli.Command {
 		Usage:     "update an existing key with a given value",
 		ArgsUsage: "<key> <value>",
 		Flags: []cli.Flag{
-			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live"},
+			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live in seconds"},
 		},
 		Action: func(c *cli.Context) error {
 			updateCommandFunc(c, mustNewKeyAPI(c))

--- a/etcdctl/ctlv2/command/update_dir_command.go
+++ b/etcdctl/ctlv2/command/update_dir_command.go
@@ -29,7 +29,7 @@ func NewUpdateDirCommand() cli.Command {
 		Usage:     "update an existing directory",
 		ArgsUsage: "<key> <value>",
 		Flags: []cli.Flag{
-			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live"},
+			cli.IntFlag{Name: "ttl", Value: 0, Usage: "key time-to-live in seconds"},
 		},
 		Action: func(c *cli.Context) error {
 			updatedirCommandFunc(c, mustNewKeyAPI(c))


### PR DESCRIPTION
Add the ttl unit (seconds) to --ttl description for etcdctl's mk, mkdir, set,
setdir, update, and updatedir commands.