### PR TITLE
.gitignore: Adding .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.test
 tools/functional-tester/docker/bin
 hack/tls-setup/certs
+.idea


### PR DESCRIPTION
This will keep  all intellij IDEA IDE related files out of git.
This helps contributors using IDEA IDE for development.

/cc @mitake
as per https://github.com/coreos/etcd/pull/7229/files/2fe7945a6b3a5f099878c70aabb8c1ce24c5518f 