### PR TITLE
tcpproxy: display endpoints, not pointers, in ready to proxy string

### DIFF
--- a/proxy/tcpproxy/userspace.go
+++ b/proxy/tcpproxy/userspace.go
@@ -82,7 +82,12 @@ func (tp *TCPProxy) Run() error {
 		tp.remotes = append(tp.remotes, &remote{srv: srv, addr: addr})
 	}
 
-	plog.Printf("ready to proxy client requests to %+v", tp.Endpoints)
+	eps := []string{}
+	for _, ep := range tp.Endpoints {
+		eps = append(eps, fmt.Sprintf("%s:%d", ep.Target, ep.Port))
+	}
+	plog.Printf("ready to proxy client requests to %+v", eps)
+
 	go tp.runMonitor()
 	for {
 		in, err := tp.Listener.Accept()


### PR DESCRIPTION
The switch to *net.SRV for endpoints caused the ready string to emit
pointers instead of endpoint strings.

Fixes #7942