### PR TITLE
embed: fix blocking Close before gRPC server start

### DIFF
--- a/embed/serve_test.go
+++ b/embed/serve_test.go
@@ -1,0 +1,38 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package embed
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/coreos/etcd/auth"
+)
+
+// TestStartEtcdWrongToken ensures that StartEtcd with wrong configs returns with error.
+func TestStartEtcdWrongToken(t *testing.T) {
+	tdir, err := ioutil.TempDir(os.TempDir(), "token-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tdir)
+	cfg := NewConfig()
+	cfg.Dir = tdir
+	cfg.AuthToken = "wrong-token"
+	if _, err = StartEtcd(cfg); err != auth.ErrInvalidAuthOpts {
+		t.Fatalf("expected %v, got %v", auth.ErrInvalidAuthOpts, err)
+	}
+}


### PR DESCRIPTION
If 'StartEtcd' returns before starting gRPC server
(e.g. mismatch snapshot, misconfiguration),
receiving from grpcServerC blocks forever. This patch
just closes the channel to not block on grpcServerC,
and proceeds to next stop operations in Close.

This was masking the issues in https://github.com/coreos/etcd/issues/7834
