### PR TITLE
gateway: fix the dns discovery method

### DIFF
--- a/etcdmain/gateway.go
+++ b/etcdmain/gateway.go
@@ -17,6 +17,7 @@ package etcdmain
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"time"
 
@@ -77,6 +78,20 @@ func newGatewayStartCommand() *cobra.Command {
 	return &cmd
 }
 
+func stripSchema(eps []string) []string {
+	var endpoints []string
+
+	for _, ep := range eps {
+
+		if u, err := url.Parse(ep); err == nil && u.Host != "" {
+			ep = u.Host
+		}
+
+		endpoints = append(endpoints, ep)
+	}
+
+	return endpoints
+}
 func startGateway(cmd *cobra.Command, args []string) {
 	endpoints := gatewayEndpoints
 	if gatewayDNSCluster != "" {
@@ -100,6 +115,9 @@ func startGateway(cmd *cobra.Command, args []string) {
 			plog.Infof("using discovered endpoints %v", endpoints)
 		}
 	}
+
+	// Strip the schema from the endpoints because we start just a TCP proxy
+	endpoints = stripSchema(endpoints)
 
 	if len(endpoints) == 0 {
 		plog.Fatalf("no endpoints found")


### PR DESCRIPTION
strip the scheme from the endpoints to have a clean hostname for TCP proxy

Fixes #7452