### PR TITLE
ctlv3: fix migration

### DIFF
--- a/e2e/ctl_v3_migrate_test.go
+++ b/e2e/ctl_v3_migrate_test.go
@@ -89,8 +89,8 @@ func TestCtlV3Migrate(t *testing.T) {
 	if len(resp.Kvs) != 1 {
 		t.Fatalf("len(resp.Kvs) expected 1, got %+v", resp.Kvs)
 	}
-	if resp.Kvs[0].CreateRevision != 4 {
-		t.Fatalf("resp.Kvs[0].CreateRevision expected 4, got %d", resp.Kvs[0].CreateRevision)
+	if resp.Kvs[0].CreateRevision != 7 {
+		t.Fatalf("resp.Kvs[0].CreateRevision expected 7, got %d", resp.Kvs[0].CreateRevision)
 	}
 }
 


### PR DESCRIPTION
/cc @wojtek-t @hongchaodeng 

I tested the example data @wojtek-t provided. It fixed the problem. I do not really have time to test this with more extensive data set now.

Please try with more data set.

WAL + no snap (new k8s cluster); WAL+snap (long running k8s cluster); fresh snap (new cluster data forced by --snapshot-count==1)

Thanks!