### PR TITLE
op-guide: use host volume in Docker command

### DIFF
--- a/Documentation/op-guide/container.md
+++ b/Documentation/op-guide/container.md
@@ -70,7 +70,7 @@ In order to expose the etcd API to clients outside of Docker host, use the host 
 
 ```
 # For each machine
-ETCD_VERSION=v3.0.0
+ETCD_VERSION=latest
 TOKEN=my-etcd-token
 CLUSTER_STATE=new
 NAME_1=etcd-node-0
@@ -80,13 +80,16 @@ HOST_1=10.20.30.1
 HOST_2=10.20.30.2
 HOST_3=10.20.30.3
 CLUSTER=${NAME_1}=http://${HOST_1}:2380,${NAME_2}=http://${HOST_2}:2380,${NAME_3}=http://${HOST_3}:2380
+DATA_DIR=/var/lib/etcd
 
 # For node 1
 THIS_NAME=${NAME_1}
 THIS_IP=${HOST_1}
-sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
+sudo docker run --net=host \
+    --volume=${DATA_DIR}:/etcd-data \
+    --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
 	/usr/local/bin/etcd \
-    --data-dir=data.etcd --name ${THIS_NAME} \
+    --data-dir=/etcd-data --name ${THIS_NAME} \
 	--initial-advertise-peer-urls http://${THIS_IP}:2380 --listen-peer-urls http://${THIS_IP}:2380 \
 	--advertise-client-urls http://${THIS_IP}:2379 --listen-client-urls http://${THIS_IP}:2379 \
 	--initial-cluster ${CLUSTER} \
@@ -95,9 +98,11 @@ sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
 # For node 2
 THIS_NAME=${NAME_2}
 THIS_IP=${HOST_2}
-sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
+sudo docker run --net=host \
+    --volume=${DATA_DIR}:/etcd-data \
+    --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
 	/usr/local/bin/etcd \
-    --data-dir=data.etcd --name ${THIS_NAME} \
+    --data-dir=/etcd-data --name ${THIS_NAME} \
 	--initial-advertise-peer-urls http://${THIS_IP}:2380 --listen-peer-urls http://${THIS_IP}:2380 \
 	--advertise-client-urls http://${THIS_IP}:2379 --listen-client-urls http://${THIS_IP}:2379 \
 	--initial-cluster ${CLUSTER} \
@@ -106,9 +111,11 @@ sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
 # For node 3
 THIS_NAME=${NAME_3}
 THIS_IP=${HOST_3}
-sudo docker run --net=host --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
+sudo docker run --net=host \
+    --volume=${DATA_DIR}:/etcd-data \
+    --name etcd quay.io/coreos/etcd:${ETCD_VERSION} \
 	/usr/local/bin/etcd \
-    --data-dir=data.etcd --name ${THIS_NAME} \
+    --data-dir=/etcd-data --name ${THIS_NAME} \
 	--initial-advertise-peer-urls http://${THIS_IP}:2380 --listen-peer-urls http://${THIS_IP}:2380 \
 	--advertise-client-urls http://${THIS_IP}:2379 --listen-client-urls http://${THIS_IP}:2379 \
 	--initial-cluster ${CLUSTER} \


### PR DESCRIPTION
One should use host volume when running etcd