### PR TITLE
auth, adt: introduce a new type ByteAffineComparable

### DIFF
--- a/auth/range_perm_cache_test.go
+++ b/auth/range_perm_cache_test.go
@@ -24,23 +24,23 @@ import (
 func TestRangePermission(t *testing.T) {
 	tests := []struct {
 		perms []adt.Interval
-		begin string
-		end   string
+		begin []byte
+		end   []byte
 		want  bool
 	}{
 		{
-			[]adt.Interval{adt.NewStringAffineInterval("a", "c"), adt.NewStringAffineInterval("x", "z")},
-			"a", "z",
+			[]adt.Interval{adt.NewBytesAffineInterval([]byte("a"), []byte("c")), adt.NewBytesAffineInterval([]byte("x"), []byte("z"))},
+			[]byte("a"), []byte("z"),
 			false,
 		},
 		{
-			[]adt.Interval{adt.NewStringAffineInterval("a", "f"), adt.NewStringAffineInterval("c", "d"), adt.NewStringAffineInterval("f", "z")},
-			"a", "z",
+			[]adt.Interval{adt.NewBytesAffineInterval([]byte("a"), []byte("f")), adt.NewBytesAffineInterval([]byte("c"), []byte("d")), adt.NewBytesAffineInterval([]byte("f"), []byte("z"))},
+			[]byte("a"), []byte("z"),
 			true,
 		},
 		{
-			[]adt.Interval{adt.NewStringAffineInterval("a", "d"), adt.NewStringAffineInterval("a", "b"), adt.NewStringAffineInterval("c", "f")},
-			"a", "f",
+			[]adt.Interval{adt.NewBytesAffineInterval([]byte("a"), []byte("d")), adt.NewBytesAffineInterval([]byte("a"), []byte("b")), adt.NewBytesAffineInterval([]byte("c"), []byte("f"))},
+			[]byte("a"), []byte("f"),
 			true,
 		},
 	}

--- a/auth/store.go
+++ b/auth/store.go
@@ -749,7 +749,7 @@ func (as *authStore) isOpPermitted(userName string, revision uint64, key, rangeE
 		return nil
 	}
 
-	if as.isRangeOpPermitted(tx, userName, string(key), string(rangeEnd), permTyp) {
+	if as.isRangeOpPermitted(tx, userName, key, rangeEnd, permTyp) {
 		return nil
 	}
 

--- a/pkg/adt/interval_tree.go
+++ b/pkg/adt/interval_tree.go
@@ -15,6 +15,7 @@
 package adt
 
 import (
+	"bytes"
 	"math"
 )
 
@@ -557,4 +558,33 @@ func (v Int64Comparable) Compare(c Comparable) int {
 		return 1
 	}
 	return 0
+}
+
+// BytesAffineComparable treats empty byte arrays as > all other byte arrays
+type BytesAffineComparable []byte
+
+func (b BytesAffineComparable) Compare(c Comparable) int {
+	bc := c.(BytesAffineComparable)
+
+	if len(b) == 0 {
+		if len(bc) == 0 {
+			return 0
+		}
+		return 1
+	}
+	if len(bc) == 0 {
+		return -1
+	}
+
+	return bytes.Compare(b, bc)
+}
+
+func NewBytesAffineInterval(begin, end []byte) Interval {
+	return Interval{BytesAffineComparable(begin), BytesAffineComparable(end)}
+}
+func NewBytesAffinePoint(b []byte) Interval {
+	be := make([]byte, len(b)+1)
+	copy(be, b)
+	be[len(b)] = 0
+	return NewBytesAffineInterval(b, be)
 }


### PR DESCRIPTION
It will be useful for avoiding a cost of casting from string to
[]byte. The permission checker is the first user of the type.