### PR TITLE
client: Allow CancelableTransport to close idle connections

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -159,6 +159,7 @@ func (cfg *Config) checkRedirect() CheckRedirectFunc {
 type CancelableTransport interface {
 	http.RoundTripper
 	CancelRequest(req *http.Request)
+	CloseIdleConnections()
 }
 
 type CheckRedirectFunc func(via int) error

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -113,6 +113,9 @@ func (t *fakeTransport) CancelRequest(*http.Request) {
 	t.startCancel <- struct{}{}
 }
 
+func (t *fakeTransport) CloseIdleConnections() {
+}
+
 type fakeAction struct{}
 
 func (a *fakeAction) HTTPRequest(url.URL) *http.Request {


### PR DESCRIPTION
By default, CancelableTransport caches connections for future re-use. This may
leave many open connections. The consumers of client package may wish to close
these open connections once they are done using the transport. This can be
achieved simply by exposing CloseIdleConnections() function.

CloseIdleConnections closes any connections which were previously connected
from previous requests but are now sitting idle in a "keep-alive" state. It
does not interrupt any connections currently in use.

Refer: https://golang.org/pkg/net/http/#Transport.CloseIdleConnections

Signed-off-by: Prashanth Pai <ppai@redhat.com>