### PR TITLE
ctlv3: add '--debug' flag (to enable grpclog)

### DIFF
--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -44,6 +46,8 @@ type GlobalFlags struct {
 	IsHex        bool
 
 	User string
+
+	Debug bool
 }
 
 type secureCfg struct {
@@ -78,6 +82,14 @@ func initDisplayFromCmd(cmd *cobra.Command) {
 
 func mustClientFromCmd(cmd *cobra.Command) *clientv3.Client {
 	flags.SetPflagsFromEnv("ETCDCTL", cmd.InheritedFlags())
+
+	debug, derr := cmd.Flags().GetBool("debug")
+	if derr != nil {
+		ExitWithError(ExitError, derr)
+	}
+	if debug {
+		clientv3.SetLogger(log.New(os.Stderr, "grpc: ", 0))
+	}
 
 	endpoints, err := cmd.Flags().GetStringSlice("endpoints")
 	if err != nil {

--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -44,6 +44,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().StringSliceVar(&globalFlags.Endpoints, "endpoints", []string{"127.0.0.1:2379"}, "gRPC endpoints")
+	rootCmd.PersistentFlags().BoolVar(&globalFlags.Debug, "debug", false, "enable client-side debug logging")
 
 	rootCmd.PersistentFlags().StringVarP(&globalFlags.OutputFormat, "write-out", "w", "simple", "set the output format (fields, json, protobuf, simple, table)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.IsHex, "hex", false, "print byte strings as hex encoded strings")


### PR DESCRIPTION
By default, grpclog is disabled. It should be configurable
for debugging purposes, as we did in v2.

I need this for debugging issues like https://github.com/coreos/etcd/issues/7654.

e.g. user forgets to specify CA in v3 ctl

current output:

```
ETCDCTL_API=3 /Users/gyuho/go/src/github.com/coreos/etcd/bin/etcdctl \
    --endpoints localhost:2379 \
    --cert $HOME/certs/my-etcd-1.pem \
    --key $HOME/certs/my-etcd-1-key.pem \
    put foo bar

Error:  grpc: timed out when dialing
```

with this patch

```
ETCDCTL_API=3 /Users/gyuho/go/src/github.com/coreos/etcd/bin/etcdctl \
    --debug \
    --endpoints localhost:2379 \
    --cert $HOME/certs/my-etcd-1.pem \
    --key $HOME/certs/my-etcd-1-key.pem \
    put foo bar

grpc: Failed to dial localhost:2379: connection error: desc = "transport: x509: certificate signed by unknown authority"; please retry.
Error:  grpc: timed out when dialing
```

Since grpc just tears down the connection without returning this error(see https://github.com/grpc/grpc-go/blob/master/clientconn.go#L599-L605), logging is the only way to tell user about it.
