### PR TITLE
pkg/transport: remove dependency on pkg/fileutils

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/pkg/tlsutil"
 )
 
@@ -86,7 +85,7 @@ func (info TLSInfo) Empty() bool {
 }
 
 func SelfCert(dirpath string, hosts []string) (info TLSInfo, err error) {
-	if err = fileutil.TouchDirAll(dirpath); err != nil {
+	if err = os.MkdirAll(dirpath, 0700); err != nil {
 		return
 	}
 


### PR DESCRIPTION
4a0f922 changed SelfCert to use a helper from pkg/fileutils which
introduced a transitive dependency on coreos/pkg/capnslog. This means
anyone who imports pkg/transport to use TLS with the clientv3 library
has the default stdlib logger hijacked by capnslog.

This PR reverts 4a0f922. There are no tests because 4a0f922 contained no
test and was not attached to a PR.

Fixes #7350 
