### PR TITLE
etcdserver: increase maxGapBetweenApplyAndCommitIndex

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -47,7 +47,7 @@ const (
 	// the applied index and committed index.
 	// However, if the committed entries are very heavy to apply, the gap might grow.
 	// We should stop accepting new proposals if the gap growing to a certain point.
-	maxGapBetweenApplyAndCommitIndex = 1000
+	maxGapBetweenApplyAndCommitIndex = 5000
 )
 
 var (


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6824.

This exists to prevent sending too many requests that
would lead to applier falling behind Raft accepting-proposal.

Based on recent benchmarks, etcd was able to process high workloads
(2 million writes with 1K concurrent clients).

The limit 1000 is too conservative to test those high workloads.

Tried 5000, and numbers look good, with no error:

```bash
$ benchmark --endpoints=10.240.0.38:2379,10.240.0.39:2379,10.240.0.40:2379 --conns=100 --clients=1000 put --key-size=8 --val-size=256 --sequential-keys --total=100000
 100000 / 100000 Boooooooooooooooooooooooooooooooooooo! 100.00%2s

Summary:
  Total:	2.1566 secs.
  Slowest:	0.0723 secs.
  Fastest:	0.0061 secs.
  Average:	0.0213 secs.
  Stddev:	0.0103 secs.
  Requests/sec:	46369.2150

Response time histogram:
  0.0061 [1]	|
  0.0127 [15698]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0193 [37674]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0259 [26321]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0326 [9060]	|∎∎∎∎∎∎∎∎∎
  0.0392 [3358]	|∎∎∎
  0.0458 [3210]	|∎∎∎
  0.0524 [2199]	|∎∎
  0.0591 [1511]	|∎
  0.0657 [733]	|
  0.0723 [235]	|

Latency distribution:
  10% in 0.0118 secs.
  25% in 0.0145 secs.
  50% in 0.0188 secs.
  75% in 0.0241 secs.
  90% in 0.0349 secs.
  95% in 0.0446 secs.
  99% in 0.0589 secs.



$ benchmark --endpoints=10.240.0.38:2379,10.240.0.39:2379,10.240.0.40:2379 --conns=100 --clients=1000 put --key-size=8 --val-size=256 --sequential-keys --total=1000000
 1000000 / 1000000 Booooooooooooooooooooooooooooooooo! 100.00%21s

Summary:
  Total:	21.1269 secs.
  Slowest:	0.2232 secs.
  Fastest:	0.0051 secs.
  Average:	0.0211 secs.
  Stddev:	0.0093 secs.
  Requests/sec:	47333.0456

Response time histogram:
  0.0051 [1]	|
  0.0269 [821533]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0487 [158306]	|∎∎∎∎∎∎∎
  0.0706 [20104]	|
  0.0924 [46]	|
  0.1142 [0]	|
  0.1360 [0]	|
  0.1578 [0]	|
  0.1796 [0]	|
  0.2014 [0]	|
  0.2232 [10]	|

Latency distribution:
  10% in 0.0117 secs.
  25% in 0.0142 secs.
  50% in 0.0193 secs.
  75% in 0.0242 secs.
  90% in 0.0338 secs.
  95% in 0.0418 secs.
  99% in 0.0520 secs.
```

@heyitsanthony @xiang90 
