### PR TITLE
rafthttp: move test-only functions to '_test.go'

### DIFF
--- a/rafthttp/util.go
+++ b/rafthttp/util.go
@@ -16,7 +16,6 @@ package rafthttp
 
 import (
 	"crypto/tls"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
@@ -27,7 +26,6 @@ import (
 
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/pkg/types"
-	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/coreos/etcd/version"
 	"github.com/coreos/go-semver/semver"
 )
@@ -59,31 +57,6 @@ func NewRoundTripper(tlsInfo transport.TLSInfo, dialTimeout time.Duration) (http
 // sent on broken connection.
 func newStreamRoundTripper(tlsInfo transport.TLSInfo, dialTimeout time.Duration) (http.RoundTripper, error) {
 	return transport.NewTimeoutTransport(tlsInfo, dialTimeout, ConnReadTimeout, ConnWriteTimeout)
-}
-
-func writeEntryTo(w io.Writer, ent *raftpb.Entry) error {
-	size := ent.Size()
-	if err := binary.Write(w, binary.BigEndian, uint64(size)); err != nil {
-		return err
-	}
-	b, err := ent.Marshal()
-	if err != nil {
-		return err
-	}
-	_, err = w.Write(b)
-	return err
-}
-
-func readEntryFrom(r io.Reader, ent *raftpb.Entry) error {
-	var l uint64
-	if err := binary.Read(r, binary.BigEndian, &l); err != nil {
-		return err
-	}
-	buf := make([]byte, int(l))
-	if _, err := io.ReadFull(r, buf); err != nil {
-		return err
-	}
-	return ent.Unmarshal(buf)
 }
 
 // createPostRequest creates a HTTP POST request that sends raft message.


### PR DESCRIPTION
Not used in actual code base, only used in tests
