### PR TITLE
auth: support "authorization" token for grpc-gateway

### DIFF
--- a/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
+++ b/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
@@ -1,32 +1,27 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "title": "etcdserver/etcdserverpb/rpc.proto",
-    "version": "version not set"
-  },
-  "schemes": [
-    "http",
-    "https"
-  ],
   "consumes": [
     "application/json"
   ],
   "produces": [
     "application/json"
   ],
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "title": "etcdserver/etcdserverpb/rpc.proto",
+    "version": "version not set"
+  },
   "paths": {
     "/v3alpha/auth/authenticate": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "Authenticate processes an authenticate request.",
         "operationId": "Authenticate",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthenticateResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -37,23 +32,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthenticateResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/disable": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "AuthDisable disables authentication.",
         "operationId": "AuthDisable",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthDisableResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -64,23 +59,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthDisableResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/enable": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "AuthEnable enables authentication.",
         "operationId": "AuthEnable",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthEnableResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -91,23 +86,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthEnableResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/role/add": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "RoleAdd adds a new role.",
         "operationId": "RoleAdd",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthRoleAddResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -118,23 +113,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthRoleAddResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/role/delete": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "RoleDelete deletes a specified role.",
         "operationId": "RoleDelete",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthRoleDeleteResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -145,23 +140,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthRoleDeleteResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/role/get": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "RoleGet gets detailed role information.",
         "operationId": "RoleGet",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthRoleGetResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -172,23 +167,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthRoleGetResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/role/grant": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "RoleGrantPermission grants a permission of a specified key or range to a specified role.",
         "operationId": "RoleGrantPermission",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthRoleGrantPermissionResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -199,23 +194,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthRoleGrantPermissionResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/role/list": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "RoleList gets lists of all roles.",
         "operationId": "RoleList",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthRoleListResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -226,23 +221,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthRoleListResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/role/revoke": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "RoleRevokePermission revokes a key or range permission of a specified role.",
         "operationId": "RoleRevokePermission",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthRoleRevokePermissionResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -253,23 +248,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthRoleRevokePermissionResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/user/add": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "UserAdd adds a new user.",
         "operationId": "UserAdd",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthUserAddResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -280,23 +275,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthUserAddResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/user/changepw": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "UserChangePassword changes the password of a specified user.",
         "operationId": "UserChangePassword",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthUserChangePasswordResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -307,23 +302,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthUserChangePasswordResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/user/delete": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "UserDelete deletes a specified user.",
         "operationId": "UserDelete",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthUserDeleteResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -334,23 +329,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthUserDeleteResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/user/get": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "UserGet gets detailed user information.",
         "operationId": "UserGet",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthUserGetResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -361,23 +356,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthUserGetResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/user/grant": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "UserGrant grants a role to a specified user.",
         "operationId": "UserGrantRole",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthUserGrantRoleResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -388,23 +383,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthUserGrantRoleResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/user/list": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "UserList gets a list of all users.",
         "operationId": "UserList",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthUserListResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -415,23 +410,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthUserListResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/auth/user/revoke": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
         "summary": "UserRevokeRole revokes a role of specified user.",
         "operationId": "UserRevokeRole",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAuthUserRevokeRoleResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -442,23 +437,23 @@
             }
           }
         ],
-        "tags": [
-          "Auth"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAuthUserRevokeRoleResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/cluster/member/add": {
       "post": {
+        "tags": [
+          "Cluster"
+        ],
         "summary": "MemberAdd adds a member into the cluster.",
         "operationId": "MemberAdd",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbMemberAddResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -469,23 +464,23 @@
             }
           }
         ],
-        "tags": [
-          "Cluster"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbMemberAddResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/cluster/member/list": {
       "post": {
+        "tags": [
+          "Cluster"
+        ],
         "summary": "MemberList lists all the members in the cluster.",
         "operationId": "MemberList",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbMemberListResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -496,23 +491,23 @@
             }
           }
         ],
-        "tags": [
-          "Cluster"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbMemberListResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/cluster/member/remove": {
       "post": {
+        "tags": [
+          "Cluster"
+        ],
         "summary": "MemberRemove removes an existing member from the cluster.",
         "operationId": "MemberRemove",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbMemberRemoveResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -523,23 +518,23 @@
             }
           }
         ],
-        "tags": [
-          "Cluster"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbMemberRemoveResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/cluster/member/update": {
       "post": {
+        "tags": [
+          "Cluster"
+        ],
         "summary": "MemberUpdate updates the member configuration.",
         "operationId": "MemberUpdate",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbMemberUpdateResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -550,23 +545,23 @@
             }
           }
         ],
-        "tags": [
-          "Cluster"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbMemberUpdateResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/kv/compaction": {
       "post": {
+        "tags": [
+          "KV"
+        ],
         "summary": "Compact compacts the event history in the etcd key-value store. The key-value\nstore should be periodically compacted or the event history will continue to grow\nindefinitely.",
         "operationId": "Compact",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbCompactionResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -577,23 +572,23 @@
             }
           }
         ],
-        "tags": [
-          "KV"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbCompactionResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/kv/deleterange": {
       "post": {
+        "tags": [
+          "KV"
+        ],
         "summary": "DeleteRange deletes the given range from the key-value store.\nA delete request increments the revision of the key-value store\nand generates a delete event in the event history for every deleted key.",
         "operationId": "DeleteRange",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbDeleteRangeResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -604,23 +599,23 @@
             }
           }
         ],
-        "tags": [
-          "KV"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbDeleteRangeResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/kv/lease/revoke": {
       "post": {
+        "tags": [
+          "Lease"
+        ],
         "summary": "LeaseRevoke revokes a lease. All keys attached to the lease will expire and be deleted.",
         "operationId": "LeaseRevoke",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbLeaseRevokeResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -631,23 +626,23 @@
             }
           }
         ],
-        "tags": [
-          "Lease"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbLeaseRevokeResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/kv/lease/timetolive": {
       "post": {
+        "tags": [
+          "Lease"
+        ],
         "summary": "LeaseTimeToLive retrieves lease information.",
         "operationId": "LeaseTimeToLive",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbLeaseTimeToLiveResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -658,23 +653,23 @@
             }
           }
         ],
-        "tags": [
-          "Lease"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbLeaseTimeToLiveResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/kv/put": {
       "post": {
+        "tags": [
+          "KV"
+        ],
         "summary": "Put puts the given key into the key-value store.\nA put request increments the revision of the key-value store\nand generates one event in the event history.",
         "operationId": "Put",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbPutResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -685,23 +680,23 @@
             }
           }
         ],
-        "tags": [
-          "KV"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbPutResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/kv/range": {
       "post": {
+        "tags": [
+          "KV"
+        ],
         "summary": "Range gets the keys in the range from the key-value store.",
         "operationId": "Range",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbRangeResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -712,23 +707,23 @@
             }
           }
         ],
-        "tags": [
-          "KV"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbRangeResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/kv/txn": {
       "post": {
+        "tags": [
+          "KV"
+        ],
         "summary": "Txn processes multiple requests in a single transaction.\nA txn request increments the revision of the key-value store\nand generates events with the same revision for every completed request.\nIt is not allowed to modify the same key several times within one txn.",
         "operationId": "Txn",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbTxnResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -739,23 +734,23 @@
             }
           }
         ],
-        "tags": [
-          "KV"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbTxnResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/lease/grant": {
       "post": {
+        "tags": [
+          "Lease"
+        ],
         "summary": "LeaseGrant creates a lease which expires if the server does not receive a keepAlive\nwithin a given time to live period. All keys attached to the lease will be expired and\ndeleted if the lease expires. Each expired key generates a delete event in the event history.",
         "operationId": "LeaseGrant",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbLeaseGrantResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -766,27 +761,27 @@
             }
           }
         ],
