### PR TITLE
functional-tester: use log-dir as data-dir in etcd-agent

### DIFF
--- a/tools/functional-tester/etcd-agent/agent.go
+++ b/tools/functional-tester/etcd-agent/agent.go
@@ -75,6 +75,7 @@ func newAgent(cfg AgentConfig) (*Agent, error) {
 
 // start starts a new etcd process with the given args.
 func (a *Agent) start(args ...string) error {
+	args = append(args, "--data-dir", a.dataDir())
 	a.cmd = exec.Command(a.cmd.Path, args...)
 	a.cmd.Env = []string{"GOFAIL_HTTP=" + a.cfg.FailpointAddr}
 	a.cmd.Stdout = a.logfile
@@ -206,17 +207,7 @@ func (a *Agent) status() client.Status {
 }
 
 func (a *Agent) dataDir() string {
-	datadir := filepath.Join(a.cfg.LogDir, "*.etcd")
-	args := a.cmd.Args
-	// only parse the simple case like "--data-dir /var/lib/etcd"
-	for i, arg := range args {
-		if arg == "--data-dir" {
-			// just take the directory name from request
-			datadir = filepath.Join(a.cfg.LogDir, filepath.Base(args[i+1]))
-			break
-		}
-	}
-	return datadir
+	return filepath.Join(a.cfg.LogDir, "etcd.data")
 }
 
 func existDir(fpath string) bool {

--- a/tools/functional-tester/etcd-tester/cluster.go
+++ b/tools/functional-tester/etcd-tester/cluster.go
@@ -34,8 +34,6 @@ type agentConfig struct {
 	clientPort    int
 	peerPort      int
 	failpointPort int
-
-	datadir string
 }
 
 type cluster struct {
@@ -78,7 +76,6 @@ func (c *cluster) bootstrap() error {
 	for i, m := range members {
 		flags := append(
 			m.Flags(),
-			"--data-dir", c.agents[i].datadir,
 			"--initial-cluster-token", token,
 			"--initial-cluster", clusterStr,
 			"--snapshot-count", "10000")

--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -43,7 +43,6 @@ func main() {
 	peerPorts := flag.String("peer-ports", "", "etcd peer port for each agent endpoint")
 	failpointPorts := flag.String("failpoint-ports", "", "etcd failpoint port for each agent endpoint")
 
-	datadir := flag.String("data-dir", "agent.etcd", "etcd data directory location on agent machine.")
 	stressKeyLargeSize := flag.Uint("stress-key-large-size", 32*1024+1, "the size of each large key written into etcd.")
 	stressKeySize := flag.Uint("stress-key-size", 100, "the size of each small key written into etcd.")
 	stressKeySuffixRange := flag.Uint("stress-key-count", 250000, "the count of key range written into etcd.")
@@ -69,7 +68,6 @@ func main() {
 		agents[i].clientPort = cports[i]
 		agents[i].peerPort = pports[i]
 		agents[i].failpointPort = fports[i]
-		agents[i].datadir = *datadir
 	}
 
 	c := &cluster{agents: agents}


### PR DESCRIPTION
Persistent data should be configured in agent side.
There is no need to specify the data-dir in tester side.