### PR TITLE
test: run unused and gosimple over all packages at once

### DIFF
--- a/test
+++ b/test
@@ -224,26 +224,22 @@ function fmt_pass {
 
 	if which gosimple >/dev/null; then
 		echo "Checking gosimple..."
-		for path in $GOSIMPLE_UNUSED_PATHS; do
-			simplResult=`gosimple ${path} 2>&1 || true`
-			if [ -n "${simplResult}" ]; then
-				echo -e "gosimple checking ${path} failed:\n${simplResult}"
-				exit 255
-			fi
-		done
+		simplResult=`gosimple ${GOSIMPLE_UNUSED_PATHS} 2>&1 || true`
+		if [ -n "${simplResult}" ]; then
+			echo -e "gosimple checking failed:\n${simplResult}"
+			exit 255
+		fi
 	else
 		echo "Skipping gosimple..."
 	fi
 
 	if which unused >/dev/null; then
 		echo "Checking unused..."
-		for path in $GOSIMPLE_UNUSED_PATHS; do
-			unusedResult=`unused ${path} 2>&1 || true`
-			if [ -n "${unusedResult}" ]; then
-				echo -e "unused checking ${path} failed:\n${unusedResult}"
-				exit 255
-			fi
-		done
+		unusedResult=`unused ${GOSIMPLE_UNUSED_PATHS} 2>&1 || true`
+		if [ -n "${unusedResult}" ]; then
+			echo -e "unused checking failed:\n${unusedResult}"
+			exit 255
+		fi
 	else
 		echo "Skipping unused..."
 	fi


### PR DESCRIPTION
fmt pass went from ~20 CPU minutes to ~1 CPU minute.

/cc @gyuho 