### PR TITLE
benchmark: a new option for configuring dial timeout

### DIFF
--- a/tools/benchmark/cmd/root.go
+++ b/tools/benchmark/cmd/root.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"sync"
+	"time"
 
 	"github.com/coreos/etcd/pkg/transport"
 
@@ -49,6 +50,8 @@ var (
 	memProfPath string
 
 	user string
+
+	dialTimeout time.Duration
 )
 
 func init() {
@@ -63,4 +66,5 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&tls.CAFile, "cacert", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
 
 	RootCmd.PersistentFlags().StringVar(&user, "user", "", "specify username and password in username:password format")
+	RootCmd.PersistentFlags().DurationVar(&dialTimeout, "dial-timeout", 0, "dial timeout for client connections")
 }

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -33,7 +33,10 @@ var (
 func mustCreateConn() *clientv3.Client {
 	endpoint := endpoints[dialTotal%len(endpoints)]
 	dialTotal++
-	cfg := clientv3.Config{Endpoints: []string{endpoint}}
+	cfg := clientv3.Config{
+		Endpoints:   []string{endpoint},
+		DialTimeout: dialTimeout,
+	}
 	if !tls.Empty() {
 		cfgtls, err := tls.ClientConfig()
 		if err != nil {


### PR DESCRIPTION
Current benchmark doesn't have an option for configuring dial timeout
of gRPC. This commit adds --dial-timeout for the purpose. It is useful
for stopping long sticking benchmarks.
