### PR TITLE
clientv3: use CheckAfterTest after terminating cluster

### DIFF
--- a/clientv3/main_test.go
+++ b/clientv3/main_test.go
@@ -15,10 +15,12 @@
 package clientv3_test
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coreos/etcd/auth"
 	"github.com/coreos/etcd/integration"
@@ -50,6 +52,10 @@ func TestMain(m *testing.M) {
 		}
 		v = m.Run()
 		clus.Terminate(nil)
+		if err := testutil.CheckAfterTest(time.Second); err != nil {
+			fmt.Fprintf(os.Stderr, "%v", err)
+			os.Exit(1)
+		}
 	} else {
 		v = m.Run()
 	}


### PR DESCRIPTION
AfterTest() has a delay that waits for runtime goroutines to exit; CheckLeakedGoroutine does not. Since the test runner manages the test cluster for examples, there is no delay between terminating the cluster and checking for leaked goroutines. Instead, apply AfterTest checking before running CheckLeakedGoroutine to let runtime http goroutines finish.