### PR TITLE
pkg/flags: fixed prefix checking of the env variables

### DIFF
--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -121,7 +121,7 @@ func verifyEnv(prefix string, usedEnvKey, alreadySet map[string]bool) {
 			plog.Infof("recognized environment variable %s, but unused: shadowed by corresponding flag ", kv[0])
 			continue
 		}
-		if strings.HasPrefix(env, prefix) {
+		if strings.HasPrefix(env, prefix+"_") {
 			plog.Warningf("unrecognized environment variable %s", env)
 		}
 	}


### PR DESCRIPTION
if the env in which ETCD starts also has the ETCDCTL_API variable set , then etcd gives a warning

```
vimal (make-v2-endpoint-optional-#7100) bin $ ./etcd
2017-01-20 11:53:07.324208 W | pkg/flags: unrecognized environment variable ETCDCTL_API=3
2017-01-20 11:53:07.324319 I | etcdmain: etcd Version: 3.2.0+git
2017-01-20 11:53:07.324344 I | etcdmain: Git SHA: b2d5c91
2017-01-20 11:53:07.324366 I | etcdmain: Go Version: go1.7
2017-01-20 11:53:07.324386 I | etcdmain: Go OS/Arch: linux/amd64
```

after this fix the warning is not there
```
vimal (fix-ETCD-prefix-check *) bin $ ./etcd
2017-01-20 13:08:58.172081 I | etcdmain: etcd Version: 3.2.0+git
2017-01-20 13:08:58.172154 I | etcdmain: Git SHA: 94eec5d
2017-01-20 13:08:58.172170 I | etcdmain: Go Version: go1.7
2017-01-20 13:08:58.172184 I | etcdmain: Go OS/Arch: linux/amd64
```


