### PR TITLE
small mistake in documentation: `endpoint-health`

### DIFF
--- a/Documentation/op-guide/container.md
+++ b/Documentation/op-guide/container.md
@@ -57,7 +57,7 @@ sudo rkt run --net=default:IP=${NODE3} coreos.com/etcd:v3.0.6 -- -name=node3 -ad
 Verify the cluster is healthy and can be reached.
 
 ```
-ETCDCTL_API=3 etcdctl --endpoints=http://172.16.28.21:2379,http://172.16.28.22:2379,http://172.16.28.23:2379 endpoint-health
+ETCDCTL_API=3 etcdctl --endpoints=http://172.16.28.21:2379,http://172.16.28.22:2379,http://172.16.28.23:2379 endpoint health
 ```
 
 ### DNS


### PR DESCRIPTION
`endpoint-health` is not a valid command, `endpoint health` is

There are also two comment references to `endpoint-health`, in case you wish to change those as well (left them untouched).

Note: My commit message is not according to the contributing guidelines. Hope it's okay for the first time, one char PR. If not, I'll change it.