### PR TITLE
clientv3/yaml: use TLS 1.2 in min version

### DIFF
--- a/clientv3/yaml/config.go
+++ b/clientv3/yaml/config.go
@@ -73,7 +73,7 @@ func NewConfig(fpath string) (*clientv3.Config, error) {
 	}
 
 	tlscfg := &tls.Config{
-		MinVersion:         tls.VersionTLS10,
+		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: yc.InsecureSkipTLSVerify,
 		RootCAs:            cp,
 	}


### PR DESCRIPTION
To be consistent with 'pkg/transport' https://github.com/coreos/etcd/blob/master/pkg/transport/listener.go#L171
