### PR TITLE
etcdserver: time out when readStateC is blocking

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -135,6 +135,7 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 	r.applyc = make(chan apply)
 	r.stopped = make(chan struct{})
 	r.done = make(chan struct{})
+	internalTimeout := time.Second
 
 	go func() {
 		defer r.onStop()
@@ -167,6 +168,8 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 				if len(rd.ReadStates) != 0 {
 					select {
 					case r.readStateC <- rd.ReadStates[len(rd.ReadStates)-1]:
+					case <-time.After(internalTimeout):
+						plog.Warningf("timed out sending read state")
 					case <-r.stopped:
 						return
 					}


### PR DESCRIPTION
Otherwise, it will block forever when the server is overloaded.

Been running this over 200 cases with no failure.
Should fix https://github.com/coreos/etcd/issues/6891.

```
2016-12-05 23:14:15.145445 I | rafthttp: receiving database snapshot [index:1877557, from 538860f4b8dc9bd3] ...
2016-12-05 23:14:15.484807 W | etcdserver: timed out waiting for read index response
2016-12-05 23:14:16.486533 W | etcdserver: timed out waiting for read index response
2016-12-05 23:14:17.487381 W | etcdserver: timed out waiting for read index response

# timed out here, instead of blocking
2016-12-05 23:14:18.802037 W | etcdserver: timed out sending read states

2016-12-05 23:14:18.973400 W | etcdserver: ignored out-of-date read index response (want [160 68 88 209 49 52 94 25], got [160 68 88 209 49 52 94 49])
2016-12-05 23:14:18.973431 W | etcdserver: ignored out-of-date read index response (want [160 68 88 209 49 52 94 48], got [160 68 88 209 49 52 94 49])
2016-12-05 23:14:19.973558 W | etcdserver: timed out waiting for read index response
2016-12-05 23:14:20.192051 W | etcdserver: ignored out-of-date read index response (want [160 68 88 209 49 52 94 49], got [160 68 88 209 49 52 94 124])
2016-12-05 23:14:21.192240 W | etcdserver: timed out waiting for read index response
2016-12-05 23:14:21.389150 W | etcdserver: ignored out-of-date read index response (want [160 68 88 209 49 52 94 124], got [160 68 88 209 49 52 94 126])
2016-12-05 23:14:23.060116 I | snap: saved database snapshot to disk [total bytes: 208023552]
2016-12-05 23:14:23.060147 I | rafthttp: received and saved database snapshot [index: 1877557, from: 538860f4b8dc9bd3] successfully
2016-12-05 23:14:23.060259 I | raft: 49c299722c86a044 [commit: 1871239, lastindex: 1871239, lastterm: 30] starts to restore snapshot [index: 1877557, term: 30]
2016-12-05 23:14:23.060278 I | raft: log [committed=1871239, applied=1871239, unstable.offset=1871240, len(unstable.Entries)=0] starts to restore snapshot [index: 1877557, term: 30]
2016-12-05 23:14:23.060293 I | raft: 49c299722c86a044 restored progress of 2d33a39906c2e8fc [next = 1877558, match = 0, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
2016-12-05 23:14:23.060299 I | raft: 49c299722c86a044 restored progress of 49c299722c86a044 [next = 1877558, match = 1877557, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
2016-12-05 23:14:23.060305 I | raft: 49c299722c86a044 restored progress of 538860f4b8dc9bd3 [next = 1877558, match = 0, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
2016-12-05 23:14:23.060310 I | raft: 49c299722c86a044 restored progress of b2a15fc29e1c2094 [next = 1877558, match = 0, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
2016-12-05 23:14:23.060315 I | raft: 49c299722c86a044 restored progress of f82b1d3fd95afc1a [next = 1877558, match = 0, state = ProgressStateProbe, waiting = false, pendingSnapshot = 0]
2016-12-05 23:14:23.060320 I | raft: 49c299722c86a044 [commit: 1877557] restored snapshot [index: 1877557, term: 30]
2016-12-05 23:14:23.060455 I | etcdserver: applying snapshot at index 1869419...
2016-12-05 23:14:23.063044 I | etcdserver: raft applied incoming snapshot at index 1877557
2016-12-05 23:14:23.072271 I | etcdserver: recovering lessor...
2016-12-05 23:14:23.074595 I | etcdserver: finished recovering lessor
2016-12-05 23:14:23.074610 I | etcdserver: restoring mvcc store...
2016-12-05 23:14:23.075406 I | mvcc: restore compact to 1305048
2016-12-05 23:14:24.798783 I | etcdserver: finished restoring mvcc store
2016-12-05 23:14:24.798811 I | etcdserver: recovering alarms...
2016-12-05 23:14:24.798895 I | etcdserver: closing old backend...
2016-12-05 23:14:24.801148 I | etcdserver: finished recovering alarms
2016-12-05 23:14:24.801165 I | etcdserver: recovering auth store...
2016-12-05 23:14:24.801176 I | etcdserver: finished recovering auth store
2016-12-05 23:14:24.801180 I | etcdserver: recovering store v2...
2016-12-05 23:14:24.801636 I | etcdserver: finished recovering store v2
2016-12-05 23:14:24.801648 I | etcdserver: recovering cluster configuration...
2016-12-05 23:14:24.801734 I | etcdserver/membership: added member 49c299722c86a044 [http://10.240.0.2:2380] to cluster 932e9025fd6b1462 from store
2016-12-05 23:14:24.801744 I | etcdserver/membership: added member 538860f4b8dc9bd3 [http://10.240.0.3:2380] to cluster 932e9025fd6b1462 from store
2016-12-05 23:14:24.801750 I | etcdserver/membership: added member b2a15fc29e1c2094 [http://10.240.0.6:2380] to cluster 932e9025fd6b1462 from store
2016-12-05 23:14:24.801755 I | etcdserver/membership: added member f82b1d3fd95afc1a [http://10.240.0.5:2380] to cluster 932e9025fd6b1462 from store
2016-12-05 23:14:24.801760 I | etcdserver/membership: added member 2d33a39906c2e8fc [http://10.240.0.4:2380] to cluster 932e9025fd6b1462 from store
2016-12-05 23:14:24.801766 I | etcdserver/membership: set the cluster version to 3.1 from store
2016-12-05 23:14:24.801770 I | etcdserver: finished recovering cluster configuration
```

@xiang90 @heyitsanthony @fanminshi 