### PR TITLE
etcd-tester: do not resolve localhost

### DIFF
--- a/tools/functional-tester/Procfile
+++ b/tools/functional-tester/Procfile
@@ -1,4 +1,4 @@
-agent-1: mkdir -p agent-1 && cd agent-1 && ../bin/etcd-agent -etcd-path ../bin/etcd -port localhost:19027 -use-root=false
-agent-2: mkdir -p agent-2 && cd agent-2 && ../bin/etcd-agent -etcd-path ../bin/etcd -port localhost:29027 -use-root=false
-agent-3: mkdir -p agent-3 && cd agent-3 && ../bin/etcd-agent -etcd-path ../bin/etcd -port localhost:39027 -use-root=false
-stresser: sleep 1s && bin/etcd-tester -agent-endpoints "localhost:19027,localhost:29027,localhost:39027"  -client-ports 12379,22379,32379 -peer-ports 12380,22380,32380
+agent-1: mkdir -p agent-1 && cd agent-1 && ../bin/etcd-agent -etcd-path ../bin/etcd -port 127.0.0.1:19027 -use-root=false
+agent-2: mkdir -p agent-2 && cd agent-2 && ../bin/etcd-agent -etcd-path ../bin/etcd -port 127.0.0.1:29027 -use-root=false
+agent-3: mkdir -p agent-3 && cd agent-3 && ../bin/etcd-agent -etcd-path ../bin/etcd -port 127.0.0.1:39027 -use-root=false
+stresser: sleep 1s && bin/etcd-tester -agent-endpoints "127.0.0.1:19027,127.0.0.1:29027,127.0.0.1:39027"  -client-ports 12379,22379,32379 -peer-ports 12380,22380,32380


### PR DESCRIPTION
DNS resolution seems to be rate limited on OSX. It can take up to 10 seconds to resolve localhost to 127.0.0.1 which cause a bunch of failures in the tester.

@fanminshi Although this is the root cause, but I found a few other issues in the tester code that shadow this problem. That is why it is so hard to debug... I will fix shadow issues in other prs.

