### PR TITLE
*: fix a bug in handling unix socket urls

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -184,6 +184,7 @@ func parseEndpoint(endpoint string) (proto string, host string, scheme string) {
 	case "http", "https":
 	case "unix":
 		proto = "unix"
+		host = url.Host + url.Path
 	default:
 		proto, host = "", ""
 	}

--- a/e2e/etcd_test.go
+++ b/e2e/etcd_test.go
@@ -465,7 +465,7 @@ func (ep *etcdProcess) Stop() error {
 	<-ep.donec
 
 	if ep.cfg.purl.Scheme == "unix" || ep.cfg.purl.Scheme == "unixs" {
-		os.RemoveAll(ep.cfg.purl.Host)
+		os.Remove(ep.cfg.purl.Host + ep.cfg.purl.Path)
 	}
 	return nil
 }

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -257,19 +257,21 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 		}
 
 		proto := "tcp"
+		addr := u.Host
 		if u.Scheme == "unix" || u.Scheme == "unixs" {
 			proto = "unix"
+			addr = u.Host + u.Path
 		}
 
 		sctx.secure = u.Scheme == "https" || u.Scheme == "unixs"
 		sctx.insecure = !sctx.secure
-		if oldctx := sctxs[u.Host]; oldctx != nil {
+		if oldctx := sctxs[addr]; oldctx != nil {
 			oldctx.secure = oldctx.secure || sctx.secure
 			oldctx.insecure = oldctx.insecure || sctx.insecure
 			continue
 		}
 
-		if sctx.l, err = net.Listen(proto, u.Host); err != nil {
+		if sctx.l, err = net.Listen(proto, addr); err != nil {
 			return nil, err
 		}
 
@@ -303,7 +305,7 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 		if cfg.Debug {
 			sctx.registerTrace()
 		}
-		sctxs[u.Host] = sctx
+		sctxs[addr] = sctx
 	}
 	return sctxs, nil
 }

--- a/pkg/transport/unix_listener.go
+++ b/pkg/transport/unix_listener.go
@@ -22,7 +22,7 @@ import (
 type unixListener struct{ net.Listener }
 
 func NewUnixListener(addr string) (net.Listener, error) {
-	if err := os.RemoveAll(addr); err != nil {
+	if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	l, err := net.Listen("unix", addr)
@@ -33,7 +33,7 @@ func NewUnixListener(addr string) (net.Listener, error) {
 }
 
 func (ul *unixListener) Close() error {
-	if err := os.RemoveAll(ul.Addr().String()); err != nil {
+	if err := os.Remove(ul.Addr().String()); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return ul.Listener.Close()


### PR DESCRIPTION
Now use url.Host + url.Path as unix socket path

Fixes #7644

Related: https://github.com/pingcap/pd/issues/595