### PR TITLE
pkg/debugutil: add 'mutex' profiler (Go 1.8+)

### DIFF
--- a/pkg/debugutil/pprof.go
+++ b/pkg/debugutil/pprof.go
@@ -17,12 +17,19 @@ package debugutil
 import (
 	"net/http"
 	"net/http/pprof"
+	"runtime"
 )
 
 const HTTPPrefixPProf = "/debug/pprof"
 
 // PProfHandlers returns a map of pprof handlers keyed by the HTTP path.
 func PProfHandlers() map[string]http.Handler {
+	// set only when there's no existing setting
+	if runtime.SetMutexProfileFraction(-1) == 0 {
+		// 1 out of 5 mutex events are reported, on average
+		runtime.SetMutexProfileFraction(5)
+	}
+
 	m := make(map[string]http.Handler)
 
 	m[HTTPPrefixPProf+"/"] = http.HandlerFunc(pprof.Index)
@@ -34,6 +41,7 @@ func PProfHandlers() map[string]http.Handler {
 	m[HTTPPrefixPProf+"/goroutine"] = pprof.Handler("goroutine")
 	m[HTTPPrefixPProf+"/threadcreate"] = pprof.Handler("threadcreate")
 	m[HTTPPrefixPProf+"/block"] = pprof.Handler("block")
+	m[HTTPPrefixPProf+"/mutex"] = pprof.Handler("mutex")
 
 	return m
 }


### PR DESCRIPTION
Sample output

```
go test -v -run=xxx -benchtime 10s -mutexprofile=mutex.out -bench=BenchmarkWatchableStoreWatchSyncPut
go tool pprof mvcc.test mutex.out
```

```
go tool pprof mvcc.test mutex.out
Entering interactive mode (type "help" for commands)
(pprof) top
9.85s of 9.85s total (  100%)
Dropped 4 nodes (cum <= 0.05s)
Showing top 10 nodes out of 14 (cum >= 5.57s)
      flat  flat%   sum%        cum   cum%
     9.85s   100%   100%      9.85s   100%  sync.(*Mutex).Unlock
         0     0%   100%      5.57s 56.62%  github.com/coreos/etcd/mvcc.(*metricsTxnWrite).End
         0     0%   100%      5.57s 56.62%  github.com/coreos/etcd/mvcc.(*storeTxnWrite).End
         0     0%   100%      4.27s 43.36%  github.com/coreos/etcd/mvcc.(*watchableStore).syncWatchers
         0     0%   100%      4.27s 43.36%  github.com/coreos/etcd/mvcc.(*watchableStore).syncWatchersLoop
         0     0%   100%      5.57s 56.62%  github.com/coreos/etcd/mvcc.(*watchableStoreTxnWrite).End
         0     0%   100%      5.57s 56.62%  github.com/coreos/etcd/mvcc.(*writeView).Put
         0     0%   100%      5.58s 56.64%  github.com/coreos/etcd/mvcc.BenchmarkWatchableStoreWatchSyncPut
         0     0%   100%      5.57s 56.62%  github.com/coreos/etcd/mvcc/backend.(*batchTx).Unlock
         0     0%   100%      5.57s 56.62%  github.com/coreos/etcd/mvcc/backend.(*batchTxBuffered).Unlock
```
