### PR TITLE
vendor: bump go-systemd to v14 to avoid build error

### DIFF
--- a/cmd/vendor/github.com/coreos/go-systemd/daemon/sdnotify.go
+++ b/cmd/vendor/github.com/coreos/go-systemd/daemon/sdnotify.go
@@ -1,3 +1,18 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 // Code forked from Docker project
 package daemon
 
@@ -7,11 +22,14 @@ import (
 )
 
 // SdNotify sends a message to the init daemon. It is common to ignore the error.
+// If `unsetEnvironment` is true, the environment variable `NOTIFY_SOCKET`
+// will be unconditionally unset.
+//
 // It returns one of the following:
 // (false, nil) - notification not supported (i.e. NOTIFY_SOCKET is unset)
 // (false, err) - notification supported, but failure happened (e.g. error connecting to NOTIFY_SOCKET or while sending data)
 // (true, nil) - notification supported, data has been sent
-func SdNotify(state string) (sent bool, err error) {
+func SdNotify(unsetEnvironment bool, state string) (sent bool, err error) {
 	socketAddr := &net.UnixAddr{
 		Name: os.Getenv("NOTIFY_SOCKET"),
 		Net:  "unixgram",
@@ -20,6 +38,13 @@ func SdNotify(state string) (sent bool, err error) {
 	// NOTIFY_SOCKET not set
 	if socketAddr.Name == "" {
 		return false, nil
+	}
+
+	if unsetEnvironment {
+		err = os.Unsetenv("NOTIFY_SOCKET")
+	}
+	if err != nil {
+		return false, err
 	}
 
 	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)

--- a/cmd/vendor/github.com/coreos/go-systemd/daemon/watchdog.go
+++ b/cmd/vendor/github.com/coreos/go-systemd/daemon/watchdog.go
@@ -1,0 +1,72 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// SdWatchdogEnabled return watchdog information for a service.
+// Process should send daemon.SdNotify("WATCHDOG=1") every time / 2.
+// If `unsetEnvironment` is true, the environment variables `WATCHDOG_USEC`
+// and `WATCHDOG_PID` will be unconditionally unset.
+//
+// It returns one of the following:
+// (0, nil) - watchdog isn't enabled or we aren't the watched PID.
+// (0, err) - an error happened (e.g. error converting time).
+// (time, nil) - watchdog is enabled and we can send ping.
+//   time is delay before inactive service will be killed.
+func SdWatchdogEnabled(unsetEnvironment bool) (time.Duration, error) {
+	wusec := os.Getenv("WATCHDOG_USEC")
+	wpid := os.Getenv("WATCHDOG_PID")
+	if unsetEnvironment {
+		wusecErr := os.Unsetenv("WATCHDOG_USEC")
+		wpidErr := os.Unsetenv("WATCHDOG_PID")
+		if wusecErr != nil {
+			return 0, wusecErr
+		}
+		if wpidErr != nil {
+			return 0, wpidErr
+		}
+	}
+
+	if wusec == "" {
+		return 0, nil
+	}
+	s, err := strconv.Atoi(wusec)
+	if err != nil {
+		return 0, fmt.Errorf("error converting WATCHDOG_USEC: %s", err)
+	}
+	if s <= 0 {
+		return 0, fmt.Errorf("error WATCHDOG_USEC must be a positive number")
+	}
+	interval := time.Duration(s) * time.Microsecond
+
+	if wpid == "" {
+		return interval, nil
+	}
+	p, err := strconv.Atoi(wpid)
+	if err != nil {
+		return 0, fmt.Errorf("error converting WATCHDOG_PID: %s", err)
+	}
+	if os.Getpid() != p {
+		return 0, nil
+	}
+
+	return interval, nil
+}

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -167,7 +167,7 @@ func startEtcdOrProxyV2() {
 		// for accepting connections. The etcd instance should be
 		// joined with the cluster and ready to serve incoming
 		// connections.
-		sent, err := daemon.SdNotify("READY=1")
+		sent, err := daemon.SdNotify(false, "READY=1")
 		if err != nil {
 			plog.Errorf("failed to notify systemd for readiness: %v", err)
 		}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 93d5ee1318c98aca7c4b42e057239806a565e5aadebdd79e260f95c206098358
-updated: 2016-11-11T09:49:50.684453902-08:00
+hash: 7f6349986c1a1557cb2f4143288f539e1ded6b4bb74e1f9cbbda88127fe8790d
+updated: 2016-12-01T13:08:06.055744535+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -18,7 +18,7 @@ imports:
   subpackages:
   - semver
 - name: github.com/coreos/go-systemd
-  version: bfdc81d0d7e0fb19447b08571f63b774495251ce
+  version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
   - daemon
   - journal

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
   subpackages:
   - semver
 - package: github.com/coreos/go-systemd
-  version: bfdc81d0d7e0fb19447b08571f63b774495251ce
+  version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
   - daemon
   - journal


### PR DESCRIPTION
Bump go-systemd to v14 ([48702e0d](https://github.com/coreos/go-systemd/commit/48702e0da86bd25e76cfef347e2adeb434a0d0a6), 2016-11-14).
Also adjust caller of `daemon.SdNotify()` to avoid build error, which can
be seen especially when running `"go get github.com/coreos/etcd"`.