### PR TITLE
embed: Delay setting initial cluster

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -246,6 +246,9 @@ func (cfg *configYAML) configFromFile(path string) error {
 		cfg.ACUrls = []url.URL(u)
 	}
 
+	if (cfg.Durl != "" || cfg.DNSCluster != "") && cfg.InitialCluster == cfg.InitialClusterFromName(cfg.Name) {
+		cfg.InitialCluster = ""
+	}
 	if cfg.ClusterState == "" {
 		cfg.ClusterState = ClusterStateFlagNew
 	}


### PR DESCRIPTION
`embed.NewConfig()` sets the initial cluster from name but we should clear it in the event that another discovery option has been specified.

Fixes #7516