### PR TITLE
Documentation/upgrades: add instruction to stop an etcd process

### DIFF
--- a/Documentation/upgrades/upgrade_3_0.md
+++ b/Documentation/upgrades/upgrade_3_0.md
@@ -57,6 +57,12 @@ $ curl http://localhost:2379/version
 
 #### 2. Stop the existing etcd process
 
+If running etcd with systemd, stop each running etcd process with `systemctl`:
+
+```sh
+sudo systemctl stop etcd2
+```
+
 When each etcd process is stopped, expected errors will be logged by other cluster members. This is normal since a cluster member connection has been (temporarily) broken:
 
 ```

--- a/Documentation/upgrades/upgrade_3_1.md
+++ b/Documentation/upgrades/upgrade_3_1.md
@@ -58,6 +58,12 @@ $ curl http://localhost:2379/version
 
 #### 2. Stop the existing etcd process
 
+If running etcd with systemd, stop each running etcd process with `systemctl`:
+
+```sh
+sudo systemctl stop etcd3
+```
+
 When each etcd process is stopped, expected errors will be logged by other cluster members. This is normal since a cluster member connection has been (temporarily) broken:
 
 ```


### PR DESCRIPTION
Updated the upgrade documents to reflect instruction to stop etcd process before upgrading
