### PR TITLE
v2http: remove deprecated /v2/machines path

### DIFF
--- a/etcdserver/api/v2http/client.go
+++ b/etcdserver/api/v2http/client.go
@@ -46,16 +46,15 @@ import (
 )
 
 const (
-	authPrefix               = "/v2/auth"
-	keysPrefix               = "/v2/keys"
-	deprecatedMachinesPrefix = "/v2/machines"
-	membersPrefix            = "/v2/members"
-	statsPrefix              = "/v2/stats"
-	varsPath                 = "/debug/vars"
-	metricsPath              = "/metrics"
-	healthPath               = "/health"
-	versionPath              = "/version"
-	configPath               = "/config"
+	authPrefix    = "/v2/auth"
+	keysPrefix    = "/v2/keys"
+	membersPrefix = "/v2/members"
+	statsPrefix   = "/v2/stats"
+	varsPath      = "/debug/vars"
+	metricsPath   = "/metrics"
+	healthPath    = "/health"
+	versionPath   = "/version"
+	configPath    = "/config"
 )
 
 // NewClientHandler generates a muxed http.Handler with the given parameters to serve etcd client requests.
@@ -84,10 +83,6 @@ func NewClientHandler(server *etcdserver.EtcdServer, timeout time.Duration) http
 		clientCertAuthEnabled: server.Cfg.ClientCertAuthEnabled,
 	}
 
-	dmh := &deprecatedMachinesHandler{
-		cluster: server.Cluster(),
-	}
-
 	sech := &authHandler{
 		sec:                   sec,
 		cluster:               server.Cluster(),
@@ -108,7 +103,6 @@ func NewClientHandler(server *etcdserver.EtcdServer, timeout time.Duration) http
 	mux.Handle(metricsPath, prometheus.Handler())
 	mux.Handle(membersPrefix, mh)
 	mux.Handle(membersPrefix+"/", mh)
-	mux.Handle(deprecatedMachinesPrefix, dmh)
 	handleAuth(mux, sech)
 
 	return requestLogger(mux)
@@ -168,18 +162,6 @@ func (h *keysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeKeyError(w, errors.New("received response with no Event/Watcher!"))
 	}
-}
-
-type deprecatedMachinesHandler struct {
-	cluster api.Cluster
-}
-
-func (h *deprecatedMachinesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if !allowMethod(w, r.Method, "GET", "HEAD") {
-		return
-	}
-	endpoints := h.cluster.ClientURLs()
-	w.Write([]byte(strings.Join(endpoints, ", ")))
 }
 
 type membersHandler struct {

--- a/etcdserver/api/v2http/client_test.go
+++ b/etcdserver/api/v2http/client_test.go
@@ -1220,56 +1220,6 @@ func TestWriteEvent(t *testing.T) {
 	}
 }
 
-func TestV2DeprecatedMachinesEndpoint(t *testing.T) {
-	tests := []struct {
-		method string
-		wcode  int
-	}{
-		{"GET", http.StatusOK},
-		{"HEAD", http.StatusOK},
-		{"POST", http.StatusMethodNotAllowed},
-	}
-
-	m := &deprecatedMachinesHandler{cluster: &fakeCluster{}}
-	s := httptest.NewServer(m)
-	defer s.Close()
-
-	for _, tt := range tests {
-		req, err := http.NewRequest(tt.method, s.URL+deprecatedMachinesPrefix, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if resp.StatusCode != tt.wcode {
-			t.Errorf("StatusCode = %d, expected %d", resp.StatusCode, tt.wcode)
-		}
-	}
-}
-
-func TestServeMachines(t *testing.T) {
-	cluster := &fakeCluster{
-		clientURLs: []string{"http://localhost:8080", "http://localhost:8081", "http://localhost:8082"},
-	}
-	writer := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	h := &deprecatedMachinesHandler{cluster: cluster}
-	h.ServeHTTP(writer, req)
-	w := "http://localhost:8080, http://localhost:8081, http://localhost:8082"
-	if g := writer.Body.String(); g != w {
-		t.Errorf("body = %s, want %s", g, w)
-	}
-	if writer.Code != http.StatusOK {
-		t.Errorf("code = %d, want %d", writer.Code, http.StatusOK)
-	}
-}
-
 func TestGetID(t *testing.T) {
 	tests := []struct {
 		path string


### PR DESCRIPTION
Left over from 0.4?