### PR TITLE
pkg/osutil: fix missing 'syscall' import

### DIFF
--- a/pkg/osutil/signal.go
+++ b/pkg/osutil/signal.go
@@ -16,4 +16,6 @@
 
 package osutil
 
+import "syscall"
+
 func dflSignal(sig syscall.Signal) { /* nop */ }


### PR DESCRIPTION
CI didn't catch this :0

With that build tag