### PR TITLE
transport: warn on user-provided CA

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"log"
 	"math/big"
 	"net"
 	"os"
@@ -235,6 +236,7 @@ func (info TLSInfo) ClientConfig() (*tls.Config, error) {
 			return nil, err
 		}
 		// if given a CA, trust any host with a cert signed by the CA
+		log.Println("warning: ignoring ServerName for user-provided CA for backwards compatibility is deprecated")
 		cfg.ServerName = ""
 	}
 


### PR DESCRIPTION
ServerName is ignored for a user-provided CA for backwards compatibility. This
breaks PKI, so warn it is deprecated.

#6440 is the right thing to do, but etcd needs to warn before fully deprecating first.

/cc @lclarkmichalek  @xiang90 