### PR TITLE
embed: Delay setting initial cluster

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -203,6 +203,8 @@ func (cfg *configYAML) configFromFile(path string) error {
 		return err
 	}
 
+	defaultInitialCluster := cfg.InitialCluster
+
 	err = yaml.Unmarshal(b, cfg)
 	if err != nil {
 		return err
@@ -246,7 +248,8 @@ func (cfg *configYAML) configFromFile(path string) error {
 		cfg.ACUrls = []url.URL(u)
 	}
 
-	if (cfg.Durl != "" || cfg.DNSCluster != "") && cfg.InitialCluster == cfg.InitialClusterFromName(cfg.Name) {
+	// If a discovery flag is set, clear default initial cluster set by InitialClusterFromName
+	if (cfg.Durl != "" || cfg.DNSCluster != "") && cfg.InitialCluster == defaultInitialCluster {
 		cfg.InitialCluster = ""
 	}
 	if cfg.ClusterState == "" {

--- a/etcdmain/config_test.go
+++ b/etcdmain/config_test.go
@@ -78,9 +78,7 @@ func TestConfigFileMemberFields(t *testing.T) {
 	tmpfile := mustCreateCfgFile(t, b)
 	defer os.Remove(tmpfile.Name())
 
-	args := []string{
-		fmt.Sprintf("--config-file=%s", tmpfile.Name()),
-	}
+	args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 
 	cfg := newConfig()
 	if err = cfg.parse(args); err != nil {
@@ -133,9 +131,7 @@ func TestConfigFileClusteringFields(t *testing.T) {
 	tmpfile := mustCreateCfgFile(t, b)
 	defer os.Remove(tmpfile.Name())
 
-	args := []string{
-		fmt.Sprintf("--config-file=%s", tmpfile.Name()),
-	}
+	args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 	cfg := newConfig()
 	err = cfg.parse(args)
 	if err != nil {
@@ -143,6 +139,60 @@ func TestConfigFileClusteringFields(t *testing.T) {
 	}
 
 	validateClusteringFlags(t, cfg)
+}
+
+func TestConfigFileClusteringFlags(t *testing.T) {
+	tests := []struct {
+		Name           string `json:"name"`
+		InitialCluster string `json:"initial-cluster"`
+		DNSCluster     string `json:"discovery-srv"`
+		Durl           string `json:"discovery"`
+	}{
+		{
+		// Use default name and generate a default inital-cluster
+		},
+		{
+			Name: "non-default",
+		},
+		{
+			InitialCluster: "0=localhost:8000",
+		},
+		{
+			Name:           "non-default",
+			InitialCluster: "0=localhost:8000",
+		},
+		{
+			DNSCluster: "example.com",
+		},
+		{
+			Name:       "non-default",
+			DNSCluster: "example.com",
+		},
+		{
+			Durl: "http://example.com/abc",
+		},
+		{
+			Name: "non-default",
+			Durl: "http://example.com/abc",
+		},
+	}
+
+	for i, tt := range tests {
+		b, err := yaml.Marshal(&tt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tmpfile := mustCreateCfgFile(t, b)
+		defer os.Remove(tmpfile.Name())
+
+		args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
+
+		cfg := newConfig()
+		if err := cfg.parse(args); err != nil {
+			t.Errorf("%d: err = %v", i, err)
+		}
+	}
 }
 
 func TestConfigParsingOtherFlags(t *testing.T) {
@@ -172,9 +222,7 @@ func TestConfigFileOtherFields(t *testing.T) {
 	tmpfile := mustCreateCfgFile(t, b)
 	defer os.Remove(tmpfile.Name())
 
-	args := []string{
-		fmt.Sprintf("--config-file=%s", tmpfile.Name()),
-	}
+	args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 
 	cfg := newConfig()
 	err = cfg.parse(args)
@@ -248,9 +296,7 @@ func TestConfigFileConflictClusteringFlags(t *testing.T) {
 		tmpfile := mustCreateCfgFile(t, b)
 		defer os.Remove(tmpfile.Name())
 
-		args := []string{
-			fmt.Sprintf("--config-file=%s", tmpfile.Name()),
-		}
+		args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 
 		cfg := newConfig()
 		if err := cfg.parse(args); err != embed.ErrConflictBootstrapFlags {
@@ -428,9 +474,7 @@ func TestConfigFileElectionTimeout(t *testing.T) {
 		tmpfile := mustCreateCfgFile(t, b)
 		defer os.Remove(tmpfile.Name())
 
-		args := []string{
-			fmt.Sprintf("--config-file=%s", tmpfile.Name()),
-		}
+		args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 
 		cfg := newConfig()
 		if err := cfg.parse(args); err == nil || !strings.Contains(err.Error(), tt.errStr) {


### PR DESCRIPTION
PR #7517 attempted to address this however it only worked if the name was left as "default".

NewConfig() sets an initial cluster (potentially using a default name) but we should clear it in the event another discovery option has been specified.

(Completely) Fixes #7516