-        "tags": [
-          "Lease"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbLeaseGrantResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/lease/keepalive": {
       "post": {
+        "tags": [
+          "Lease"
+        ],
         "summary": "LeaseKeepAlive keeps the lease alive by streaming keep alive requests from the client\nto the server and streaming keep alive responses from the server to the client.",
         "operationId": "LeaseKeepAlive",
-        "responses": {
-          "200": {
-            "description": "(streaming responses)",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbLeaseKeepAliveResponse"
-            }
-          }
-        },
         "parameters": [
           {
-            "name": "body",
             "description": "(streaming inputs)",
+            "name": "body",
             "in": "body",
             "required": true,
             "schema": {
@@ -794,23 +789,23 @@
             }
           }
         ],
-        "tags": [
-          "Lease"
-        ]
+        "responses": {
+          "200": {
+            "description": "(streaming responses)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbLeaseKeepAliveResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/maintenance/alarm": {
       "post": {
+        "tags": [
+          "Maintenance"
+        ],
         "summary": "Alarm activates, deactivates, and queries alarms regarding cluster health.",
         "operationId": "Alarm",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbAlarmResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -821,23 +816,23 @@
             }
           }
         ],
-        "tags": [
-          "Maintenance"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbAlarmResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/maintenance/defragment": {
       "post": {
+        "tags": [
+          "Maintenance"
+        ],
         "summary": "Defragment defragments a member's backend database to recover storage space.",
         "operationId": "Defragment",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbDefragmentResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -848,23 +843,23 @@
             }
           }
         ],
-        "tags": [
-          "Maintenance"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbDefragmentResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/maintenance/hash": {
       "post": {
+        "tags": [
+          "Maintenance"
+        ],
         "summary": "Hash returns the hash of the local KV state for consistency checking purpose.\nThis is designed for testing; do not use this in production when there\nare ongoing transactions.",
         "operationId": "Hash",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbHashResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -875,23 +870,23 @@
             }
           }
         ],
-        "tags": [
-          "Maintenance"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbHashResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/maintenance/snapshot": {
       "post": {
+        "tags": [
+          "Maintenance"
+        ],
         "summary": "Snapshot sends a snapshot of the entire backend from a member over a stream to a client.",
         "operationId": "Snapshot",
-        "responses": {
-          "200": {
-            "description": "(streaming responses)",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbSnapshotResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -902,23 +897,23 @@
             }
           }
         ],
-        "tags": [
-          "Maintenance"
-        ]
+        "responses": {
+          "200": {
+            "description": "(streaming responses)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbSnapshotResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/maintenance/status": {
       "post": {
+        "tags": [
+          "Maintenance"
+        ],
         "summary": "Status gets the status of the member.",
         "operationId": "Status",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbStatusResponse"
-            }
-          }
-        },
         "parameters": [
           {
             "name": "body",
@@ -929,27 +924,27 @@
             }
           }
         ],
-        "tags": [
-          "Maintenance"
-        ]
+        "responses": {
+          "200": {
+            "description": "(empty)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbStatusResponse"
+            }
+          }
+        }
       }
     },
     "/v3alpha/watch": {
       "post": {
+        "tags": [
+          "Watch"
+        ],
         "summary": "Watch watches for events happening or that have happened. Both input and output\nare streams; the input stream is for creating and canceling watchers and the output\nstream sends events. One watch RPC can watch on multiple key ranges, streaming events\nfor several watches at once. The entire event history can be watched starting from the\nlast compaction revision.",
         "operationId": "Watch",
-        "responses": {
-          "200": {
-            "description": "(streaming responses)",
-            "schema": {
-              "$ref": "#/definitions/etcdserverpbWatchResponse"
-            }
-          }
-        },
         "parameters": [
           {
-            "name": "body",
             "description": "(streaming inputs)",
+            "name": "body",
             "in": "body",
             "required": true,
             "schema": {
@@ -957,116 +952,121 @@
             }
           }
         ],
-        "tags": [
-          "Watch"
-        ]
+        "responses": {
+          "200": {
+            "description": "(streaming responses)",
+            "schema": {
+              "$ref": "#/definitions/etcdserverpbWatchResponse"
+            }
+          }
+        }
       }
     }
   },
   "definitions": {
     "AlarmRequestAlarmAction": {
       "type": "string",
+      "default": "GET",
       "enum": [
         "GET",
         "ACTIVATE",
         "DEACTIVATE"
-      ],
-      "default": "GET"
+      ]
     },
     "CompareCompareResult": {
       "type": "string",
+      "default": "EQUAL",
       "enum": [
         "EQUAL",
         "GREATER",
         "LESS",
         "NOT_EQUAL"
-      ],
-      "default": "EQUAL"
+      ]
     },
     "CompareCompareTarget": {
       "type": "string",
+      "default": "VERSION",
       "enum": [
         "VERSION",
         "CREATE",
         "MOD",
         "VALUE"
-      ],
-      "default": "VERSION"
+      ]
     },
     "EventEventType": {
       "type": "string",
+      "default": "PUT",
       "enum": [
         "PUT",
         "DELETE"
-      ],
-      "default": "PUT"
+      ]
     },
     "RangeRequestSortOrder": {
       "type": "string",
+      "default": "NONE",
       "enum": [
         "NONE",
         "ASCEND",
         "DESCEND"
-      ],
-      "default": "NONE"
+      ]
     },
     "RangeRequestSortTarget": {
       "type": "string",
+      "default": "KEY",
       "enum": [
         "KEY",
         "VERSION",
         "CREATE",
         "MOD",
         "VALUE"
-      ],
-      "default": "KEY"
+      ]
     },
     "WatchCreateRequestFilterType": {
+      "description": " - NOPUT: filter out put event.\n - NODELETE: filter out delete event.",
       "type": "string",
+      "default": "NOPUT",
       "enum": [
         "NOPUT",
         "NODELETE"
-      ],
-      "default": "NOPUT",
-      "description": " - NOPUT: filter out put event.\n - NODELETE: filter out delete event."
+      ]
     },
     "authpbPermission": {
       "type": "object",
+      "title": "Permission is a single entity",
       "properties": {
-        "permType": {
-          "$ref": "#/definitions/authpbPermissionType"
-        },
         "key": {
           "type": "string",
           "format": "byte"
+        },
+        "permType": {
+          "$ref": "#/definitions/authpbPermissionType"
         },
         "range_end": {
           "type": "string",
           "format": "byte"
         }
-      },
-      "title": "Permission is a single entity"
+      }
     },
     "authpbPermissionType": {
       "type": "string",
+      "default": "READ",
       "enum": [
         "READ",
         "WRITE",
         "READWRITE"
-      ],
-      "default": "READ"
+      ]
     },
     "etcdserverpbAlarmMember": {
       "type": "object",
       "properties": {
-        "memberID": {
-          "type": "string",
-          "format": "uint64",
-          "description": "memberID is the ID of the member associated with the raised alarm."
-        },
         "alarm": {
-          "$ref": "#/definitions/etcdserverpbAlarmType",
-          "description": "alarm is the type of alarm which has been raised."
+          "description": "alarm is the type of alarm which has been raised.",
+          "$ref": "#/definitions/etcdserverpbAlarmType"
+        },
+        "memberID": {
+          "description": "memberID is the ID of the member associated with the raised alarm.",
+          "type": "string",
+          "format": "uint64"
         }
       }
     },
