### PR TITLE
Highlight differences between example run commands in docker_guide

### DIFF
--- a/Documentation/v2/docker_guide.md
+++ b/Documentation/v2/docker_guide.md
@@ -42,7 +42,7 @@ etcdctl -C http://192.168.12.50:4001 member list
 Using Docker to setup a multi-node cluster is very similar to the standalone mode configuration.
 The main difference being the value used for the `-initial-cluster` flag, which must contain the peer urls for each etcd member in the cluster.
 
-**Although the following commands look the same, please note that _-name_, _-advertise-client-urls_ and _-initial-advertise-peer-urls_ differ between the cluster members!**
+**Although the following commands look very similar, note that `-name`, `-advertise-client-urls` and `-initial-advertise-peer-urls` differ for each cluster member**
 
 ### etcd0
 

--- a/Documentation/v2/docker_guide.md
+++ b/Documentation/v2/docker_guide.md
@@ -44,48 +44,48 @@ The main difference being the value used for the `-initial-cluster` flag, which 
 
 ### etcd0
 
-```
+<pre>
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
  --name etcd quay.io/coreos/etcd \
- -name etcd0 \
- -advertise-client-urls http://192.168.12.50:2379,http://192.168.12.50:4001 \
+ <b>-name etcd0</b> \
+ <b>-advertise-client-urls http://192.168.12.50:2379,http://192.168.12.50:4001</b> \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
- -initial-advertise-peer-urls http://192.168.12.50:2380 \
+ <b>-initial-advertise-peer-urls http://192.168.12.50:2380</b> \
  -listen-peer-urls http://0.0.0.0:2380 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster etcd0=http://192.168.12.50:2380,etcd1=http://192.168.12.51:2380,etcd2=http://192.168.12.52:2380 \
  -initial-cluster-state new
-```
+</pre>
 
 ### etcd1
 
-```
+<pre>
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
  --name etcd quay.io/coreos/etcd \
- -name etcd1 \
- -advertise-client-urls http://192.168.12.51:2379,http://192.168.12.51:4001 \
+ <b>-name etcd1</b> \
+ <b>-advertise-client-urls http://192.168.12.51:2379,http://192.168.12.51:4001</b> \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
- -initial-advertise-peer-urls http://192.168.12.51:2380 \
+ <b>-initial-advertise-peer-urls http://192.168.12.51:2380</b> \
  -listen-peer-urls http://0.0.0.0:2380 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster etcd0=http://192.168.12.50:2380,etcd1=http://192.168.12.51:2380,etcd2=http://192.168.12.52:2380 \
  -initial-cluster-state new
-```
+</pre>
 
 ### etcd2
 
-```
+<pre>
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
  --name etcd quay.io/coreos/etcd \
- -name etcd2 \
- -advertise-client-urls http://192.168.12.52:2379,http://192.168.12.52:4001 \
+ <b>-name etcd2</b> \
+ <b>-advertise-client-urls http://192.168.12.52:2379,http://192.168.12.52:4001</b> \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
- -initial-advertise-peer-urls http://192.168.12.52:2380 \
+ <b>-initial-advertise-peer-urls http://192.168.12.52:2380</b> \
  -listen-peer-urls http://0.0.0.0:2380 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster etcd0=http://192.168.12.50:2380,etcd1=http://192.168.12.51:2380,etcd2=http://192.168.12.52:2380 \
  -initial-cluster-state new
-```
+</pre>
 
 Once the cluster has been bootstrapped etcd clients can be configured with a list of etcd members:
 

--- a/Documentation/v2/docker_guide.md
+++ b/Documentation/v2/docker_guide.md
@@ -42,50 +42,52 @@ etcdctl -C http://192.168.12.50:4001 member list
 Using Docker to setup a multi-node cluster is very similar to the standalone mode configuration.
 The main difference being the value used for the `-initial-cluster` flag, which must contain the peer urls for each etcd member in the cluster.
 
+**Although the following commands look the same, please note that _-name_, _-advertise-client-urls_ and _-initial-advertise-peer-urls_ differ between the cluster members!**
+
 ### etcd0
 
-<pre>
+```
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
  --name etcd quay.io/coreos/etcd \
- <b>-name etcd0</b> \
- <b>-advertise-client-urls http://192.168.12.50:2379,http://192.168.12.50:4001</b> \
+ -name etcd0 \
+ -advertise-client-urls http://192.168.12.50:2379,http://192.168.12.50:4001 \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
- <b>-initial-advertise-peer-urls http://192.168.12.50:2380</b> \
+ -initial-advertise-peer-urls http://192.168.12.50:2380 \
  -listen-peer-urls http://0.0.0.0:2380 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster etcd0=http://192.168.12.50:2380,etcd1=http://192.168.12.51:2380,etcd2=http://192.168.12.52:2380 \
  -initial-cluster-state new
-</pre>
+```
 
 ### etcd1
 
-<pre>
+```
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
  --name etcd quay.io/coreos/etcd \
- <b>-name etcd1</b> \
- <b>-advertise-client-urls http://192.168.12.51:2379,http://192.168.12.51:4001</b> \
+ -name etcd1 \
+ -advertise-client-urls http://192.168.12.51:2379,http://192.168.12.51:4001 \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
- <b>-initial-advertise-peer-urls http://192.168.12.51:2380</b> \
+ -initial-advertise-peer-urls http://192.168.12.51:2380 \
  -listen-peer-urls http://0.0.0.0:2380 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster etcd0=http://192.168.12.50:2380,etcd1=http://192.168.12.51:2380,etcd2=http://192.168.12.52:2380 \
  -initial-cluster-state new
-</pre>
+```
 
 ### etcd2
 
-<pre>
+```
 docker run -d -v /usr/share/ca-certificates/:/etc/ssl/certs -p 4001:4001 -p 2380:2380 -p 2379:2379 \
  --name etcd quay.io/coreos/etcd \
- <b>-name etcd2</b> \
- <b>-advertise-client-urls http://192.168.12.52:2379,http://192.168.12.52:4001</b> \
+ -name etcd2 \
+ -advertise-client-urls http://192.168.12.52:2379,http://192.168.12.52:4001 \
  -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
- <b>-initial-advertise-peer-urls http://192.168.12.52:2380</b> \
+ -initial-advertise-peer-urls http://192.168.12.52:2380 \
  -listen-peer-urls http://0.0.0.0:2380 \
  -initial-cluster-token etcd-cluster-1 \
  -initial-cluster etcd0=http://192.168.12.50:2380,etcd1=http://192.168.12.51:2380,etcd2=http://192.168.12.52:2380 \
  -initial-cluster-state new
-</pre>
+```
 
 Once the cluster has been bootstrapped etcd clients can be configured with a list of etcd members:
 


### PR DESCRIPTION
Hi everyone,

when my team set up our first etcd cluster based on docker, we strictly followed the instructions found in docker_guide.md. One thing that was a bit problematic for us is that the run commands for all cluster members are _mostly_ the same, with only minor variations. I felt like it would be useful to highlight these differences in the documentation so that they are visible right away. In order to highlight the parts within a code block, I changed the code block to a ```<pre></pre>``` block.

Regards,

Tobi