### PR TITLE
test: bump grpcproxy pass timeout to 15m

### DIFF
--- a/test
+++ b/test
@@ -98,7 +98,7 @@ function integration_e2e_pass {
 }
 
 function grpcproxy_pass {
-	go test -timeout 10m -v ${RACE} -tags cluster_proxy -cpu 1,2,4 $@ ${REPO_PATH}/integration
+	go test -timeout 15m -v ${RACE} -tags cluster_proxy -cpu 1,2,4 $@ ${REPO_PATH}/integration
 }
 
 function release_pass {


### PR DESCRIPTION
integration tests have a 15m timeout elsewhere. The lease stress tests
seem to have pushed the running time over 10m on proxy CI, causing
failures from timeout.