### PR TITLE
etcdserver: TODO remove unnecessary if check

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -643,14 +643,9 @@ func (s *EtcdServer) run() {
 				}
 			}
 
-			// TODO: remove the nil checking
 			// current test utility does not provide the stats
-			if s.stats != nil {
-				s.stats.BecomeLeader()
-			}
-			if s.r.td != nil {
-				s.r.td.Reset()
-			}
+			s.stats.BecomeLeader()
+			s.r.td.Reset()
 		},
 		updateCommittedIndex: func(ci uint64) {
 			cci := s.getCommittedIndex()


### PR DESCRIPTION
Removed unnecessary if check since the s.stats will never be nil since its a structure.
Same is the case with td contention.TimeoutDetector.
