### PR TITLE
.gitignore: Adding vendor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 tools/functional-tester/docker/bin
 hack/tls-setup/certs
 .idea
+vendor/


### PR DESCRIPTION
vendor packages are added to .gitignore

Avoid Git from marking all vendor packages as modified files.