### PR TITLE
etcdserver: apply() sets consistIndex for any entry type

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1272,9 +1272,14 @@ func (s *EtcdServer) apply(es []raftpb.Entry, confState *raftpb.ConfState) (appl
 		case raftpb.EntryNormal:
 			s.applyEntryNormal(&e)
 		case raftpb.EntryConfChange:
+			// set the consistent index of current executing entry
+			if e.Index > s.consistIndex.ConsistentIndex() {
+				s.consistIndex.setConsistentIndex(e.Index)
+			}
 			var cc raftpb.ConfChange
 			pbutil.MustUnmarshal(&cc, e.Data)
 			removedSelf, err := s.applyConfChange(cc, confState)
+			s.setAppliedIndex(e.Index)
 			shouldStop = shouldStop || removedSelf
 			s.w.Trigger(cc.ID, &confChangeResponse{s.cluster.Members(), err})
 		default:


### PR DESCRIPTION
previously, apply() doesn't set consistIndex for EntryConfChange type.
    this causes a misalignment between consistIndex and applied index
    where EntryConfChange entry results setting applied index but not consistIndex.

suppose that addMember() is called and leader reflects that change.
    1. applied index and consistIndex is now misaligned.
    2. a new follower node joined.
    3. leader sends the snapshot to follower
            where the applied index is the snapshot metadata index.
    4. follower node saves the snapshot and database(includes consistIndex) from leader.
    5. restarting follower loads snapshot and database.
    6. follower checks snapshot metadata index(same as applied index) and database consistIndex,
            finds them don't match, and then panic.

FIXES #7834