### PR TITLE
clientv3: pass back dial error on dial timeout

### DIFF
--- a/clientv3/client_test.go
+++ b/clientv3/client_test.go
@@ -72,9 +72,9 @@ func TestDialTimeout(t *testing.T) {
 
 	donec := make(chan error)
 	go func() {
-		// without timeout, grpc keeps redialing if connection refused
+		// without timeout, dial continues forever on ipv4 blackhole
 		cfg := Config{
-			Endpoints:   []string{"localhost:12345"},
+			Endpoints:   []string{"http://254.0.0.1:12345"},
 			DialTimeout: 2 * time.Second}
 		c, err := New(cfg)
 		if c != nil || err == nil {


### PR DESCRIPTION
Fixes #7419

Before:
```sh
$ ETCDCTL_API=3 etcdctl get whatever
Error:  grpc: timed out when dialing
```

After:
```sh
$ ETCDCTL_API=3 etcdctl get whatever
Error:  dial tcp 127.0.0.1:2379: getsockopt: connection refused
```