### PR TITLE
e2e: Stop() lock/elect etcdctl process if Close times out

### DIFF
--- a/e2e/ctl_v3_elect_test.go
+++ b/e2e/ctl_v3_elect_test.go
@@ -80,7 +80,7 @@ func testElect(cx ctlCtx) {
 	if err = blocked.Signal(os.Interrupt); err != nil {
 		cx.t.Fatal(err)
 	}
-	if err = blocked.Close(); err != nil {
+	if err := closeWithTimeout(blocked, time.Second); err != nil {
 		cx.t.Fatal(err)
 	}
 
@@ -88,7 +88,7 @@ func testElect(cx ctlCtx) {
 	if err = holder.Signal(os.Interrupt); err != nil {
 		cx.t.Fatal(err)
 	}
-	if err = holder.Close(); err != nil {
+	if err = closeWithTimeout(holder, time.Second); err != nil {
 		cx.t.Fatal(err)
 	}
 

--- a/e2e/ctl_v3_lock_test.go
+++ b/e2e/ctl_v3_lock_test.go
@@ -103,7 +103,7 @@ func testLock(cx ctlCtx) {
 	if err = blocked.Signal(os.Interrupt); err != nil {
 		cx.t.Fatal(err)
 	}
-	if err = blocked.Close(); err != nil {
+	if err = closeWithTimeout(blocked, time.Second); err != nil {
 		cx.t.Fatal(err)
 	}
 
@@ -111,7 +111,7 @@ func testLock(cx ctlCtx) {
 	if err = holder.Signal(os.Interrupt); err != nil {
 		cx.t.Fatal(err)
 	}
-	if err = holder.Close(); err != nil {
+	if err = closeWithTimeout(holder, time.Second); err != nil {
 		cx.t.Fatal(err)
 	}
 


### PR DESCRIPTION
Gets backtrace by sending SIGQUIT if Close hangs after sending a SIGINT.

Bug showed up in CI again but it's hanging on an expected close so the SIGQUITs won't fire.