### PR TITLE
etcd-runner: use golang.org/x/net/context for election command

### DIFF
--- a/tools/functional-tester/etcd-runner/command/election_command.go
+++ b/tools/functional-tester/etcd-runner/command/election_command.go
@@ -15,12 +15,12 @@
 package command
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 // NewElectionCommand returns the cobra command for "election runner".


### PR DESCRIPTION
grpc isn't using the "context" package, so when it checks for an expected
context error with a pointer comparison, the pointers are different so
there's no match and it defaults through to panicking.

Fixes #7091

/cc @fanminshi