### PR TITLE
grpcproxy: fix deadlock on watch broadcasts stop

### DIFF
--- a/proxy/grpcproxy/watch_broadcasts.go
+++ b/proxy/grpcproxy/watch_broadcasts.go
@@ -116,13 +116,12 @@ func (wbs *watchBroadcasts) empty() bool { return len(wbs.bcasts) == 0 }
 
 func (wbs *watchBroadcasts) stop() {
 	wbs.mu.Lock()
-	defer wbs.mu.Unlock()
-
 	for wb := range wbs.bcasts {
 		wb.stop()
 	}
 	wbs.bcasts = nil
 	close(wbs.updatec)
+	wbs.mu.Unlock()
 	<-wbs.donec
 }
 


### PR DESCRIPTION
Holding the WatchBroadcasts lock and waiting on donec was
causing a deadlock with the coalesce loop. Was causing
TestV3WatchSyncCancel to hang.