### PR TITLE
etcd-tester: check expired lease with -1 TTL

### DIFF
--- a/tools/functional-tester/etcd-tester/checks.go
+++ b/tools/functional-tester/etcd-tester/checks.go
@@ -133,7 +133,8 @@ func (lc *leaseChecker) checkShortLivedLease(ctx context.Context, leaseID int64)
 	var resp *pb.LeaseTimeToLiveResponse
 	for i := 0; i < retries; i++ {
 		resp, err = lc.getLeaseByID(ctx, leaseID)
-		if rpctypes.Error(err) == rpctypes.ErrLeaseNotFound {
+		// lease not found, for ~v3.1 compatibilities, check ErrLeaseNotFound
+		if (err == nil && resp.TTL == -1) || (err != nil && rpctypes.Error(err) == rpctypes.ErrLeaseNotFound) {
 			return nil
 		}
 		if err != nil {
@@ -195,11 +196,13 @@ func (lc *leaseChecker) hasLeaseExpired(ctx context.Context, leaseID int64) (boo
 	// keep retrying until lease's state is known or ctx is being canceled
 	for ctx.Err() == nil {
 		resp, err := lc.getLeaseByID(ctx, leaseID)
-		if err == nil {
-			return false, nil
-		}
-		if rpctypes.Error(err) == rpctypes.ErrLeaseNotFound {
-			return true, nil
+		if err != nil {
+			// for ~v3.1 compatibilities
+			if rpctypes.Error(err) == rpctypes.ErrLeaseNotFound {
+				return true, nil
+			}
+		} else {
+			return resp.TTL == -1, nil
 		}
 		plog.Warningf("hasLeaseExpired %v resp %v error %v (endpoint %q)", leaseID, resp, err, lc.endpoint)
 	}


### PR DESCRIPTION
Following the change at
https://github.com/coreos/etcd/commit/2ca1823a96105409febb89479d53c6c5e0f83dc2

This fixes the error that we are getting

> [round#6 case#0] functional-tester returning with error (tt.checkConsistency error (lease 5264526043634585873 expiration mismatch (lease expired=false, keys expired=true), lease 8791688976795817481 expiration mismatch (lease expired=false, keys expired=true), lease 1772547482562197041 expiration mismatch (lease expired=false, keys expired=true), lease 7369958869430294037 expiration mismatch (lease expired=false, keys expired=true), lease 8847421022184526416 expiration mismatch (lease expired=false, keys expired=true)))