@@ -1074,42 +1074,42 @@
       "type": "object",
       "properties": {
         "action": {
-          "$ref": "#/definitions/AlarmRequestAlarmAction",
-          "description": "action is the kind of alarm request to issue. The action\nmay GET alarm statuses, ACTIVATE an alarm, or DEACTIVATE a\nraised alarm."
-        },
-        "memberID": {
-          "type": "string",
-          "format": "uint64",
-          "description": "memberID is the ID of the member associated with the alarm. If memberID is 0, the\nalarm request covers all members."
+          "description": "action is the kind of alarm request to issue. The action\nmay GET alarm statuses, ACTIVATE an alarm, or DEACTIVATE a\nraised alarm.",
+          "$ref": "#/definitions/AlarmRequestAlarmAction"
         },
         "alarm": {
-          "$ref": "#/definitions/etcdserverpbAlarmType",
-          "description": "alarm is the type of alarm to consider for this request."
+          "description": "alarm is the type of alarm to consider for this request.",
+          "$ref": "#/definitions/etcdserverpbAlarmType"
+        },
+        "memberID": {
+          "description": "memberID is the ID of the member associated with the alarm. If memberID is 0, the\nalarm request covers all members.",
+          "type": "string",
+          "format": "uint64"
         }
       }
     },
     "etcdserverpbAlarmResponse": {
       "type": "object",
       "properties": {
-        "header": {
-          "$ref": "#/definitions/etcdserverpbResponseHeader"
-        },
         "alarms": {
+          "description": "alarms is a list of alarms associated with the alarm request.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/etcdserverpbAlarmMember"
-          },
-          "description": "alarms is a list of alarms associated with the alarm request."
+          }
+        },
+        "header": {
+          "$ref": "#/definitions/etcdserverpbResponseHeader"
         }
       }
     },
     "etcdserverpbAlarmType": {
       "type": "string",
+      "default": "NONE",
       "enum": [
         "NONE",
         "NOSPACE"
-      ],
-      "default": "NONE"
+      ]
     },
     "etcdserverpbAuthDisableRequest": {
       "type": "object"
@@ -1137,8 +1137,8 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "description": "name is the name of the role to add to the authentication system."
+          "description": "name is the name of the role to add to the authentication system.",
+          "type": "string"
         }
       }
     },
@@ -1192,12 +1192,12 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "description": "name is the name of the role which will be granted the permission."
+          "description": "name is the name of the role which will be granted the permission.",
+          "type": "string"
         },
         "perm": {
-          "$ref": "#/definitions/authpbPermission",
-          "description": "perm is the permission to grant to the role."
+          "description": "perm is the permission to grant to the role.",
+          "$ref": "#/definitions/authpbPermission"
         }
       }
     },
@@ -1229,13 +1229,13 @@
     "etcdserverpbAuthRoleRevokePermissionRequest": {
       "type": "object",
       "properties": {
-        "role": {
-          "type": "string"
-        },
         "key": {
           "type": "string"
         },
         "range_end": {
+          "type": "string"
+        },
+        "role": {
           "type": "string"
         }
       }
@@ -1271,12 +1271,12 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "description": "name is the name of the user whose password is being changed."
+          "description": "name is the name of the user whose password is being changed.",
+          "type": "string"
         },
         "password": {
-          "type": "string",
-          "description": "password is the new password for the user."
+          "description": "password is the new password for the user.",
+          "type": "string"
         }
       }
     },
@@ -1292,8 +1292,8 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string",
-          "description": "name is the name of the user to delete."
+          "description": "name is the name of the user to delete.",
+          "type": "string"
         }
       }
     },
@@ -1330,13 +1330,13 @@
     "etcdserverpbAuthUserGrantRoleRequest": {
       "type": "object",
       "properties": {
-        "user": {
-          "type": "string",
-          "description": "user is the name of the user which should be granted a given role."
-        },
         "role": {
-          "type": "string",
-          "description": "role is the name of the role to grant to the user."
+          "description": "role is the name of the role to grant to the user.",
+          "type": "string"
+        },
+        "user": {
+          "description": "user is the name of the user which should be granted a given role.",
+          "type": "string"
         }
       }
     },
@@ -1408,20 +1408,20 @@
       }
     },
     "etcdserverpbCompactionRequest": {
+      "description": "CompactionRequest compacts the key-value store up to a given revision. All superseded keys\nwith a revision less than the compaction revision will be removed.",
       "type": "object",
       "properties": {
-        "revision": {
-          "type": "string",
-          "format": "int64",
-          "description": "revision is the key-value store revision for the compaction operation."
-        },
         "physical": {
+          "description": "physical is set so the RPC will wait until the compaction is physically\napplied to the local database such that compacted entries are totally\nremoved from the backend database.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "physical is set so the RPC will wait until the compaction is physically\napplied to the local database such that compacted entries are totally\nremoved from the backend database."
+          "format": "boolean"
+        },
+        "revision": {
+          "description": "revision is the key-value store revision for the compaction operation.",
+          "type": "string",
+          "format": "int64"
         }
-      },
-      "description": "CompactionRequest compacts the key-value store up to a given revision. All superseded keys\nwith a revision less than the compaction revision will be removed."
+      }
     },
     "etcdserverpbCompactionResponse": {
       "type": "object",
@@ -1434,38 +1434,38 @@
     "etcdserverpbCompare": {
       "type": "object",
       "properties": {
-        "result": {
-          "$ref": "#/definitions/CompareCompareResult",
-          "description": "result is logical comparison operation for this comparison."
-        },
-        "target": {
-          "$ref": "#/definitions/CompareCompareTarget",
-          "description": "target is the key-value field to inspect for the comparison."
-        },
-        "key": {
-          "type": "string",
-          "format": "byte",
-          "description": "key is the subject key for the comparison operation."
-        },
-        "version": {
-          "type": "string",
-          "format": "int64",
-          "title": "version is the version of the given key"
-        },
         "create_revision": {
           "type": "string",
           "format": "int64",
           "title": "create_revision is the creation revision of the given key"
         },
-        "mod_revision": {
+        "key": {
+          "description": "key is the subject key for the comparison operation.",
           "type": "string",
-          "format": "int64",
-          "description": "mod_revision is the last modified revision of the given key."
+          "format": "byte"
+        },
+        "mod_revision": {
+          "description": "mod_revision is the last modified revision of the given key.",
+          "type": "string",
+          "format": "int64"
+        },
+        "result": {
+          "description": "result is logical comparison operation for this comparison.",
+          "$ref": "#/definitions/CompareCompareResult"
+        },
+        "target": {
+          "description": "target is the key-value field to inspect for the comparison.",
+          "$ref": "#/definitions/CompareCompareTarget"
         },
         "value": {
+          "description": "value is the value of the given key, in bytes.",
           "type": "string",
-          "format": "byte",
-          "description": "value is the value of the given key, in bytes."
+          "format": "byte"
+        },
+        "version": {
+          "type": "string",
+          "format": "int64",
+          "title": "version is the version of the given key"
         }
       }
     },
@@ -1484,39 +1484,39 @@
       "type": "object",
       "properties": {
         "key": {
+          "description": "key is the first key to delete in the range.",
           "type": "string",
-          "format": "byte",
-          "description": "key is the first key to delete in the range."
-        },
-        "range_end": {
-          "type": "string",
-          "format": "byte",
-          "description": "range_end is the key following the last key to delete for the range [key, range_end).\nIf range_end is not given, the range is defined to contain only the key argument.\nIf range_end is one bit larger than the given key, then the range is all the keys\nwith the prefix (the given key).\nIf range_end is '\\0', the range is all keys greater than or equal to the key argument."
+          "format": "byte"
         },
         "prev_kv": {
+          "description": "If prev_kv is set, etcd gets the previous key-value pairs before deleting it.\nThe previous key-value pairs will be returned in the delete response.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "If prev_kv is set, etcd gets the previous key-value pairs before deleting it.\nThe previous key-value pairs will be returned in the delete response."
+          "format": "boolean"
+        },
+        "range_end": {
+          "description": "range_end is the key following the last key to delete for the range [key, range_end).\nIf range_end is not given, the range is defined to contain only the key argument.\nIf range_end is one bit larger than the given key, then the range is all the keys\nwith the prefix (the given key).\nIf range_end is '\\0', the range is all keys greater than or equal to the key argument.",
+          "type": "string",
+          "format": "byte"
         }
       }
     },
     "etcdserverpbDeleteRangeResponse": {
       "type": "object",
       "properties": {
+        "deleted": {
+          "description": "deleted is the number of keys deleted by the delete range request.",
+          "type": "string",
+          "format": "int64"
+        },
         "header": {
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
-        "deleted": {
-          "type": "string",
-          "format": "int64",
-          "description": "deleted is the number of keys deleted by the delete range request."
-        },
         "prev_kvs": {
+          "description": "if prev_kv is set in the request, the previous key-value pairs will be returned.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/mvccpbKeyValue"
-          },
-          "description": "if prev_kv is set in the request, the previous key-value pairs will be returned."
+          }
         }
       }
     },
