### PR TITLE
doc: fix etcd docker startup commands

### DIFF
--- a/Documentation/v2/docker_guide.md
+++ b/Documentation/v2/docker_guide.md
@@ -16,7 +16,7 @@ This will run the latest release version of etcd. You can specify version if nee
 
 ```
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
- --name etcd quay.io/coreos/etcd \
+ --name etcd quay.io/coreos/etcd etcd \
  -name etcd0 \
  -advertise-client-urls http://${HostIP}:2379,http://${HostIP}:4001 \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
@@ -46,7 +46,7 @@ The main difference being the value used for the `-initial-cluster` flag, which 
 
 ```
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
- --name etcd quay.io/coreos/etcd \
+ --name etcd quay.io/coreos/etcd etcd \
  -name etcd0 \
  -advertise-client-urls http://192.168.12.50:2379,http://192.168.12.50:4001 \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
@@ -61,7 +61,7 @@ docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380
 
 ```
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
- --name etcd quay.io/coreos/etcd \
+ --name etcd quay.io/coreos/etcd etcd \
  -name etcd1 \
  -advertise-client-urls http://192.168.12.51:2379,http://192.168.12.51:4001 \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
@@ -76,7 +76,7 @@ docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380
 
 ```
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
- --name etcd quay.io/coreos/etcd \
+ --name etcd quay.io/coreos/etcd etcd \
  -name etcd2 \
  -advertise-client-urls http://192.168.12.52:2379,http://192.168.12.52:4001 \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \


### PR DESCRIPTION
This fixes failure to start etcd node(s) when following https://coreos.com/etcd/docs/latest/docker_guide.html ;The error message is: "docker: Error response from daemon: Container command '-name' not found or does not exist.."