### PR TITLE
wal: only consider a wal directory as Existing if it has wal files

### DIFF
--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -785,3 +785,31 @@ func TestOpenOnTornWrite(t *testing.T) {
 		t.Fatalf("expected len(ents) = %d, got %d", wEntries, len(ents))
 	}
 }
+
+func TestWalExist(t *testing.T) {
+	p, err := ioutil.TempDir(os.TempDir(), "waltest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(p)
+
+	if Exist(p) {
+		t.Fatalf("empty directory treated as existing wal directory")
+	}
+
+	if err := os.Mkdir(path.Join(p, "lost+found"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if Exist(p) {
+		t.Fatalf("directory with only non-wal data treated as existing wal directory")
+	}
+
+	f, ferr := os.Create(path.Join(p, "0000000000000001-0000000000000001.wal"))
+	if ferr != nil {
+		t.Fatal(ferr)
+	}
+	f.Close()
+	if !Exist(p) {
+		t.Fatalf("directory with wal file treated as non-existing wal")
+	}
+}


### PR DESCRIPTION
In cases where etcd is started with a user-defined wal directory, it's possible
there may already be contents in the directory (e.g., lost+found on a fresh
filesystem), which will be treated as initialized even though it is not.
Instead, if there are no wal files, the directory should be treated as an
uninitialized wal directory.

/cc @pizzarabe