### PR TITLE
discovery: remove dead token argument from SRVGetCluster

### DIFF
--- a/discovery/srv.go
+++ b/discovery/srv.go
@@ -31,9 +31,8 @@ var (
 
 // SRVGetCluster gets the cluster information via DNS discovery.
 // TODO(barakmich): Currently ignores priority and weight (as they don't make as much sense for a bootstrap)
-// Also doesn't do any lookups for the token (though it could)
 // Also sees each entry as a separate instance.
-func SRVGetCluster(name, dns string, defaultToken string, apurls types.URLs) (string, string, error) {
+func SRVGetCluster(name, dns string, apurls types.URLs) (string, error) {
 	tempName := int(0)
 	tcp2ap := make(map[string]url.URL)
 
@@ -42,7 +41,7 @@ func SRVGetCluster(name, dns string, defaultToken string, apurls types.URLs) (st
 		tcpAddr, err := resolveTCPAddr("tcp", url.Host)
 		if err != nil {
 			plog.Errorf("couldn't resolve host %s during SRV discovery", url.Host)
-			return "", "", err
+			return "", err
 		}
 		tcp2ap[tcpAddr.String()] = url
 	}
@@ -98,7 +97,7 @@ func SRVGetCluster(name, dns string, defaultToken string, apurls types.URLs) (st
 		plog.Warningf(srvErr[0])
 		plog.Warningf(srvErr[1])
 		plog.Errorf("SRV discovery failed: too many errors querying DNS SRV records")
-		return "", "", err
+		return "", err
 	}
-	return strings.Join(stringParts, ","), defaultToken, nil
+	return strings.Join(stringParts, ","), nil
 }

--- a/discovery/srv_test.go
+++ b/discovery/srv_test.go
@@ -110,12 +110,9 @@ func TestSRVGetCluster(t *testing.T) {
 			return "", nil, errors.New("Unknown service in mock")
 		}
 		urls := testutil.MustNewURLs(t, tt.urls)
-		str, token, err := SRVGetCluster(name, "example.com", "token", urls)
+		str, err := SRVGetCluster(name, "example.com", urls)
 		if err != nil {
 			t.Fatalf("%d: err: %#v", i, err)
-		}
-		if token != "token" {
-			t.Errorf("%d: token: %s", i, token)
 		}
 		if str != tt.expected {
 			t.Errorf("#%d: cluster = %s, want %s", i, str, tt.expected)

--- a/embed/config.go
+++ b/embed/config.go
@@ -312,6 +312,7 @@ func (cfg *Config) Validate() error {
 
 // PeerURLsMapAndToken sets up an initial peer URLsMap and cluster token for bootstrap or discovery.
 func (cfg *Config) PeerURLsMapAndToken(which string) (urlsmap types.URLsMap, token string, err error) {
+	token = cfg.InitialClusterToken
 	switch {
 	case cfg.Durl != "":
 		urlsmap = types.URLsMap{}
@@ -321,7 +322,7 @@ func (cfg *Config) PeerURLsMapAndToken(which string) (urlsmap types.URLsMap, tok
 		token = cfg.Durl
 	case cfg.DNSCluster != "":
 		var clusterStr string
-		clusterStr, token, err = discovery.SRVGetCluster(cfg.Name, cfg.DNSCluster, cfg.InitialClusterToken, cfg.APUrls)
+		clusterStr, err = discovery.SRVGetCluster(cfg.Name, cfg.DNSCluster, cfg.APUrls)
 		if err != nil {
 			return nil, "", err
 		}
@@ -339,7 +340,6 @@ func (cfg *Config) PeerURLsMapAndToken(which string) (urlsmap types.URLsMap, tok
 	default:
 		// We're statically configured, and cluster has appropriately been set.
 		urlsmap, err = types.NewURLsMap(cfg.InitialCluster)
-		token = cfg.InitialClusterToken
 	}
 	return urlsmap, token, err
 }


### PR DESCRIPTION
Can add the argument back when it's actually used something.