### PR TITLE
embed: support user defined grpc services.

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/ghodss/yaml"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -126,6 +127,8 @@ type Config struct {
 	// The map key is the route path for the handler, and
 	// you must ensure it can't be conflicted with etcd's.
 	UserHandlers map[string]http.Handler `json:"-"`
+	// ServiceRegister is for registering users' gRPC services.
+	ServiceRegister func(*grpc.Server) `json:"-"`
 }
 
 // configYAML holds the config suitable for yaml parsing

--- a/embed/config.go
+++ b/embed/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/etcd/pkg/netutil"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/pkg/types"
+
 	"github.com/ghodss/yaml"
 	"google.golang.org/grpc"
 )
@@ -127,7 +128,13 @@ type Config struct {
 	// The map key is the route path for the handler, and
 	// you must ensure it can't be conflicted with etcd's.
 	UserHandlers map[string]http.Handler `json:"-"`
-	// ServiceRegister is for registering users' gRPC services.
+	// ServiceRegister is for registering users' gRPC services. A simple usage example:
+	//	cfg := embed.NewConfig()
+	//	cfg.ServerRegister = func(s *grpc.Server) {
+	//		pb.RegisterFooServer(s, &fooServer{})
+	//		pb.RegisterBarServer(s, &barServer{})
+	//	}
+	//	embed.StartEtcd(cfg)
 	ServiceRegister func(*grpc.Server) `json:"-"`
 }
 

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -289,6 +289,7 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 		for k := range cfg.UserHandlers {
 			sctx.userHandlers[k] = cfg.UserHandlers[k]
 		}
+		sctx.serviceRegister = cfg.ServiceRegister
 		if cfg.EnablePprof {
 			sctx.registerPprof()
 		}


### PR DESCRIPTION
Fixes #7200

Hi again,
My original design does not progress well, the main problem is that the code generated by gRPC does not export corresponding ServiceDesc. Please refer https://github.com/grpc/grpc-go/blob/master/examples/helloworld/helloworld/helloworld.pb.go#L123
It seems we have to setup a `func(*grpc.Server)` instead.
/cc @xiang90 @heyitsanthony 