### PR TITLE
Fsync metric warning counter, so that there's an explicit metric for …

### DIFF
--- a/wal/metrics.go
+++ b/wal/metrics.go
@@ -17,6 +17,13 @@ package wal
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
+	syncGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "etcd",
+		Subsystem: "disk",
+		Name:      "wal_fsync_duration_current",
+		Help:      "The current WAL fsync time, if its rising, disk slowness may decrease availability",
+	})
+
 	syncDurations = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "etcd",
 		Subsystem: "disk",
@@ -28,4 +35,5 @@ var (
 
 func init() {
 	prometheus.MustRegister(syncDurations)
+	prometheus.MustRegister(syncGauge)
 }

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -447,6 +447,8 @@ func (w *WAL) sync() error {
 	if duration > warnSyncDuration {
 		plog.Warningf("sync duration of %v, expected less than %v", duration, warnSyncDuration)
 	}
+	// Instantaneous value of the gauge for debugging disk slowness.
+	syncGauge.Set(duration.Seconds())
 	syncDurations.Observe(duration.Seconds())
 
 	return err


### PR DESCRIPTION
Problem:

Alot of people seem to use this log as an indicator but the metrics that are published don't give enough resolution on what the WAL write speeds slowing down are looking like in the current window.

Solution: 
(revised)
Add a gauge to track instantaneous WAL performance, keep the exponential buckets alongside it.

Example issues where this is critical info:
https://github.com/coreos/etcd/issues/6530 
https://github.com/coreos/etcd/issues/6138