### PR TITLE
etcdctl: etcdctl v3 should print out its API version

### DIFF
--- a/etcdctl/ctlv3/command/version_command.go
+++ b/etcdctl/ctlv3/command/version_command.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/coreos/etcd/version"
-	"github.com/coreos/go-semver/semver"
 	"github.com/spf13/cobra"
 )
 
@@ -33,12 +32,5 @@ func NewVersionCommand() *cobra.Command {
 
 func versionCommandFunc(cmd *cobra.Command, args []string) {
 	fmt.Println("etcdctl version:", version.Version)
-	ver, err := semver.NewVersion(version.Version)
-	var vs string
-	if err == nil {
-		vs = fmt.Sprintf("%d.%d", ver.Major, ver.Minor)
-	} else {
-		vs = "unknown"
-	}
-	fmt.Println("API version:", vs)
+	fmt.Println("API version:", version.APIVersion)
 }

--- a/etcdctl/ctlv3/help.go
+++ b/etcdctl/ctlv3/help.go
@@ -68,6 +68,12 @@ VERSION:
 {{end}}\
 {{if .Cmd.HasSubCommands}}\
 
+API VERSION:
+{{printf "\t%s" .APIVersion}}
+{{end}}\
+{{if .Cmd.HasSubCommands}}\
+
+
 COMMANDS:
 {{range .SubCommands}}\
 {{ $cmdname := cmdName . $cmd }}\
@@ -148,12 +154,14 @@ func usageFunc(cmd *cobra.Command) error {
 		GlobalFlags string
 		SubCommands []*cobra.Command
 		Version     string
+		APIVersion  string
 	}{
 		cmd,
 		etcdFlagUsages(cmd.LocalFlags()),
 		etcdFlagUsages(cmd.InheritedFlags()),
 		subCommands,
 		version.Version,
+		version.APIVersion,
 	})
 	tabOut.Flush()
 	return nil

--- a/version/version.go
+++ b/version/version.go
@@ -19,16 +19,26 @@ package version
 import (
 	"fmt"
 	"strings"
+
+	"github.com/coreos/go-semver/semver"
 )
 
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
 	Version           = "3.1.0-rc.0+git"
+	APIVersion        = "unknown"
 
 	// Git SHA Value will be set during build
 	GitSHA = "Not provided (use ./build instead of go build)"
 )
+
+func init() {
+	ver, err := semver.NewVersion(Version)
+	if err == nil {
+		APIVersion = fmt.Sprintf("%d.%d", ver.Major, ver.Minor)
+	}
+}
 
 type Versions struct {
 	Server  string `json:"etcdserver"`


### PR DESCRIPTION
Fix #6814 


```bash
$ ETCDCTL_API=3 ./etcdctl
NAME:
	etcdctl - A simple command line client for etcd3.

USAGE:
	etcdctl

VERSION:
	3.1.0-rc.0+git

API VERSION:
	3.1
...

$ ETCDCTL_API=3 ./etcdctl version
etcdctl version: 3.1.0-rc.0+git
API version: 3.1

$ ETCDCTL_API=2 ./etcdctl -v
etcdctl version: 3.1.0-rc.0+git
API version: 2
```