@@ -1526,49 +1526,49 @@
     "etcdserverpbHashResponse": {
       "type": "object",
       "properties": {
+        "hash": {
+          "description": "hash is the hash value computed from the responding member's key-value store.",
+          "type": "integer",
+          "format": "int64"
+        },
         "header": {
           "$ref": "#/definitions/etcdserverpbResponseHeader"
-        },
-        "hash": {
-          "type": "integer",
-          "format": "int64",
-          "description": "hash is the hash value computed from the responding member's key-value store."
         }
       }
     },
     "etcdserverpbLeaseGrantRequest": {
       "type": "object",
       "properties": {
-        "TTL": {
-          "type": "string",
-          "format": "int64",
-          "description": "TTL is the advisory time-to-live in seconds."
-        },
         "ID": {
+          "description": "ID is the requested ID for the lease. If ID is set to 0, the lessor chooses an ID.",
           "type": "string",
-          "format": "int64",
-          "description": "ID is the requested ID for the lease. If ID is set to 0, the lessor chooses an ID."
+          "format": "int64"
+        },
+        "TTL": {
+          "description": "TTL is the advisory time-to-live in seconds.",
+          "type": "string",
+          "format": "int64"
         }
       }
     },
     "etcdserverpbLeaseGrantResponse": {
       "type": "object",
       "properties": {
-        "header": {
-          "$ref": "#/definitions/etcdserverpbResponseHeader"
-        },
         "ID": {
+          "description": "ID is the lease ID for the granted lease.",
           "type": "string",
-          "format": "int64",
-          "description": "ID is the lease ID for the granted lease."
+          "format": "int64"
         },
         "TTL": {
+          "description": "TTL is the server chosen lease time-to-live in seconds.",
           "type": "string",
-          "format": "int64",
-          "description": "TTL is the server chosen lease time-to-live in seconds."
+          "format": "int64"
         },
         "error": {
           "type": "string"
+        },
+        "header": {
+          "$ref": "#/definitions/etcdserverpbResponseHeader"
         }
       }
     },
@@ -1576,27 +1576,27 @@
       "type": "object",
       "properties": {
         "ID": {
+          "description": "ID is the lease ID for the lease to keep alive.",
           "type": "string",
-          "format": "int64",
-          "description": "ID is the lease ID for the lease to keep alive."
+          "format": "int64"
         }
       }
     },
     "etcdserverpbLeaseKeepAliveResponse": {
       "type": "object",
       "properties": {
-        "header": {
-          "$ref": "#/definitions/etcdserverpbResponseHeader"
-        },
         "ID": {
+          "description": "ID is the lease ID from the keep alive request.",
           "type": "string",
-          "format": "int64",
-          "description": "ID is the lease ID from the keep alive request."
+          "format": "int64"
         },
         "TTL": {
+          "description": "TTL is the new time-to-live for the lease.",
           "type": "string",
-          "format": "int64",
-          "description": "TTL is the new time-to-live for the lease."
+          "format": "int64"
+        },
+        "header": {
+          "$ref": "#/definitions/etcdserverpbResponseHeader"
         }
       }
     },
@@ -1604,9 +1604,9 @@
       "type": "object",
       "properties": {
         "ID": {
+          "description": "ID is the lease ID to revoke. When the ID is revoked, all associated keys will be deleted.",
           "type": "string",
-          "format": "int64",
-          "description": "ID is the lease ID to revoke. When the ID is revoked, all associated keys will be deleted."
+          "format": "int64"
         }
       }
     },
@@ -1622,45 +1622,45 @@
       "type": "object",
       "properties": {
         "ID": {
+          "description": "ID is the lease ID for the lease.",
           "type": "string",
-          "format": "int64",
-          "description": "ID is the lease ID for the lease."
+          "format": "int64"
         },
         "keys": {
+          "description": "keys is true to query all the keys attached to this lease.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "keys is true to query all the keys attached to this lease."
+          "format": "boolean"
         }
       }
     },
     "etcdserverpbLeaseTimeToLiveResponse": {
       "type": "object",
       "properties": {
+        "ID": {
+          "description": "ID is the lease ID from the keep alive request.",
+          "type": "string",
+          "format": "int64"
+        },
+        "TTL": {
+          "description": "TTL is the remaining TTL in seconds for the lease; the lease will expire in under TTL+1 seconds.",
+          "type": "string",
+          "format": "int64"
+        },
+        "grantedTTL": {
+          "description": "GrantedTTL is the initial granted time in seconds upon lease creation/renewal.",
+          "type": "string",
+          "format": "int64"
+        },
         "header": {
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
-        "ID": {
-          "type": "string",
-          "format": "int64",
-          "description": "ID is the lease ID from the keep alive request."
-        },
-        "TTL": {
-          "type": "string",
-          "format": "int64",
-          "description": "TTL is the remaining TTL in seconds for the lease; the lease will expire in under TTL+1 seconds."
-        },
-        "grantedTTL": {
-          "type": "string",
-          "format": "int64",
-          "description": "GrantedTTL is the initial granted time in seconds upon lease creation/renewal."
-        },
         "keys": {
+          "description": "Keys is the list of keys attached to this lease.",
           "type": "array",
           "items": {
             "type": "string",
             "format": "byte"
-          },
-          "description": "Keys is the list of keys attached to this lease."
+          }
         }
       }
     },
@@ -1668,27 +1668,27 @@
       "type": "object",
       "properties": {
         "ID": {
+          "description": "ID is the member ID for this member.",
           "type": "string",
-          "format": "uint64",
-          "description": "ID is the member ID for this member."
-        },
-        "name": {
-          "type": "string",
-          "description": "name is the human-readable name of the member. If the member is not started, the name will be an empty string."
-        },
-        "peerURLs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "peerURLs is the list of URLs the member exposes to the cluster for communication."
+          "format": "uint64"
         },
         "clientURLs": {
+          "description": "clientURLs is the list of URLs the member exposes to clients for communication. If the member is not started, clientURLs will be empty.",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "clientURLs is the list of URLs the member exposes to clients for communication. If the member is not started, clientURLs will be empty."
+          }
+        },
+        "name": {
+          "description": "name is the human-readable name of the member. If the member is not started, the name will be an empty string.",
+          "type": "string"
+        },
+        "peerURLs": {
+          "description": "peerURLs is the list of URLs the member exposes to the cluster for communication.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1696,11 +1696,11 @@
       "type": "object",
       "properties": {
         "peerURLs": {
+          "description": "peerURLs is the list of URLs the added member will use to communicate with the cluster.",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "peerURLs is the list of URLs the added member will use to communicate with the cluster."
+          }
         }
       }
     },
@@ -1711,15 +1711,15 @@
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
         "member": {
-          "$ref": "#/definitions/etcdserverpbMember",
-          "description": "member is the member information for the added member."
+          "description": "member is the member information for the added member.",
+          "$ref": "#/definitions/etcdserverpbMember"
         },
         "members": {
+          "description": "members is a list of all members after adding the new member.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/etcdserverpbMember"
-          },
-          "description": "members is a list of all members after adding the new member."
+          }
         }
       }
     },
@@ -1733,11 +1733,11 @@
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
         "members": {
+          "description": "members is a list of all members associated with the cluster.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/etcdserverpbMember"
-          },
-          "description": "members is a list of all members associated with the cluster."
+          }
         }
       }
     },
