### PR TITLE
clientv3/integration: fix test name, desc on balancer

### DIFF
--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -661,8 +661,8 @@ func TestKVCompact(t *testing.T) {
 	}
 }
 
-// TestKVGetRetry ensures get will retry on disconnect.
-func TestKVGetRetry(t *testing.T) {
+// TestKVGetBlock ensures get block on disconnect, then resume.
+func TestKVGetBlock(t *testing.T) {
 	defer testutil.AfterTest(t)
 
 	clusterSize := 3
@@ -684,7 +684,7 @@ func TestKVGetRetry(t *testing.T) {
 
 	donec := make(chan struct{})
 	go func() {
-		// Get will fail, but reconnect will trigger
+		// Get will block until reconnect
 		gresp, gerr := kv.Get(ctx, "foo")
 		if gerr != nil {
 			t.Fatal(gerr)
@@ -714,8 +714,8 @@ func TestKVGetRetry(t *testing.T) {
 	}
 }
 
-// TestKVPutFailGetRetry ensures a get will retry following a failed put.
-func TestKVPutFailGetRetry(t *testing.T) {
+// TestKVPutFailGetBlock ensures a get block following a failed put, then resume on reconnect.
+func TestKVPutFailGetBlock(t *testing.T) {
 	defer testutil.AfterTest(t)
 
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
@@ -733,7 +733,7 @@ func TestKVPutFailGetRetry(t *testing.T) {
 
 	donec := make(chan struct{})
 	go func() {
-		// Get will fail, but reconnect will trigger
+		// Get will block until reconnect
 		gresp, gerr := kv.Get(context.TODO(), "foo")
 		if gerr != nil {
 			t.Fatal(gerr)

--- a/clientv3/integration/txn_test.go
+++ b/clientv3/integration/txn_test.go
@@ -99,7 +99,9 @@ func TestTxnWriteFail(t *testing.T) {
 	clus.Members[0].Restart(t)
 }
 
-func TestTxnReadRetry(t *testing.T) {
+// TestTxnReadBlock ensures failfast=false request block on balancer Get
+// until there is address ready for transmission.
+func TestTxnReadBlock(t *testing.T) {
 	defer testutil.AfterTest(t)
 
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})


### PR DESCRIPTION
Those tests were written before gRPC balancer introduced
`BalancerGetOptions.BlockingWait` option. With current gRPC
vendor, there is no retry in failfast=false request. Instead,
it blocks on grpc.ClientConn.getTransport until the reconnect.

- etcd test commit https://github.com/coreos/etcd/commit/9523c2d29f44320d0d5b1529dce459c67c6355ee (Feb 3, 2016)
- grpc `BalancerGetOption` commit https://github.com/grpc/grpc-go/commit/0b1df3bca2197b6c636cb19c9b6c4f310be95a03 (May 24, 2016)

c.f. https://github.com/coreos/etcd/issues/7066