### PR TITLE
*: add 'staticcheck' to 'test'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_install:
  - go get -v github.com/chzchzchz/goword
  - go get -v honnef.co/go/tools/cmd/gosimple
  - go get -v honnef.co/go/tools/cmd/unused
+ - go get -v honnef.co/go/tools/cmd/staticcheck
 
 # disable godep restore override
 install:

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -345,7 +345,7 @@ func TestRoleRevokePermission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := as.RoleGet(&pb.AuthRoleGetRequest{Role: "role-test-1"})
+	_, err = as.RoleGet(&pb.AuthRoleGetRequest{Role: "role-test-1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,6 +359,7 @@ func TestRoleRevokePermission(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var r *pb.AuthRoleGetResponse
 	r, err = as.RoleGet(&pb.AuthRoleGetRequest{Role: "role-test-1"})
 	if err != nil {
 		t.Fatal(err)

--- a/etcdctl/ctlv2/command/role_commands.go
+++ b/etcdctl/ctlv2/command/role_commands.go
@@ -117,13 +117,13 @@ func actionRoleAdd(c *cli.Context) error {
 	api, role := mustRoleAPIAndName(c)
 	ctx, cancel := contextWithTotalTimeout(c)
 	defer cancel()
-	currentRole, err := api.GetRole(ctx, role)
+	currentRole, _ := api.GetRole(ctx, role)
 	if currentRole != nil {
 		fmt.Fprintf(os.Stderr, "Role %s already exists\n", role)
 		os.Exit(1)
 	}
 
-	err = api.AddRole(ctx, role)
+	err := api.AddRole(ctx, role)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)

--- a/etcdctl/ctlv3/command/printer_protobuf.go
+++ b/etcdctl/ctlv3/command/printer_protobuf.go
@@ -60,5 +60,5 @@ func printPB(v interface{}) {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return
 	}
-	fmt.Printf(string(b))
+	fmt.Print(string(b))
 }

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -113,7 +113,7 @@ type raftNode struct {
 	readStateC chan raft.ReadState
 
 	// utility
-	ticker <-chan time.Time
+	ticker *time.Ticker
 	// contention detectors for raft heartbeat message
 	td          *contention.TimeoutDetector
 	heartbeat   time.Duration // for logging
@@ -143,7 +143,7 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 
 		for {
 			select {
-			case <-r.ticker:
+			case <-r.ticker.C:
 				r.Tick()
 			case rd := <-r.Ready():
 				if rd.SoftState != nil {
@@ -303,6 +303,7 @@ func (r *raftNode) stop() {
 
 func (r *raftNode) onStop() {
 	r.Stop()
+	r.ticker.Stop()
 	r.transport.Stop()
 	if err := r.storage.Close(); err != nil {
 		plog.Panicf("raft close storage error: %v", err)

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -158,6 +158,7 @@ func TestStopRaftWhenWaitingForApplyDone(t *testing.T) {
 		storage:     mockstorage.NewStorageRecorder(""),
 		raftStorage: raft.NewMemoryStorage(),
 		transport:   rafthttp.NewNopTransporter(),
+		ticker:      &time.Ticker{},
 	}}
 	srv.r.start(nil)
 	n.readyc <- raft.Ready{}

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -603,7 +603,7 @@ func (m *member) Launch() error {
 	if m.s, err = etcdserver.NewServer(&m.ServerConfig); err != nil {
 		return fmt.Errorf("failed to initialize the etcd server: %v", err)
 	}
-	m.s.SyncTicker = time.Tick(500 * time.Millisecond)
+	m.s.SyncTicker = time.NewTicker(500 * time.Millisecond)
 	m.s.Start()
 
 	m.raftHandler = &testutil.PauseableHandler{Next: v2http.NewPeerHandler(m.s)}

--- a/integration/v3_lease_test.go
+++ b/integration/v3_lease_test.go
@@ -105,7 +105,7 @@ func TestV3LeaseGrantByID(t *testing.T) {
 	}
 
 	// create duplicate fixed lease
-	lresp, err = toGRPC(clus.RandClient()).Lease.LeaseGrant(
+	_, err = toGRPC(clus.RandClient()).Lease.LeaseGrant(
 		context.TODO(),
 		&pb.LeaseGrantRequest{ID: 1, TTL: 1})
 	if !eqErrGRPC(err, rpctypes.ErrGRPCLeaseExist) {

--- a/lease/lessor_test.go
+++ b/lease/lessor_test.go
@@ -55,11 +55,12 @@ func TestLessorGrant(t *testing.T) {
 		t.Errorf("term = %v, want at least %v", l.Remaining(), minLeaseTTLDuration-time.Second)
 	}
 
-	nl, err := le.Grant(1, 1)
+	_, err = le.Grant(1, 1)
 	if err == nil {
 		t.Errorf("allocated the same lease")
 	}
 
+	var nl *Lease
 	nl, err = le.Grant(2, 1)
 	if err != nil {
 		t.Errorf("could not grant lease 2 (%v)", err)

--- a/mvcc/kvstore_bench_test.go
+++ b/mvcc/kvstore_bench_test.go
@@ -108,7 +108,6 @@ func benchmarkStoreRestore(revsPerKey int, b *testing.B) {
 		}
 	}
 	b.ResetTimer()
-	s = NewStore(be, &lease.FakeLessor{}, &i)
 }
 
 func BenchmarkStoreRestoreRevs1(b *testing.B) {

--- a/pkg/transport/keepalive_listener_test.go
+++ b/pkg/transport/keepalive_listener_test.go
@@ -45,6 +45,10 @@ func TestNewKeepAliveListener(t *testing.T) {
 	ln.Close()
 
 	ln, err = net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("unexpected Listen error: %v", err)
+	}
+
 	// tls
 	tmp, err := createTempFile([]byte("XXX"))
 	if err != nil {

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -301,6 +301,7 @@ func TestNodeProposeAddDuplicateNode(t *testing.T) {
 	n.Campaign(context.TODO())
 	rdyEntries := make([]raftpb.Entry, 0)
 	ticker := time.NewTicker(time.Millisecond * 100)
+	defer ticker.Stop()
 	done := make(chan struct{})
 	stop := make(chan struct{})
 	applyConfChan := make(chan struct{})

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -142,7 +142,8 @@ func (cw *streamWriter) run() {
 		flusher    http.Flusher
 		batched    int
 	)
-	tickc := time.Tick(ConnReadTimeout / 3)
+	tickc := time.NewTicker(ConnReadTimeout / 3)
+	defer tickc.Stop()
 	unflushed := 0
 
 	plog.Infof("started streaming with peer %s (writer)", cw.peerID)
@@ -214,7 +215,7 @@ func (cw *streamWriter) run() {
 				plog.Warningf("closed an existing TCP streaming connection with peer %s (%s writer)", cw.peerID, t)
 			}
 			plog.Infof("established a TCP streaming connection with peer %s (%s writer)", cw.peerID, t)
-			heartbeatc, msgc = tickc, cw.msgc
+			heartbeatc, msgc = tickc.C, cw.msgc
 		case <-cw.stopc:
 			if cw.close() {
 				plog.Infof("closed the TCP streaming connection with peer %s (%s writer)", cw.peerID, t)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -348,6 +348,7 @@ func TestStoreUpdateValueTTL(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	_, err := s.Update("/foo", "baz", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
+	assert.Nil(t, err, "")
 	e, _ := s.Get("/foo", false, false)
 	assert.Equal(t, *e.Node.Value, "baz", "")
 	assert.Equal(t, e.EtcdIndex, eidx, "")
@@ -368,6 +369,7 @@ func TestStoreUpdateDirTTL(t *testing.T) {
 	s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Create("/foo/bar", false, "baz", false, TTLOptionSet{ExpireTime: Permanent})
 	e, err := s.Update("/foo", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
+	assert.Nil(t, err, "")
 	assert.Equal(t, e.Node.Dir, true, "")
 	assert.Equal(t, e.EtcdIndex, eidx, "")
 	e, _ = s.Get("/foo/bar", false, false)
@@ -911,6 +913,7 @@ func TestStoreRecover(t *testing.T) {
 	s.Update("/foo/x", "barbar", TTLOptionSet{ExpireTime: Permanent})
 	s.Create("/foo/y", false, "baz", false, TTLOptionSet{ExpireTime: Permanent})
 	b, err := s.Save()
+	assert.Nil(t, err, "")
 
 	s2 := newStore()
 	s2.Recovery(b)
@@ -940,6 +943,7 @@ func TestStoreRecoverWithExpiration(t *testing.T) {
 	s.Create("/foo/x", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Create("/foo/y", false, "baz", false, TTLOptionSet{ExpireTime: fc.Now().Add(5 * time.Millisecond)})
 	b, err := s.Save()
+	assert.Nil(t, err, "")
 
 	time.Sleep(10 * time.Millisecond)
 

--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -116,7 +116,7 @@ func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeInde
 }
 
 func (wh *watcherHub) add(e *Event) {
-	e = wh.EventHistory.addEvent(e)
+	wh.EventHistory.addEvent(e)
 }
 
 // notify function accepts an event and notify to the watchers.

--- a/test
+++ b/test
@@ -35,7 +35,7 @@ TESTABLE_AND_FORMATTABLE=`echo "$TEST_PKGS" | egrep -v "$INTEGRATION_PKGS"`
 
 # TODO: 'client' pkg fails with gosimple from generated files
 # TODO: 'rafttest' is failing with unused
-GOSIMPLE_UNUSED_PATHS=`find . -name \*.go | while read a; do dirname $a; done | sort | uniq | egrep -v "$IGNORE_PKGS" | grep -v 'client'`
+STATIC_ANALYSIS_PATHS=`find . -name \*.go | while read a; do dirname $a; done | sort | uniq | egrep -v "$IGNORE_PKGS" | grep -v 'client'`
 
 if [ -z "$GOARCH" ]; then
 	GOARCH=$(go env GOARCH);
@@ -232,7 +232,7 @@ function fmt_pass {
 
 	if which gosimple >/dev/null; then
 		echo "Checking gosimple..."
-		simplResult=`gosimple ${GOSIMPLE_UNUSED_PATHS} 2>&1 || true`
+		simplResult=`gosimple ${STATIC_ANALYSIS_PATHS} 2>&1 || true`
 		if [ -n "${simplResult}" ]; then
 			echo -e "gosimple checking failed:\n${simplResult}"
 			exit 255
@@ -243,13 +243,32 @@ function fmt_pass {
 
 	if which unused >/dev/null; then
 		echo "Checking unused..."
-		unusedResult=`unused ${GOSIMPLE_UNUSED_PATHS} 2>&1 || true`
+		unusedResult=`unused ${STATIC_ANALYSIS_PATHS} 2>&1 || true`
 		if [ -n "${unusedResult}" ]; then
 			echo -e "unused checking failed:\n${unusedResult}"
 			exit 255
 		fi
 	else
 		echo "Skipping unused..."
+	fi
+
+	if which unused >/dev/null; then
+		echo "Checking staticcheck..."
+		staticcheckResult=`staticcheck ${STATIC_ANALYSIS_PATHS} 2>&1 || true`
+		if [ ! -n "${staticcheckResult}" ]; then
+			continue
+		fi
+		# TODO: resolve these after go1.8 migration
+		# See https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck
+		STATIC_CHECK_MASK="SA(1016|1019|2002)"
+		if egrep -v "$STATIC_CHECK_MASK" "${staticcheckResult}"; then
+			echo -e "staticcheck checking ${path} failed:\n${staticcheckResult}"
+			exit 255
+		else
+			echo -e "staticcheck warning:\n${staticcheckResult}"
+		fi
+	else
+		echo "Skipping staticcheck..."
 	fi
 
 	echo "Checking for license header..."

--- a/wal/repair_test.go
+++ b/wal/repair_test.go
@@ -49,7 +49,11 @@ func testRepair(t *testing.T, ents [][]raftpb.Entry, corrupt corruptFunc, expect
 	defer os.RemoveAll(p)
 	// create WAL
 	w, err := Create(p, nil)
-	defer w.Close()
+	defer func() {
+		if err = w.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -546,7 +546,11 @@ func TestReleaseLockTo(t *testing.T) {
 	defer os.RemoveAll(p)
 	// create WAL
 	w, err := Create(p, nil)
-	defer w.Close()
+	defer func() {
+		if err = w.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -712,7 +716,11 @@ func TestOpenOnTornWrite(t *testing.T) {
 	}
 	defer os.RemoveAll(p)
 	w, err := Create(p, nil)
-	defer w.Close()
+	defer func() {
+		if err = w.Close(); err != nil && err != os.ErrInvalid {
+			t.Fatal(err)
+		}
+	}()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/7298.

We will still have some failures until we migrate to Go 1.8.
So this just mask those errors to not fail the whole test suite.

```
skipping error:
contrib/raftexample/raftexample_test.go:105:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
skipping error:
e2e/ctl_v3_watch_test.go:72:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
e2e/etcd_release_upgrade_test.go:156:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
skipping error:
etcdctl/ctlv3/command/elect_command.go:76:36: os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)
etcdctl/ctlv3/command/elect_command.go:110:36: os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)
etcdctl/ctlv3/command/lock_command.go:60:36: os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)
etcdctl/ctlv3/command/snapshot_command.go:313:36: os.SEEK_END is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
etcdctl/ctlv3/command/snapshot_command.go:320:25: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
etcdctl/ctlv3/command/snapshot_command.go:338:26: os.SEEK_END is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
etcdctl/ctlv3/command/snapshot_command.go:356:27: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
skipping error:
etcdmain/etcd.go:338:27: prometheus.Handler is deprecated: Please note the issues described in the doc comment of InstrumentHandler. You might want to consider using promhttp.Handler instead (which is non instrumented).  (SA1019)
etcdmain/grpc_proxy.go:131:29: prometheus.Handler is deprecated: Please note the issues described in the doc comment of InstrumentHandler. You might want to consider using promhttp.Handler instead (which is non instrumented).  (SA1019)
skipping error:
etcdserver/server_test.go:863:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
etcdserver/server_test.go:875:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
etcdserver/server_test.go:925:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
skipping error:
etcdserver/api/v2http/client.go:108:26: prometheus.Handler is deprecated: Please note the issues described in the doc comment of InstrumentHandler. You might want to consider using promhttp.Handler instead (which is non instrumented).  (SA1019)
skipping error:
integration/v2_http_kv_test.go:891:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v2_http_kv_test.go:978:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_barrier_test.go:51:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_double_barrier_test.go:39:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_double_barrier_test.go:39:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_double_barrier_test.go:115:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_double_barrier_test.go:124:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_election_test.go:44:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_election_test.go:69:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_election_test.go:69:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_election_test.go:144:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
integration/v3_lock_test.go:51:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_lock_test.go:130:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_lock_test.go:130:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_queue_test.go:37:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_stm_test.go:163:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_stm_test.go:219:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
integration/v3_watch_test.go:244:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_watch_test.go:479:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_watch_test.go:921:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
integration/v3_watch_test.go:1085:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
integration/v3_watch_test.go:1178:3: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
skipping error:
lease/lessor_test.go:256:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
lease/lessor_test.go:308:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
skipping error:
lease/leasehttp/http.go:158:2: req.Cancel is deprecated: Use the Context and WithContext methods instead. If a Request's Cancel field and context are both set, it is undefined whether Cancel is respected.  (SA1019)
skipping error:
pkg/expect/expect_test.go:108:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
skipping error:
pkg/fileutil/fileutil.go:104:24: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/fileutil.go:108:26: os.SEEK_END is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/fileutil.go:119:23: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/fileutil_test.go:136:26: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/fileutil_test.go:142:25: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/lock_linux.go:39:17: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/lock_test.go:61:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
pkg/fileutil/lock_test.go:61:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
pkg/fileutil/preallocate.go:32:27: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/preallocate.go:36:35: os.SEEK_END is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/preallocate.go:40:29: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
pkg/fileutil/purge_test.go:55:3: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
skipping error:
pkg/transport/timeout_dialer_test.go:31:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
pkg/transport/timeout_listener_test.go:61:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
pkg/transport/timeout_listener_test.go:89:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
pkg/transport/timeout_transport.go:42:2: tr.Dial is deprecated: Use DialContext instead, which allows the transport to cancel dials as soon as they are no longer needed. If both are set, DialContext takes priority.  (SA1019)
pkg/transport/timeout_transport_test.go:40:15: tr.Dial is deprecated: Use DialContext instead, which allows the transport to cancel dials as soon as they are no longer needed. If both are set, DialContext takes priority.  (SA1019)
pkg/transport/tls.go:37:17: t.Dial is deprecated: Use DialContext instead, which allows the transport to cancel dials as soon as they are no longer needed. If both are set, DialContext takes priority.  (SA1019)
skipping error:
rafthttp/fake_roundtripper_test.go:31:9: req.Cancel is deprecated: Use the Context and WithContext methods instead. If a Request's Cancel field and context are both set, it is undefined whether Cancel is respected.  (SA1019)
skipping error:
tools/functional-tester/etcd-tester/main.go:137:26: prometheus.Handler is deprecated: Please note the issues described in the doc comment of InstrumentHandler. You might want to consider using promhttp.Handler instead (which is non instrumented).  (SA1019)
skipping error:
wal/encoder.go:55:27: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/repair.go:65:26: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/repair_test.go:52:2: should check returned error before deferring w.Close() (SA5001)
wal/repair_test.go:63:34: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal.go:115:24: os.SEEK_END is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal.go:325:53: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal.go:364:32: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal.go:404:30: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal.go:421:32: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal.go:567:34: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal_test.go:49:31: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal_test.go:622:32: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal_test.go:727:41: os.SEEK_CUR is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
wal/wal_test.go:741:39: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
```
