### PR TITLE
etcdctl: add a new option --open-ended for unlimited range permission

### DIFF
--- a/auth/range_perm_cache_test.go
+++ b/auth/range_perm_cache_test.go
@@ -29,17 +29,17 @@ func TestRangePermission(t *testing.T) {
 		want  bool
 	}{
 		{
-			[]adt.Interval{adt.NewStringInterval("a", "c"), adt.NewStringInterval("x", "z")},
+			[]adt.Interval{adt.NewStringAffineInterval("a", "c"), adt.NewStringAffineInterval("x", "z")},
 			"a", "z",
 			false,
 		},
 		{
-			[]adt.Interval{adt.NewStringInterval("a", "f"), adt.NewStringInterval("c", "d"), adt.NewStringInterval("f", "z")},
+			[]adt.Interval{adt.NewStringAffineInterval("a", "f"), adt.NewStringAffineInterval("c", "d"), adt.NewStringAffineInterval("f", "z")},
 			"a", "z",
 			true,
 		},
 		{
-			[]adt.Interval{adt.NewStringInterval("a", "d"), adt.NewStringInterval("a", "b"), adt.NewStringInterval("c", "f")},
+			[]adt.Interval{adt.NewStringAffineInterval("a", "d"), adt.NewStringAffineInterval("a", "b"), adt.NewStringAffineInterval("c", "f")},
 			"a", "f",
 			true,
 		},

--- a/etcdctl/ctlv3/command/printer_simple.go
+++ b/etcdctl/ctlv3/command/printer_simple.go
@@ -141,7 +141,11 @@ func (s *simplePrinter) RoleGet(role string, r v3.AuthRoleGetResponse) {
 	printRange := func(perm *v3.Permission) {
 		sKey := string(perm.Key)
 		sRangeEnd := string(perm.RangeEnd)
-		fmt.Printf("\t[%s, %s)", sKey, sRangeEnd)
+		if strings.Compare(sRangeEnd, "\x00") != 0 {
+			fmt.Printf("\t[%s, %s)", sKey, sRangeEnd)
+		} else {
+			fmt.Printf("\t[%s, <open ended>", sKey)
+		}
 		if strings.Compare(v3.GetPrefixRangeEnd(sKey), sRangeEnd) == 0 {
 			fmt.Printf(" (prefix %s)", sKey)
 		}
@@ -188,7 +192,11 @@ func (s *simplePrinter) RoleRevokePermission(role string, key string, end string
 		fmt.Printf("Permission of key %s is revoked from role %s\n", key, role)
 		return
 	}
-	fmt.Printf("Permission of range [%s, %s) is revoked from role %s\n", key, end, role)
+	if strings.Compare(end, "\x00") != 0 {
+		fmt.Printf("Permission of range [%s, %s) is revoked from role %s\n", key, end, role)
+	} else {
+		fmt.Printf("Permission of range [%s, <open ended> is revoked from role %s\n", key, role)
+	}
 }
 
 func (s *simplePrinter) UserAdd(name string, r v3.AuthUserAddResponse) {


### PR DESCRIPTION
This commit adds a new option --open-ended to the command etcdctl role
grant-permission. If the option is passed, an open ended permission
will be granted to a role e.g. from start-key to any keys those are
larger than start-key.

```
Example:
$ ETCDCTL_API=3 bin/etcdctl --user root:p role grant r1 readwrite a b
$ ETCDCTL_API=3 bin/etcdctl --user root:p role grant --open-ended r1 readwrite c
$ ETCDCTL_API=3 bin/etcdctl --user root:p role get r1
Role r1
KV Read:
        [a, b) (prefix a)
        [c, <open ended>
KV Write:
        [a, b) (prefix a)
        [c, <open ended>
```

Note that a closed parenthesis doesn't follow the above <open ended>
for indicating that the role has an open ended permission ("<open
ended>" is a valid range end).

Fixes https://github.com/coreos/etcd/issues/7468                                                                                
