### PR TITLE
mvcc: cache consistent index

### DIFF
--- a/mvcc/kvstore_bench_test.go
+++ b/mvcc/kvstore_bench_test.go
@@ -45,6 +45,24 @@ func BenchmarkStorePut(b *testing.B) {
 	}
 }
 
+func BenchmarkConsistentIndex(b *testing.B) {
+	fci := fakeConsistentIndex(10)
+	be, tmpPath := backend.NewDefaultTmpBackend()
+	s := NewStore(be, &lease.FakeLessor{}, &fci)
+	defer cleanup(s, be, tmpPath)
+
+	tx := s.b.BatchTx()
+	tx.Lock()
+	s.saveIndex(tx)
+	tx.Unlock()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.ConsistentIndex()
+	}
+}
+
 // BenchmarkStoreTxnPutUpdate is same as above, but instead updates single key
 func BenchmarkStorePutUpdate(b *testing.B) {
 	var i fakeConsistentIndex


### PR DESCRIPTION
Called on every entry apply and boltdb requests aren't free.

Old:
```sh
$ go test -bench=Consistent -v -count=5 -run=Consistent
BenchmarkConsistentIndex-8       3000000               452 ns/op              96 B/op          3 allocs/op
BenchmarkConsistentIndex-8       3000000               457 ns/op              96 B/op          3 allocs/op
BenchmarkConsistentIndex-8       3000000               452 ns/op              96 B/op          3 allocs/op
BenchmarkConsistentIndex-8       3000000               466 ns/op              96 B/op          3 allocs/op
BenchmarkConsistentIndex-8       3000000               446 ns/op              96 B/op          3 allocs/op
PASS
ok      _/home/anthony/go/src/github.com/coreos/etcd/mvcc       12.831s
```
New:
```sh
$ GOPATH=~/etcd-gopath/ go test -bench=Consistent -v -count=5 -run=Consistent
BenchmarkConsistentIndex-8      300000000                5.22 ns/op            0 B/op          0 allocs/op
BenchmarkConsistentIndex-8      300000000                5.30 ns/op            0 B/op          0 allocs/op
BenchmarkConsistentIndex-8      300000000                5.22 ns/op            0 B/op          0 allocs/op
BenchmarkConsistentIndex-8      300000000                5.24 ns/op            0 B/op          0 allocs/op
BenchmarkConsistentIndex-8      300000000                5.38 ns/op            0 B/op          0 allocs/op
```