### PR TITLE
store: set e.Node.Dir attribute, when node expired

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -682,6 +682,9 @@ func (s *store) DeleteExpiredKeys(cutoff time.Time) {
 		e := newEvent(Expire, node.Path, s.CurrentIndex, node.CreatedIndex)
 		e.EtcdIndex = s.CurrentIndex
 		e.PrevNode = node.Repr(false, false, s.clock)
+		if node.IsDir() {
+			e.Node.Dir = true
+		}
 
 		callback := func(path string) { // notify function
 			// notify the watchers with deleted set true


### PR DESCRIPTION
Sets `e.Node.Dir` attribute in `DeleteExpiredKeys`

When a directory node expired, the `prevNode` has a `"dir":true` attribute in the received expire event, but the `node` has no `"dir":true` attribute

Fixes #7033