### PR TITLE
raftexample: fix blocking restart with snapshot

### DIFF
--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -77,7 +77,7 @@ func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {
 			if err := s.recoverFromSnapshot(snapshot.Data); err != nil {
 				log.Panic(err)
 			}
-			continue
+			return
 		}
 
 		var dataKv kv


### PR DESCRIPTION
Replace https://github.com/coreos/etcd/pull/7098.

I re-read the code and now I think this is the right fix,
since we send nil to trigger snapshot load and when
the snapshot load is done, `readCommits` should exit and
let later commits be handled by second `go readCommits` call.

Otherwise it blocks on restart as @upccup pointed out.
