### PR TITLE
etcdserver: let Status() not require authentication

### DIFF
--- a/etcdserver/api/v3rpc/maintenance.go
+++ b/etcdserver/api/v3rpc/maintenance.go
@@ -186,9 +186,5 @@ func (ams *authMaintenanceServer) Hash(ctx context.Context, r *pb.HashRequest) (
 }
 
 func (ams *authMaintenanceServer) Status(ctx context.Context, ar *pb.StatusRequest) (*pb.StatusResponse, error) {
-	if err := ams.isAuthenticated(ctx); err != nil {
-		return nil, err
-	}
-
 	return ams.maintenanceServer.Status(ctx, ar)
 }


### PR DESCRIPTION
The information that can be obtained with the RPC doesn't need to be
protected.

Fix https://github.com/coreos/etcd/issues/7721

/cc @raoofm @heyitsanthony 