### PR TITLE
etcd-tester: use 10K for '--snapshot-count'

### DIFF
--- a/tools/functional-tester/etcd-tester/cluster.go
+++ b/tools/functional-tester/etcd-tester/cluster.go
@@ -80,7 +80,8 @@ func (c *cluster) bootstrap() error {
 			m.Flags(),
 			"--data-dir", c.agents[i].datadir,
 			"--initial-cluster-token", token,
-			"--initial-cluster", clusterStr)
+			"--initial-cluster", clusterStr,
+			"--snapshot-count", "10000")
 
 		if _, err := m.Agent.Start(flags...); err != nil {
 			// cleanup


### PR DESCRIPTION
Since we want to send snapshot more often in failure injected cluster
