### PR TITLE
Remove the = 0 from var declarations

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -372,7 +372,7 @@ func (rc *raftNode) serveChannels() {
 
 	// send proposals over raft
 	go func() {
-		var confChangeCount uint64 = 0
+		var confChangeCount uint64
 
 		for rc.proposeC != nil && rc.confChangeC != nil {
 			select {

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -63,7 +63,7 @@ var (
 
 	// integration test uses unique ports, counting up, to listen for each
 	// member, ensuring restarted members can listen on the same port again.
-	localListenCount int64 = 0
+	localListenCount int64
 
 	testTLSInfo = transport.TLSInfo{
 		KeyFile:        "./fixtures/server.key.insecure",

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -611,7 +611,7 @@ func TestStoreCompareAndSwapPrevIndexFailsIfNotMatch(t *testing.T) {
 // Ensure that the store can watch for key creation.
 func TestStoreWatchCreate(t *testing.T) {
 	s := newStore()
-	var eidx uint64 = 0
+	var eidx uint64
 	w, _ := s.Watch("/foo", false, false, 0)
 	c := w.EventChan()
 	assert.Equal(t, w.StartIndex(), eidx, "")
@@ -628,7 +628,7 @@ func TestStoreWatchCreate(t *testing.T) {
 // Ensure that the store can watch for recursive key creation.
 func TestStoreWatchRecursiveCreate(t *testing.T) {
 	s := newStore()
-	var eidx uint64 = 0
+	var eidx uint64
 	w, _ := s.Watch("/foo", true, false, 0)
 	assert.Equal(t, w.StartIndex(), eidx, "")
 	eidx = 1

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -237,7 +237,7 @@ func TestSaveWithCut(t *testing.T) {
 	const EntrySize int = 500
 	SegmentSizeBytes = 2 * 1024
 	defer func() { SegmentSizeBytes = restoreLater }()
-	var index uint64 = 0
+	var index uint64
 	for totalSize := 0; totalSize < int(SegmentSizeBytes); totalSize += EntrySize {
 		ents := []raftpb.Entry{{Index: index, Term: 1, Data: bigData}}
 		if err = w.Save(state, ents); err != nil {


### PR DESCRIPTION
Some variable declarations were initialized to zero explicitly, which is unnecessary in go. I removed the '= 0' from the end of the line.

i.e.
var somethingSomething int = 0 
->
var somethingSomething int

Signed-off-by: nick <nicholasjamesrusso@gmail.com>