### PR TITLE
test: Fix gosimple errors

### DIFF
--- a/etcdserver/util.go
+++ b/etcdserver/util.go
@@ -87,7 +87,7 @@ type notifier struct {
 
 func newNotifier() *notifier {
 	return &notifier{
-		c: make(chan struct{}, 0),
+		c: make(chan struct{}),
 	}
 }
 

--- a/integration/v3_election_test.go
+++ b/integration/v3_election_test.go
@@ -112,7 +112,7 @@ func TestElectionFailover(t *testing.T) {
 	cctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
-	ss := make([]*concurrency.Session, 3, 3)
+	ss := make([]*concurrency.Session, 3)
 
 	for i := 0; i < 3; i++ {
 		var err error

--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -101,7 +101,7 @@ func NewStore(b backend.Backend, le lease.Lessor, ig ConsistentIndexGetter) *sto
 		currentRev:     revision{main: 1},
 		compactMainRev: -1,
 
-		bytesBuf8: make([]byte, 8, 8),
+		bytesBuf8: make([]byte, 8),
 		fifoSched: schedule.NewFIFOScheduler(),
 
 		stopc: make(chan struct{}),

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -453,9 +453,9 @@ func TestReadyContainUpdates(t *testing.T) {
 		{Ready{}, false},
 		{Ready{SoftState: &SoftState{Lead: 1}}, true},
 		{Ready{HardState: raftpb.HardState{Vote: 1}}, true},
-		{Ready{Entries: make([]raftpb.Entry, 1, 1)}, true},
-		{Ready{CommittedEntries: make([]raftpb.Entry, 1, 1)}, true},
-		{Ready{Messages: make([]raftpb.Message, 1, 1)}, true},
+		{Ready{Entries: make([]raftpb.Entry, 1)}, true},
+		{Ready{CommittedEntries: make([]raftpb.Entry, 1)}, true},
+		{Ready{Messages: make([]raftpb.Message, 1)}, true},
 		{Ready{Snapshot: raftpb.Snapshot{Metadata: raftpb.SnapshotMetadata{Index: 1}}}, true},
 	}
 

--- a/tools/functional-tester/etcd-runner/command/global.go
+++ b/tools/functional-tester/etcd-runner/command/global.go
@@ -66,7 +66,7 @@ func doRounds(rcs []roundClient, rounds int) {
 	var wg sync.WaitGroup
 
 	wg.Add(len(rcs))
-	finished := make(chan struct{}, 0)
+	finished := make(chan struct{})
 	for i := range rcs {
 		go func(rc *roundClient) {
 			defer wg.Done()


### PR DESCRIPTION
Getting gosimple suggestion while running test script, so this PR is for fixing gosimple S1019 check.
raft/node_test.go:456:40: should use make([]raftpb.Entry, 1) instead (S1019)
raft/node_test.go:457:49: should use make([]raftpb.Entry, 1) instead (S1019)
raft/node_test.go:458:43: should use make([]raftpb.Message, 1) instead (S1019)

Refer https://github.com/dominikh/go-tools/blob/master/cmd/gosimple/README.md#checks for more information.