### PR TITLE
raft: Remove return error from raft.Step

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -320,7 +320,7 @@ func (n *node) run(r *raft) {
 		case m := <-n.recvc:
 			// filter out response message from unknown From.
 			if _, ok := r.prs[m.From]; ok || !IsResponseMsg(m.Type) {
-				r.Step(m) // raft never returns an error
+				r.Step(m)
 			}
 		case cc := <-n.confc:
 			if cc.NodeID == None {

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -676,7 +676,7 @@ func (r *raft) poll(id uint64, t pb.MessageType, v bool) (granted int) {
 	return granted
 }
 
-func (r *raft) Step(m pb.Message) error {
+func (r *raft) Step(m pb.Message) {
 	// Handle the message term, which may result in our stepping down to a follower.
 	switch {
 	case m.Term == 0:
@@ -691,7 +691,7 @@ func (r *raft) Step(m pb.Message) error {
 				// of hearing from a current leader, it does not update its term or grant its vote
 				r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] ignored %s from %x [logterm: %d, index: %d] at term %d: lease is not expired (remaining ticks: %d)",
 					r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term, r.electionTimeout-r.electionElapsed)
-				return nil
+				return
 			}
 			lead = None
 		}
@@ -731,7 +731,7 @@ func (r *raft) Step(m pb.Message) error {
 			r.logger.Infof("%x [term: %d] ignored a %s message with lower term from %x [term: %d]",
 				r.id, r.Term, m.Type, m.From, m.Term)
 		}
-		return nil
+		return
 	}
 
 	switch m.Type {
@@ -743,7 +743,7 @@ func (r *raft) Step(m pb.Message) error {
 			}
 			if n := numOfPendingConf(ents); n != 0 && r.raftLog.committed > r.raftLog.applied {
 				r.logger.Warningf("%x cannot campaign at term %d since there are still %d pending configuration changes to apply", r.id, r.Term, n)
-				return nil
+				return
 			}
 
 			r.logger.Infof("%x is starting a new election at term %d", r.id, r.Term)
@@ -777,7 +777,6 @@ func (r *raft) Step(m pb.Message) error {
 	default:
 		r.step(r, m)
 	}
-	return nil
 }
 
 type stepFunc func(r *raft, m pb.Message)

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -37,7 +37,7 @@ func nextEnts(r *raft, s *MemoryStorage) (ents []pb.Entry) {
 }
 
 type stateMachine interface {
-	Step(m pb.Message) error
+	Step(m pb.Message)
 	readMessages() []pb.Message
 }
 
@@ -497,9 +497,7 @@ func testVoteFromAnyState(t *testing.T, vt pb.MessageType) {
 			LogTerm: newTerm,
 			Index:   42,
 		}
-		if err := r.Step(msg); err != nil {
-			t.Errorf("%s,%s: Step failed: %s", vt, st, err)
-		}
+		r.Step(msg)
 		if len(r.msgs) != 1 {
 			t.Errorf("%s,%s: %d response messages, want 1: %+v", vt, st, len(r.msgs), r.msgs)
 		} else {
@@ -3213,7 +3211,7 @@ type connem struct {
 
 type blackHole struct{}
 
-func (blackHole) Step(pb.Message) error      { return nil }
+func (blackHole) Step(pb.Message)            {}
 func (blackHole) readMessages() []pb.Message { return nil }
 
 var nopStepper = &blackHole{}


### PR DESCRIPTION
`raft.Step` never returned an error, but yet had an error in its
signature, which was in turn propagated in a number of places. This
change gets rid of the unnecessary return value.

I suspect that this may have been intentional in order to maintain some
form of backwards-compatibility somewhere.