### PR TITLE
embed/etcd.go: make v2 endpoint optional. fixes #7100

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -140,6 +140,12 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 + default: 0
 + env variable: ETCD_AUTO_COMPACTION_RETENTION
 
+
+### --enable-v2
++ Accept etcd V2 client requests
++ default: true
++ env variable: ETCD_ENABLE_V2
+
 ## Proxy flags
 
 `--proxy` prefix flags configures etcd to run in [proxy mode][proxy]. "proxy" supports v2 API only.

--- a/embed/config.go
+++ b/embed/config.go
@@ -102,6 +102,7 @@ type Config struct {
 	InitialCluster      string `json:"initial-cluster"`
 	InitialClusterToken string `json:"initial-cluster-token"`
 	StrictReconfigCheck bool   `json:"strict-reconfig-check"`
+	EnableV2            bool   `json:"enable-v2"`
 
 	// security
 
@@ -175,6 +176,7 @@ func NewConfig() *Config {
 		InitialClusterToken: "etcd-cluster",
 		StrictReconfigCheck: true,
 		Metrics:             "basic",
+		EnableV2:            true,
 	}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	return cfg

--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -69,6 +69,9 @@ initial-cluster-state: 'new'
 # Reject reconfiguration requests that would cause quorum loss.
 strict-reconfig-check: false
 
+# Accept etcd V2 client requests
+enable-v2: true
+
 # Valid values include 'on', 'readonly', 'off'
 proxy: 'off'
 

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -155,6 +155,7 @@ func newConfig() *config {
 		plog.Panicf("unexpected error setting up clusterStateFlag: %v", err)
 	}
 	fs.BoolVar(&cfg.StrictReconfigCheck, "strict-reconfig-check", cfg.StrictReconfigCheck, "Reject reconfiguration requests that would cause quorum loss.")
+	fs.BoolVar(&cfg.EnableV2, "enable-v2", true, "Accept etcd V2 client requests.")
 
 	// proxy
 	fs.Var(cfg.proxy, "proxy", fmt.Sprintf("Valid values include %s", strings.Join(cfg.proxy.Values, ", ")))

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -88,6 +88,8 @@ clustering flags:
 		reject reconfiguration requests that would cause quorum loss.
 	--auto-compaction-retention '0'
 		auto compaction retention in hour. 0 means disable auto compaction.
+	--enable-v2
+		Accept etcd V2 client requests.
 
 proxy flags:
 	"proxy" supports v2 API only.


### PR DESCRIPTION
- added a config flag `enable-v2` with default value `true`
- if this flag is set to false, v2 handler is not created