### PR TITLE
etcd-tester: cancel lease stream; fix OOM panic

### DIFF
--- a/tools/functional-tester/etcd-tester/lease_stresser.go
+++ b/tools/functional-tester/etcd-tester/lease_stresser.go
@@ -266,6 +266,7 @@ func (ls *leaseStresser) keepLeaseAlive(leaseID int64) {
 	defer ls.aliveWg.Done()
 	ctx, cancel := context.WithCancel(ls.ctx)
 	stream, err := ls.lc.LeaseKeepAlive(ctx)
+	defer func() { cancel() }()
 	for {
 		select {
 		case <-time.After(500 * time.Millisecond):


### PR DESCRIPTION
It was never closing lease keep-alive streams, leaking memory.
Fix OOM panics in etcd-tester (after 1K rounds).