### PR TITLE
pkg/report: do not fill-in empty rows for missing timestamps

### DIFF
--- a/pkg/report/timeseries.go
+++ b/pkg/report/timeseries.go
@@ -19,7 +19,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"log"
-	"math"
 	"sort"
 	"sync"
 	"time"
@@ -60,7 +59,7 @@ func (sp *secondPoints) Add(ts time.Time, lat time.Duration) {
 		sp.tm[tk] = secondPoint{totalLatency: lat, count: 1}
 	} else {
 		v.totalLatency += lat
-		v.count += 1
+		v.count++
 		sp.tm[tk] = v
 	}
 }
@@ -68,24 +67,6 @@ func (sp *secondPoints) Add(ts time.Time, lat time.Duration) {
 func (sp *secondPoints) getTimeSeries() TimeSeries {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
-
-	var (
-		minTs int64 = math.MaxInt64
-		maxTs int64 = -1
-	)
-	for k := range sp.tm {
-		if minTs > k {
-			minTs = k
-		}
-		if maxTs < k {
-			maxTs = k
-		}
-	}
-	for ti := minTs; ti < maxTs; ti++ {
-		if _, ok := sp.tm[ti]; !ok { // fill-in empties
-			sp.tm[ti] = secondPoint{totalLatency: 0, count: 0}
-		}
-	}
 
 	var (
 		tslice = make(TimeSeries, len(sp.tm))

--- a/pkg/report/timeseries_test.go
+++ b/pkg/report/timeseries_test.go
@@ -25,7 +25,7 @@ func TestGetTimeseries(t *testing.T) {
 	sp.Add(now, time.Second)
 	sp.Add(now.Add(5*time.Second), time.Second)
 	n := sp.getTimeSeries().Len()
-	if n < 3 {
-		t.Fatalf("expected at 6 points of time series, got %s", sp.getTimeSeries())
+	if n != 2 {
+		t.Fatalf("expected 2 points of time series, got %s", sp.getTimeSeries())
 	}
 }


### PR DESCRIPTION
Need this for https://github.com/coreos/dbtester/issues/230.
`benchmark` CLI or other libraries that rely on this doesn't need to do anything.
This just adds a few more fields accessible outside of `pkg/report` for
more fine-grained aggregation.

@heyitsanthony @xiang90 @fanminshi 