### PR TITLE
Fix documentation for  docker run command

### DIFF
--- a/Documentation/v2/docker_guide.md
+++ b/Documentation/v2/docker_guide.md
@@ -16,7 +16,7 @@ This will run the latest release version of etcd. You can specify version if nee
 
 ```
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
- --name etcd quay.io/coreos/etcd \
+ --name etcd quay.io/coreos/etcd /usr/local/bin/etcd \
  -name etcd0 \
  -advertise-client-urls http://${HostIP}:2379,http://${HostIP}:4001 \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \


### PR DESCRIPTION
When i startd etcd using docker using run command as provided in the documentation,  I get an error: 
```
docker: Error response from daemon: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"exec: \\\"-name\\\": executable file not found in $PATH\"\n".
```

Added the COMMAND instruction as part of run command to run etcd using docker.