### PR TITLE
travis: disable email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ go:
   - 1.7.4
   - tip
 
+notifications:
+  on_success: never
+  on_failure: never
+
 env:
   matrix:
    - TARGET=amd64


### PR DESCRIPTION
Was spamming security@coreos.com

Alternative is to have it spam team-etcd, but that seems kind of noisy.

/cc @crawford @xiang90 