### PR TITLE
auth: keep old revision in 'NewAuthStore'

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -916,7 +916,9 @@ func NewAuthStore(be backend.Backend, indexWaiter func(uint64) <-chan struct{}) 
 		as.simpleTokenKeeper = NewSimpleTokenTTLKeeper(newDeleterFunc(as))
 	}
 
-	as.commitRevision(tx)
+	if as.revision == 0 {
+		as.commitRevision(tx)
+	}
 
 	tx.Unlock()
 	be.ForceCommit()


### PR DESCRIPTION
When there's no changes yet (right after auth
store initialization), we should commit old revision.

Fix https://github.com/coreos/etcd/issues/7359.

Seems like `commitRevision` was introduced long time ago,
and we recently fixed it to have correct revision in `authStore`,
so it starts failing in our hash tests.

Do we have any reason to bump up revision for every `commitRevision` call,
even around store initialization?