### PR TITLE
clientv3: remove unused fields from 'auth'

### DIFF
--- a/clientv3/auth.go
+++ b/clientv3/auth.go
@@ -100,19 +100,11 @@ type Auth interface {
 }
 
 type auth struct {
-	c *Client
-
-	conn   *grpc.ClientConn // conn in-use
 	remote pb.AuthClient
 }
 
 func NewAuth(c *Client) Auth {
-	conn := c.ActiveConnection()
-	return &auth{
-		conn:   c.ActiveConnection(),
-		remote: pb.NewAuthClient(conn),
-		c:      c,
-	}
+	return &auth{remote: pb.NewAuthClient(c.ActiveConnection())}
 }
 
 func (auth *auth) AuthEnable(ctx context.Context) (*AuthEnableResponse, error) {


### PR DESCRIPTION
I don't see anywhere using these fields... Will close if test fails.