### PR TITLE
protect membership change RPCs with auth

### DIFF
--- a/e2e/ctl_v3_member_test.go
+++ b/e2e/ctl_v3_member_test.go
@@ -98,11 +98,14 @@ func ctlV3MemberRemove(cx ctlCtx, memberID, clusterID string) error {
 }
 
 func memberAddTest(cx ctlCtx) {
-	peerURL := fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)
-	cmdArgs := append(cx.PrefixArgs(), "member", "add", "newmember", fmt.Sprintf("--peer-urls=%s", peerURL))
-	if err := spawnWithExpect(cmdArgs, " added to cluster "); err != nil {
+	if err := ctlV3MemberAdd(cx, fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)); err != nil {
 		cx.t.Fatal(err)
 	}
+}
+
+func ctlV3MemberAdd(cx ctlCtx, peerURL string) error {
+	cmdArgs := append(cx.PrefixArgs(), "member", "add", "newmember", fmt.Sprintf("--peer-urls=%s", peerURL))
+	return spawnWithExpect(cmdArgs, " added to cluster ")
 }
 
 func memberUpdateTest(cx ctlCtx) {
@@ -112,8 +115,13 @@ func memberUpdateTest(cx ctlCtx) {
 	}
 
 	peerURL := fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)
-	cmdArgs := append(cx.PrefixArgs(), "member", "update", fmt.Sprintf("%x", mr.Members[0].ID), fmt.Sprintf("--peer-urls=%s", peerURL))
-	if err = spawnWithExpect(cmdArgs, " updated in cluster "); err != nil {
+	memberID := fmt.Sprintf("%x", mr.Members[0].ID)
+	if err = ctlV3MemberUpdate(cx, memberID, peerURL); err != nil {
 		cx.t.Fatal(err)
 	}
+}
+
+func ctlV3MemberUpdate(cx ctlCtx, memberID, peerURL string) error {
+	cmdArgs := append(cx.PrefixArgs(), "member", "update", memberID, fmt.Sprintf("--peer-urls=%s", peerURL))
+	return spawnWithExpect(cmdArgs, " updated in cluster ")
 }


### PR DESCRIPTION
This PR add a mechanism for protecting the membership change RPCs with auth.

Fixes https://github.com/coreos/etcd/issues/6899