### PR TITLE
etcdserver: fix racey raft log snap term look-up

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -772,7 +772,11 @@ func (s *EtcdServer) applyAll(ep *etcdProgress, apply *apply) {
 	select {
 	// snapshot requested via send()
 	case m := <-s.r.msgSnapC:
-		merged := s.createMergedSnapshotMessage(m, ep.appliedi, ep.confState)
+		snapt, snapi := apply.snapshot.Metadata.Term, apply.snapshot.Metadata.Index
+		if len(apply.entries) > 0 {
+			snapt, snapi = apply.entries[0].Term, apply.entries[0].Index
+		}
+		merged := s.createMergedSnapshotMessage(m, snapt, snapi, ep.confState)
 		s.sendMergedSnap(merged)
 	default:
 	}

--- a/etcdserver/snapshot_merge.go
+++ b/etcdserver/snapshot_merge.go
@@ -16,7 +16,6 @@ package etcdserver
 
 import (
 	"io"
-	"log"
 
 	"github.com/coreos/etcd/mvcc/backend"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -26,12 +25,7 @@ import (
 // createMergedSnapshotMessage creates a snapshot message that contains: raft status (term, conf),
 // a snapshot of v2 store inside raft.Snapshot as []byte, a snapshot of v3 KV in the top level message
 // as ReadCloser.
-func (s *EtcdServer) createMergedSnapshotMessage(m raftpb.Message, snapi uint64, confState raftpb.ConfState) snap.Message {
-	snapt, err := s.r.raftStorage.Term(snapi)
-	if err != nil {
-		log.Panicf("get term should never fail: %v", err)
-	}
-
+func (s *EtcdServer) createMergedSnapshotMessage(m raftpb.Message, snapt, snapi uint64, confState raftpb.ConfState) snap.Message {
 	// get a snapshot of v2 store as []byte
 	clone := s.store.Clone()
 	d, err := clone.SaveNoCopy()


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/7470.

This removes unnecessary 'raftStorage.Term' method call
in 'createMergedSnapshotMessage', because at the moment,
the server already knows which term to put in the snapshot
metadata. And it is possible that entries in
'EtcdServer.raftStorage' are already compacted.

