### PR TITLE
auth: nil check AuthInfo when checking admin permissions

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -744,6 +744,9 @@ func (as *authStore) IsAdminPermitted(authInfo *AuthInfo) error {
 	if !as.isAuthEnabled() {
 		return nil
 	}
+	if authInfo == nil {
+		return ErrUserEmpty
+	}
 
 	tx := as.be.BatchTx()
 	tx.Lock()


### PR DESCRIPTION
If the context does not include auth information, get authinfo will
return a nil auth info and a nil error. This is then passed to
IsAdminPermitted, which would dereference the nil auth info.

via #7471

/cc @mitake