### PR TITLE
raft: make TestNodeTick reliable

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -402,7 +402,11 @@ func TestNodeTick(t *testing.T) {
 	go n.run(r)
 	elapsed := r.electionElapsed
 	n.Tick()
-	testutil.WaitSchedule()
+
+	for len(n.tickc) != 0 {
+		time.Sleep(100 * time.Millisecond)
+	}
+
 	n.Stop()
 	if r.electionElapsed != elapsed+1 {
 		t.Errorf("elapsed = %d, want %d", r.electionElapsed, elapsed+1)


### PR DESCRIPTION
TestNodeTick relies on a unreliable func `waitForSchedule` when running
with GOMAXPROCS > 1. This commit changes the test to make sure we stop
the node after it drains the tick chan. The test should be reliable now.

Fix #7374 

/cc @fanminshi @heyitsanthony 