### PR TITLE
test: generate coverage report even if some tests fail

### DIFF
--- a/test
+++ b/test
@@ -109,25 +109,35 @@ function cov_pass {
 	mkdir -p "$COVERDIR"
 
 	# run code coverage for unit and integration tests
+	GOCOVFLAGS="-covermode=set -coverpkg $PKGS_COMMA -v -timeout 15m"
+	failed=""
 	for t in `echo "${TEST_PKGS}" | egrep -v "(e2e|functional-tester)"`; do
 		tf=`echo $t | tr / _`
 		# cache package compilation data for faster repeated builds
-		go test -covermode=set -coverpkg $PKGS_COMMA -i -v ${REPO_PATH}/$t
+		go test $GOCOVFLAGS -i ${REPO_PATH}/$t || true
 		# uses -run=Test to skip examples because clientv3/ example tests will leak goroutines
-		go test -covermode=set -coverpkg $PKGS_COMMA -timeout 15m -run=Test -v -coverprofile "$COVERDIR/${tf}.coverprofile"  ${REPO_PATH}/$t
+		go test $GOCOVFLAGS -run=Test -coverprofile "$COVERDIR/${tf}.coverprofile"  ${REPO_PATH}/$t || failed="$failed $t"
 	done
 
 	# proxy tests
-	go test -tags cluster_proxy -covermode=set -coverpkg $PKGS_COMMA -timeout 15m -v -coverprofile "$COVERDIR/proxy_integration.coverprofile" ${REPO_PATH}/integration
-	go test -tags cluster_proxy -covermode=set -coverpkg $PKGS_COMMA -timeout 15m -v -coverprofile "$COVERDIR/proxy_clientv3.coverprofile" ${REPO_PATH}/clientv3/integration
+	go test -tags cluster_proxy $GOCOVFLAGS -coverprofile "$COVERDIR/proxy_integration.coverprofile" ${REPO_PATH}/integration || failed="$failed proxy-integration"
+	go test -tags cluster_proxy $GOCOVFLAGS -coverprofile "$COVERDIR/proxy_clientv3.coverprofile" ${REPO_PATH}/clientv3/integration || failed="$failed proxy-clientv3/integration"
 
 	# run code coverage for e2e tests
 	# use 30m timeout because e2e coverage takes longer
 	# due to many tests cause etcd process to wait
 	# on leadership transfer timeout during gracefully shutdown
-	go test -tags cov -timeout 30m -v ${REPO_PATH}"/e2e"
+	go test -tags cov -timeout 30m -v ${REPO_PATH}"/e2e" || failed="$failed e2e"
 
 	gocovmerge "$COVERDIR"/*.coverprofile >"$COVERDIR"/cover.out
+
+	# held failures to generate the full coverage file, now fail
+	if [ -n "$failed" ]; then
+		for f in $failed; do
+			echo FAIL $f
+		done
+		exit 255
+	fi
 }
 
 function e2e_pass {


### PR DESCRIPTION
The coverage data is still useful even if some tests fail. Instead of
terminating the coverage pass on any test failure, collect and pass
the failed tests, generate the coverage report, then report the failed
packages and exit with an error.

See: https://jenkins-etcd-public.prod.coreos.systems/job/etcd-coverage/782/console