### PR TITLE
e2e: force endpoint for member removal

### DIFF
--- a/e2e/ctl_v3_auth_test.go
+++ b/e2e/ctl_v3_auth_test.go
@@ -487,17 +487,17 @@ func authTestMemberRemove(cx ctlCtx) {
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
 
-	memIDToRemove, clusterID := cx.memberToRemove()
+	ep, memIDToRemove, clusterID := cx.memberToRemove()
 
 	// ordinal user cannot remove a member
 	cx.user, cx.pass = "test-user", "pass"
-	if err := ctlV3MemberRemove(cx, memIDToRemove, clusterID); err == nil {
+	if err := ctlV3MemberRemove(cx, ep, memIDToRemove, clusterID); err == nil {
 		cx.t.Fatalf("ordinal user must not be allowed to remove a member")
 	}
 
 	// root can remove a member
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3MemberRemove(cx, memIDToRemove, clusterID); err != nil {
+	if err := ctlV3MemberRemove(cx, ep, memIDToRemove, clusterID); err != nil {
 		cx.t.Fatal(err)
 	}
 }

--- a/e2e/ctl_v3_member_test.go
+++ b/e2e/ctl_v3_member_test.go
@@ -71,14 +71,14 @@ func getMemberList(cx ctlCtx) (etcdserverpb.MemberListResponse, error) {
 }
 
 func memberRemoveTest(cx ctlCtx) {
-	memIDToRemove, clusterID := cx.memberToRemove()
-	if err := ctlV3MemberRemove(cx, memIDToRemove, clusterID); err != nil {
+	ep, memIDToRemove, clusterID := cx.memberToRemove()
+	if err := ctlV3MemberRemove(cx, ep, memIDToRemove, clusterID); err != nil {
 		cx.t.Fatal(err)
 	}
 }
 
-func ctlV3MemberRemove(cx ctlCtx, memberID, clusterID string) error {
-	cmdArgs := append(cx.PrefixArgs(), "member", "remove", memberID)
+func ctlV3MemberRemove(cx ctlCtx, ep, memberID, clusterID string) error {
+	cmdArgs := append(cx.prefixArgs([]string{ep}), "member", "remove", memberID)
 	return spawnWithExpect(cmdArgs, fmt.Sprintf("%s removed from cluster %s", memberID, clusterID))
 }
 

--- a/e2e/ctl_v3_test.go
+++ b/e2e/ctl_v3_test.go
@@ -215,7 +215,7 @@ func isGRPCTimedout(err error) bool {
 	return strings.Contains(err.Error(), "grpc: timed out trying to connect")
 }
 
-func (cx *ctlCtx) memberToRemove() (memberID string, clusterID string) {
+func (cx *ctlCtx) memberToRemove() (ep string, memberID string, clusterID string) {
 	n1 := cx.cfg.clusterSize
 	if n1 < 2 {
 		cx.t.Fatalf("%d-node is too small to test 'member remove'", n1)
@@ -229,15 +229,9 @@ func (cx *ctlCtx) memberToRemove() (memberID string, clusterID string) {
 		cx.t.Fatalf("expected %d, got %d", n1, len(resp.Members))
 	}
 
+	ep = resp.Members[0].ClientURLs[0]
 	clusterID = fmt.Sprintf("%x", resp.Header.ClusterId)
+	memberID = fmt.Sprintf("%x", resp.Members[1].ID)
 
-	// remove one member that is not the one we connected to.
-	for _, m := range resp.Members {
-		if m.ID != resp.Header.MemberId {
-			memberID = fmt.Sprintf("%x", m.ID)
-			break
-		}
-	}
-
-	return memberID, clusterID
+	return ep, memberID, clusterID
 }


### PR DESCRIPTION
e2e tests use different invocations of etcdctl, so the endpoint used to get
the member list will not necessarily be the same to make the remove call.
Instead, select an endpoint that is not being remove, and connect with that.

Cf. https://semaphoreci.com/coreos/etcd/branches/master/builds/1676