### PR TITLE
v3rpc: remove duplicated error case for lease.ErrLeaseNotFound

### DIFF
--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -42,8 +42,6 @@ func togRPCError(err error) error {
 		return rpctypes.ErrGRPCCompacted
 	case mvcc.ErrFutureRev:
 		return rpctypes.ErrGRPCFutureRev
-	case lease.ErrLeaseNotFound:
-		return rpctypes.ErrGRPCLeaseNotFound
 	case etcdserver.ErrRequestTooLarge:
 		return rpctypes.ErrGRPCRequestTooLarge
 	case etcdserver.ErrNoSpace:


### PR DESCRIPTION
There is the same case at line 69.