@@ -1745,9 +1745,9 @@
       "type": "object",
       "properties": {
         "ID": {
+          "description": "ID is the member ID of the member to remove.",
           "type": "string",
-          "format": "uint64",
-          "description": "ID is the member ID of the member to remove."
+          "format": "uint64"
         }
       }
     },
@@ -1758,11 +1758,11 @@
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
         "members": {
+          "description": "members is a list of all members after removing the member.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/etcdserverpbMember"
-          },
-          "description": "members is a list of all members after removing the member."
+          }
         }
       }
     },
@@ -1770,16 +1770,16 @@
       "type": "object",
       "properties": {
         "ID": {
+          "description": "ID is the member ID of the member to update.",
           "type": "string",
-          "format": "uint64",
-          "description": "ID is the member ID of the member to update."
+          "format": "uint64"
         },
         "peerURLs": {
+          "description": "peerURLs is the new list of URLs the member will use to communicate with the cluster.",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "peerURLs is the new list of URLs the member will use to communicate with the cluster."
+          }
         }
       }
     },
@@ -1790,46 +1790,46 @@
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
         "members": {
+          "description": "members is a list of all members after updating the member.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/etcdserverpbMember"
-          },
-          "description": "members is a list of all members after updating the member."
+          }
         }
       }
     },
     "etcdserverpbPutRequest": {
       "type": "object",
       "properties": {
-        "key": {
-          "type": "string",
-          "format": "byte",
-          "description": "key is the key, in bytes, to put into the key-value store."
-        },
-        "value": {
-          "type": "string",
-          "format": "byte",
-          "description": "value is the value, in bytes, to associate with the key in the key-value store."
-        },
-        "lease": {
-          "type": "string",
-          "format": "int64",
-          "description": "lease is the lease ID to associate with the key in the key-value store. A lease\nvalue of 0 indicates no lease."
-        },
-        "prev_kv": {
+        "ignore_lease": {
+          "description": "If ignore_lease is set, etcd updates the key using its current lease.\nReturns an error if the key does not exist.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "If prev_kv is set, etcd gets the previous key-value pair before changing it.\nThe previous key-value pair will be returned in the put response."
+          "format": "boolean"
         },
         "ignore_value": {
+          "description": "If ignore_value is set, etcd updates the key using its current value.\nReturns an error if the key does not exist.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "If ignore_value is set, etcd updates the key using its current value.\nReturns an error if the key does not exist."
+          "format": "boolean"
         },
-        "ignore_lease": {
+        "key": {
+          "description": "key is the key, in bytes, to put into the key-value store.",
+          "type": "string",
+          "format": "byte"
+        },
+        "lease": {
+          "description": "lease is the lease ID to associate with the key in the key-value store. A lease\nvalue of 0 indicates no lease.",
+          "type": "string",
+          "format": "int64"
+        },
+        "prev_kv": {
+          "description": "If prev_kv is set, etcd gets the previous key-value pair before changing it.\nThe previous key-value pair will be returned in the put response.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "If ignore_lease is set, etcd updates the key using its current lease.\nReturns an error if the key does not exist."
+          "format": "boolean"
+        },
+        "value": {
+          "description": "value is the value, in bytes, to associate with the key in the key-value store.",
+          "type": "string",
+          "format": "byte"
         }
       }
     },
@@ -1840,115 +1840,115 @@
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
         "prev_kv": {
-          "$ref": "#/definitions/mvccpbKeyValue",
-          "description": "if prev_kv is set in the request, the previous key-value pair will be returned."
+          "description": "if prev_kv is set in the request, the previous key-value pair will be returned.",
+          "$ref": "#/definitions/mvccpbKeyValue"
         }
       }
     },
     "etcdserverpbRangeRequest": {
       "type": "object",
       "properties": {
-        "key": {
-          "type": "string",
-          "format": "byte",
-          "description": "key is the first key for the range. If range_end is not given, the request only looks up key."
-        },
-        "range_end": {
-          "type": "string",
-          "format": "byte",
-          "description": "range_end is the upper bound on the requested range [key, range_end).\nIf range_end is '\\0', the range is all keys \u003e= key.\nIf range_end is key plus one (e.g., \"aa\"+1 == \"ab\", \"a\\xff\"+1 == \"b\"),\nthen the range request gets all keys prefixed with key.\nIf both key and range_end are '\\0', then the range request returns all keys."
-        },
-        "limit": {
-          "type": "string",
-          "format": "int64",
-          "description": "limit is a limit on the number of keys returned for the request. When limit is set to 0,\nit is treated as no limit."
-        },
-        "revision": {
-          "type": "string",
-          "format": "int64",
-          "description": "revision is the point-in-time of the key-value store to use for the range.\nIf revision is less or equal to zero, the range is over the newest key-value store.\nIf the revision has been compacted, ErrCompacted is returned as a response."
-        },
-        "sort_order": {
-          "$ref": "#/definitions/RangeRequestSortOrder",
-          "description": "sort_order is the order for returned sorted results."
-        },
-        "sort_target": {
-          "$ref": "#/definitions/RangeRequestSortTarget",
-          "description": "sort_target is the key-value field to use for sorting."
-        },
-        "serializable": {
+        "count_only": {
+          "description": "count_only when set returns only the count of the keys in the range.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "serializable sets the range request to use serializable member-local reads.\nRange requests are linearizable by default; linearizable requests have higher\nlatency and lower throughput than serializable requests but reflect the current\nconsensus of the cluster. For better performance, in exchange for possible stale reads,\na serializable range request is served locally without needing to reach consensus\nwith other nodes in the cluster."
+          "format": "boolean"
+        },
+        "key": {
+          "description": "key is the first key for the range. If range_end is not given, the request only looks up key.",
+          "type": "string",
+          "format": "byte"
         },
         "keys_only": {
+          "description": "keys_only when set returns only the keys and not the values.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "keys_only when set returns only the keys and not the values."
+          "format": "boolean"
         },
-        "count_only": {
-          "type": "boolean",
-          "format": "boolean",
-          "description": "count_only when set returns only the count of the keys in the range."
-        },
-        "min_mod_revision": {
+        "limit": {
+          "description": "limit is a limit on the number of keys returned for the request. When limit is set to 0,\nit is treated as no limit.",
           "type": "string",
-          "format": "int64",
-          "description": "min_mod_revision is the lower bound for returned key mod revisions; all keys with\nlesser mod revisions will be filtered away."
-        },
-        "max_mod_revision": {
-          "type": "string",
-          "format": "int64",
-          "description": "max_mod_revision is the upper bound for returned key mod revisions; all keys with\ngreater mod revisions will be filtered away."
-        },
-        "min_create_revision": {
-          "type": "string",
-          "format": "int64",
-          "description": "min_create_revision is the lower bound for returned key create revisions; all keys with\nlesser create trevisions will be filtered away."
+          "format": "int64"
         },
         "max_create_revision": {
+          "description": "max_create_revision is the upper bound for returned key create revisions; all keys with\ngreater create revisions will be filtered away.",
           "type": "string",
-          "format": "int64",
-          "description": "max_create_revision is the upper bound for returned key create revisions; all keys with\ngreater create revisions will be filtered away."
+          "format": "int64"
+        },
+        "max_mod_revision": {
+          "description": "max_mod_revision is the upper bound for returned key mod revisions; all keys with\ngreater mod revisions will be filtered away.",
+          "type": "string",
+          "format": "int64"
+        },
+        "min_create_revision": {
+          "description": "min_create_revision is the lower bound for returned key create revisions; all keys with\nlesser create trevisions will be filtered away.",
+          "type": "string",
+          "format": "int64"
+        },
+        "min_mod_revision": {
+          "description": "min_mod_revision is the lower bound for returned key mod revisions; all keys with\nlesser mod revisions will be filtered away.",
+          "type": "string",
+          "format": "int64"
+        },
+        "range_end": {
+          "description": "range_end is the upper bound on the requested range [key, range_end).\nIf range_end is '\\0', the range is all keys \u003e= key.\nIf range_end is key plus one (e.g., \"aa\"+1 == \"ab\", \"a\\xff\"+1 == \"b\"),\nthen the range request gets all keys prefixed with key.\nIf both key and range_end are '\\0', then the range request returns all keys.",
+          "type": "string",
+          "format": "byte"
+        },
+        "revision": {
+          "description": "revision is the point-in-time of the key-value store to use for the range.\nIf revision is less or equal to zero, the range is over the newest key-value store.\nIf the revision has been compacted, ErrCompacted is returned as a response.",
+          "type": "string",
+          "format": "int64"
+        },
+        "serializable": {
+          "description": "serializable sets the range request to use serializable member-local reads.\nRange requests are linearizable by default; linearizable requests have higher\nlatency and lower throughput than serializable requests but reflect the current\nconsensus of the cluster. For better performance, in exchange for possible stale reads,\na serializable range request is served locally without needing to reach consensus\nwith other nodes in the cluster.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "sort_order": {
+          "description": "sort_order is the order for returned sorted results.",
+          "$ref": "#/definitions/RangeRequestSortOrder"
+        },
+        "sort_target": {
+          "description": "sort_target is the key-value field to use for sorting.",
+          "$ref": "#/definitions/RangeRequestSortTarget"
         }
       }
     },
     "etcdserverpbRangeResponse": {
       "type": "object",
       "properties": {
+        "count": {
+          "description": "count is set to the number of keys within the range when requested.",
+          "type": "string",
+          "format": "int64"
+        },
         "header": {
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
         "kvs": {
+          "description": "kvs is the list of key-value pairs matched by the range request.\nkvs is empty when count is requested.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/mvccpbKeyValue"
-          },
-          "description": "kvs is the list of key-value pairs matched by the range request.\nkvs is empty when count is requested."
+          }
         },
         "more": {
+          "description": "more indicates if there are more keys to return in the requested range.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "more indicates if there are more keys to return in the requested range."
-        },
-        "count": {
-          "type": "string",
-          "format": "int64",
-          "description": "count is set to the number of keys within the range when requested."
+          "format": "boolean"
         }
       }
     },
     "etcdserverpbRequestOp": {
       "type": "object",
       "properties": {
-        "request_range": {
-          "$ref": "#/definitions/etcdserverpbRangeRequest"
+        "request_delete_range": {
+          "$ref": "#/definitions/etcdserverpbDeleteRangeRequest"
         },
         "request_put": {
           "$ref": "#/definitions/etcdserverpbPutRequest"
         },
-        "request_delete_range": {
-          "$ref": "#/definitions/etcdserverpbDeleteRangeRequest"
+        "request_range": {
+          "$ref": "#/definitions/etcdserverpbRangeRequest"
         }
       }
     },
@@ -1956,38 +1956,38 @@
       "type": "object",
       "properties": {
         "cluster_id": {
+          "description": "cluster_id is the ID of the cluster which sent the response.",
           "type": "string",
-          "format": "uint64",
-          "description": "cluster_id is the ID of the cluster which sent the response."
+          "format": "uint64"
         },
         "member_id": {
+          "description": "member_id is the ID of the member which sent the response.",
           "type": "string",
-          "format": "uint64",
-          "description": "member_id is the ID of the member which sent the response."
-        },
-        "revision": {
-          "type": "string",
-          "format": "int64",
-          "description": "revision is the key-value store revision when the request was applied."
+          "format": "uint64"
         },
         "raft_term": {
+          "description": "raft_term is the raft term when the request was applied.",
           "type": "string",
-          "format": "uint64",
-          "description": "raft_term is the raft term when the request was applied."
+          "format": "uint64"
+        },
+        "revision": {
+          "description": "revision is the key-value store revision when the request was applied.",
+          "type": "string",
+          "format": "int64"
         }
       }
     },
     "etcdserverpbResponseOp": {
       "type": "object",
       "properties": {
-        "response_range": {
-          "$ref": "#/definitions/etcdserverpbRangeResponse"
+        "response_delete_range": {
+          "$ref": "#/definitions/etcdserverpbDeleteRangeResponse"
         },
         "response_put": {
           "$ref": "#/definitions/etcdserverpbPutResponse"
         },
-        "response_delete_range": {
-          "$ref": "#/definitions/etcdserverpbDeleteRangeResponse"
+        "response_range": {
+          "$ref": "#/definitions/etcdserverpbRangeResponse"
         }
       }
     },
@@ -1997,19 +1997,19 @@
     "etcdserverpbSnapshotResponse": {
       "type": "object",
       "properties": {
+        "blob": {
+          "description": "blob contains the next chunk of the snapshot in the snapshot stream.",
+          "type": "string",
+          "format": "byte"
+        },
         "header": {
-          "$ref": "#/definitions/etcdserverpbResponseHeader",
-          "description": "header has the current key-value store information. The first header in the snapshot\nstream indicates the point in time of the snapshot."
+          "description": "header has the current key-value store information. The first header in the snapshot\nstream indicates the point in time of the snapshot.",
+          "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
         "remaining_bytes": {
           "type": "string",
           "format": "uint64",
           "title": "remaining_bytes is the number of blob bytes to be sent after this message"
-        },
-        "blob": {
-          "type": "string",
-          "format": "byte",
-          "description": "blob contains the next chunk of the snapshot in the snapshot stream."
         }
       }
     },
@@ -2019,61 +2019,61 @@
     "etcdserverpbStatusResponse": {
       "type": "object",
       "properties": {
+        "dbSize": {
+          "description": "dbSize is the size of the backend database, in bytes, of the responding member.",
+          "type": "string",
+          "format": "int64"
+        },
         "header": {
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
-        "version": {
-          "type": "string",
-          "description": "version is the cluster protocol version used by the responding member."
-        },
-        "dbSize": {
-          "type": "string",
-          "format": "int64",
-          "description": "dbSize is the size of the backend database, in bytes, of the responding member."
-        },
         "leader": {
+          "description": "leader is the member ID which the responding member believes is the current leader.",
           "type": "string",
-          "format": "uint64",
-          "description": "leader is the member ID which the responding member believes is the current leader."
+          "format": "uint64"
         },
         "raftIndex": {
+          "description": "raftIndex is the current raft index of the responding member.",
           "type": "string",
-          "format": "uint64",
-          "description": "raftIndex is the current raft index of the responding member."
+          "format": "uint64"
         },
         "raftTerm": {
+          "description": "raftTerm is the current raft term of the responding member.",
           "type": "string",
-          "format": "uint64",
-          "description": "raftTerm is the current raft term of the responding member."
+          "format": "uint64"
+        },
+        "version": {
+          "description": "version is the cluster protocol version used by the responding member.",
+          "type": "string"
         }
       }
     },
     "etcdserverpbTxnRequest": {
+      "description": "From google paxosdb paper:\nOur implementation hinges around a powerful primitive which we call MultiOp. All other database\noperations except for iteration are implemented as a single call to MultiOp. A MultiOp is applied atomically\nand consists of three components:\n1. A list of tests called guard. Each test in guard checks a single entry in the database. It may check\nfor the absence or presence of a value, or compare with a given value. Two different tests in the guard\nmay apply to the same or different entries in the database. All tests in the guard are applied and\nMultiOp returns the results. If all tests are true, MultiOp executes t op (see item 2 below), otherwise\nit executes f op (see item 3 below).\n2. A list of database operations called t op. Each operation in the list is either an insert, delete, or\nlookup operation, and applies to a single database entry. Two different operations in the list may apply\nto the same or different entries in the database. These operations are executed\nif guard evaluates to\ntrue.\n3. A list of database operations called f op. Like t op, but executed if guard evaluates to false.",
       "type": "object",
       "properties": {
         "compare": {
+          "description": "compare is a list of predicates representing a conjunction of terms.\nIf the comparisons succeed, then the success requests will be processed in order,\nand the response will contain their respective responses in order.\nIf the comparisons fail, then the failure requests will be processed in order,\nand the response will contain their respective responses in order.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/etcdserverpbCompare"
-          },
-          "description": "compare is a list of predicates representing a conjunction of terms.\nIf the comparisons succeed, then the success requests will be processed in order,\nand the response will contain their respective responses in order.\nIf the comparisons fail, then the failure requests will be processed in order,\nand the response will contain their respective responses in order."
-        },
-        "success": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/etcdserverpbRequestOp"
-          },
-          "description": "success is a list of requests which will be applied when compare evaluates to true."
+          }
         },
         "failure": {
+          "description": "failure is a list of requests which will be applied when compare evaluates to false.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/etcdserverpbRequestOp"
-          },
-          "description": "failure is a list of requests which will be applied when compare evaluates to false."
+          }
+        },
+        "success": {
+          "description": "success is a list of requests which will be applied when compare evaluates to true.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/etcdserverpbRequestOp"
+          }
         }
-      },
-      "description": "From google paxosdb paper:\nOur implementation hinges around a powerful primitive which we call MultiOp. All other database\noperations except for iteration are implemented as a single call to MultiOp. A MultiOp is applied atomically\nand consists of three components:\n1. A list of tests called guard. Each test in guard checks a single entry in the database. It may check\nfor the absence or presence of a value, or compare with a given value. Two different tests in the guard\nmay apply to the same or different entries in the database. All tests in the guard are applied and\nMultiOp returns the results. If all tests are true, MultiOp executes t op (see item 2 below), otherwise\nit executes f op (see item 3 below).\n2. A list of database operations called t op. Each operation in the list is either an insert, delete, or\nlookup operation, and applies to a single database entry. Two different operations in the list may apply\nto the same or different entries in the database. These operations are executed\nif guard evaluates to\ntrue.\n3. A list of database operations called f op. Like t op, but executed if guard evaluates to false."
+      }
     },
     "etcdserverpbTxnResponse": {
       "type": "object",
@@ -2081,17 +2081,17 @@
         "header": {
           "$ref": "#/definitions/etcdserverpbResponseHeader"
         },
-        "succeeded": {
-          "type": "boolean",
-          "format": "boolean",
-          "description": "succeeded is set to true if the compare evaluated to true or false otherwise."
-        },
         "responses": {
+          "description": "responses is a list of responses corresponding to the results from applying\nsuccess if succeeded is true or failure if succeeded is false.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/etcdserverpbResponseOp"
-          },
-          "description": "responses is a list of responses corresponding to the results from applying\nsuccess if succeeded is true or failure if succeeded is false."
+          }
+        },
+        "succeeded": {
+          "description": "succeeded is set to true if the compare evaluated to true or false otherwise.",
+          "type": "boolean",
+          "format": "boolean"
         }
       }
     },
