### PR TITLE
etcdctl, e2e: use 0xe7cd as argument separator in cov-enabled etcdctl

### DIFF
--- a/e2e/etcd_spawn_cov.go
+++ b/e2e/etcd_spawn_cov.go
@@ -56,7 +56,8 @@ func spawnCmd(args []string) (*expect.ExpectProcess, error) {
 		}
 		// avoid test flag conflicts in coverage enabled etcdctl by putting flags in ETCDCTL_ARGS
 		ctl_cov_env := []string{
-			"ETCDCTL_ARGS" + "=" + strings.Join(args, "\xff"),
+			// was \xff, but that's used for testing boundary conditions; 0xe7cd should be safe
+			"ETCDCTL_ARGS=" + strings.Join(args, "\xe7\xcd"),
 		}
 		// when withFlagByEnv() is used in testCtl(), env variables for ctl is set to os.env.
 		// they must be included in ctl_cov_env.

--- a/etcdctl/ctlv2/ctl_cov.go
+++ b/etcdctl/ctlv2/ctl_cov.go
@@ -24,5 +24,5 @@ import (
 )
 
 func runCtlV2(app *cli.App) error {
-	return app.Run(strings.Split(os.Getenv("ETCDCTL_ARGS"), "\xff"))
+	return app.Run(strings.Split(os.Getenv("ETCDCTL_ARGS"), "\xe7\xcd"))
 }

--- a/etcdctl/ctlv3/ctl_cov.go
+++ b/etcdctl/ctlv3/ctl_cov.go
@@ -26,7 +26,7 @@ import (
 func Start() {
 	// ETCDCTL_ARGS=etcdctl_test arg1 arg2...
 	// SetArgs() takes arg1 arg2...
-	rootCmd.SetArgs(strings.Split(os.Getenv("ETCDCTL_ARGS"), "\xff")[1:])
+	rootCmd.SetArgs(strings.Split(os.Getenv("ETCDCTL_ARGS"), "\xe7\xcd")[1:])
 	if err := rootCmd.Execute(); err != nil {
 		command.ExitWithError(command.ExitError, err)
 	}


### PR DESCRIPTION
Fixes #7980