### PR TITLE
etcdserver: do not block on raft stopping

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -260,7 +260,11 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 						// blocks until 'applyAll' calls 'applyWait.Trigger'
 						// to be in sync with scheduled config-change job
 						// (assume raftDone has cap of 1)
-						raftDone <- struct{}{}
+						select {
+						case raftDone <- struct{}{}:
+						case <-r.stopped:
+							return
+						}
 					}
 
 					// gofail: var raftBeforeFollowerSend struct{}


### PR DESCRIPTION
@heyitsanthony pointed out sending to `raftDone` blocks on raft shutdown, so just return when the raft is stopped.

Thanks!