### PR TITLE
lease: force leader to apply its pending committed index for lease op…

### DIFF
--- a/etcdserver/api/v2http/peer.go
+++ b/etcdserver/api/v2http/peer.go
@@ -31,8 +31,9 @@ const (
 // NewPeerHandler generates an http.Handler to handle etcd peer requests.
 func NewPeerHandler(s *etcdserver.EtcdServer) http.Handler {
 	var lh http.Handler
-	if l := s.Lessor(); l != nil {
-		lh = leasehttp.NewHandler(l)
+	l := s.Lessor()
+	if l != nil {
+		lh = leasehttp.NewHandler(l, func() <-chan struct{} { return s.ApplyWait() })
 	}
 	return newPeerHandler(s.Cluster(), s.RaftHandler(), lh)
 }

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -565,6 +565,8 @@ func (s *EtcdServer) RaftHandler() http.Handler { return s.r.transport.Handler()
 
 func (s *EtcdServer) Lessor() lease.Lessor { return s.lessor }
 
+func (s *EtcdServer) ApplyWait() <-chan struct{} { return s.applyWait.Wait(s.getCommittedIndex()) }
+
 func (s *EtcdServer) Process(ctx context.Context, m raftpb.Message) error {
 	if s.cluster.IsIDRemoved(types.ID(m.From)) {
 		plog.Warningf("reject message from removed member %s", types.ID(m.From).String())

--- a/lease/leasehttp/http.go
+++ b/lease/leasehttp/http.go
@@ -206,7 +206,8 @@ func TimeToLiveHTTP(ctx context.Context, id lease.LeaseID, keys bool, url string
 
 	cc := &http.Client{Transport: rt}
 	var b []byte
-	errc := make(chan error)
+	// buffer errc channel so that errc don't block inside the go routinue
+	errc := make(chan error, 2)
 	go func() {
 		resp, err := cc.Do(req)
 		if err != nil {


### PR DESCRIPTION
suppose a lease granting request from a follower goes through and followed by a lease look up or renewal, the leader might not apply the lease grant request locally. So the leader might not find the lease from the lease look up or renewal request which will result lease not found error. To fix this issue, we force the leader to apply its pending committed index before looking up lease.

FIX #6978