### PR TITLE
integration/fixtures-expired: do not force 'rm'

### DIFF
--- a/integration/fixtures-expired/gencerts.sh
+++ b/integration/fixtures-expired/gencerts.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+if ! [[ "$0" =~ "./gencerts.sh" ]]; then
+	echo "must be run from 'fixtures-expired'"
+	exit 255
+fi
+
 if which cfssl >/dev/null; then
     echo "cfssl is installed; generating certs"
 else
@@ -77,8 +82,8 @@ cfssl gencert \
     --config ./etcd-gencert.json \
     ./server-ca-csr.json | cfssljson --bare ./server
 
-rm -f ./*.json
-rm -f ./*.csr
+rm ./*.json
+rm ./*.csr
 
 if which openssl >/dev/null; then
     openssl x509 -in ./etcd-root-ca.pem -text -noout


### PR DESCRIPTION
To make gencerts.sh script safer.
