### PR TITLE
raft: add chain core to notable users list

### DIFF
--- a/raft/README.md
+++ b/raft/README.md
@@ -49,6 +49,7 @@ This raft implementation also includes a few optional enhancements:
 - [etcd](https://github.com/coreos/etcd) A distributed reliable key-value store
 - [tikv](https://github.com/pingcap/tikv) A Distributed transactional key value database powered by Rust and Raft
 - [swarmkit](https://github.com/docker/swarmkit) A toolkit for orchestrating distributed systems at any scale.
+- [chain core](https://github.com/chain/chain) Software for operating permissioned, multi-asset blockchain networks
 
 ## Usage
 


### PR DESCRIPTION
Per @xiang90's comment on https://github.com/coreos/etcd/pull/7515#issuecomment-287126104, this adds Chain Core to the notable users list for the raft package. 