### PR TITLE
raftexample: load snapshot when opening WAL

### DIFF
--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -77,6 +77,7 @@ func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {
 			if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
 				log.Panic(err)
 			}
+			continue
 		}
 
 		var dataKv kv


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/7056.
Previously we don't load snapshot when replaying WAL.

Example logs

```
2016-12-30 16:33:48.654724 I | replaying WAL of member 3
2016-12-30 16:33:48.655074 I | loading WAL at term 4 and index 12
raft2016/12/30 16:33:48 INFO: 3 became follower at term 4
raft2016/12/30 16:33:48 INFO: newRaft 3 [peers: [1,2,3], term: 4, commit: 15, applied: 12, lastindex: 16, lastterm: 4]
```
