### PR TITLE
Documentation: add encryption wrapper to integrations

### DIFF
--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -21,6 +21,7 @@
 - [etcd/clientv3](https://github.com/coreos/etcd/blob/master/clientv3) - the officially maintained Go client for v3
 - [etcd/client](https://github.com/coreos/etcd/blob/master/client) - the officially maintained Go client for v2
 - [go-etcd](https://github.com/coreos/go-etcd) - the deprecated official client. May be useful for older (<2.0.0) versions of etcd.
+- [encWrapper](https://github.com/lumjjb/etcd/tree/enc_wrapper/clientwrap/encwrapper) - encWrapper is an encryption wrapper for the etcd client Keys API/KV.
 
 **Java libraries**
 


### PR DESCRIPTION
Added to `Documentation/integrations.md` from discussion of https://github.com/coreos/etcd/issues/7542