### PR TITLE
grpcproxy: respect CompactRevision in watcher

### DIFF
--- a/proxy/grpcproxy/watcher.go
+++ b/proxy/grpcproxy/watcher.go
@@ -102,16 +102,17 @@ func (w *watcher) send(wr clientv3.WatchResponse) {
 	}
 
 	// all events are filtered out?
-	if !wr.IsProgressNotify() && !wr.Created && len(events) == 0 {
+	if !wr.IsProgressNotify() && !wr.Created && len(events) == 0 && wr.CompactRevision == 0 {
 		return
 	}
 
 	w.lastHeader = wr.Header
 	w.post(&pb.WatchResponse{
-		Header:  &wr.Header,
-		Created: wr.Created,
-		WatchId: w.id,
-		Events:  events,
+		Header:          &wr.Header,
+		Created:         wr.Created,
+		CompactRevision: wr.CompactRevision,
+		WatchId:         w.id,
+		Events:          events,
 	})
 }
 


### PR DESCRIPTION
CompactRevision wasn't sent over watch stream, causing TestKVCompact to hang.