### PR TITLE
resolve  parsing time "2017-01-04T04:20:08.431347779Z"" as ""2006-01-…

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/pkg/pathutil"
-	"github.com/ugorji/go/codec"
 	"golang.org/x/net/context"
 )
 
@@ -659,7 +658,7 @@ func unmarshalHTTPResponse(code int, header http.Header, body []byte) (res *Resp
 
 func unmarshalSuccessfulKeysResponse(header http.Header, body []byte) (*Response, error) {
 	var res Response
-	err := codec.NewDecoderBytes(body, new(codec.JsonHandle)).Decode(&res)
+	err := json.Unmarshal(body, &res)
 	if err != nil {
 		return nil, ErrInvalidJSON
 	}


### PR DESCRIPTION
rpcx调用etcd 的client 

{"action":"get","node":{"key":"/rpcx/Arith","dir":true,"nodes":[{"key":"/rpcx/Arith/tcp@127.0.0.1:8972","value":"weight=1\u0026m=devops","expiration":"2017-01-04T04:20:08.431347779Z","ttl":65,"modifiedIndex":97,"createdIndex":97}],"modifiedIndex":5,"createdIndex":5}}

解析json里面的  expiration报错 ,是github.com/ugorji/go/codec这个第三方包导致的