### PR TITLE
etcdmain: SdNotify when gateway, grpc-proxy are ready

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -39,8 +39,6 @@ import (
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/proxy/httpproxy"
 	"github.com/coreos/etcd/version"
-	"github.com/coreos/go-systemd/daemon"
-	systemdutil "github.com/coreos/go-systemd/util"
 	"github.com/coreos/pkg/capnslog"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -163,20 +161,12 @@ func startEtcdOrProxyV2() {
 
 	osutil.HandleInterrupts()
 
-	if systemdutil.IsRunningSystemd() {
-		// At this point, the initialization of etcd is done.
-		// The listeners are listening on the TCP ports and ready
-		// for accepting connections. The etcd instance should be
-		// joined with the cluster and ready to serve incoming
-		// connections.
-		sent, err := daemon.SdNotify(false, "READY=1")
-		if err != nil {
-			plog.Errorf("failed to notify systemd for readiness: %v", err)
-		}
-		if !sent {
-			plog.Errorf("forgot to set Type=notify in systemd service file?")
-		}
-	}
+	// At this point, the initialization of etcd is done.
+	// The listeners are listening on the TCP ports and ready
+	// for accepting connections. The etcd instance should be
+	// joined with the cluster and ready to serve incoming
+	// connections.
+	notifySystemd()
 
 	select {
 	case lerr := <-errc:

--- a/etcdmain/gateway.go
+++ b/etcdmain/gateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/proxy/tcpproxy"
+
 	"github.com/spf13/cobra"
 )
 
@@ -134,6 +135,9 @@ func startGateway(cmd *cobra.Command, args []string) {
 		Endpoints:       endpoints,
 		MonitorInterval: getewayRetryDelay,
 	}
+
+	// At this point, etcd gateway listener is initialized
+	notifySystemd()
 
 	tp.Run()
 }

--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -165,6 +165,9 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 
 	go func() { errc <- m.Serve() }()
 
+	// grpc-proxy is initialized, ready to serve
+	notifySystemd()
+
 	fmt.Fprintln(os.Stderr, <-errc)
 	os.Exit(1)
 }

--- a/etcdmain/main.go
+++ b/etcdmain/main.go
@@ -17,6 +17,9 @@ package etcdmain
 import (
 	"fmt"
 	"os"
+
+	"github.com/coreos/go-systemd/daemon"
+	systemdutil "github.com/coreos/go-systemd/util"
 )
 
 func Main() {
@@ -34,4 +37,17 @@ func Main() {
 	}
 
 	startEtcdOrProxyV2()
+}
+
+func notifySystemd() {
+	if !systemdutil.IsRunningSystemd() {
+		return
+	}
+	sent, err := daemon.SdNotify(false, "READY=1")
+	if err != nil {
+		plog.Errorf("failed to notify systemd for readiness: %v", err)
+	}
+	if !sent {
+		plog.Errorf("forgot to set Type=notify in systemd service file?")
+	}
 }


### PR DESCRIPTION
Just tried this on Container Linux with systemd, confirmed that it works well without sd-notify errors.

```
Mar 09 17:52:19 gyuho-coreos.c.etcd-development.internal systemd[1]: Starting etcd...
Mar 09 17:52:19 gyuho-coreos.c.etcd-development.internal etcd[25737]: ready to proxy client requests to [127.0.0.1:2379]
Mar 09 17:52:19 gyuho-coreos.c.etcd-development.internal systemd[1]: Started etcd.

Mar 09 17:54:06 gyuho-coreos.c.etcd-development.internal systemd[1]: Starting etcd...
Mar 09 17:54:06 gyuho-coreos.c.etcd-development.internal etcd[25832]: listening for grpc-proxy client requests on 127.0.0.1:23791
Mar 09 17:54:06 gyuho-coreos.c.etcd-development.internal systemd[1]: Started etcd.
```

Fix https://github.com/coreos/etcd/issues/7465

