### PR TITLE
grpcproxy: fix race between watch ranges delete() and broadcasts empty()

### DIFF
--- a/proxy/grpcproxy/watch_broadcasts.go
+++ b/proxy/grpcproxy/watch_broadcasts.go
@@ -96,7 +96,8 @@ func (wbs *watchBroadcasts) add(w *watcher) {
 	wbs.bcasts[wb] = struct{}{}
 }
 
-func (wbs *watchBroadcasts) delete(w *watcher) {
+// delete removes a watcher and returns the number of remaining watchers.
+func (wbs *watchBroadcasts) delete(w *watcher) int {
 	wbs.mu.Lock()
 	defer wbs.mu.Unlock()
 
@@ -110,9 +111,8 @@ func (wbs *watchBroadcasts) delete(w *watcher) {
 		delete(wbs.bcasts, wb)
 		wb.stop()
 	}
+	return len(wbs.bcasts)
 }
-
-func (wbs *watchBroadcasts) empty() bool { return len(wbs.bcasts) == 0 }
 
 func (wbs *watchBroadcasts) stop() {
 	wbs.mu.Lock()

--- a/proxy/grpcproxy/watch_ranges.go
+++ b/proxy/grpcproxy/watch_ranges.go
@@ -53,8 +53,7 @@ func (wrs *watchRanges) delete(w *watcher) {
 	if !ok {
 		panic("deleting missing range")
 	}
-	wbs.delete(w)
-	if wbs.empty() {
+	if wbs.delete(w) == 0 {
 		wbs.stop()
 		delete(wrs.bcasts, w.wr)
 	}


### PR DESCRIPTION
Checking empty() wasn't grabbing the broadcasts lock so the race detector
flags it as a data race with coalesce(). Instead, just return the number
of remaining watches following delete() and get rid of empty().