@@ -2099,149 +2099,161 @@
       "type": "object",
       "properties": {
         "watch_id": {
+          "description": "watch_id is the watcher id to cancel so that no more events are transmitted.",
           "type": "string",
-          "format": "int64",
-          "description": "watch_id is the watcher id to cancel so that no more events are transmitted."
+          "format": "int64"
         }
       }
     },
     "etcdserverpbWatchCreateRequest": {
       "type": "object",
       "properties": {
-        "key": {
-          "type": "string",
-          "format": "byte",
-          "description": "key is the key to register for watching."
-        },
-        "range_end": {
-          "type": "string",
-          "format": "byte",
-          "description": "range_end is the end of the range [key, range_end) to watch. If range_end is not given,\nonly the key argument is watched. If range_end is equal to '\\0', all keys greater than\nor equal to the key argument are watched.\nIf the range_end is one bit larger than the given key,\nthen all keys with the prefix (the given key) will be watched."
-        },
-        "start_revision": {
-          "type": "string",
-          "format": "int64",
-          "description": "start_revision is an optional revision to watch from (inclusive). No start_revision is \"now\"."
-        },
-        "progress_notify": {
-          "type": "boolean",
-          "format": "boolean",
-          "description": "progress_notify is set so that the etcd server will periodically send a WatchResponse with\nno events to the new watcher if there are no recent events. It is useful when clients\nwish to recover a disconnected watcher starting from a recent known revision.\nThe etcd server may decide how often it will send notifications based on current load."
-        },
         "filters": {
+          "description": "filters filter the events at server side before it sends back to the watcher.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/WatchCreateRequestFilterType"
-          },
-          "description": "filters filter the events at server side before it sends back to the watcher."
+          }
+        },
+        "key": {
+          "description": "key is the key to register for watching.",
+          "type": "string",
+          "format": "byte"
         },
         "prev_kv": {
+          "description": "If prev_kv is set, created watcher gets the previous KV before the event happens.\nIf the previous KV is already compacted, nothing will be returned.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "If prev_kv is set, created watcher gets the previous KV before the event happens.\nIf the previous KV is already compacted, nothing will be returned."
+          "format": "boolean"
+        },
+        "progress_notify": {
+          "description": "progress_notify is set so that the etcd server will periodically send a WatchResponse with\nno events to the new watcher if there are no recent events. It is useful when clients\nwish to recover a disconnected watcher starting from a recent known revision.\nThe etcd server may decide how often it will send notifications based on current load.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "range_end": {
+          "description": "range_end is the end of the range [key, range_end) to watch. If range_end is not given,\nonly the key argument is watched. If range_end is equal to '\\0', all keys greater than\nor equal to the key argument are watched.\nIf the range_end is one bit larger than the given key,\nthen all keys with the prefix (the given key) will be watched.",
+          "type": "string",
+          "format": "byte"
+        },
+        "start_revision": {
+          "description": "start_revision is an optional revision to watch from (inclusive). No start_revision is \"now\".",
+          "type": "string",
+          "format": "int64"
         }
       }
     },
     "etcdserverpbWatchRequest": {
       "type": "object",
       "properties": {
-        "create_request": {
-          "$ref": "#/definitions/etcdserverpbWatchCreateRequest"
-        },
         "cancel_request": {
           "$ref": "#/definitions/etcdserverpbWatchCancelRequest"
+        },
+        "create_request": {
+          "$ref": "#/definitions/etcdserverpbWatchCreateRequest"
         }
       }
     },
     "etcdserverpbWatchResponse": {
       "type": "object",
       "properties": {
-        "header": {
-          "$ref": "#/definitions/etcdserverpbResponseHeader"
-        },
-        "watch_id": {
-          "type": "string",
-          "format": "int64",
-          "description": "watch_id is the ID of the watcher that corresponds to the response."
-        },
-        "created": {
-          "type": "boolean",
-          "format": "boolean",
-          "description": "created is set to true if the response is for a create watch request.\nThe client should record the watch_id and expect to receive events for\nthe created watcher from the same stream.\nAll events sent to the created watcher will attach with the same watch_id."
+        "cancel_reason": {
+          "description": "cancel_reason indicates the reason for canceling the watcher.",
+          "type": "string"
         },
         "canceled": {
+          "description": "canceled is set to true if the response is for a cancel watch request.\nNo further events will be sent to the canceled watcher.",
           "type": "boolean",
-          "format": "boolean",
-          "description": "canceled is set to true if the response is for a cancel watch request.\nNo further events will be sent to the canceled watcher."
+          "format": "boolean"
         },
         "compact_revision": {
+          "description": "compact_revision is set to the minimum index if a watcher tries to watch\nat a compacted index.\n\nThis happens when creating a watcher at a compacted revision or the watcher cannot\ncatch up with the progress of the key-value store. \n\nThe client should treat the watcher as canceled and should not try to create any\nwatcher with the same start_revision again.",
           "type": "string",
-          "format": "int64",
-          "description": "compact_revision is set to the minimum index if a watcher tries to watch\nat a compacted index.\n\nThis happens when creating a watcher at a compacted revision or the watcher cannot\ncatch up with the progress of the key-value store. \n\nThe client should treat the watcher as canceled and should not try to create any\nwatcher with the same start_revision again."
+          "format": "int64"
         },
-        "cancel_reason": {
-          "type": "string",
-          "description": "cancel_reason indicates the reason for canceling the watcher."
+        "created": {
+          "description": "created is set to true if the response is for a create watch request.\nThe client should record the watch_id and expect to receive events for\nthe created watcher from the same stream.\nAll events sent to the created watcher will attach with the same watch_id.",
+          "type": "boolean",
+          "format": "boolean"
         },
         "events": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/mvccpbEvent"
           }
+        },
+        "header": {
+          "$ref": "#/definitions/etcdserverpbResponseHeader"
+        },
+        "watch_id": {
+          "description": "watch_id is the ID of the watcher that corresponds to the response.",
+          "type": "string",
+          "format": "int64"
         }
       }
     },
     "mvccpbEvent": {
       "type": "object",
       "properties": {
-        "type": {
-          "$ref": "#/definitions/EventEventType",
-          "description": "type is the kind of event. If type is a PUT, it indicates\nnew data has been stored to the key. If type is a DELETE,\nit indicates the key was deleted."
-        },
         "kv": {
-          "$ref": "#/definitions/mvccpbKeyValue",
-          "description": "kv holds the KeyValue for the event.\nA PUT event contains current kv pair.\nA PUT event with kv.Version=1 indicates the creation of a key.\nA DELETE/EXPIRE event contains the deleted key with\nits modification revision set to the revision of deletion."
+          "description": "kv holds the KeyValue for the event.\nA PUT event contains current kv pair.\nA PUT event with kv.Version=1 indicates the creation of a key.\nA DELETE/EXPIRE event contains the deleted key with\nits modification revision set to the revision of deletion.",
+          "$ref": "#/definitions/mvccpbKeyValue"
         },
         "prev_kv": {
-          "$ref": "#/definitions/mvccpbKeyValue",
-          "description": "prev_kv holds the key-value pair before the event happens."
+          "description": "prev_kv holds the key-value pair before the event happens.",
+          "$ref": "#/definitions/mvccpbKeyValue"
+        },
+        "type": {
+          "description": "type is the kind of event. If type is a PUT, it indicates\nnew data has been stored to the key. If type is a DELETE,\nit indicates the key was deleted.",
+          "$ref": "#/definitions/EventEventType"
         }
       }
     },
     "mvccpbKeyValue": {
       "type": "object",
       "properties": {
-        "key": {
-          "type": "string",
-          "format": "byte",
-          "description": "key is the key in bytes. An empty key is not allowed."
-        },
         "create_revision": {
+          "description": "create_revision is the revision of last creation on this key.",
           "type": "string",
-          "format": "int64",
-          "description": "create_revision is the revision of last creation on this key."
+          "format": "int64"
         },
-        "mod_revision": {
+        "key": {
+          "description": "key is the key in bytes. An empty key is not allowed.",
           "type": "string",
-          "format": "int64",
-          "description": "mod_revision is the revision of last modification on this key."
-        },
-        "version": {
-          "type": "string",
-          "format": "int64",
-          "description": "version is the version of the key. A deletion resets\nthe version to zero and any modification of the key\nincreases its version."
-        },
-        "value": {
-          "type": "string",
-          "format": "byte",
-          "description": "value is the value held by the key, in bytes."
+          "format": "byte"
         },
         "lease": {
+          "description": "lease is the ID of the lease that attached to key.\nWhen the attached lease expires, the key will be deleted.\nIf lease is 0, then no lease is attached to the key.",
           "type": "string",
-          "format": "int64",
-          "description": "lease is the ID of the lease that attached to key.\nWhen the attached lease expires, the key will be deleted.\nIf lease is 0, then no lease is attached to the key."
+          "format": "int64"
+        },
+        "mod_revision": {
+          "description": "mod_revision is the revision of last modification on this key.",
+          "type": "string",
+          "format": "int64"
+        },
+        "value": {
+          "description": "value is the value held by the key, in bytes.",
+          "type": "string",
+          "format": "byte"
+        },
+        "version": {
+          "description": "version is the version of the key. A deletion resets\nthe version to zero and any modification of the key\nincreases its version.",
+          "type": "string",
+          "format": "int64"
         }
       }
     }
-  }
+  },
+  "securityDefinitions": {
+    "ApiKey": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  },
+  "security": [
+    {
+      "ApiKey": []
+    }
+  ]
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -1000,8 +1000,12 @@ func (as *authStore) AuthInfoFromCtx(ctx context.Context) (*AuthInfo, error) {
 		return nil, nil
 	}
 
