### PR TITLE
pkg/srv: fix error checks from resolveTCPAddr

### DIFF
--- a/pkg/srv/srv.go
+++ b/pkg/srv/srv.go
@@ -55,7 +55,7 @@ func GetCluster(service, name, dns string, apurls types.URLs) ([]string, error) 
 			host := net.JoinHostPort(srv.Target, port)
 			tcpAddr, terr := resolveTCPAddr("tcp", host)
 			if terr != nil {
-				terr = err
+				err = terr
 				continue
 			}
 			n := ""


### PR DESCRIPTION
So that 'terr' can be returned later.
