### PR TITLE
*: rename Snapshot STM isolation to SerializableSnapshot

### DIFF
--- a/clientv3/concurrency/stm.go
+++ b/clientv3/concurrency/stm.go
@@ -43,8 +43,9 @@ type STM interface {
 type Isolation int
 
 const (
-	// Snapshot is serializable but also checks writes for conflicts.
-	Snapshot Isolation = iota
+	// SerializableSnapshot provides serializable isolation and also checks
+	// for write conflicts.
+	SerializableSnapshot Isolation = iota
 	// Serializable reads within the same transactiona attempt return data
 	// from the at the revision of the first read.
 	Serializable
@@ -102,7 +103,7 @@ func NewSTM(c *v3.Client, apply func(STM) error, so ...stmOption) (*v3.TxnRespon
 
 func mkSTM(c *v3.Client, opts *stmOptions) STM {
 	switch opts.iso {
-	case Snapshot:
+	case SerializableSnapshot:
 		s := &stmSerializable{
 			stm:      stm{client: c, ctx: opts.ctx},
 			prefetch: make(map[string]*v3.GetResponse),

--- a/tools/benchmark/cmd/stm.go
+++ b/tools/benchmark/cmd/stm.go
@@ -88,7 +88,7 @@ func stmFunc(cmd *cobra.Command, args []string) {
 	case "s":
 		stmIso = v3sync.Serializable
 	case "ss":
-		stmIso = v3sync.Snapshot
+		stmIso = v3sync.SerializableSnapshot
 	default:
 		fmt.Fprintln(os.Stderr, cmd.Usage())
 		os.Exit(1)


### PR DESCRIPTION
Pure Snapshot isolation would permit read conflicts. Change the name
from Snapshot to SerializableSnapshot to reflect that it will also
reject read conflicts.