### PR TITLE
*: handle request timeout error to '/member' when bootstrapping

### DIFF
--- a/integration/member_test.go
+++ b/integration/member_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"time"
+
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/pkg/testutil"
 	"golang.org/x/net/context"
@@ -69,6 +71,7 @@ func TestLaunchDuplicateMemberShouldFail(t *testing.T) {
 	size := 3
 	c := NewCluster(t, size)
 	m := c.Members[0].Clone(t)
+	m.BootstrapTimeout = time.Second
 	var err error
 	m.DataDir, err = ioutil.TempDir(os.TempDir(), "etcd")
 	if err != nil {


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/7267.

In slow CPU machine, it often takes more than 10ms, so times out.

When log is enabled, I get a bunch of

```
2017-05-04 01:28:59.260298 W | etcdserver: could not get cluster response from unix://127.0.0.1:2100723422: Get unix://127.0.0.1:2100723422/members: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
2017-05-04 01:28:59.260471 W | etcdserver: could not get cluster response from unix://127.0.0.1:2100723422: Get unix://127.0.0.1:2100723422/members: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```
