### PR TITLE
auth: store cached permission information in a form of interval tree

### DIFF
--- a/auth/range_perm_cache_test.go
+++ b/auth/range_perm_cache_test.go
@@ -15,155 +15,45 @@
 package auth
 
 import (
-	"bytes"
-	"fmt"
 	"testing"
+
+	"github.com/coreos/etcd/auth/authpb"
+	"github.com/coreos/etcd/pkg/adt"
 )
 
-func isPermsEqual(a, b []*rangePerm) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := range a {
-		if len(b) <= i {
-			return false
-		}
-
-		if !bytes.Equal(a[i].begin, b[i].begin) || !bytes.Equal(a[i].end, b[i].end) {
-			return false
-		}
-	}
-
-	return true
-}
-
-func TestGetMergedPerms(t *testing.T) {
+func TestRangePermission(t *testing.T) {
 	tests := []struct {
-		params []*rangePerm
-		want   []*rangePerm
+		perms []adt.Interval
+		begin string
+		end   string
+		want  bool
 	}{
-		{ // subsets converge
-			[]*rangePerm{{[]byte{2}, []byte{3}}, {[]byte{2}, []byte{5}}, {[]byte{1}, []byte{4}}},
-			[]*rangePerm{{[]byte{1}, []byte{5}}},
-		},
-		{ // subsets converge
-			[]*rangePerm{{[]byte{0}, []byte{3}}, {[]byte{0}, []byte{1}}, {[]byte{2}, []byte{4}}, {[]byte{0}, []byte{2}}},
-			[]*rangePerm{{[]byte{0}, []byte{4}}},
-		},
-		{ // biggest range at the end
-			[]*rangePerm{{[]byte{2}, []byte{3}}, {[]byte{0}, []byte{2}}, {[]byte{1}, []byte{4}}, {[]byte{0}, []byte{5}}},
-			[]*rangePerm{{[]byte{0}, []byte{5}}},
-		},
-		{ // biggest range at the beginning
-			[]*rangePerm{{[]byte{0}, []byte{5}}, {[]byte{2}, []byte{3}}, {[]byte{0}, []byte{2}}, {[]byte{1}, []byte{4}}},
-			[]*rangePerm{{[]byte{0}, []byte{5}}},
-		},
-		{ // no overlapping ranges
-			[]*rangePerm{{[]byte{2}, []byte{3}}, {[]byte{0}, []byte{1}}, {[]byte{4}, []byte{7}}, {[]byte{8}, []byte{15}}},
-			[]*rangePerm{{[]byte{0}, []byte{1}}, {[]byte{2}, []byte{3}}, {[]byte{4}, []byte{7}}, {[]byte{8}, []byte{15}}},
+		{
+			[]adt.Interval{adt.NewStringInterval("a", "c"), adt.NewStringInterval("x", "z")},
+			"a", "z",
+			false,
 		},
 		{
-			[]*rangePerm{makePerm("00", "03"), makePerm("18", "19"), makePerm("02", "08"), makePerm("10", "12")},
-			[]*rangePerm{makePerm("00", "08"), makePerm("10", "12"), makePerm("18", "19")},
+			[]adt.Interval{adt.NewStringInterval("a", "f"), adt.NewStringInterval("c", "d"), adt.NewStringInterval("f", "z")},
+			"a", "z",
+			true,
 		},
 		{
-			[]*rangePerm{makePerm("a", "b")},
-			[]*rangePerm{makePerm("a", "b")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("b", "")},
-			[]*rangePerm{makePerm("a", "b"), makePerm("b", "")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("b", "c")},
-			[]*rangePerm{makePerm("a", "c")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "c"), makePerm("b", "d")},
-			[]*rangePerm{makePerm("a", "d")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("b", "c"), makePerm("d", "e")},
-			[]*rangePerm{makePerm("a", "c"), makePerm("d", "e")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("c", "d"), makePerm("e", "f")},
-			[]*rangePerm{makePerm("a", "b"), makePerm("c", "d"), makePerm("e", "f")},
-		},
-		{
-			[]*rangePerm{makePerm("e", "f"), makePerm("c", "d"), makePerm("a", "b")},
-			[]*rangePerm{makePerm("a", "b"), makePerm("c", "d"), makePerm("e", "f")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("c", "d"), makePerm("a", "z")},
-			[]*rangePerm{makePerm("a", "z")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("c", "d"), makePerm("a", "z"), makePerm("1", "9")},
-			[]*rangePerm{makePerm("1", "9"), makePerm("a", "z")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("c", "d"), makePerm("a", "z"), makePerm("1", "a")},
-			[]*rangePerm{makePerm("1", "z")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("a", "z"), makePerm("5", "6"), makePerm("1", "9")},
-			[]*rangePerm{makePerm("1", "9"), makePerm("a", "z")},
-		},
-		{
-			[]*rangePerm{makePerm("a", "b"), makePerm("b", "c"), makePerm("c", "d"), makePerm("b", "f"), makePerm("1", "9")},
-			[]*rangePerm{makePerm("1", "9"), makePerm("a", "f")},
-		},
-		// overlapping
-		{
-			[]*rangePerm{makePerm("a", "f"), makePerm("b", "g")},
-			[]*rangePerm{makePerm("a", "g")},
-		},
-		// keys
-		{
-			[]*rangePerm{makePerm("a", ""), makePerm("b", "")},
-			[]*rangePerm{makePerm("a", ""), makePerm("b", "")},
-		},
-		{
-			[]*rangePerm{makePerm("a", ""), makePerm("a", "c")},
-			[]*rangePerm{makePerm("a", "c")},
-		},
-		{
-			[]*rangePerm{makePerm("a", ""), makePerm("a", "c"), makePerm("b", "")},
-			[]*rangePerm{makePerm("a", "c")},
-		},
-		{
-			[]*rangePerm{makePerm("a", ""), makePerm("b", "c"), makePerm("b", ""), makePerm("c", ""), makePerm("d", "")},
-			[]*rangePerm{makePerm("a", ""), makePerm("b", "c"), makePerm("c", ""), makePerm("d", "")},
-		},
-		// duplicate ranges
-		{
-			[]*rangePerm{makePerm("a", "f"), makePerm("a", "f")},
-			[]*rangePerm{makePerm("a", "f")},
-		},
-		// duplicate keys
-		{
-			[]*rangePerm{makePerm("a", ""), makePerm("a", ""), makePerm("a", "")},
-			[]*rangePerm{makePerm("a", "")},
+			[]adt.Interval{adt.NewStringInterval("a", "d"), adt.NewStringInterval("a", "b"), adt.NewStringInterval("c", "f")},
+			"a", "f",
+			true,
 		},
 	}
 
 	for i, tt := range tests {
-		result := mergeRangePerms(tt.params)
-		if !isPermsEqual(result, tt.want) {
-			t.Errorf("#%d: result=%q, want=%q", i, sprintPerms(result), sprintPerms(tt.want))
+		readPerms := &adt.IntervalTree{}
+		for _, p := range tt.perms {
+			readPerms.Insert(p, struct{}{})
+		}
+
+		result := checkKeyInterval(&unifiedRangePermissions{readPerms: readPerms}, tt.begin, tt.end, authpb.READ)
+		if result != tt.want {
+			t.Errorf("#%d: result=%t, want=%t", i, result, tt.want)
 		}
 	}
-}
-
-func makePerm(a, b string) *rangePerm {
-	return &rangePerm{begin: []byte(a), end: []byte(b)}
-}
-
-func sprintPerms(rs []*rangePerm) (s string) {
-	for _, rp := range rs {
-		s += fmt.Sprintf("[%s %s] ", rp.begin, rp.end)
-	}
-	return
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -747,7 +747,7 @@ func (as *authStore) isOpPermitted(userName string, revision uint64, key, rangeE
 		return nil
 	}
 
-	if as.isRangeOpPermitted(tx, userName, key, rangeEnd, permTyp) {
+	if as.isRangeOpPermitted(tx, userName, string(key), string(rangeEnd), permTyp) {
 		return nil
 	}
 


### PR DESCRIPTION
This commit change the type of cached permission information from the
home made thing to interval tree. It improves computational complexity
of permission checking from O(n) to O(lg n).

/cc @heyitsanthony This is a preparation for https://github.com/coreos/etcd/issues/7468 , could you take a look? We can support the unlimited range by configuring a permission like ["a", "\xff") in a simple manner thanks to interval tree.