### PR TITLE
travis: skip 'fmt' tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,6 @@ matrix:
   - go: tip
     env: TARGET=ppc64le
 
-addons:
-  apt:
-    packages:
-    - libpcap-dev
-    - libaspell-dev
-    - libhunspell-dev
-
-before_install:
- - go get -v github.com/chzchzchz/goword
- - go get -v honnef.co/go/tools/cmd/gosimple
- - go get -v honnef.co/go/tools/cmd/unused
-
 # disable godep restore override
 install:
  - pushd cmd/etcd && go get -t -v ./... && popd
@@ -53,7 +41,7 @@ script:
  - >
     case "${TARGET}" in
       amd64)
-        GOARCH=amd64 ./test
+        GOARCH=amd64 PASSES="dep compile build unit" ./test
         ;;
       386)
         GOARCH=386 PASSES="build unit" ./test


### PR DESCRIPTION
For https://github.com/coreos/etcd/issues/7377

Disable these in Travis for now.
Will set up separate Jenkins job once https://github.com/coreos/etcd/pull/7347 gets in master.