### PR TITLE
etcdmain: exit hanging process with wrong configuration

### DIFF
--- a/e2e/ctl_v2_test.go
+++ b/e2e/ctl_v2_test.go
@@ -254,7 +254,7 @@ func TestCtlV2Backup(t *testing.T) { // For https://github.com/coreos/etcd/issue
 	// restart from the backup directory
 	cfg2 := configNoTLS
 	cfg2.dataDirPath = backupDir
-	cfg2.keepDataDir = true
+	cfg2.keepDataDirStart = true
 	cfg2.forceNewCluster = true
 	epc2 := setupEtcdctlTest(t, &cfg2, false)
 

--- a/e2e/ctl_v3_auth_test.go
+++ b/e2e/ctl_v3_auth_test.go
@@ -468,13 +468,13 @@ func authTestMemberAdd(cx ctlCtx) {
 	peerURL := fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)
 	// ordinal user cannot add a new member
 	cx.user, cx.pass = "test-user", "pass"
-	if err := ctlV3MemberAdd(cx, peerURL); err == nil {
+	if err := ctlV3MemberAdd(cx, "newmember", peerURL); err == nil {
 		cx.t.Fatalf("ordinal user must not be allowed to add a member")
 	}
 
 	// root can add a new member
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3MemberAdd(cx, peerURL); err != nil {
+	if err := ctlV3MemberAdd(cx, "newmember", peerURL); err != nil {
 		cx.t.Fatal(err)
 	}
 }

--- a/e2e/ctl_v3_member_test.go
+++ b/e2e/ctl_v3_member_test.go
@@ -18,10 +18,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
+	"github.com/coreos/etcd/pkg/testutil"
 )
 
 func TestCtlV3MemberList(t *testing.T) { testCtl(t, memberListTest) }
@@ -83,13 +86,13 @@ func ctlV3MemberRemove(cx ctlCtx, ep, memberID, clusterID string) error {
 }
 
 func memberAddTest(cx ctlCtx) {
-	if err := ctlV3MemberAdd(cx, fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)); err != nil {
+	if err := ctlV3MemberAdd(cx, "newmember", fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)); err != nil {
 		cx.t.Fatal(err)
 	}
 }
 
