### PR TITLE
clientv3: remove strict yaml dependency

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -79,15 +79,6 @@ func NewFromURL(url string) (*Client, error) {
 	return New(Config{Endpoints: []string{url}})
 }
 
-// NewFromConfigFile creates a new etcdv3 client from a configuration file.
-func NewFromConfigFile(path string) (*Client, error) {
-	cfg, err := configFromFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return New(*cfg)
-}
-
 // Close shuts down the client's etcd connections.
 func (c *Client) Close() error {
 	c.cancel()

--- a/clientv3/config.go
+++ b/clientv3/config.go
@@ -16,98 +16,26 @@ package clientv3
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"io/ioutil"
 	"time"
-
-	"github.com/coreos/etcd/pkg/tlsutil"
-	"github.com/ghodss/yaml"
 )
 
 type Config struct {
-	// Endpoints is a list of URLs
-	Endpoints []string
+	// Endpoints is a list of URLs.
+	Endpoints []string `json:"endpoints"`
 
 	// AutoSyncInterval is the interval to update endpoints with its latest members.
 	// 0 disables auto-sync. By default auto-sync is disabled.
-	AutoSyncInterval time.Duration
+	AutoSyncInterval time.Duration `json:"auto-sync-interval"`
 
 	// DialTimeout is the timeout for failing to establish a connection.
-	DialTimeout time.Duration
+	DialTimeout time.Duration `json:"dial-timeout"`
 
 	// TLS holds the client secure credentials, if any.
 	TLS *tls.Config
 
-	// Username is a username for authentication
-	Username string
+	// Username is a username for authentication.
+	Username string `json:"username"`
 
-	// Password is a password for authentication
-	Password string
-}
-
-type yamlConfig struct {
-	Endpoints             []string      `json:"endpoints"`
-	AutoSyncInterval      time.Duration `json:"auto-sync-interval"`
-	DialTimeout           time.Duration `json:"dial-timeout"`
-	InsecureTransport     bool          `json:"insecure-transport"`
-	InsecureSkipTLSVerify bool          `json:"insecure-skip-tls-verify"`
-	Certfile              string        `json:"cert-file"`
-	Keyfile               string        `json:"key-file"`
-	CAfile                string        `json:"ca-file"`
-}
-
-func configFromFile(fpath string) (*Config, error) {
-	b, err := ioutil.ReadFile(fpath)
-	if err != nil {
-		return nil, err
-	}
-
-	yc := &yamlConfig{}
-
-	err = yaml.Unmarshal(b, yc)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg := &Config{
-		Endpoints:        yc.Endpoints,
-		AutoSyncInterval: yc.AutoSyncInterval,
-		DialTimeout:      yc.DialTimeout,
-	}
-
-	if yc.InsecureTransport {
-		cfg.TLS = nil
-		return cfg, nil
-	}
-
-	var (
-		cert *tls.Certificate
-		cp   *x509.CertPool
-	)
-
-	if yc.Certfile != "" && yc.Keyfile != "" {
-		cert, err = tlsutil.NewCert(yc.Certfile, yc.Keyfile, nil)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if yc.CAfile != "" {
-		cp, err = tlsutil.NewCertPool([]string{yc.CAfile})
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	tlscfg := &tls.Config{
-		MinVersion:         tls.VersionTLS10,
-		InsecureSkipVerify: yc.InsecureSkipTLSVerify,
-		RootCAs:            cp,
-	}
-	if cert != nil {
-		tlscfg.Certificates = []tls.Certificate{*cert}
-	}
-	cfg.TLS = tlscfg
-
-	return cfg, nil
+	// Password is a password for authentication.
+	Password string `json:"password"`
 }

--- a/clientv3/yaml/config.go
+++ b/clientv3/yaml/config.go
@@ -1,0 +1,86 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yaml
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/tlsutil"
+)
+
+type yamlConfig struct {
+	clientv3.Config
+
+	InsecureTransport     bool   `json:"insecure-transport"`
+	InsecureSkipTLSVerify bool   `json:"insecure-skip-tls-verify"`
+	Certfile              string `json:"cert-file"`
+	Keyfile               string `json:"key-file"`
+	CAfile                string `json:"ca-file"`
+}
+
+// NewConfig creates a new clientv3.Config from a yaml file.
+func NewConfig(fpath string) (*clientv3.Config, error) {
+	b, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return nil, err
+	}
+
+	yc := &yamlConfig{}
+
+	err = yaml.Unmarshal(b, yc)
+	if err != nil {
+		return nil, err
+	}
+
+	if yc.InsecureTransport {
+		return &yc.Config, nil
+	}
+
+	var (
+		cert *tls.Certificate
+		cp   *x509.CertPool
+	)
+
+	if yc.Certfile != "" && yc.Keyfile != "" {
+		cert, err = tlsutil.NewCert(yc.Certfile, yc.Keyfile, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if yc.CAfile != "" {
+		cp, err = tlsutil.NewCertPool([]string{yc.CAfile})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	tlscfg := &tls.Config{
+		MinVersion:         tls.VersionTLS10,
+		InsecureSkipVerify: yc.InsecureSkipTLSVerify,
+		RootCAs:            cp,
+	}
+	if cert != nil {
+		tlscfg.Certificates = []tls.Certificate{*cert}
+	}
+	yc.Config.TLS = tlscfg
+
+	return &yc.Config, nil
+}

--- a/clientv3/yaml/config_test.go
+++ b/clientv3/yaml/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package clientv3
+package yaml
 
 import (
 	"io/ioutil"
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	certPath       = "../integration/fixtures/server.crt"
-	privateKeyPath = "../integration/fixtures/server.key.insecure"
-	caPath         = "../integration/fixtures/ca.crt"
+	certPath       = "../../integration/fixtures/server.crt"
+	privateKeyPath = "../../integration/fixtures/server.key.insecure"
+	caPath         = "../../integration/fixtures/ca.crt"
 )
 
 func TestConfigFromFile(t *testing.T) {
@@ -92,7 +92,7 @@ func TestConfigFromFile(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cfg, cerr := configFromFile(tmpfile.Name())
+		cfg, cerr := NewConfig(tmpfile.Name())
 		if cerr != nil && !tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, cerr, tt.werr)
 			continue


### PR DESCRIPTION
Moved to clientv3/yaml

Should this also include username/password fields too? They're missing right now.