### PR TITLE
grpcproxy: fix deadlock in watchbroadcast

### DIFF
--- a/proxy/grpcproxy/watch_broadcast.go
+++ b/proxy/grpcproxy/watch_broadcast.go
@@ -89,8 +89,8 @@ func (wb *watchBroadcast) bcast(wr clientv3.WatchResponse) {
 	for r := range wb.receivers {
 		r.send(wr)
 	}
-	if wb.size() > 0 {
-		eventsCoalescing.Add(float64(wb.size() - 1))
+	if len(wb.receivers) > 0 {
+		eventsCoalescing.Add(float64(len(wb.receivers) - 1))
 	}
 }
 
@@ -135,7 +135,7 @@ func (wb *watchBroadcast) delete(w *watcher) {
 		panic("deleting missing watcher from broadcast")
 	}
 	delete(wb.receivers, w)
-	if !wb.empty() {
+	if len(wb.receivers) > 0 {
 		// do not dec the only left watcher for coalescing.
 		watchersCoalescing.Dec()
 	}


### PR DESCRIPTION
Calling empty() in watchbroadcast methods was trying to
lock the rwmutex when it was already held.

Fixes #6937