### PR TITLE
etcd-tester: limit max retry backoff delay

### DIFF
--- a/tools/functional-tester/etcd-tester/lease_stresser.go
+++ b/tools/functional-tester/etcd-tester/lease_stresser.go
@@ -114,7 +114,7 @@ func (ls *leaseStresser) setupOnce() error {
 		panic("expect keysPerLease to be set")
 	}
 
-	conn, err := grpc.Dial(ls.endpoint, grpc.WithInsecure())
+	conn, err := grpc.Dial(ls.endpoint, grpc.WithInsecure(), grpc.WithBackoffMaxDelay(1*time.Second))
 	if err != nil {
 		return fmt.Errorf("%v (%s)", err, ls.endpoint)
 	}


### PR DESCRIPTION
grpc uses expoential retry if a connection is lost. grpc will sleep base on exponential delay.
if delay is too large, it slows down tester.