### PR TITLE
v3client: fix doc to use e.Server

### DIFF
--- a/etcdserver/api/v3client/doc.go
+++ b/etcdserver/api/v3client/doc.go
@@ -34,7 +34,7 @@
 //	}
 //
 //	// wrap the EtcdServer with v3client
-//	cli := v3client.New(e)
+//	cli := v3client.New(e.Server)
 //
 //	// use like an ordinary clientv3
 //	resp, err := cli.Put(context.TODO(), "some-key", "it works!")


### PR DESCRIPTION
Was passing embed.Etcd instead of etcdserver.EtcdServer.

/cc @darasion