### PR TITLE
etcdserver: Return HTTP 429 while waiting out health interval

### DIFF
--- a/etcdserver/api/v2http/http_test.go
+++ b/etcdserver/api/v2http/http_test.go
@@ -109,6 +109,10 @@ func TestWriteError(t *testing.T) {
 			"456",
 		},
 		{
+			err:   etcdserver.ErrRejectReconfiguration,
+			wcode: http.StatusTooManyRequests,
+		},
+		{
 			err:   errors.New("something went wrong"),
 			wcode: http.StatusInternalServerError,
 		},

--- a/etcdserver/api/v3rpc/rpctypes/error.go
+++ b/etcdserver/api/v3rpc/rpctypes/error.go
@@ -64,6 +64,7 @@ var (
 	ErrGRPCTimeout                    = grpc.Errorf(codes.Unavailable, "etcdserver: request timed out")
 	ErrGRPCTimeoutDueToLeaderFail     = grpc.Errorf(codes.Unavailable, "etcdserver: request timed out, possibly due to previous leader failure")
 	ErrGRPCTimeoutDueToConnectionLost = grpc.Errorf(codes.Unavailable, "etcdserver: request timed out, possibly due to connection lost")
+	ErrGRPCRejectReconfiguration      = grpc.Errorf(codes.Unavailable, "etcdserver: re-configuration rejected, cluster not healhthy")
 	ErrGRPCUnhealthy                  = grpc.Errorf(codes.Unavailable, "etcdserver: unhealthy cluster")
 
 	errStringToError = map[string]error{
@@ -111,6 +112,7 @@ var (
 		grpc.ErrorDesc(ErrGRPCTimeout):                    ErrGRPCTimeout,
 		grpc.ErrorDesc(ErrGRPCTimeoutDueToLeaderFail):     ErrGRPCTimeoutDueToLeaderFail,
 		grpc.ErrorDesc(ErrGRPCTimeoutDueToConnectionLost): ErrGRPCTimeoutDueToConnectionLost,
+		grpc.ErrorDesc(ErrGRPCRejectReconfiguration):      ErrGRPCRejectReconfiguration,
 		grpc.ErrorDesc(ErrGRPCUnhealthy):                  ErrGRPCUnhealthy,
 	}
 
@@ -158,6 +160,7 @@ var (
 	ErrTimeout                    = Error(ErrGRPCTimeout)
 	ErrTimeoutDueToLeaderFail     = Error(ErrGRPCTimeoutDueToLeaderFail)
 	ErrTimeoutDueToConnectionLost = Error(ErrGRPCTimeoutDueToConnectionLost)
+	ErrRejectReconfiguration      = Error(ErrGRPCRejectReconfiguration)
 	ErrUnhealthy                  = Error(ErrGRPCUnhealthy)
 )
 

--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -61,6 +61,8 @@ func togRPCError(err error) error {
 		return rpctypes.ErrGRPCTimeoutDueToLeaderFail
 	case etcdserver.ErrTimeoutDueToConnectionLost:
 		return rpctypes.ErrGRPCTimeoutDueToConnectionLost
+	case etcdserver.ErrRejectReconfiguration:
+		return rpctypes.ErrGRPCRejectReconfiguration
 	case etcdserver.ErrUnhealthy:
 		return rpctypes.ErrGRPCUnhealthy
 	case etcdserver.ErrKeyNotFound:

--- a/etcdserver/errors.go
+++ b/etcdserver/errors.go
@@ -33,6 +33,7 @@ var (
 	ErrNoSpace                    = errors.New("etcdserver: no space")
 	ErrTooManyRequests            = errors.New("etcdserver: too many requests")
 	ErrUnhealthy                  = errors.New("etcdserver: unhealthy cluster")
+	ErrRejectReconfiguration      = errors.New("etcdserver: re-configuration rejected, cluster not healhthy")
 	ErrKeyNotFound                = errors.New("etcdserver: key not found")
 )
 

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1066,7 +1066,7 @@ func (s *EtcdServer) AddMember(ctx context.Context, memb membership.Member) erro
 		}
 		if !isConnectedFullySince(s.r.transport, time.Now().Add(-HealthInterval), s.ID(), s.cluster.Members()) {
 			plog.Warningf("not healthy for reconfigure, rejecting member add %+v", memb)
-			return ErrUnhealthy
+			return ErrRejectReconfiguration
 		}
 	}
 
@@ -1120,7 +1120,7 @@ func (s *EtcdServer) mayRemoveMember(id types.ID) error {
 	active := numConnectedSince(s.r.transport, time.Now().Add(-HealthInterval), s.ID(), m)
 	if (active - 1) < 1+((len(m)-1)/2) {
 		plog.Warningf("reconfigure breaks active quorum, rejecting remove member %s", id)
-		return ErrUnhealthy
+		return ErrRejectReconfiguration
 	}
 
 	return nil


### PR DESCRIPTION
When `-strict-reconfig-check=true`, reconfigurations of the cluster
cannot occur more than once per `HealthInterval` (5 seconds). If a
client attempts to add or remove a member during this period they should
not receive an HTTP 500, but instead be told to try again at a later
time, i.e. HTTP 429.

Fixes #7678