### PR TITLE
etcdctl: remove GetUser check before mutable commands

### DIFF
--- a/etcdctl/ctlv2/command/user_commands.go
+++ b/etcdctl/ctlv2/command/user_commands.go
@@ -112,11 +112,6 @@ func actionUserAdd(c *cli.Context) error {
 	ctx, cancel := contextWithTotalTimeout(c)
 	defer cancel()
 	user, _, _ := getUsernamePassword("", userarg+":")
-	currentUser, err := api.GetUser(ctx, user)
-	if currentUser != nil {
-		fmt.Fprintf(os.Stderr, "User %s already exists\n", user)
-		os.Exit(1)
-	}
 
 	_, pass, err := getUsernamePassword("New password: ", userarg)
 	if err != nil {
@@ -151,11 +146,6 @@ func actionUserPasswd(c *cli.Context) error {
 	api, user := mustUserAPIAndName(c)
 	ctx, cancel := contextWithTotalTimeout(c)
 	defer cancel()
-	currentUser, err := api.GetUser(ctx, user)
-	if currentUser == nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
 	pass, err := speakeasy.Ask("New password: ")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error reading password:", err)
@@ -193,12 +183,7 @@ func userGrantRevoke(c *cli.Context, grant bool) {
 	defer cancel()
 
 	api, user := mustUserAPIAndName(c)
-	currentUser, err := api.GetUser(ctx, user)
-	if currentUser == nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
+	var err error
 	if grant {
 		_, err = api.GrantUser(ctx, user, roles)
 	} else {


### PR DESCRIPTION
etcdctl was checking if the user exists before applying mutable calls;
if etcdctl contacts a minority member, the member may not know the user
exists on the cluster yet, causing command failure when it should succeed.

If the user does not exist, it will be picked up once the command goes
through raft.

Fixes #6932