### PR TITLE
*: remove unused, fix typos

### DIFF
--- a/etcdmain/config_test.go
+++ b/etcdmain/config_test.go
@@ -149,7 +149,7 @@ func TestConfigFileClusteringFlags(t *testing.T) {
 		Durl           string `json:"discovery"`
 	}{
 		{
-		// Use default name and generate a default inital-cluster
+		// Use default name and generate a default initial-cluster
 		},
 		{
 			Name: "non-default",

--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -65,7 +65,7 @@ type TLSInfo struct {
 	// ServerName ensures the cert matches the given host in case of discovery / virtual hosting
 	ServerName string
 
-	// HandshakeFailure is optinally called when a connection fails to handshake. The
+	// HandshakeFailure is optionally called when a connection fails to handshake. The
 	// connection will be closed immediately afterwards.
 	HandshakeFailure func(*tls.Conn, error)
 

--- a/tools/functional-tester/etcd-tester/main.go
+++ b/tools/functional-tester/etcd-tester/main.go
@@ -36,8 +36,6 @@ const (
 	defaultFailpointPort = 2381
 )
 
-const pprofPrefix = "/debug/pprof-tester"
-
 func main() {
 	endpointStr := flag.String("agent-endpoints", "localhost:9027", "HTTP RPC endpoints of agents. Do not specify the schema.")
 	clientPorts := flag.String("client-ports", "", "etcd client port for each agent endpoint")


### PR DESCRIPTION
Fixes CI, some other fixes from go report https://goreportcard.com/report/github.com/coreos/etcd#misspell