### PR TITLE
integration: match more TLS errors for wrong certs

### DIFF
--- a/integration/v3_grpc_test.go
+++ b/integration/v3_grpc_test.go
@@ -1518,14 +1518,12 @@ func TestTLSReloadCopy(t *testing.T) {
 		for {
 			cc, err := ts.ClientConfig()
 			if err != nil {
-				// from concurrent certs overwriting
-				switch err.Error() {
-				case "tls: private key does not match public key":
-					fallthrough
-				case "tls: failed to find any PEM data in key input":
-					continue
-				}
-				t.Fatal(err)
+				// errors in 'go/src/crypto/tls/tls.go'
+				// tls: private key does not match public key
+				// tls: failed to find any PEM data in key input
+				// tls: failed to find any PEM data in certificate input
+				t.Log(err)
+				continue
 			}
 			cli, cerr := clientv3.New(clientv3.Config{
 				Endpoints:   []string{clus.Members[0].GRPCAddr()},


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/7835.
