### PR TITLE
e2e: unset ETCDCTL_API env var before running e2e tests

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -18,6 +18,7 @@ var certDir string
 
 func TestMain(m *testing.M) {
 	os.Setenv("ETCD_UNSUPPORTED_ARCH", runtime.GOARCH)
+	os.Unsetenv("ETCDCTL_API")
 
 	flag.StringVar(&binDir, "bin-dir", "../bin", "The directory for store etcd and etcdctl binaries.")
 	flag.StringVar(&certDir, "cert-dir", "../integration/fixtures", "The directory for store certificate files.")


### PR DESCRIPTION
existing ETCDCTL_API env var causes e2e to fail some of its tests.  ETCDCTL_API should not be set before e2e tests start.
the tests themselves should set ETCDCTL_API properly.
