### PR TITLE
etcdserver: linearizable password checking at the API layer

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -421,6 +421,11 @@ func (s *EtcdServer) AuthDisable(ctx context.Context, r *pb.AuthDisableRequest) 
 func (s *EtcdServer) Authenticate(ctx context.Context, r *pb.AuthenticateRequest) (*pb.AuthenticateResponse, error) {
 	var result *applyResult
 
+	err := s.linearizableReadNotify(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	for {
 		checkedRevision, err := s.AuthStore().CheckPassword(r.Name, r.Password)
 		if err != nil {


### PR DESCRIPTION
For avoiding a schedule that can cause an inconsistent auth store [1],
password checking must be done in a linearizable manner.

Fixes https://github.com/coreos/etcd/issues/6675 and https://github.com/coreos/etcd/issues/6683

[1] https://github.com/coreos/etcd/issues/6675#issuecomment-255006389

/cc @xiang90 @heyitsanthony 