### PR TITLE
github: make bug reporting link non-relative

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,4 +5,4 @@ A good bug report has some very specific qualities, so please read over our shor
 
 To ask a question, go ahead and ignore this.
 
-[report_bugs]: ../Documentation/reporting_bugs.md
+[report_bugs]: https://github.com/coreos/etcd/blob/master/Documentation/reporting_bugs.md


### PR DESCRIPTION
Works when accessed through code browser, blank if accessed via issues/

/cc @suranap