### PR TITLE
tools/etcd-tester: add timeout for 'defrag'

### DIFF
--- a/tools/functional-tester/etcd-tester/member.go
+++ b/tools/functional-tester/etcd-tester/member.go
@@ -79,7 +79,10 @@ func (m *member) Defrag() error {
 		return err
 	}
 	defer cli.Close()
-	if _, err = cli.Defragment(context.Background(), m.ClientURL); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	_, err = cli.Defragment(ctx, m.ClientURL)
+	cancel()
+	if err != nil {
 		return err
 	}
 	plog.Printf("defragmented %s\n", m.ClientURL)


### PR DESCRIPTION
etcd panic-ed, so defrag response just blocked for "days";
the actual 'v3rpc' path never returned.

We should catch this earlier.

ref. https://github.com/coreos/etcd/issues/7526
