### PR TITLE
rafthttp: bump up timeout in pipeline test

### DIFF
--- a/rafthttp/pipeline_test.go
+++ b/rafthttp/pipeline_test.go
@@ -78,7 +78,7 @@ func TestPipelineExceedMaximumServing(t *testing.T) {
 	for i := 0; i < connPerPipeline+pipelineBufSize; i++ {
 		select {
 		case p.msgc <- raftpb.Message{}:
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(time.Second):
 			t.Errorf("failed to send out message")
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6283.

The timeout is too short. It could take more than 10ms
to send when the buffer gets full after `pipelineBufSize` of
requests.
