### PR TITLE
Fix watch_test.go TestEvent

### DIFF
--- a/clientv3/watch_test.go
+++ b/clientv3/watch_test.go
@@ -42,7 +42,7 @@ func TestEvent(t *testing.T) {
 				ModRevision:    4,
 			},
 		},
-		isModify: false,
+		isModify: true,
 	}}
 	for i, tt := range tests {
 		if tt.isCreate && !tt.ev.IsCreate() {


### PR DESCRIPTION
Fix watch_test.go TestEvent

Prior to This fix the isModify case of the table driven test was never checked.

# Contributing guidelines

Please read our [contribution workflow][contributing] before submitting a pull request.

[contributing]: https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow
