### PR TITLE
Update ugorji/go with embedded interface support

### DIFF
--- a/cmd/vendor/github.com/ugorji/go/codec/gen-helper.generated.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/gen-helper.generated.go
@@ -1,4 +1,4 @@
-// // +build ignore
+/* // +build ignore */
 
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.

--- a/cmd/vendor/github.com/ugorji/go/codec/gen.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/gen.go
@@ -165,15 +165,9 @@ type genRunner struct {
 //
 // Library users: *DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.*
 func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, ti *TypeInfos, typ ...reflect.Type) {
-	// trim out all types which already implement Selfer
-	typ2 := make([]reflect.Type, 0, len(typ))
-	for _, t := range typ {
-		if reflect.PtrTo(t).Implements(selferTyp) || t.Implements(selferTyp) {
-			continue
-		}
-		typ2 = append(typ2, t)
-	}
-	typ = typ2
+	// All types passed to this method do not have a codec.Selfer method implemented directly.
+	// codecgen already checks the AST and skips any types that define the codec.Selfer methods.
+	// Consequently, there's no need to check and trim them if they implement codec.Selfer
 
 	if len(typ) == 0 {
 		return

--- a/cmd/vendor/github.com/ugorji/go/codec/simple.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/simple.go
@@ -347,7 +347,7 @@ func (d *simpleDecDriver) decLen() int {
 		}
 		return int(ui)
 	}
-	d.d.errorf("decLen: Cannot read length: bd%8 must be in range 0..4. Got: %d", d.bd%8)
+	d.d.errorf("decLen: Cannot read length: bd%%8 must be in range 0..4. Got: %d", d.bd%8)
 	return -1
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f5e65261a5c4f6d9d4f1a7958d59d1cc94c80d8304773c0a515fb3c32e875dce
-updated: 2016-12-08T14:15:57.098159227-08:00
+hash: e19ee990cd69a4691200ce929e44477f4e5a1a43fb72303a172cdfaddc16cb47
+updated: 2017-01-09T12:10:50.0887037+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -100,7 +100,7 @@ imports:
   subpackages:
   - assert
 - name: github.com/ugorji/go
-  version: 9c7f9b7a2bc3a520f7c7b30b34b7f85f47fe27b6
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: github.com/urfave/cli

--- a/glide.yaml
+++ b/glide.yaml
@@ -60,7 +60,7 @@ import:
 - package: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - package: github.com/ugorji/go
-  version: 9c7f9b7a2bc3a520f7c7b30b34b7f85f47fe27b6
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - package: github.com/urfave/cli
@@ -105,4 +105,3 @@ import:
   version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert
-


### PR DESCRIPTION
Counterpart of https://github.com/kubernetes/kubernetes/pull/37557 to avoid that future etcd dependency updates in kube undo essential ugorji/go changes (https://github.com/ugorji/go/commit/ded73eae5db7e7a0ef6f55aace87a2873c5d2b74).