### PR TITLE
osutil: force SIG_DFL before resending terminating signal 

### DIFF
--- a/pkg/osutil/interrupt_unix.go
+++ b/pkg/osutil/interrupt_unix.go
@@ -68,6 +68,7 @@ func HandleInterrupts() {
 		if pid == 1 {
 			os.Exit(0)
 		}
+		setDflSignal(sig.(syscall.Signal))
 		syscall.Kill(pid, sig.(syscall.Signal))
 	}()
 }

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -24,6 +24,9 @@ import (
 
 var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/etcd", "pkg/osutil")
+
+	// support to override setting SIG_DFL so tests don't terminate early
+	setDflSignal = dflSignal
 )
 
 func Unsetenv(key string) error {

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 )
 
+func init() { setDflSignal = func(syscall.Signal) {} }
+
 func TestUnsetenv(t *testing.T) {
 	tests := []string{
 		"data",

--- a/pkg/osutil/signal.go
+++ b/pkg/osutil/signal.go
@@ -1,0 +1,19 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package osutil
+
+func dflSignal(sig syscall.Signal) { /* nop */ }

--- a/pkg/osutil/signal_linux.go
+++ b/pkg/osutil/signal_linux.go
@@ -1,0 +1,30 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package osutil
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// dflSignal sets the given signal to SIG_DFL
+func dflSignal(sig syscall.Signal) {
+	// clearing out the sigact sets the signal to SIG_DFL
+	var sigactBuf [32]uint64
+	ptr := unsafe.Pointer(&sigactBuf)
+	syscall.Syscall6(uintptr(syscall.SYS_RT_SIGACTION), uintptr(sig), uintptr(ptr), 0, 8, 0, 0)
+}


### PR DESCRIPTION
The go runtime won't always reinstall the default signal handler on the
SIGTERM path, so it's possible the signal won't terminate the process.
Instead, permit etcd to exit normally after processing a signal.