### PR TITLE
benchmark: a new flag --target-leader for targetting a leader endpoint

### DIFF
--- a/tools/benchmark/cmd/root.go
+++ b/tools/benchmark/cmd/root.go
@@ -52,6 +52,8 @@ var (
 	user string
 
 	dialTimeout time.Duration
+
+	targetLeader bool
 )
 
 func init() {
@@ -67,4 +69,6 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&user, "user", "", "specify username and password in username:password format")
 	RootCmd.PersistentFlags().DurationVar(&dialTimeout, "dial-timeout", 0, "dial timeout for client connections")
+
+	RootCmd.PersistentFlags().BoolVar(&targetLeader, "target-leader", false, "connect only to the leader node")
 }


### PR DESCRIPTION
Current benchmark picks destinations of RPCs in a random
manner. However, it will result divergent benchmarking result because
RPCs other than serializable range must be forwarded when a follower
node receives it. This commit adds a new flag --target-leader for
avoid the problem. If the flag is passed, benchmark always picks an
endpoint of a leader node.
