### PR TITLE
grpcproxy: lock store when getting size

### DIFF
--- a/proxy/grpcproxy/cache/store.go
+++ b/proxy/grpcproxy/cache/store.go
@@ -157,5 +157,7 @@ func (c *cache) Compact(revision int64) {
 }
 
 func (c *cache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.lru.Len()
 }


### PR DESCRIPTION
Fixes data race in proxy integration tests.