### PR TITLE
integration: use only digits in unix ports

### DIFF
--- a/integration/bridge.go
+++ b/integration/bridge.go
@@ -39,7 +39,8 @@ type bridge struct {
 
 func newBridge(addr string) (*bridge, error) {
 	b := &bridge{
-		inaddr:  addr + ".bridge",
+		// bridge "port" is ("%05d%05d0", port, pid) since go1.8 expects the port to be a number
+		inaddr:  addr + "0",
 		outaddr: addr,
 		conns:   make(map[*bridgeConn]struct{}),
 		stopc:   make(chan struct{}, 1),

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -404,7 +404,7 @@ func (c *cluster) waitVersion() {
 }
 
 func (c *cluster) name(i int) string {
-	return fmt.Sprint("node", i)
+	return fmt.Sprint(i)
 }
 
 // isMembersEqual checks whether two members equal except ID field.
@@ -420,7 +420,8 @@ func isMembersEqual(membs []client.Member, wmembs []client.Member) bool {
 
 func newLocalListener(t *testing.T) net.Listener {
 	c := atomic.AddInt64(&localListenCount, 1)
-	addr := fmt.Sprintf("127.0.0.1:%d.%d.sock", c+basePort, os.Getpid())
+	// Go 1.8+ allows only numbers in port
+	addr := fmt.Sprintf("127.0.0.1:%05d%05d", c+basePort, os.Getpid())
 	return NewListenerWithAddr(t, addr)
 }
 
@@ -510,7 +511,7 @@ func mustNewMember(t *testing.T, mcfg memberConfig) *member {
 // listenGRPC starts a grpc server over a unix domain socket on the member
 func (m *member) listenGRPC() error {
 	// prefix with localhost so cert has right domain
-	m.grpcAddr = "localhost:" + m.Name + ".sock"
+	m.grpcAddr = "localhost:" + m.Name
 	l, err := transport.NewUnixListener(m.grpcAddr)
 	if err != nil {
 		return fmt.Errorf("listen failed on grpc socket %s (%v)", m.grpcAddr, err)

--- a/integration/embed_test.go
+++ b/integration/embed_test.go
@@ -93,7 +93,7 @@ func TestEmbedEtcd(t *testing.T) {
 
 func newEmbedURLs(n int) (urls []url.URL) {
 	for i := 0; i < n; i++ {
-		u, _ := url.Parse(fmt.Sprintf("unix://localhost:%d.%d.sock", os.Getpid(), i))
+		u, _ := url.Parse(fmt.Sprintf("unix://localhost:%d%06d", os.Getpid(), i))
 		urls = append(urls, *u)
 	}
 	return


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/6959.

Otherwise Travis keeps failing.