### PR TITLE
*: fix minor typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 etcd v3.1.2 (2017-02-24)
-- use IPv4 default host, by default (when IPv4 amd IPv6 are available)
+- use IPv4 default host, by default (when IPv4 and IPv6 are available)
 - fix 'etcd gateway' with multiple endpoints
 
 etcd v3.1.1 (2017-02-17)

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -64,7 +64,7 @@ func (t *tokenJWT) info(ctx context.Context, token string, rev uint64) (*AuthInf
 }
 
 func (t *tokenJWT) assign(ctx context.Context, username string, revision uint64) (string, error) {
-	// Future work: let a jwt token include permission infomation would be useful for
+	// Future work: let a jwt token include permission information would be useful for
 	// permission checking in proxy side.
 	tk := jwt.NewWithClaims(jwt.GetSigningMethod(t.signMethod),
 		jwt.MapClaims{

--- a/integration/v3_lease_test.go
+++ b/integration/v3_lease_test.go
@@ -240,8 +240,8 @@ func TestV3LeaseRenewStress(t *testing.T) {
 	testLeaseStress(t, stressLeaseRenew)
 }
 
-// TestV3LeaseTimeToLiveStress keeps creating lease and retriving it immediately to ensure the lease can be retrived.
-// it was oberserved that the immediate lease retrival after granting a lease from follower resulted lease not found.
+// TestV3LeaseTimeToLiveStress keeps creating lease and retrieving it immediately to ensure the lease can be retrieved.
+// it was oberserved that the immediate lease retrieval after granting a lease from follower resulted lease not found.
 // related issue https://github.com/coreos/etcd/issues/6978
 func TestV3LeaseTimeToLiveStress(t *testing.T) {
 	testLeaseStress(t, stressLeaseTimeToLive)
@@ -334,7 +334,7 @@ func TestV3PutOnNonExistLease(t *testing.T) {
 	}
 }
 
-// TestV3GetNonExistLease ensures client retriving nonexistent lease on a follower doesn't result node panic
+// TestV3GetNonExistLease ensures client retrieving nonexistent lease on a follower doesn't result node panic
 // related issue https://github.com/coreos/etcd/issues/6537
 func TestV3GetNonExistLease(t *testing.T) {
 	defer testutil.AfterTest(t)

--- a/pkg/adt/interval_tree.go
+++ b/pkg/adt/interval_tree.go
@@ -402,7 +402,7 @@ func (ivt *IntervalTree) MaxHeight() int {
 	return int((2 * math.Log2(float64(ivt.Len()+1))) + 0.5)
 }
 
-// IntervalVisitor is used on tree searchs; return false to stop searching.
+// IntervalVisitor is used on tree searches; return false to stop searching.
 type IntervalVisitor func(n *IntervalValue) bool
 
 // Visit calls a visitor function on every tree node intersecting the given interval.

--- a/test
+++ b/test
@@ -252,7 +252,7 @@ function fmt_pass {
 		echo "Skipping unused..."
 	fi
 
-	if which unused >/dev/null; then
+	if which staticcheck >/dev/null; then
 		echo "Checking staticcheck..."
 		staticcheckResult=`staticcheck ${STATIC_ANALYSIS_PATHS} 2>&1 || true`
 		if [ ! -n "${staticcheckResult}" ]; then


### PR DESCRIPTION
Mainly to fix the wrong command name in `test` script (to `staticcheck`).
Might as well fix others.