### PR TITLE
github: make contribution link non-relative

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 
 Please read our [contribution workflow][contributing] before submitting a pull request.
 
-[contributing]: ../CONTRIBUTING.md#contribution-flow
+[contributing]: https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow


### PR DESCRIPTION
Works when accessed through code browser, blank if accessed via pull request.