### PR TITLE
Documentation: add a doc of v3 auth

### DIFF
--- a/Documentation/docs.md
+++ b/Documentation/docs.md
@@ -30,6 +30,7 @@ Administrators who need to create reliable and scalable key-value stores for the
  - [Hardware recommendations][hardware]
  - [Configuration][conf]
  - [Security][security]
+ - [Authentication][authentication]
  - [Monitoring][monitoring]
  - [Maintenance][maintenance]
  - [Understand failures][failures]
@@ -90,3 +91,4 @@ Answers to [common questions] about etcd.
 [experimental]: dev-guide/experimental_apis.md
 [v3_upgrade]: upgrades/upgrade_3_0.md
 [v31_upgrade]: upgrades/upgrade_3_1.md
+[authentication]: op-guide/authentication.md

--- a/Documentation/op-guide/authentication.md
+++ b/Documentation/op-guide/authentication.md
@@ -1,0 +1,164 @@
+# Authentication Guide
+
+## Overview
+
+Authentication was added in etcd 2.1. The etcd v3 API slightly modified the authentication feature's API and user interface to better fit the new data model. This guide is intended to help users set up basic authentication in etcd v3.
+
+## Special users and roles
+
+There is one special user, `root`, and there are two special roles, `root` and `guest`.
+
+### User `root`
+
+The `root` user, which has full access to etcd, must be created before activating authentication. The idea behind the `root` user is for administrative purposes: managing roles and ordinary users. The `root` user must have the `root` role and is allowed to change anything inside etcd.
+
+### Role `root`
+
+The role `root` may be granted to any user, in addition to the root user. A user with the `root` role has both global read-write access and permission to update the cluster's authentication configuration. Furthermore, the `root` role grants privileges for general cluster maintenance, including modifying cluster membership, defragmenting the store, and taking snapshots.
+
+## Working with users
+
+The `user` subcommand for `etcdctl` handles all things having to do with user accounts.
+
+A listing of users can be found with:
+
+```
+$ etcdctl user list
+```
+
+Creating a user is as easy as
+
+```
+$ etcdctl user add myusername
+```
+
+Creating a new user will prompt for a new password. The password can be supplied from standard input when an option `--interactive=false` is given.
+
+Roles can be granted and revoked for a user with:
+
+```
+$ etcdctl user grant-role myusername foo
+$ etcdctl user revoke-role myusername bar
+```
+
+The user's settings can be inspected with:
+
+```
+$ etcdctl user get myusername
+```
+
+And the password for a user can be changed with
+
+```
+$ etcdctl user passwd myusername
+```
+
+Changing the password will prompt again for a new password. The password can be supplied from standard input when an option `--interactive=false` is given.
+
+Delete an account with:
+```
+$ etcdctl user delete myusername
+```
+
+
+## Working with roles
+
+The `role` subcommand for `etcdctl` handles all things having to do with access controls for particular roles, as were granted to individual users.
+
+List roles with:
+
+```
+$ etcdctl role list
+```
+
+Create a new role with:
+
+```
+$ etcdctl role add myrolename
+```
+
+A role has no password; it merely defines a new set of access rights.
+
+Roles are granted access to a single key or a range of keys.
+
+The range can be specified as an interval [start-key, end-key) where start-key should be lexically less than end-key in an alphabetical manner.
+
+Access can be granted as either read, write, or both, as in the following examples:
+
+```
+# Give read access to a key /foo
+$ etcdctl role grant-permission myrolename read /foo
+
+# Give read access to keys with a prefix /foo/. The prefix is equal to the range [/foo/, /foo0)
+$ etcdctl role grant-permission myrolename --prefix=true read /foo/
+
+# Give write-only access to the key at /foo/bar
+$ etcdctl role grant-permission myrolename write /foo/bar
+
+# Give full access to keys in a range of [key1, key5)
+$ etcdctl role grant-permission myrolename readwrite key1 key5
+
+# Give full access to keys with a prefix /pub/
+$ etcdctl role grant-permission myrolename --prefix=true readwrite /pub/
+```
+
+To see what's granted, we can look at the role at any time:
+
+```
+$ etcdctl role get myrolename
+```
+
+Revocation of permissions is done the same logical way:
+
+```
+$ etcdctl role revoke-permission myrolename /foo/bar
+```
+
+As is removing a role entirely:
+
+```
+$ etcdctl role remove myrolename
+```
+
+## Enabling authentication
+
+The minimal steps to enabling auth are as follows. The administrator can set up users and roles before or after enabling authentication, as a matter of preference. 
+
+Make sure the root user is created:
+
+```
+$ etcdctl user add root 
+Password of root:
+```
+
+Enable authentication:
+
+```
+$ etcdctl auth enable
+```
+
+After this, etcd is running with authentication enabled. To disable it for any reason, use the reciprocal command:
+
+```
+$ etcdctl --user root:rootpw auth disable
+```
+
+## Using `etcdctl` to authenticate
+
+`etcdctl` supports a similar flag as `curl` for authentication.
+
+```
+$ etcdctl --user user:password get foo
+```
+
+The password can be taken from a prompt:
+
+```
+$ etcdctl --user user get foo
+```
+
+Otherwise, all `etcdctl` commands remain the same. Users and roles can still be created and modified, but require authentication by a user with the root role.
+
+## Using TLS Common Name
+
+If an etcd server is launched with the option `--client-cert-auth=true`, the field of Common Name (CN) in the client's TLS cert will be used as an etcd user. In this case, the common name authenticates the user and the client does not need a password.


### PR DESCRIPTION
It is almost same to Documentation/v2/authentication.md because a
major part of its user interface is shared with the v2 auth. The newly
added doc includes some refinements for the v3 auth.
