### PR TITLE
test: passed the test script arguments to the function parameters

### DIFF
--- a/test
+++ b/test
@@ -293,7 +293,7 @@ function build_pass {
 }
 
 for pass in $PASSES; do
-	${pass}_pass
+	${pass}_pass $@
 done
 
 echo "Success"


### PR DESCRIPTION
the `${pass}_pass` functions in the `${REPO_PATH}/test` script make use of the function arguments in invoking the  `go test`  , but there are no parameters being passed while invoking the function.

modified to pass the script arguments as the function parameters

this way selective tests can be run (if needed in developer testing environment). 
e.g. `PASSES='e2e' ./test -run TestCtlV3 2>&1 | tee e2e_test.log`

can run the V3 etcdctl tests only.
