### PR TITLE
grpcproxy, etcdmain, integration: add close channel to kv proxy

### DIFF
--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -103,7 +103,7 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	kvp := grpcproxy.NewKvProxy(client)
+	kvp, _ := grpcproxy.NewKvProxy(client)
 	watchp, _ := grpcproxy.NewWatchProxy(client)
 	clusterp := grpcproxy.NewClusterProxy(client)
 	leasep := grpcproxy.NewLeaseProxy(client)

--- a/proxy/grpcproxy/cache/store.go
+++ b/proxy/grpcproxy/cache/store.go
@@ -39,6 +39,7 @@ type Cache interface {
 	Get(req *pb.RangeRequest) (*pb.RangeResponse, error)
 	Compact(revision int64)
 	Invalidate(key []byte, endkey []byte)
+	Close()
 }
 
 // keyFunc returns the key of an request, which is used to look up in the cache for it's caching response.
@@ -57,6 +58,8 @@ func NewCache(maxCacheEntries int) Cache {
 		compactedRev: -1,
 	}
 }
+
+func (c *cache) Close() { c.lru.Stop() }
 
 // cache implements Cache
 type cache struct {

--- a/proxy/grpcproxy/kv_test.go
+++ b/proxy/grpcproxy/kv_test.go
@@ -76,7 +76,7 @@ func newKVProxyServer(endpoints []string, t *testing.T) *kvproxyTestServer {
 		t.Fatal(err)
 	}
 
-	kvp := NewKvProxy(client)
+	kvp, _ := NewKvProxy(client)
 
 	kvts := &kvproxyTestServer{
 		kp: kvp,


### PR DESCRIPTION
ccache launches some goroutines that need to be explicitly stopped.

Fixes #7158

May still need to patch ccache's Stop in upstream if the goroutines are too slow to exit since it doesn't wait for its goroutines to exit.