### PR TITLE
functional-tester: increase lease TTL

### DIFF
--- a/tools/functional-tester/etcd-tester/lease_stresser.go
+++ b/tools/functional-tester/etcd-tester/lease_stresser.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// time to live for lease
-	TTL = 30
+	TTL = 120
 	// leasesStressRoundPs indicates the rate that leaseStresser.run() creates and deletes leases per second
 	leasesStressRoundPs = 1
 )


### PR DESCRIPTION
increasing lease TTL ensure that lease doesn't expire during hashes stabilization period.
I observed that it can take a long time for etcd cluster to become stable.