### PR TITLE
clientv3: ensure KeepAlive channel is closed or error is returned

### DIFF
--- a/clientv3/integration/lease_test.go
+++ b/clientv3/integration/lease_test.go
@@ -569,7 +569,8 @@ func TestLeaseKeepAliveLoopExit(t *testing.T) {
 	}
 	cli.Lease.Close()
 
-	if _, err := cli.KeepAlive(ctx, resp.ID); err != clientv3.ErrLeaseHalted {
-		t.Fatalf("expected %v, got %v", clientv3.ErrLeaseHalted, err)
+	_, err = cli.KeepAlive(ctx, resp.ID)
+	if _, ok := err.(clientv3.ErrKeepAliveHalted); !ok {
+		t.Fatalf("expected %T, got %v(%T)", clientv3.ErrKeepAliveHalted{}, err, err)
 	}
 }

--- a/clientv3/integration/lease_test.go
+++ b/clientv3/integration/lease_test.go
@@ -553,3 +553,23 @@ func TestLeaseRenewLostQuorum(t *testing.T) {
 		t.Fatalf("timed out waiting for keepalive")
 	}
 }
+
+func TestLeaseKeepAliveLoopExit(t *testing.T) {
+	defer testutil.AfterTest(t)
+
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	ctx := context.Background()
+	cli := clus.Client(0)
+
+	resp, err := cli.Grant(ctx, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli.Lease.Close()
+
+	if _, err := cli.KeepAlive(ctx, resp.ID); err != clientv3.ErrLeaseHalted {
+		t.Fatalf("expected %v, got %v", clientv3.ErrLeaseHalted, err)
+	}
+}


### PR DESCRIPTION
After `recvKeepAliveLoop` exits client might call `KeepAlive`, adding request channel that will not be closed.
This fix makes sure that `recvKeepAliveLoop` is running before adding request to lessor's list and returns error otherwise.

Fixes #6922