### PR TITLE
raft: Set the RecentActive flag for newly added nodes

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1159,6 +1159,10 @@ func (r *raft) addNode(id uint64) {
 	}
 
 	r.setProgress(id, 0, r.raftLog.lastIndex()+1)
+	// When a node is first added, we should mark it as recently active.
+	// Otherwise, CheckQuorum may cause us to step down if it is invoked
+	// before the added node has a chance to communicate with us.
+	r.prs[id].RecentActive = true
 }
 
 func (r *raft) removeNode(id uint64) {


### PR DESCRIPTION
I found that enabling the `CheckQuorum` flag led to spurious leader elections when new nodes joined. It looks like in the time between a new node joining the cluster, and that node first communicating with the leader, the quorum check could fail because the new node looks inactive. To solve this, set the `RecentActive` flag when nodes are first added. This gives a grace period for the node to communicate before it causes the quorum check to fail.

This seems like a decent way to solve the problem, but please feel free to suggest other approaches instead.