### PR TITLE
eiipii/etcdhttpclient library added to documentation on external clients

### DIFF
--- a/Documentation/libraries-and-tools.md
+++ b/Documentation/libraries-and-tools.md
@@ -34,6 +34,7 @@
 **Scala libraries**
 
 - [maciej/etcd-client](https://github.com/maciej/etcd-client) - Supports v2. Akka HTTP-based fully async client
+- [eiipii/etcdhttpclient](https://bitbucket.org/eiipii/etcdhttpclient) - Supports v2. Async HTTP client based on Netty and Scala Futures.
 
 **Python libraries**
 


### PR DESCRIPTION
Documentation: link added to libraries-and-tools.md with a new v2 Scala Client

We would like to share our etcd Scala client with the etcd community. Therefore, we would like our client to be featured in the etcd documentation. It would help us share it with a broader public. The details of the library can be found here: http://etcdscalaclient.eiipii.com/ and here: https://bitbucket.org/eiipii/etcdhttpclient. You can reach us through GitHub or at contact@eiipii.com. Thank you!