-	ts, tok := md["token"]
-	if !tok {
+	//TODO(mitake|hexfusion) review unifying key names
+	ts, ok := md["token"]
+	if !ok {
+		ts, ok = md["authorization"]
+	}
+	if !ok {
 		return nil, nil
 	}
 
@@ -1011,6 +1015,7 @@ func (as *authStore) AuthInfoFromCtx(ctx context.Context) (*AuthInfo, error) {
 		plog.Warningf("invalid auth token: %s", token)
 		return nil, ErrInvalidAuthToken
 	}
+
 	return authInfo, nil
 }
 

--- a/e2e/v2_curl_test.go
+++ b/e2e/v2_curl_test.go
@@ -127,6 +127,7 @@ type cURLReq struct {
 
 	value    string
 	expected string
+	header   string
 }
 
 // cURLPrefixArgs builds the beginning of a curl command for a given key
@@ -154,6 +155,10 @@ func cURLPrefixArgs(clus *etcdProcessCluster, method string, req cURLReq) []stri
 	}
 	if req.timeout != 0 {
 		cmdArgs = append(cmdArgs, "-m", fmt.Sprintf("%d", req.timeout))
+	}
+
+	if req.header != "" {
+		cmdArgs = append(cmdArgs, "-H", req.header)
 	}
 
 	switch method {

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -18,9 +18,10 @@ fi
 # directories containing protos to be built
 DIRS="./wal/walpb ./etcdserver/etcdserverpb ./snap/snappb ./raft/raftpb ./mvcc/mvccpb ./lease/leasepb ./auth/authpb ./etcdserver/api/v3lock/v3lockpb ./etcdserver/api/v3election/v3electionpb"
 
-# exact version of protoc-gen-gogo to build
+# exact version of packages to build
 GOGO_PROTO_SHA="100ba4e885062801d56799d78530b73b178a78f3"
 GRPC_GATEWAY_SHA="18d159699f2e83fc5bb9ef2f79465ca3f3122676"
+SCHWAG_SHA="b7d0fc9aadaaae3d61aaadfc12e4a2f945514912"
 
 # set up self-contained GOPATH for building
 export GOPATH=${PWD}/gopath.proto
@@ -30,6 +31,7 @@ export PATH="${GOBIN}:${PATH}"
 COREOS_ROOT="${GOPATH}/src/github.com/coreos"
 ETCD_ROOT="${COREOS_ROOT}/etcd"
 GOGOPROTO_ROOT="${GOPATH}/src/github.com/gogo/protobuf"
+SCHWAG_ROOT="${GOPATH}/src/github.com/hexfusion/schwag"
 GOGOPROTO_PATH="${GOGOPROTO_ROOT}:${GOGOPROTO_ROOT}/protobuf"
 GRPC_GATEWAY_ROOT="${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway"
 
@@ -100,6 +102,14 @@ for pb in etcdserverpb/rpc api/v3lock/v3lockpb/v3lock api/v3election/v3electionp
 		Documentation/dev-guide/apispec/swagger/${swaggerName}.swagger.json
 done
 rm -rf Documentation/dev-guide/apispec/swagger/etcdserver/
+
+# append security to swagger spec
+go get -u "github.com/hexfusion/schwag"
+pushd "${SCHWAG_ROOT}"
+	git reset --hard "${SCHWAG_SHA}"
+	go install .
+popd
+schwag -input=Documentation/dev-guide/apispec/swagger/rpc.swagger.json
 
 # install protodoc
 # go get -v -u github.com/coreos/protodoc


### PR DESCRIPTION
The allows native use of grpc-gateway authorization header, providing direct access to metadata context while using intuitive naming.

Fixes #6643