### PR TITLE
grpcproxy: return closing error when stream is canceled from conn close

### DIFF
--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -73,7 +73,12 @@ func (wp *watchProxy) Watch(stream pb.Watch_WatchServer) (err error) {
 	select {
 	case <-wp.ctx.Done():
 		wp.mu.Unlock()
-		return
+		select {
+		case <-wp.leader.disconnectNotify():
+			return grpc.ErrClientConnClosing
+		default:
+			return wp.ctx.Err()
+		}
 	default:
 		wp.wg.Add(1)
 	}


### PR DESCRIPTION
Fixes #6630