### PR TITLE
testutil: check for grpc resources in AfterTest

### DIFF
--- a/pkg/testutil/leak.go
+++ b/pkg/testutil/leak.go
@@ -76,6 +76,7 @@ func CheckAfterTest(d time.Duration) error {
 		"net.(*netFD).connect(":                        "a timing out dial",
 		").noteClientGone(":                            "a closenotifier sender",
 		").readLoop(":                                  "a Transport",
+		".grpc":                                        "a gRPC resource",
 	}
 
 	var stacks string


### PR DESCRIPTION
gRPC leaks only show up at the final leak check, making it difficult to
determine which test is causing the leak.