### PR TITLE
embed: deep copy user handlers

### DIFF
--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -286,7 +286,9 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 				plog.Info("stopping listening for client requests on ", u.Host)
 			}
 		}()
-		sctx.userHandlers = cfg.UserHandlers
+		for k := range cfg.UserHandlers {
+			sctx.userHandlers[k] = cfg.UserHandlers[k]
+		}
 		if cfg.EnablePprof {
 			sctx.registerPprof()
 		}

--- a/embed/serve.go
+++ b/embed/serve.go
@@ -51,7 +51,7 @@ type serveCtx struct {
 
 func newServeCtx() *serveCtx {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &serveCtx{ctx: ctx, cancel: cancel}
+	return &serveCtx{ctx: ctx, cancel: cancel, userHandlers: make(map[string]http.Handler)}
 }
 
 // serve accepts incoming connections on the listener l,


### PR DESCRIPTION
Shallow copy of user handlers leads to a nil map assignment when
enabling pprof. Since the map is being modified, it should probably
be deep copied into the server context, which fixes the crash.