### PR TITLE
store: set e.Node.Dir attribute, when node expired

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -682,6 +682,9 @@ func (s *store) DeleteExpiredKeys(cutoff time.Time) {
 		e := newEvent(Expire, node.Path, s.CurrentIndex, node.CreatedIndex)
 		e.EtcdIndex = s.CurrentIndex
 		e.PrevNode = node.Repr(false, false, s.clock)
+		if node.IsDir() {
+			e.Node.Dir = true
+		}
 
 		callback := func(path string) { // notify function
 			// notify the watchers with deleted set true

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -736,9 +736,10 @@ func TestStoreWatchExpire(t *testing.T) {
 	fc := newFakeClock()
 	s.clock = fc
 
-	var eidx uint64 = 2
-	s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
-	s.Create("/foofoo", false, "barbarbar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
+	var eidx uint64 = 3
+	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(400 * time.Millisecond)})
+	s.Create("/foofoo", false, "barbarbar", false, TTLOptionSet{ExpireTime: fc.Now().Add(450 * time.Millisecond)})
+	s.Create("/foodir", true, "", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 
 	w, _ := s.Watch("/", true, false, 0)
 	assert.Equal(t, w.StartIndex(), eidx, "")
@@ -747,19 +748,24 @@ func TestStoreWatchExpire(t *testing.T) {
 	assert.Nil(t, e, "")
 	fc.Advance(600 * time.Millisecond)
 	s.DeleteExpiredKeys(fc.Now())
-	eidx = 3
+	eidx = 4
 	e = nbselect(c)
 	assert.Equal(t, e.EtcdIndex, eidx, "")
 	assert.Equal(t, e.Action, "expire", "")
 	assert.Equal(t, e.Node.Key, "/foo", "")
-	assert.Equal(t, e.Node.Dir, true, "")
-	w, _ = s.Watch("/", true, false, 4)
-	eidx = 4
+	w, _ = s.Watch("/", true, false, 5)
+	eidx = 6
 	assert.Equal(t, w.StartIndex(), eidx, "")
 	e = nbselect(w.EventChan())
 	assert.Equal(t, e.EtcdIndex, eidx, "")
 	assert.Equal(t, e.Action, "expire", "")
 	assert.Equal(t, e.Node.Key, "/foofoo", "")
+	w, _ = s.Watch("/", true, false, 6)
+	e = nbselect(w.EventChan())
+	assert.Equal(t, e.EtcdIndex, eidx, "")
+	assert.Equal(t, e.Action, "expire", "")
+	assert.Equal(t, e.Node.Key, "/foodir", "")
+	assert.Equal(t, e.Node.Dir, true, "")
 }
 
 // Ensure that the store can watch for key expiration when refreshing.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -737,7 +737,7 @@ func TestStoreWatchExpire(t *testing.T) {
 	s.clock = fc
 
 	var eidx uint64 = 2
-	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
+	s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 	s.Create("/foofoo", false, "barbarbar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 
 	w, _ := s.Watch("/", true, false, 0)
@@ -752,6 +752,7 @@ func TestStoreWatchExpire(t *testing.T) {
 	assert.Equal(t, e.EtcdIndex, eidx, "")
 	assert.Equal(t, e.Action, "expire", "")
 	assert.Equal(t, e.Node.Key, "/foo", "")
+	assert.Equal(t, e.Node.Dir, true, "")
 	w, _ = s.Watch("/", true, false, 4)
 	eidx = 4
 	assert.Equal(t, w.StartIndex(), eidx, "")


### PR DESCRIPTION
Sets `e.Node.Dir` attribute in `DeleteExpiredKeys`

When a directory node expired, the `prevNode` has a `"dir":true` attribute in the received expire event, but the `node` has no `"dir":true` attribute

Fixes #7033