### PR TITLE
vendor: update 'golang.org/x/time/rate' with context

### DIFF
--- a/cmd/vendor/golang.org/x/text/unicode/norm/composition.go
+++ b/cmd/vendor/golang.org/x/text/unicode/norm/composition.go
@@ -33,17 +33,9 @@ const (
 // streamSafe implements the policy of when a CGJ should be inserted.
 type streamSafe uint8
 
-// mkStreamSafe is a shorthand for declaring a streamSafe var and calling
-// first on it.
-func mkStreamSafe(p Properties) streamSafe {
-	return streamSafe(p.nTrailingNonStarters())
-}
-
-// first inserts the first rune of a segment.
+// first inserts the first rune of a segment. It is a faster version of next if
+// it is known p represents the first rune in a segment.
 func (ss *streamSafe) first(p Properties) {
-	if *ss != 0 {
-		panic("!= 0")
-	}
 	*ss = streamSafe(p.nTrailingNonStarters())
 }
 
@@ -66,7 +58,7 @@ func (ss *streamSafe) next(p Properties) ssState {
 	// be a non-starter. Note that it always hold that if nLead > 0 then
 	// nLead == nTrail.
 	if n == 0 {
-		*ss = 0
+		*ss = streamSafe(p.nTrailingNonStarters())
 		return ssStarter
 	}
 	return ssSuccess
@@ -142,7 +134,6 @@ func (rb *reorderBuffer) setFlusher(out []byte, f func(*reorderBuffer) bool) {
 func (rb *reorderBuffer) reset() {
 	rb.nrune = 0
 	rb.nbyte = 0
-	rb.ss = 0
 }
 
 func (rb *reorderBuffer) doFlush() bool {
@@ -257,6 +248,9 @@ func (rb *reorderBuffer) insertUnsafe(src input, i int, info Properties) {
 // It flushes the buffer on each new segment start.
 func (rb *reorderBuffer) insertDecomposed(dcomp []byte) insertErr {
 	rb.tmpBytes.setBytes(dcomp)
+	// As the streamSafe accounting already handles the counting for modifiers,
+	// we don't have to call next. However, we do need to keep the accounting
+	// intact when flushing the buffer.
 	for i := 0; i < len(dcomp); {
 		info := rb.f.info(rb.tmpBytes, i)
 		if info.BoundaryBefore() && rb.nrune > 0 && !rb.doFlush() {

--- a/cmd/vendor/golang.org/x/time/rate/rate.go
+++ b/cmd/vendor/golang.org/x/time/rate/rate.go
@@ -6,12 +6,11 @@
 package rate
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // Limit defines the maximum frequency of some events.
@@ -199,9 +198,10 @@ func (lim *Limiter) Reserve() *Reservation {
 // The Limiter takes this Reservation into account when allowing future events.
 // ReserveN returns false if n exceeds the Limiter's burst size.
 // Usage example:
-//   r, ok := lim.ReserveN(time.Now(), 1)
-//   if !ok {
+//   r := lim.ReserveN(time.Now(), 1)
+//   if !r.OK() {
 //     // Not allowed to act! Did you remember to set lim.burst to be > 0 ?
+//     return
 //   }
 //   time.Sleep(r.Delay())
 //   Act()
@@ -221,8 +221,9 @@ func (lim *Limiter) Wait(ctx context.Context) (err error) {
 // WaitN blocks until lim permits n events to happen.
 // It returns an error if n exceeds the Limiter's burst size, the Context is
 // canceled, or the expected wait time exceeds the Context's Deadline.
+// The burst limit is ignored if the rate limit is Inf.
 func (lim *Limiter) WaitN(ctx context.Context, n int) (err error) {
-	if n > lim.burst {
+	if n > lim.burst && lim.limit != Inf {
 		return fmt.Errorf("rate: Wait(n=%d) exceeds limiter's burst %d", n, lim.burst)
 	}
 	// Check if ctx is already cancelled
@@ -281,9 +282,9 @@ func (lim *Limiter) SetLimitAt(now time.Time, newLimit Limit) {
 // reserveN returns Reservation, not *Reservation, to avoid allocation in AllowN and WaitN.
 func (lim *Limiter) reserveN(now time.Time, n int, maxFutureReserve time.Duration) Reservation {
 	lim.mu.Lock()
-	defer lim.mu.Unlock()
 
 	if lim.limit == Inf {
+		lim.mu.Unlock()
 		return Reservation{
 			ok:        true,
 			lim:       lim,
@@ -326,6 +327,7 @@ func (lim *Limiter) reserveN(now time.Time, n int, maxFutureReserve time.Duratio
 		lim.last = last
 	}
 
+	lim.mu.Unlock()
 	return r
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b9e05532b0948a89c8f63c21c3ef85b22d1d06755554942056e004849aae1739
-updated: 2017-04-17T14:32:27.313252456-07:00
+hash: 22bec0dcd6fb064a5bb4a88cd9e0e37e3f034ba8a5c7f59288c45c3ee3a2b5d5
+updated: 2017-04-20T11:18:11.503876035-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -133,14 +133,14 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: f4b4367115ec2de254587813edaa901bc1c723a8
+  version: 19e3104b43db45fca0303f489a9536087b184802
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/time
-  version: a4bde12657593d5e90d0533a3e4fd95e635124cb
+  version: c06e80d9300e4443158a03817b8a8cb37d230320
   subpackages:
   - rate
 - name: google.golang.org/grpc

--- a/glide.yaml
+++ b/glide.yaml
@@ -93,7 +93,7 @@ import:
 - package: golang.org/x/sys
   version: e48874b42435b4347fc52bdee0424a52abc974d7
 - package: golang.org/x/time
-  version: a4bde12657593d5e90d0533a3e4fd95e635124cb
+  version: c06e80d9300e4443158a03817b8a8cb37d230320
   subpackages:
   - rate
 - package: google.golang.org/grpc


### PR DESCRIPTION
Go just updated its import path https://github.com/golang/time/commit/c06e80d9300e4443158a03817b8a8cb37d230320

For https://github.com/coreos/etcd/issues/6174.
