### PR TITLE
test: remove generated files from coverage statistics

### DIFF
--- a/test
+++ b/test
@@ -130,6 +130,8 @@ function cov_pass {
 	go test -tags cov -timeout 30m -v ${REPO_PATH}"/e2e" || failed="$failed e2e"
 
 	gocovmerge "$COVERDIR"/*.coverprofile >"$COVERDIR"/cover.out
+	# strip out generated files (using GNU-style sed)
+	sed --in-place '/generated.go/d' "$COVERDIR"/cover.out || true
 
 	# held failures to generate the full coverage file, now fail
 	if [ -n "$failed" ]; then


### PR DESCRIPTION
client/keys.generated.go has poor coverage but it's generated; other
generated files (e.g., pb stuff) are ignored, so this should be ignored too.