### PR TITLE
op-guide: Remove guest role from v3 auth doc

### DIFF
--- a/Documentation/op-guide/authentication.md
+++ b/Documentation/op-guide/authentication.md
@@ -6,7 +6,7 @@ Authentication was added in etcd 2.1. The etcd v3 API slightly modified the auth
 
 ## Special users and roles
 
-There is one special user, `root`, and there are two special roles, `root` and `guest`.
+There is one special user, `root`, and one special role, `root`.
 
 ### User `root`
 


### PR DESCRIPTION
As i understand there is no guest role in v3 auth. guest role was introduced in v2 auth to be backward compatible.