### PR TITLE
auth: reject empty user name when checking op permissions

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -706,6 +706,11 @@ func (as *authStore) isOpPermitted(userName string, revision uint64, key, rangeE
 		return nil
 	}
 
+	// only gets rev == 0 when passed AuthInfo{}; no user given
+	if revision == 0 {
+		return ErrUserEmpty
+	}
+
 	if revision < as.revision {
 		return ErrAuthOldRevision
 	}

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -889,4 +889,6 @@ type grpcAPI struct {
 	Watch pb.WatchClient
 	// Maintenance is the maintenance API for the client's connection.
 	Maintenance pb.MaintenanceClient
+	// Auth is the authentication API for the client's connection.
+	Auth pb.AuthClient
 }

--- a/integration/cluster_direct.go
+++ b/integration/cluster_direct.go
@@ -28,6 +28,7 @@ func toGRPC(c *clientv3.Client) grpcAPI {
 		pb.NewLeaseClient(c.ActiveConnection()),
 		pb.NewWatchClient(c.ActiveConnection()),
 		pb.NewMaintenanceClient(c.ActiveConnection()),
+		pb.NewAuthClient(c.ActiveConnection()),
 	}
 }
 

--- a/integration/cluster_proxy.go
+++ b/integration/cluster_proxy.go
@@ -49,6 +49,7 @@ func toGRPC(c *clientv3.Client) grpcAPI {
 		pb.NewLeaseClient(c.ActiveConnection()),
 		grpcproxy.WatchServerToWatchClient(wp),
 		pb.NewMaintenanceClient(c.ActiveConnection()),
+		pb.NewAuthClient(c.ActiveConnection()),
 	}
 	proxies[c] = grpcClientProxy{grpc: grpc, wdonec: wpch}
 	return grpc

--- a/integration/v3_auth_test.go
+++ b/integration/v3_auth_test.go
@@ -1,0 +1,57 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
+	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/etcd/pkg/testutil"
+)
+
+// TestV3AuthEmptyUserGet ensures that a get with an empty user will return an empty user error.
+func TestV3AuthEmptyUserGet(t *testing.T) {
+	defer testutil.AfterTest(t)
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	api := toGRPC(clus.Client(0))
+	auth := api.Auth
+
+	if _, err := auth.UserAdd(ctx, &pb.AuthUserAddRequest{Name: "root", Password: "123"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := auth.RoleAdd(ctx, &pb.AuthRoleAddRequest{Name: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := auth.UserGrantRole(ctx, &pb.AuthUserGrantRoleRequest{User: "root", Role: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := auth.AuthEnable(ctx, &pb.AuthEnableRequest{}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := api.KV.Range(ctx, &pb.RangeRequest{Key: []byte("abc")})
+	if !eqErrGRPC(err, rpctypes.ErrUserEmpty) {
+		t.Fatalf("got %v, expected %v", err, rpctypes.ErrUserEmpty)
+	}
+}


### PR DESCRIPTION
Passing AuthInfo{} to permission checking was causing an infinite loop
because it would always return an old revision error.

Fixes #7124

/cc @mitake