### PR TITLE
clientv3/namespace: fix incorrect watching prefix-end

### DIFF
--- a/clientv3/namespace/doc.go
+++ b/clientv3/namespace/doc.go
@@ -27,7 +27,7 @@
 //	unprefixedKV := cli.KV
 //	cli.KV = namespace.NewKV(cli.KV, "my-prefix/")
 //	cli.Watcher = namespace.NewWatcher(cli.Watcher, "my-prefix/")
-//	cli.Leases = namespace.NewLease(cli.Lease, "my-prefix/")
+//	cli.Lease = namespace.NewLease(cli.Lease, "my-prefix/")
 //
 // Now calls using 'cli' will namespace / prefix all keys with "my-prefix/":
 //

--- a/clientv3/namespace/watch.go
+++ b/clientv3/namespace/watch.go
@@ -40,7 +40,7 @@ func NewWatcher(w clientv3.Watcher, prefix string) clientv3.Watcher {
 
 func (w *watcherPrefix) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
 	// since OpOption is opaque, determine range for prefixing through an OpGet
-	op := clientv3.OpGet("abc", opts...)
+	op := clientv3.OpGet(key, opts...)
 	end := op.RangeBytes()
 	pfxBegin, pfxEnd := prefixInterval(w.pfx, []byte(key), end)
 	if pfxEnd != nil {


### PR DESCRIPTION
using "abc" will watch the wrong range when WithPrefix() specified.