### PR TITLE
add cluster info after adding new member

### DIFF
--- a/etcdctl/ctlv3/command/member_command.go
+++ b/etcdctl/ctlv3/command/member_command.go
@@ -99,6 +99,7 @@ func memberAddCommandFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		ExitWithError(ExitBadArgs, fmt.Errorf("member name not provided."))
 	}
+	newMemberName := args[0]
 
 	if len(memberPeerURLs) == 0 {
 		ExitWithError(ExitBadArgs, fmt.Errorf("member peer urls not provided."))
@@ -111,8 +112,34 @@ func memberAddCommandFunc(cmd *cobra.Command, args []string) {
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
+	newID := resp.Member.ID
 
 	display.MemberAdd(*resp)
+
+	ctx, cancel = commandCtx(cmd)
+	listResp, err := mustClientFromCmd(cmd).MemberList(ctx)
+	cancel()
+
+	if err != nil {
+		ExitWithError(ExitError, err)
+	}
+
+	conf := []string{}
+	for _, memb := range listResp.Members {
+		for _, u := range memb.PeerURLs {
+			n := memb.Name
+			if memb.ID == newID {
+				n = newMemberName
+			}
+			conf = append(conf, fmt.Sprintf("%s=%s", n, u))
+		}
+	}
+
+	fmt.Print("\n")
+	fmt.Printf("ETCD_NAME=%q\n", newMemberName)
+	fmt.Printf("ETCD_INITIAL_CLUSTER=%q\n", strings.Join(conf, ","))
+	fmt.Printf("ETCD_INITIAL_CLUSTER_STATE=\"existing\"\n")
+
 }
 
 // memberRemoveCommandFunc executes the "member remove" command.


### PR DESCRIPTION
Finish feature in issue: https://github.com/coreos/etcd/issues/7049
 - add cluster info after adding new member