### PR TITLE
discovery: warn on scheme mismatch

### DIFF
--- a/discovery/srv.go
+++ b/discovery/srv.go
@@ -17,6 +17,7 @@ package discovery
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/coreos/etcd/pkg/types"
@@ -33,11 +34,8 @@ var (
 // Also doesn't do any lookups for the token (though it could)
 // Also sees each entry as a separate instance.
 func SRVGetCluster(name, dns string, defaultToken string, apurls types.URLs) (string, string, error) {
-	var (
-		stringParts []string
-		tcpAPUrls   []string
-	)
 	tempName := int(0)
+	tcp2ap := make(map[string]url.URL)
 
 	// First, resolve the apurls
 	for _, url := range apurls {
@@ -46,10 +44,11 @@ func SRVGetCluster(name, dns string, defaultToken string, apurls types.URLs) (st
 			plog.Errorf("couldn't resolve host %s during SRV discovery", url.Host)
 			return "", "", err
 		}
-		tcpAPUrls = append(tcpAPUrls, tcpAddr.String())
+		tcp2ap[tcpAddr.String()] = url
 	}
 
-	updateNodeMap := func(service, prefix string) error {
+	stringParts := []string{}
+	updateNodeMap := func(service, scheme string) error {
 		_, addrs, err := lookupSRV(service, "tcp", dns)
 		if err != nil {
 			return err
@@ -63,10 +62,9 @@ func SRVGetCluster(name, dns string, defaultToken string, apurls types.URLs) (st
 				continue
 			}
 			n := ""
-			for _, url := range tcpAPUrls {
-				if url == tcpAddr.String() {
-					n = name
-				}
+			url, ok := tcp2ap[tcpAddr.String()]
+			if ok {
+				n = name
 			}
 			if n == "" {
 				n = fmt.Sprintf("%d", tempName)
@@ -75,20 +73,23 @@ func SRVGetCluster(name, dns string, defaultToken string, apurls types.URLs) (st
 			// SRV records have a trailing dot but URL shouldn't.
 			shortHost := strings.TrimSuffix(srv.Target, ".")
 			urlHost := net.JoinHostPort(shortHost, port)
-			stringParts = append(stringParts, fmt.Sprintf("%s=%s%s", n, prefix, urlHost))
-			plog.Noticef("got bootstrap from DNS for %s at %s%s", service, prefix, urlHost)
+			stringParts = append(stringParts, fmt.Sprintf("%s=%s://%s", n, scheme, urlHost))
+			plog.Noticef("got bootstrap from DNS for %s at %s%s", service, scheme, urlHost)
+			if ok && url.Scheme != scheme {
+				plog.Errorf("bootstrap at %s from DNS for %s has scheme mismatch with expected peer %s", scheme+"://"+urlHost, service, url.String())
+			}
 		}
 		return nil
 	}
 
 	failCount := 0
-	err := updateNodeMap("etcd-server-ssl", "https://")
+	err := updateNodeMap("etcd-server-ssl", "https")
 	srvErr := make([]string, 2)
 	if err != nil {
 		srvErr[0] = fmt.Sprintf("error querying DNS SRV records for _etcd-server-ssl %s", err)
 		failCount++
 	}
-	err = updateNodeMap("etcd-server", "http://")
+	err = updateNodeMap("etcd-server", "http")
 	if err != nil {
 		srvErr[1] = fmt.Sprintf("error querying DNS SRV records for _etcd-server %s", err)
 		failCount++


### PR DESCRIPTION
via discussion on etcd-dev on lack of error message if configured for tls but srv records are for cleartext