### PR TITLE
contrib: suppress gosimple errors of raftexample

### DIFF
--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -75,7 +75,7 @@ func (clus *cluster) Close() (err error) {
 			// drain pending commits
 		}
 		// wait for channel to close
-		if erri, _ := <-clus.errorC[i]; erri != nil {
+		if erri := <-clus.errorC[i]; erri != nil {
 			err = erri
 		}
 		// clean intermediates
@@ -111,7 +111,7 @@ func TestProposeOnCommit(t *testing.T) {
 				select {
 				case pC <- *s:
 					continue
-				case err, _ := <-eC:
+				case err := <-eC:
 					t.Fatalf("eC message (%v)", err)
 				}
 			}


### PR DESCRIPTION
Travis claimed errors of gosimple like below
(https://travis-ci.org/coreos/etcd/jobs/208098545):
gosimple checking failed:
contrib/raftexample/raftexample_test.go:78:6: should write erri := <-clus.errorC[i] instead of erri, _ := <-clus.errorC[i]
contrib/raftexample/raftexample_test.go:114:10: should write err := <-eC instead of err, _ := <-eC

This commit fixes the errors.
