### PR TITLE
e2e: dump stacks on ctlTest timeout

### DIFF
--- a/e2e/ctl_v3_test.go
+++ b/e2e/ctl_v3_test.go
@@ -163,7 +163,7 @@ func testCtl(t *testing.T, testFunc func(ctlCtx), opts ...ctlOption) {
 	}
 	select {
 	case <-time.After(timeout):
-		t.Fatalf("test timed out after %v", timeout)
+		testutil.FatalStack(t, fmt.Sprintf("test timed out after %v", timeout))
 	case <-donec:
 	}
 }


### PR DESCRIPTION
Figure out which process is blocking for Elect/Lock test timeouts.