### PR TITLE
backend: force initial mmap size to 0 for windows

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -124,7 +124,7 @@ func newBackend(bcfg BackendConfig) *backend {
 	if boltOpenOptions != nil {
 		*bopts = *boltOpenOptions
 	}
-	bopts.InitialMmapSize = int(bcfg.MmapSize)
+	bopts.InitialMmapSize = bcfg.mmapSize()
 
 	db, err := bolt.Open(bcfg.Path, 0600, bopts)
 	if err != nil {

--- a/mvcc/backend/config_default.go
+++ b/mvcc/backend/config_default.go
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !linux
+// +build !linux,!windows
 
 package backend
 
 import "github.com/boltdb/bolt"
 
 var boltOpenOptions *bolt.Options = nil
+
+func (bcfg *BackendConfig) mmapSize() int { return int(bcfg.MmapSize) }

--- a/mvcc/backend/config_linux.go
+++ b/mvcc/backend/config_linux.go
@@ -29,3 +29,5 @@ import (
 var boltOpenOptions = &bolt.Options{
 	MmapFlags: syscall.MAP_POPULATE,
 }
+
+func (bcfg *BackendConfig) mmapSize() int { return int(bcfg.MmapSize) }

--- a/mvcc/backend/config_windows.go
+++ b/mvcc/backend/config_windows.go
@@ -1,0 +1,26 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package backend
+
+import "github.com/boltdb/bolt"
+
+var boltOpenOptions *bolt.Options = nil
+
+// setting mmap size != 0 on windows will allocate the entire
+// mmap size for the file, instead of growing it. So, force 0.
+
+func (bcfg *BackendConfig) mmapSize() int { return 0 }


### PR DESCRIPTION
boltdb on windows allocates a file with the full mmap size even if the
db is empty. Force the initial mmap size to 0 so there's no huge initial
db file on windows.

Fixes #7910

Currently untested on windows; will give it a spin/unWIP it in a day or two when I can get to my windows VM.

/cc @danielfaust