### PR TITLE
clientv3/integration: drain keepalives before waiting for leader loss

### DIFF
--- a/clientv3/integration/lease_test.go
+++ b/clientv3/integration/lease_test.go
@@ -729,6 +729,12 @@ func TestLeaseWithRequireLeader(t *testing.T) {
 	}
 
 	clus.Members[1].Stop(t)
+	// kaReqLeader may issue multiple requests while waiting for the first
+	// response from proxy server; drain any stray keepalive responses
+	time.Sleep(100 * time.Millisecond)
+	for len(kaReqLeader) > 0 {
+		<-kaReqLeader
+	}
 
 	select {
 	case resp, ok := <-kaReqLeader:


### PR DESCRIPTION
500ms keepalive delay on proxy side causes client to sometimes send
a second keepalive since it waits more than 500ms for the first response.

Fixes #7658

No longer shows up when burning TestLeaseWithRequireLeader.

Also includes a proxy integration fix from the punted lease patch to take care of occasional goroutine leaks from not closing proxy the lease client.