### PR TITLE
clientv3: sends keepalive reqs immediately after lease keep alive stream reset

### DIFF
--- a/clientv3/lease.go
+++ b/clientv3/lease.go
@@ -452,16 +452,6 @@ func (l *lessor) deadlineLoop() {
 // sendKeepAliveLoop sends LeaseKeepAliveRequests for the lifetime of a lease stream
 func (l *lessor) sendKeepAliveLoop(stream pb.Lease_LeaseKeepAliveClient) {
 	for {
-		select {
-		case <-time.After(500 * time.Millisecond):
-		case <-stream.Context().Done():
-			return
-		case <-l.donec:
-			return
-		case <-l.stopCtx.Done():
-			return
-		}
-
 		var tosend []LeaseID
 
 		now := time.Now()
@@ -479,6 +469,16 @@ func (l *lessor) sendKeepAliveLoop(stream pb.Lease_LeaseKeepAliveClient) {
 				// TODO do something with this error?
 				return
 			}
+		}
+
+		select {
+		case <-time.After(500 * time.Millisecond):
+		case <-stream.Context().Done():
+			return
+		case <-l.donec:
+			return
+		case <-l.stopCtx.Done():
+			return
 		}
 	}
 }


### PR DESCRIPTION
when lease client resets lease keep alive stream, sendKeepAliveLoop() should send out keep alive reqs immediately instead of waiting for 500ms.

