### PR TITLE
mvcc: chunk reads for restoring

### DIFF
--- a/mvcc/kvstore_bench_test.go
+++ b/mvcc/kvstore_bench_test.go
@@ -89,7 +89,8 @@ func benchmarkStoreRestore(revsPerKey int, b *testing.B) {
 	var i fakeConsistentIndex
 	be, tmpPath := backend.NewDefaultTmpBackend()
 	s := NewStore(be, &lease.FakeLessor{}, &i)
-	defer cleanup(s, be, tmpPath)
+	// use closure to capture 's' to pick up the reassignment
+	defer func() { cleanup(s, be, tmpPath) }()
 
 	// arbitrary number of bytes
 	bytesN := 64
@@ -103,7 +104,11 @@ func benchmarkStoreRestore(revsPerKey int, b *testing.B) {
 			txn.End()
 		}
 	}
+	s.Close()
+
+	b.ReportAllocs()
 	b.ResetTimer()
+	s = NewStore(be, &lease.FakeLessor{}, &i)
 }
 
 func BenchmarkStoreRestoreRevs1(b *testing.B) {

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -373,8 +373,10 @@ func TestStoreRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 	b.tx.rangeRespc <- rangeResp{[][]byte{finishedCompactKeyName}, [][]byte{newTestRevBytes(revision{3, 0})}}
-	b.tx.rangeRespc <- rangeResp{[][]byte{putkey, delkey}, [][]byte{putkvb, delkvb}}
 	b.tx.rangeRespc <- rangeResp{[][]byte{scheduledCompactKeyName}, [][]byte{newTestRevBytes(revision{3, 0})}}
+
+	b.tx.rangeRespc <- rangeResp{[][]byte{putkey, delkey}, [][]byte{putkvb, delkvb}}
+	b.tx.rangeRespc <- rangeResp{nil, nil}
 
 	s.restore()
 
@@ -386,8 +388,8 @@ func TestStoreRestore(t *testing.T) {
 	}
 	wact := []testutil.Action{
 		{"range", []interface{}{metaBucketName, finishedCompactKeyName, []byte(nil), int64(0)}},
-		{"range", []interface{}{keyBucketName, newTestRevBytes(revision{1, 0}), newTestRevBytes(revision{math.MaxInt64, math.MaxInt64}), int64(0)}},
 		{"range", []interface{}{metaBucketName, scheduledCompactKeyName, []byte(nil), int64(0)}},
+		{"range", []interface{}{keyBucketName, newTestRevBytes(revision{1, 0}), newTestRevBytes(revision{math.MaxInt64, math.MaxInt64}), int64(restoreChunkKeys)}},
 	}
 	if g := b.tx.Action(); !reflect.DeepEqual(g, wact) {
 		t.Errorf("tx actions = %+v, want %+v", g, wact)


### PR DESCRIPTION
Loading all keys at once would cause etcd to use twice as much
memory than it would need to serve the keys, causing RSS to spike on
boot. Instead, load the keys into the mvcc by chunk. Uses pipelining
for some concurrency.

Fixes #7822

tmpfs benchmarks:

Before:
```
go test -v -run=BenchmarkStoreRestore -bench=BenchmarkStoreRestore
BenchmarkStoreRestoreRevs1-8     1000000      4446 ns/op     814 B/op      7 allocs/op
BenchmarkStoreRestoreRevs10-8     200000     11053 ns/op    5397 B/op     38 allocs/op
BenchmarkStoreRestoreRevs20-8     100000     17458 ns/op   10518 B/op     69 allocs/op
```

After:
```
go test -bench=BenchmarkStoreRestore -run=BenchmarkStoreRestore
BenchmarkStoreRestoreRevs1-8    	 1000000	      2464 ns/op	     641 B/op	       6 allocs/op
BenchmarkStoreRestoreRevs10-8   	  200000	      7396 ns/op	    4924 B/op	      37 allocs/op
BenchmarkStoreRestoreRevs20-8   	  100000	     13664 ns/op	    9715 B/op	      68 allocs/op
```