### PR TITLE
raft: fix read index request for #7331

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -823,6 +823,11 @@ func stepLeader(r *raft, m pb.Message) {
 		return
 	case pb.MsgReadIndex:
 		if r.quorum() > 1 {
+			if r.raftLog.zeroTermOnErrCompacted(r.raftLog.term(r.raftLog.committed)) != r.Term {
+				// Reject read only request when this leader has not committed any log entry at its term.
+				return
+			}
+
 			// thinking: use an interally defined context instead of the user given context.
 			// We can express this in terms of the term and index instead of a user-supplied value.
 			// This would allow multiple reads to piggyback on the same message.


### PR DESCRIPTION
Hi,

This PR tries to fix issue #7331 . It follows the raft thesis 6.4 to reject read only request when a new leader has not committed any log entry at its term.