### PR TITLE
store: set e.Node.Dir attribute, when node expired

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -682,6 +682,9 @@ func (s *store) DeleteExpiredKeys(cutoff time.Time) {
 		e := newEvent(Expire, node.Path, s.CurrentIndex, node.CreatedIndex)
 		e.EtcdIndex = s.CurrentIndex
 		e.PrevNode = node.Repr(false, false, s.clock)
+		if node.IsDir() {
+			e.Node.Dir = true
+		}
 
 		callback := func(path string) { // notify function
 			// notify the watchers with deleted set true

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -737,7 +737,7 @@ func TestStoreWatchExpire(t *testing.T) {
 	s.clock = fc
 
 	var eidx uint64 = 2
-	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
+	s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 	s.Create("/foofoo", false, "barbarbar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 
 	w, _ := s.Watch("/", true, false, 0)
@@ -752,6 +752,7 @@ func TestStoreWatchExpire(t *testing.T) {
 	assert.Equal(t, e.EtcdIndex, eidx, "")
 	assert.Equal(t, e.Action, "expire", "")
 	assert.Equal(t, e.Node.Key, "/foo", "")
+	assert.Equal(t, e.Node.Dir, true, "")
 	w, _ = s.Watch("/", true, false, 4)
 	eidx = 4
 	assert.Equal(t, w.StartIndex(), eidx, "")


### PR DESCRIPTION
Sets e.Node.Dir attribute in `DeleteExpiredKeys`

When a directory node expired, the `prevNode` has a `"dir":true` attribute in the received expire event, but the `node` has no `"dir":true` attribute

Fixes #7033