### PR TITLE
integration: wait on leader before progress check in TestRestartMember

### DIFF
--- a/integration/member_test.go
+++ b/integration/member_test.go
@@ -61,7 +61,7 @@ func TestRestartMember(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-
+	c.waitLeader(t, c.Members)
 	clusterMustProgress(t, c.Members)
 }
 


### PR DESCRIPTION
In rare cases, the last member may not have the leader by the time the
final cluster progress check tries to open a watch, causing a timeout.

Cf. https://jenkins-etcd-public.prod.coreos.systems/job/etcd-proxy/1046/consoleFull