### PR TITLE
raft: Require sync when committed index changes

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -532,6 +532,7 @@ func MustSync(st, prevst pb.HardState, entsnum int) bool {
 	// (Updated on stable storage before responding to RPCs)
 	// currentTerm
 	// votedFor
+	// commit index
 	// log entries[]
-	return entsnum != 0 || st.Vote != prevst.Vote || st.Term != prevst.Term
+	return entsnum != 0 || st.Vote != prevst.Vote || st.Term != prevst.Term || st.Commit != prevst.Commit
 }

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -696,3 +696,25 @@ func TestIsHardStateEqual(t *testing.T) {
 		}
 	}
 }
+
+func TestMustSync(t *testing.T) {
+	tests := []struct {
+		st       raftpb.HardState
+		prevst   raftpb.HardState
+		entsnum  int
+		expected bool
+	}{
+		{emptyState, emptyState, 0, false},
+		{emptyState, emptyState, 1, true},
+		{raftpb.HardState{Commit: 1}, emptyState, 0, true},
+		{raftpb.HardState{Vote: 1}, emptyState, 0, true},
+		{raftpb.HardState{Term: 1}, emptyState, 0, true},
+	}
+
+	for i, tt := range tests {
+		result := MustSync(tt.st, tt.prevst, tt.entsnum)
+		if result != tt.expected {
+			t.Errorf("#%d, MustSync = %v, want %v", i, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
I ran into an issue when the following things occurred:

1. new entries were added to raft
2. a node crashed
3. the node restarted

```
raft2017/05/09 10:52:42 applied(38) is out of range [prevApplied(0), committed(37)]
panic: applied(38) is out of range [prevApplied(0), committed(37)] [recovered]
	panic: applied(38) is out of range [prevApplied(0), committed(37)]
```

It turns out that in my application code, when I would `Save` the WAL before applying raft entries (and then persist the new `applied` index), raft wasn't always persisting the committed index to disk when it changed, per the logic in `MustSync`.

Before this change, `MustSync` would return `true` if the number of entries was non-zero or the `HardState`'s `Vote` or `Term` value changed, but not if the `HardState`'s `Commit` value changed.

With this change, when the client calls `Save` on the WAL, if the committed index has increased, it will cause the `HardState` to be persisted to disk.