### PR TITLE
Documentation: fixed  typo

### DIFF
--- a/Documentation/dev-guide/grpc_naming.md
+++ b/Documentation/dev-guide/grpc_naming.md
@@ -9,7 +9,7 @@ The etcd client provides a gRPC resolver for resolving gRPC endpoints with an et
 ```go
 import (
 	"github.com/coreos/etcd/clientv3"
-	etcdnaming "github.com/coroes/etcd/clientv3/naming"
+	etcdnaming "github.com/coreos/etcd/clientv3/naming"
 
 	"google.golang.org/grpc"
 )


### PR DESCRIPTION
`etcdnaming "github.com/coroes/etcd/clientv3/naming"`

should be

`etcdnaming "github.com/coreos/etcd/clientv3/naming"`
