### PR TITLE
vendor: use 'x/net/trace' with std 'context'

### DIFF
--- a/cmd/vendor/golang.org/x/net/http2/server.go
+++ b/cmd/vendor/golang.org/x/net/http2/server.go
@@ -1049,7 +1049,11 @@ func (sc *serverConn) wroteFrame(res frameWriteResult) {
 			// stateClosed after the RST_STREAM frame is
 			// written.
 			st.state = stateHalfClosedLocal
-			sc.resetStream(streamError(st.id, ErrCodeCancel))
+			// Section 8.1: a server MAY request that the client abort
+			// transmission of a request without error by sending a
+			// RST_STREAM with an error code of NO_ERROR after sending
+			// a complete response.
+			sc.resetStream(streamError(st.id, ErrCodeNo))
 		case stateHalfClosedRemote:
 			sc.closeStream(st, errHandlerComplete)
 		}

--- a/cmd/vendor/golang.org/x/net/trace/trace.go
+++ b/cmd/vendor/golang.org/x/net/trace/trace.go
@@ -64,6 +64,7 @@ package trace // import "golang.org/x/net/trace"
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"html/template"
 	"io"
@@ -77,7 +78,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/net/internal/timeseries"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 22bec0dcd6fb064a5bb4a88cd9e0e37e3f034ba8a5c7f59288c45c3ee3a2b5d5
-updated: 2017-04-20T11:18:11.503876035-07:00
+hash: b2eaa5916c4ace220242794b77f42b82956cff5cd1bf9887fe53f054bbcb5c8a
+updated: 2017-04-20T17:28:41.548354957-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -119,7 +119,7 @@ imports:
   - bcrypt
   - blowfish
 - name: golang.org/x/net
-  version: d1e1b351919c6738fdeb9893d5c998b161464f0c
+  version: c8c74377599bd978aee1cf3b9b63a8634051cec2
   subpackages:
   - context
   - http2

--- a/glide.yaml
+++ b/glide.yaml
@@ -83,7 +83,7 @@ import:
   - bcrypt
   - blowfish
 - package: golang.org/x/net
-  version: d1e1b351919c6738fdeb9893d5c998b161464f0c
+  version: c8c74377599bd978aee1cf3b9b63a8634051cec2
   subpackages:
   - context
   - http2


### PR DESCRIPTION
For https://github.com/coreos/etcd/issues/6174.
