### PR TITLE
wal: remove wal directory on windows before renaming tmpdir

### DIFF
--- a/wal/wal_windows.go
+++ b/wal/wal_windows.go
@@ -25,6 +25,9 @@ func (w *WAL) renameWal(tmpdirpath string) (*WAL, error) {
 	// windows; close the WAL to release the locks so the directory
 	// can be renamed
 	w.Close()
+	if err := os.RemoveAll(w.dir); err != nil {
+		return nil, err
+	}
 	if err := os.Rename(tmpdirpath, w.dir); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Renaming on windows will not work if the destination already exists. This change removes the wal directory before the wal tmpdir is renamed to `wal`.

This has resolved an issue we had with embedded etcd failing to start. I'm not aware of any consequences of this change but please let me know if I'm missing something!
