### PR TITLE
etcdmain: add '--metrics' option

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -247,7 +247,7 @@ The security flags help to [build a secure etcd cluster][security].
 + env variable: ETCD_DEBUG
 
 ### --log-package-levels
-+ Set individual etcd subpackages to specific log levels. An example being `etcdserver=WARNING,security=DEBUG` 
++ Set individual etcd subpackages to specific log levels. An example being `etcdserver=WARNING,security=DEBUG`
 + default: none (INFO for all packages)
 + env variable: ETCD_LOG_PACKAGE_LEVELS
 
@@ -278,6 +278,10 @@ Follow the instructions when using these flags.
 ### --enable-pprof
 + Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof/"
 + default: false
+
+### --metrics
++ Set level of detail for exported metrics, specify 'extensive' to include histogram metrics.
++ default: basic
 
 [build-cluster]: clustering.md#static
 [reconfig]: runtime-configuration.md

--- a/embed/config.go
+++ b/embed/config.go
@@ -115,6 +115,7 @@ type Config struct {
 	Debug        bool   `json:"debug"`
 	LogPkgLevels string `json:"log-package-levels"`
 	EnablePprof  bool
+	Metrics      string `json:"metrics"`
 
 	// ForceNewCluster starts a new cluster even if previously started; unsafe.
 	ForceNewCluster bool `json:"force-new-cluster"`
@@ -173,6 +174,7 @@ func NewConfig() *Config {
 		ClusterState:        ClusterStateFlagNew,
 		InitialClusterToken: "etcd-cluster",
 		StrictReconfigCheck: true,
+		Metrics:             "basic",
 	}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	return cfg

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -198,6 +198,9 @@ func newConfig() *config {
 	// pprof profiler via HTTP
 	fs.BoolVar(&cfg.EnablePprof, "enable-pprof", false, "Enable runtime profiling data via HTTP server. Address is at client URL + \"/debug/pprof/\"")
 
+	// additional metrics
+	fs.StringVar(&cfg.Metrics, "metrics", cfg.Metrics, "Set level of detail for exported metrics, specify 'extensive' to include histogram metrics")
+
 	// ignored
 	for _, f := range cfg.ignored {
 		fs.Var(&flags.IgnoredFlag{Name: f}, f, "")

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -42,6 +42,7 @@ import (
 	"github.com/coreos/go-systemd/daemon"
 	systemdutil "github.com/coreos/go-systemd/util"
 	"github.com/coreos/pkg/capnslog"
+	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 )
@@ -195,6 +196,10 @@ func startEtcd(cfg *embed.Config) (<-chan struct{}, <-chan error, error) {
 		} else {
 			plog.Noticef("failed to detect default host, advertise falling back to %q (%v)", defaultHost, dhErr)
 		}
+	}
+
+	if cfg.Metrics == "extensive" {
+		grpc_prometheus.EnableHandlingTimeHistogram()
 	}
 
 	e, err := embed.StartEtcd(cfg)

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -149,9 +149,11 @@ given by the consensus protocol.
 
 	--force-new-cluster 'false'
 		force to create a new one-member cluster.
-	
+
 profiling flags:
 	--enable-pprof 'false'
 		Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof/"
+	--metrics 'basic'
+	  Set level of detail for exported metrics, specify 'extensive' to include histogram metrics.
 `
 )


### PR DESCRIPTION
Addresses #7024, adds a flag for enabling GRPC Prometheus time histogram metrics.