### PR TITLE
etcdserver: increase snapshot to 100,000

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -28,7 +28,7 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 
 ### --snapshot-count
 + Number of committed transactions to trigger a snapshot to disk.
-+ default: "10000"
++ default: "100000"
 + env variable: ETCD_SNAPSHOT_COUNT
 
 ### --heartbeat-interval

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -42,7 +42,7 @@ member flags:
 		path to the data directory.
 	--wal-dir ''
 		path to the dedicated wal directory.
-	--snapshot-count '10000'
+	--snapshot-count '100000'
 		number of committed transactions to trigger a snapshot to disk.
 	--heartbeat-interval '100'
 		time (in milliseconds) of a heartbeat interval.

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -61,7 +61,7 @@ import (
 )
 
 const (
-	DefaultSnapCount = 10000
+	DefaultSnapCount = 100000
 
 	StoreClusterPrefix = "/0"
 	StoreKeysPrefix    = "/1"


### PR DESCRIPTION
Keep more wal entries in memory for fast follower recovery and less snapshots.
10,000 was a too small number that triggers quite a few compactions/snapshots.
ZK proves that 100,000 is a reasonable number for even old less powerful
machines.

Eventually we should provide both count and max memory (for large entries).

