### PR TITLE
grpcproxy/cache: only check compaction revision for historical revisions

### DIFF
--- a/integration/v3_grpc_test.go
+++ b/integration/v3_grpc_test.go
@@ -123,15 +123,24 @@ func TestV3CompactCurrentRev(t *testing.T) {
 			t.Fatalf("couldn't put key (%v)", err)
 		}
 	}
+	// get key to add to proxy cache, if any
+	if _, err := kvc.Range(context.TODO(), &pb.RangeRequest{Key: []byte("foo")}); err != nil {
+		t.Fatal(err)
+	}
 	// compact on current revision
 	_, err := kvc.Compact(context.Background(), &pb.CompactionRequest{Revision: 4})
 	if err != nil {
 		t.Fatalf("couldn't compact kv space (%v)", err)
 	}
-	// key still exists?
+	// key still exists when linearized?
 	_, err = kvc.Range(context.Background(), &pb.RangeRequest{Key: []byte("foo")})
 	if err != nil {
 		t.Fatalf("couldn't get key after compaction (%v)", err)
+	}
+	// key still exists when serialized?
+	_, err = kvc.Range(context.Background(), &pb.RangeRequest{Key: []byte("foo"), Serializable: true})
+	if err != nil {
+		t.Fatalf("couldn't get serialized key after compaction (%v)", err)
 	}
 }
 

--- a/proxy/grpcproxy/cache/store.go
+++ b/proxy/grpcproxy/cache/store.go
@@ -111,7 +111,7 @@ func (c *cache) Get(req *pb.RangeRequest) (*pb.RangeResponse, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if req.Revision < c.compactedRev {
+	if req.Revision > 0 && req.Revision < c.compactedRev {
 		c.lru.Remove(key)
 		return nil, ErrCompacted
 	}


### PR DESCRIPTION
Since the current revision is 0, it'll always be less than the compaction
revision. If the proxy sees a compaction, it would always reject the
current revision requests since it's less than the compaction revision.
Instead, check if the revision is historical before trying to reject on
compaction revision.

Fixes #7599