### PR TITLE
e2e, etcdserver: fix wrong usages of ordinal

### DIFF
--- a/e2e/ctl_v3_auth_test.go
+++ b/e2e/ctl_v3_auth_test.go
@@ -466,10 +466,10 @@ func authTestMemberAdd(cx ctlCtx) {
 	authSetupTestUser(cx)
 
 	peerURL := fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)
-	// ordinal user cannot add a new member
+	// ordinary user cannot add a new member
 	cx.user, cx.pass = "test-user", "pass"
 	if err := ctlV3MemberAdd(cx, peerURL); err == nil {
-		cx.t.Fatalf("ordinal user must not be allowed to add a member")
+		cx.t.Fatalf("ordinary user must not be allowed to add a member")
 	}
 
 	// root can add a new member
@@ -489,10 +489,10 @@ func authTestMemberRemove(cx ctlCtx) {
 
 	ep, memIDToRemove, clusterID := cx.memberToRemove()
 
-	// ordinal user cannot remove a member
+	// ordinary user cannot remove a member
 	cx.user, cx.pass = "test-user", "pass"
 	if err := ctlV3MemberRemove(cx, ep, memIDToRemove, clusterID); err == nil {
-		cx.t.Fatalf("ordinal user must not be allowed to remove a member")
+		cx.t.Fatalf("ordinary user must not be allowed to remove a member")
 	}
 
 	// root can remove a member
@@ -515,12 +515,12 @@ func authTestMemberUpdate(cx ctlCtx) {
 		cx.t.Fatal(err)
 	}
 
-	// ordinal user cannot update a member
+	// ordinary user cannot update a member
 	cx.user, cx.pass = "test-user", "pass"
 	peerURL := fmt.Sprintf("http://localhost:%d", etcdProcessBasePort+11)
 	memberID := fmt.Sprintf("%x", mr.Members[0].ID)
 	if err = ctlV3MemberUpdate(cx, memberID, peerURL); err == nil {
-		cx.t.Fatalf("ordinal user must not be allowed to update a member")
+		cx.t.Fatalf("ordinary user must not be allowed to update a member")
 	}
 
 	// root can update a member

--- a/e2e/ctl_v3_defrag_test.go
+++ b/e2e/ctl_v3_defrag_test.go
@@ -50,10 +50,10 @@ func defragTestWithAuth(cx ctlCtx) {
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
 
-	// ordinal user cannot defrag
+	// ordinary user cannot defrag
 	cx.user, cx.pass = "test-user", "pass"
 	if err := ctlV3Defrag(cx); err == nil {
-		cx.t.Fatal("ordinal user should not be able to issue a defrag request")
+		cx.t.Fatal("ordinary user should not be able to issue a defrag request")
 	}
 
 	// root can defrag

--- a/e2e/ctl_v3_endpoint_test.go
+++ b/e2e/ctl_v3_endpoint_test.go
@@ -68,7 +68,7 @@ func endpointHealthTestWithAuth(cx ctlCtx) {
 		cx.t.Fatalf("endpointStatusTest ctlV3EndpointHealth error (%v)", err)
 	}
 
-	// health checking with an ordinal user "succeeds" since permission denial goes through consensus
+	// health checking with an ordinary user "succeeds" since permission denial goes through consensus
 	cx.user, cx.pass = "test-user", "pass"
 	if err := ctlV3EndpointHealth(cx); err != nil {
 		cx.t.Fatalf("endpointStatusTest ctlV3EndpointHealth error (%v)", err)

--- a/e2e/ctl_v3_snapshot_test.go
+++ b/e2e/ctl_v3_snapshot_test.go
@@ -261,10 +261,10 @@ func snapshotTestWithAuth(cx ctlCtx) {
 	fpath := "test.snapshot"
 	defer os.RemoveAll(fpath)
 
-	// ordinal user cannot save a snapshot
+	// ordinary user cannot save a snapshot
 	cx.user, cx.pass = "test-user", "pass"
 	if err := ctlV3SnapshotSave(cx, fpath); err == nil {
-		cx.t.Fatal("ordinal user should not be able to save a snapshot")
+		cx.t.Fatal("ordinary user should not be able to save a snapshot")
 	}
 
 	// root can save a snapshot

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1027,7 +1027,7 @@ func (s *EtcdServer) StoreStats() []byte { return s.store.JsonStats() }
 
 func (s *EtcdServer) checkMembershipOperationPermission(ctx context.Context) error {
 	if s.authStore == nil {
-		// In the context of ordinal etcd process, s.authStore will never be nil.
+		// In the context of ordinary etcd process, s.authStore will never be nil.
 		// This branch is for handling cases in server_test.go
 		return nil
 	}


### PR DESCRIPTION
They must be "ordinary".
