### PR TITLE
grpcproxy: reliably track rid in watchergroups

### DIFF
--- a/proxy/grpcproxy/watcher_group_test.go
+++ b/proxy/grpcproxy/watcher_group_test.go
@@ -17,6 +17,8 @@ package grpcproxy
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/coreos/etcd/clientv3"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 )
@@ -30,8 +32,8 @@ func TestWatchgroupBroadcast(t *testing.T) {
 	for i := range chs {
 		chs[i] = make(chan *pb.WatchResponse, 1)
 		w := watcher{
-			id: int64(i),
-			ch: chs[i],
+			id:  int64(i),
+			sws: &serverWatchStream{watchCh: chs[i], ctx: context.TODO()},
 
 			progress: true,
 		}

--- a/proxy/grpcproxy/watcher_single.go
+++ b/proxy/grpcproxy/watcher_single.go
@@ -54,7 +54,6 @@ func (ws watcherSingle) run() {
 	for wr := range ws.ch {
 		ws.lastStoreRev = wr.Header.Revision
 		ws.w.send(wr)
-
 		if ws.sws.maybeCoalesceWatcher(ws) {
 			return
 		}


### PR DESCRIPTION
Couldn't find watcher group from rid on server stream close, leading to
watcher group sending on a closed channel.

Also got rid of send closing the watcher stream if the buffer is full,
this could lead to a send after close while broadcasting to all receivers.
Instead, if a send times out, have the caller issue a cancel().

Fixes #6739

/cc @xiang90