-func ctlV3MemberAdd(cx ctlCtx, peerURL string) error {
-	cmdArgs := append(cx.PrefixArgs(), "member", "add", "newmember", fmt.Sprintf("--peer-urls=%s", peerURL))
+func ctlV3MemberAdd(cx ctlCtx, name, peerURL string) error {
+	cmdArgs := append(cx.PrefixArgs(), "member", "add", name, fmt.Sprintf("--peer-urls=%s", peerURL))
 	return spawnWithExpect(cmdArgs, " added to cluster ")
 }
 
@@ -109,4 +112,111 @@ func memberUpdateTest(cx ctlCtx) {
 func ctlV3MemberUpdate(cx ctlCtx, memberID, peerURL string) error {
 	cmdArgs := append(cx.PrefixArgs(), "member", "update", memberID, fmt.Sprintf("--peer-urls=%s", peerURL))
 	return spawnWithExpect(cmdArgs, " updated in cluster ")
+}
+
+// TestCtlV3MemberAddRemove tests cluster member add,remove
+// and makes sure removed member cannot join the cluster and exits "in time".
+// (Related https://github.com/coreos/etcd/issues/7512)
+func TestCtlV3MemberAddRemove(t *testing.T) {
+	defer testutil.AfterTest(t)
+
+	// 1. start single-member cluster
+	readyc1, stopc1, closedc1 := make(chan ctlCtx), make(chan struct{}), make(chan struct{})
+	go func() {
+		testCtl(t, func(ret ctlCtx) {},
+			withCfg(configNoTLS), withNoStrictReconfig(), withTestTimeout(time.Minute),
+			withKeepDataDirStop(), withReadyc(readyc1), withStopc(stopc1), withClosedc(closedc1))
+	}()
+	c1 := <-readyc1
+	c1s := c1.epc.procs[0].cfg.initialCluster
+	dataDir1 := c1.epc.procs[0].cfg.dataDirPath
+	defer os.RemoveAll(dataDir1)
+
+	// 2. add a new member
+	nameprefix := "newmember"
+	basePort := etcdProcessBasePort + 10000
+	addc := make(chan struct{})
+	go func() {
+		defer close(addc)
+		if err := ctlV3MemberAdd(c1, nameprefix+"0", fmt.Sprintf("http://localhost:%d", basePort+1)); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	select {
+	case <-time.After(c1.dialTimeout + 3*time.Second):
+		t.Fatalf("c1 member add timed out after %v", c1.dialTimeout+3*time.Second)
+	case <-addc:
+	}
+
+	// 3. start new member with 'existing' flag
+	cc2 := configNoTLS
+	cc2.basePort = basePort
+	readyc2, stopc2, closedc2 := make(chan ctlCtx), make(chan struct{}), make(chan struct{})
+	go func() {
+		testCtl(t, func(ret ctlCtx) {},
+			withCfg(cc2), withNoStrictReconfig(), withNamePrefix(nameprefix),
+			withExistingInitialCluster(c1s), withExistingCluster(), withTestTimeout(time.Minute),
+			withReadyc(readyc2), withStopc(stopc2), withClosedc(closedc2))
+	}()
+	c2 := <-readyc2
+	defer func() {
+		// shut down second member
+		stopc2 <- struct{}{}
+		<-closedc2
+	}()
+
+	ls, err := getMemberList(c1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ls.Members) != 2 {
+		t.Fatalf("len(ls.Members) expected 2, got %d", len(ls.Members))
+	}
+	cid := ls.Header.ClusterId
+	var id1, id2 uint64
+	for _, m := range ls.Members {
+		if m.Name == c1.epc.procs[0].cfg.name {
+			id1 = m.ID
+		} else {
+			id2 = m.ID
+		}
+	}
+
+	// 4. remove first member
+	removec := make(chan struct{})
+	go func() {
+		defer close(removec)
+		if err = ctlV3MemberRemove(c2, c1.epc.grpcEndpoints()[0], fmt.Sprintf("%16x", id1), fmt.Sprintf("%16x", cid)); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	select {
+	case <-time.After(c2.dialTimeout + 3*time.Second):
+		t.Fatalf("c2 member remove timed out after %v", c2.dialTimeout+3*time.Second)
+	case <-removec:
+	}
+
+	// 5. shut down first member, without deleting data directory
+	stopc1 <- struct{}{}
+	<-closedc1
+
+	// 6. wait for new leader
+	if err = waitExpect(c2.epc.procs[0].proc, []string{fmt.Sprintf("raft: %x became leader", id2)}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 7. restart first member with 'initial-cluster-state=new'; wrong config, expects exit within ReqTimeout
+	exitc := make(chan struct{})
+	go func() {
+		defer close(exitc)
+		c1.epc.procs[0].cfg.keepDataDirStart = true
+		if err := c1.epc.procs[0].Restart(); err == nil {
+			t.Fatal("first member Restart expected error, got nil")
+		}
+	}()
+	select {
+	case <-time.After(time.Minute):
+		t.Fatalf("test timed out waiting %v for process exit", time.Minute)
+	case <-exitc:
+	}
 }

--- a/e2e/ctl_v3_migrate_test.go
+++ b/e2e/ctl_v3_migrate_test.go
@@ -65,7 +65,7 @@ func TestCtlV3Migrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	epc.procs[0].cfg.keepDataDir = true
+	epc.procs[0].cfg.keepDataDirStart = true
 	if err := epc.RestartAll(); err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/ctl_v3_snapshot_test.go
+++ b/e2e/ctl_v3_snapshot_test.go
@@ -138,9 +138,9 @@ func TestIssue6361(t *testing.T) {
 	defer os.Unsetenv("ETCDCTL_API")
 
 	epc, err := newEtcdProcessCluster(&etcdProcessClusterConfig{
-		clusterSize:  1,
-		initialToken: "new",
-		keepDataDir:  true,
+		clusterSize:      1,
+		initialToken:     "new",
+		keepDataDirStart: true,
 	})
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)

--- a/e2e/etcd_release_upgrade_test.go
+++ b/e2e/etcd_release_upgrade_test.go
@@ -88,7 +88,7 @@ func TestReleaseUpgrade(t *testing.T) {
 			t.Fatalf("#%d: error closing etcd process (%v)", i, err)
 		}
 		epc.procs[i].cfg.execPath = binDir + "/etcd"
-		epc.procs[i].cfg.keepDataDir = true
+		epc.procs[i].cfg.keepDataDirStart = true
 
 		if err := epc.procs[i].Restart(); err != nil {
 			t.Fatalf("error restarting etcd process (%v)", err)
@@ -155,7 +155,7 @@ func TestReleaseUpgradeWithRestart(t *testing.T) {
 	for i := range epc.procs {
 		go func(i int) {
 			epc.procs[i].cfg.execPath = binDir + "/etcd"
-			epc.procs[i].cfg.keepDataDir = true
+			epc.procs[i].cfg.keepDataDirStart = true
 			if err := epc.procs[i].Restart(); err != nil {
 				t.Fatalf("error restarting etcd process (%v)", err)
 			}

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -189,7 +189,11 @@ func startEtcd(cfg *embed.Config) (<-chan struct{}, <-chan error, error) {
 		return nil, nil, err
 	}
 	osutil.RegisterInterruptHandler(e.Server.Stop)
-	<-e.Server.ReadyNotify() // wait for e.Server to join the cluster
+	select {
+	case <-e.Server.ReadyNotify(): // wait for e.Server to join the cluster
+	case <-e.Server.StopNotify(): // publish aborted from 'ErrStopped'
+		e.Server.HardStop()
+	}
 	return e.Server.StopNotify(), e.Err(), nil
 }
 


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/7512.

We don't have any real e2e tests on membership changes.
So adding more fields to do that. The new test takes around
10 seconds in my machine.
