### PR TITLE
Dockerfile-release: Add ca-certificates package

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,5 +1,8 @@
 FROM alpine:latest
 
+RUN apk add --quiet --no-cache ca-certificates && \
+  rm -rf /var/cache/*
+
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/
 RUN mkdir -p /var/etcd/


### PR DESCRIPTION
Fixes the following error when running etcd in a Docker container.

```
discovery: error #0: x509: failed to load system roots and no roots provided
discovery: cluster status check: error connecting to https://discovery.etcd.io, retrying in XX
```