### PR TITLE
integration: bump up 'TestV3LeaseRequireLeader' timeout to 5-sec

### DIFF
--- a/integration/v3_lease_test.go
+++ b/integration/v3_lease_test.go
@@ -528,8 +528,8 @@ func TestV3LeaseRequireLeader(t *testing.T) {
 		}
 	}()
 	select {
-	case <-time.After(time.Duration(5*electionTicks) * tickDuration):
-		t.Fatalf("did not receive leader loss error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("did not receive leader loss error (in 5-sec)")
 	case <-donec:
 	}
 }


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/7952.