### PR TITLE
*: simply ignore ErrAuthNotEnabled in clientv3 if auth is not enabled

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -282,6 +282,10 @@ func (as *authStore) Authenticate(ctx context.Context, username, password string
 }
 
 func (as *authStore) CheckPassword(username, password string) (uint64, error) {
+	if !as.isAuthEnabled() {
+		return 0, ErrAuthNotEnabled
+	}
+
 	tx := as.be.BatchTx()
 	tx.Lock()
 	defer tx.Unlock()

--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -306,14 +306,18 @@ func (c *Client) dial(endpoint string, dopts ...grpc.DialOption) (*grpc.ClientCo
 			defer cancel()
 			ctx = cctx
 		}
-		if err := c.getToken(ctx); err != nil {
-			if err == ctx.Err() && ctx.Err() != c.ctx.Err() {
-				err = grpc.ErrClientConnTimeout
-			}
-			return nil, err
-		}
 
-		opts = append(opts, grpc.WithPerRPCCredentials(c.tokenCred))
+		err := c.getToken(ctx)
+		if err != nil {
+			if toErr(ctx, err) != rpctypes.ErrAuthNotEnabled {
+				if err == ctx.Err() && ctx.Err() != c.ctx.Err() {
+					err = grpc.ErrClientConnTimeout
+				}
+				return nil, err
+			}
+		} else {
+			opts = append(opts, grpc.WithPerRPCCredentials(c.tokenCred))
+		}
 	}
 
 	opts = append(opts, c.cfg.DialOptions...)

--- a/e2e/ctl_v3_auth_test.go
+++ b/e2e/ctl_v3_auth_test.go
@@ -88,9 +88,9 @@ func authDisableTest(cx ctlCtx) {
 		cx.t.Fatalf("authDisableTest ctlV3AuthDisable error (%v)", err)
 	}
 
-	// now auth fails unconditionally, note that failed RPC is Authenticate(), not Put()
+	// now ErrAuthNotEnabled of Authenticate() is simply ignored
 	cx.user, cx.pass = "test-user", "pass"
-	if err := ctlV3PutFailAuthDisabled(cx, "hoo", "bar"); err != nil {
+	if err := ctlV3Put(cx, "hoo", "bar", ""); err != nil {
 		cx.t.Fatal(err)
 	}
 
@@ -328,10 +328,6 @@ func ctlV3PutFailAuth(cx ctlCtx, key, val string) error {
 
 func ctlV3PutFailPerm(cx ctlCtx, key, val string) error {
 	return spawnWithExpect(append(cx.PrefixArgs(), "put", key, val), "permission denied")
-}
-
-func ctlV3PutFailAuthDisabled(cx ctlCtx, key, val string) error {
-	return spawnWithExpect(append(cx.PrefixArgs(), "put", key, val), "authentication is not enabled")
 }
 
 func authSetupTestUser(cx ctlCtx) {

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -374,7 +374,9 @@ func (s *EtcdServer) Authenticate(ctx context.Context, r *pb.AuthenticateRequest
 	for {
 		checkedRevision, err := s.AuthStore().CheckPassword(r.Name, r.Password)
 		if err != nil {
-			plog.Errorf("invalid authentication request to user %s was issued", r.Name)
+			if err != auth.ErrAuthNotEnabled {
+				plog.Errorf("invalid authentication request to user %s was issued", r.Name)
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/7724

/cc @raoofm @heyitsanthony 