### PR TITLE
embed: use '*url.URL.Hostname(),Port()' for Go 1.8

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -387,7 +387,7 @@ func (cfg *Config) UpdateDefaultClusterFromName(defaultInitialCluster string) (s
 	}
 
 	used := false
-	pip, pport, _ := net.SplitHostPort(cfg.LPUrls[0].Host)
+	pip, pport := cfg.LPUrls[0].Hostname(), cfg.LPUrls[0].Port()
 	if cfg.defaultPeerHost() && pip == "0.0.0.0" {
 		cfg.APUrls[0] = url.URL{Scheme: cfg.APUrls[0].Scheme, Host: fmt.Sprintf("%s:%s", defaultHostname, pport)}
 		used = true
@@ -397,7 +397,7 @@ func (cfg *Config) UpdateDefaultClusterFromName(defaultInitialCluster string) (s
 		cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	}
 
-	cip, cport, _ := net.SplitHostPort(cfg.LCUrls[0].Host)
+	cip, cport := cfg.LCUrls[0].Hostname(), cfg.LCUrls[0].Port()
 	if cfg.defaultClientHost() && cip == "0.0.0.0" {
 		cfg.ACUrls[0] = url.URL{Scheme: cfg.ACUrls[0].Scheme, Host: fmt.Sprintf("%s:%s", defaultHostname, cport)}
 		used = true

--- a/embed/config_test.go
+++ b/embed/config_test.go
@@ -17,7 +17,6 @@ package embed
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/url"
 	"os"
 	"testing"
@@ -74,7 +73,7 @@ func TestUpdateDefaultClusterFromName(t *testing.T) {
 	origadvc := cfg.ACUrls[0].String()
 
 	cfg.Name = "abc"
-	_, lpport, _ := net.SplitHostPort(cfg.LPUrls[0].Host)
+	lpport := cfg.LPUrls[0].Port()
 
 	// in case of 'etcd --name=abc'
 	exp := fmt.Sprintf("%s=%s://localhost:%s", cfg.Name, oldscheme, lpport)
@@ -105,13 +104,13 @@ func TestUpdateDefaultClusterFromNameOverwrite(t *testing.T) {
 	origadvc := cfg.ACUrls[0].String()
 
 	cfg.Name = "abc"
-	_, lpport, _ := net.SplitHostPort(cfg.LPUrls[0].Host)
+	lpport := cfg.LPUrls[0].Port()
 	cfg.LPUrls[0] = url.URL{Scheme: cfg.LPUrls[0].Scheme, Host: fmt.Sprintf("0.0.0.0:%s", lpport)}
 	dhost, _ := cfg.UpdateDefaultClusterFromName(defaultInitialCluster)
 	if dhost != defaultHostname {
 		t.Fatalf("expected default host %q, got %q", defaultHostname, dhost)
 	}
-	aphost, apport, _ := net.SplitHostPort(cfg.APUrls[0].Host)
+	aphost, apport := cfg.APUrls[0].Hostname(), cfg.APUrls[0].Port()
 	if apport != lpport {
 		t.Fatalf("advertise peer url got different port %s, expected %s", apport, lpport)
 	}


### PR DESCRIPTION
Wherever `net.SplitHostPort` is used and we don't care about the parsing error, we can just use the new methods `Hostname` and `Port` that strip out the port or hostname.

https://golang.org/doc/go1.8#net_url
