### PR TITLE
testutil: increase size of buffer for stack dump

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -50,7 +50,7 @@ func MustNewURL(t *testing.T, s string) *url.URL {
 
 // FatalStack helps to fatal the test and print out the stacks of all running goroutines.
 func FatalStack(t *testing.T, s string) {
-	stackTrace := make([]byte, 8*1024)
+	stackTrace := make([]byte, 1024*1024)
 	n := runtime.Stack(stackTrace, true)
 	t.Error(string(stackTrace[:n]))
 	t.Fatalf(s)


### PR DESCRIPTION
Too many goroutines to fit all stack traces in 8kb.

(cf. https://semaphoreci.com/coreos/etcd/branches/master/builds/1403)