### PR TITLE
rafthttp: configurable stream reader retry timeout

### DIFF
--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -189,6 +189,7 @@ func startPeer(transport *Transport, urls types.URLs, peerID types.ID, fs *stats
 		status: status,
 		recvc:  p.recvc,
 		propc:  p.propc,
+		rl:     rate.NewLimiter(transport.DialRetryFrequency, 1),
 	}
 	p.msgAppReader = &streamReader{
 		peerID: peerID,
@@ -198,12 +199,7 @@ func startPeer(transport *Transport, urls types.URLs, peerID types.ID, fs *stats
 		status: status,
 		recvc:  p.recvc,
 		propc:  p.propc,
-	}
-
-	if transport.DialRetryTimeout != 0 {
-		limit := rate.Every(transport.DialRetryTimeout)
-		p.msgAppV2Reader.rl = rate.NewLimiter(limit, 1)
-		p.msgAppReader.rl = rate.NewLimiter(limit, 1)
+		rl:     rate.NewLimiter(transport.DialRetryFrequency, 1),
 	}
 
 	p.msgAppV2Reader.start()

--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/coreos/etcd/snap"
 	"golang.org/x/net/context"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -198,6 +199,13 @@ func startPeer(transport *Transport, urls types.URLs, peerID types.ID, fs *stats
 		recvc:  p.recvc,
 		propc:  p.propc,
 	}
+
+	if transport.DialRetryTimeout != 0 {
+		limit := rate.Every(transport.DialRetryTimeout)
+		p.msgAppV2Reader.rl = rate.NewLimiter(limit, 1)
+		p.msgAppReader.rl = rate.NewLimiter(limit, 1)
+	}
+
 	p.msgAppV2Reader.start()
 	p.msgAppReader.start()
 

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -246,7 +246,7 @@ func (cw *streamWriter) closeUnlocked() bool {
 		return false
 	}
 	if err := cw.closer.Close(); err != nil {
-		plog.Errorf("Peer %s (writer) connection close error: %v", cw.peerID, err)
+		plog.Errorf("peer %s (writer) connection close error: %v", cw.peerID, err)
 	}
 	if len(cw.msgc) > 0 {
 		cw.r.ReportUnreachable(uint64(cw.peerID))
@@ -501,7 +501,7 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 func (cr *streamReader) close() {
 	if cr.closer != nil {
 		if err := cr.closer.Close(); err != nil {
-			plog.Errorf("Peer %s (reader) connection close error: %v", cr.peerID, err)
+			plog.Errorf("peer %s (reader) connection close error: %v", cr.peerID, err)
 		}
 	}
 	cr.closer = nil

--- a/rafthttp/stream.go
+++ b/rafthttp/stream.go
@@ -299,14 +299,6 @@ func (cr *streamReader) start() {
 	if cr.errorc == nil {
 		cr.errorc = cr.tr.ErrorC
 	}
-
-	if cr.rl == nil {
-		// If client didn't provide rate limiter, use the default which will
-		// wait 100ms to create a new stream, so it doesn't bring too much
-		// overhead when retry.
-		cr.rl = rate.NewLimiter(rate.Every(100*time.Millisecond), 1)
-	}
-
 	go cr.run()
 }
 

--- a/rafthttp/stream_test.go
+++ b/rafthttp/stream_test.go
@@ -15,6 +15,7 @@
 package rafthttp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -115,7 +116,7 @@ func TestStreamReaderDialRequest(t *testing.T) {
 			peerID: types.ID(2),
 			tr:     &Transport{streamRt: tr, ClusterID: types.ID(1), ID: types.ID(1)},
 			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
-			rl:     rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
+			ctx:    context.Background(),
 		}
 		sr.dial(tt)
 
@@ -170,7 +171,7 @@ func TestStreamReaderDialResult(t *testing.T) {
 			tr:     &Transport{streamRt: tr, ClusterID: types.ID(1)},
 			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
 			errorc: make(chan error, 1),
-			rl:     rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
+			ctx:    context.Background(),
 		}
 
 		_, err := sr.dial(streamTypeMessage)
@@ -251,7 +252,7 @@ func TestStreamReaderDialDetectUnsupport(t *testing.T) {
 			peerID: types.ID(2),
 			tr:     &Transport{streamRt: tr, ClusterID: types.ID(1)},
 			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
-			rl:     rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
+			ctx:    context.Background(),
 		}
 
 		_, err := sr.dial(typ)

--- a/rafthttp/stream_test.go
+++ b/rafthttp/stream_test.go
@@ -317,6 +317,7 @@ func TestStream(t *testing.T) {
 			status: newPeerStatus(types.ID(2)),
 			recvc:  recvc,
 			propc:  propc,
+			rl:     rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
 		}
 		sr.start()
 

--- a/rafthttp/stream_test.go
+++ b/rafthttp/stream_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/coreos/etcd/etcdserver/stats"
 	"github.com/coreos/etcd/pkg/testutil"
 	"github.com/coreos/etcd/pkg/types"
@@ -113,6 +115,7 @@ func TestStreamReaderDialRequest(t *testing.T) {
 			peerID: types.ID(2),
 			tr:     &Transport{streamRt: tr, ClusterID: types.ID(1), ID: types.ID(1)},
 			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
+			rl:     rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
 		}
 		sr.dial(tt)
 
@@ -167,6 +170,7 @@ func TestStreamReaderDialResult(t *testing.T) {
 			tr:     &Transport{streamRt: tr, ClusterID: types.ID(1)},
 			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
 			errorc: make(chan error, 1),
+			rl:     rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
 		}
 
 		_, err := sr.dial(streamTypeMessage)
@@ -192,6 +196,7 @@ func TestStreamReaderStopOnDial(t *testing.T) {
 		errorc: make(chan error, 1),
 		typ:    streamTypeMessage,
 		status: newPeerStatus(types.ID(2)),
+		rl:     rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
 	}
 	tr.onResp = func() {
 		// stop() waits for the run() goroutine to exit, but that exit
@@ -246,6 +251,7 @@ func TestStreamReaderDialDetectUnsupport(t *testing.T) {
 			peerID: types.ID(2),
 			tr:     &Transport{streamRt: tr, ClusterID: types.ID(1)},
 			picker: mustNewURLPicker(t, []string{"http://localhost:2380"}),
+			rl:     rate.NewLimiter(rate.Every(100*time.Millisecond), 1),
 		}
 
 		_, err := sr.dial(typ)

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -94,8 +94,10 @@ type Transporter interface {
 // User needs to call Start before calling other functions, and call
 // Stop when the Transport is no longer used.
 type Transport struct {
-	DialTimeout time.Duration     // maximum duration before timing out dial of the request
-	TLSInfo     transport.TLSInfo // TLS information used when creating connection
+	DialTimeout      time.Duration // maximum duration before timing out dial of the request
+	DialRetryTimeout time.Duration // alters the frequency of streamReader dial retrial attempts
+
+	TLSInfo transport.TLSInfo // TLS information used when creating connection
 
 	ID          types.ID   // local member ID
 	URLs        types.URLs // local peer URLs

--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/xiang90/probing"
 	"golang.org/x/net/context"
+	"golang.org/x/time/rate"
 )
 
 var plog = logutil.NewMergeLogger(capnslog.NewPackageLogger("github.com/coreos/etcd", "rafthttp"))
@@ -94,8 +95,10 @@ type Transporter interface {
 // User needs to call Start before calling other functions, and call
 // Stop when the Transport is no longer used.
 type Transport struct {
-	DialTimeout      time.Duration // maximum duration before timing out dial of the request
-	DialRetryTimeout time.Duration // alters the frequency of streamReader dial retrial attempts
+	DialTimeout time.Duration // maximum duration before timing out dial of the request
+	// DialRetryFrequency defines the frequency of streamReader dial retrial attempts;
+	// a distinct rate limiter is created per every peer (default value: 10 events/sec)
+	DialRetryFrequency rate.Limit
 
 	TLSInfo transport.TLSInfo // TLS information used when creating connection
 
@@ -137,6 +140,13 @@ func (t *Transport) Start() error {
 	t.remotes = make(map[types.ID]*remote)
 	t.peers = make(map[types.ID]Peer)
 	t.prober = probing.NewProber(t.pipelineRt)
+
+	// If client didn't provide dial retry frequence, use the default
+	// (100ms backoff between attempts to create a new stream),
+	// so it doesn't bring too much overhead when retry.
+	if t.DialRetryFrequency == 0 {
+		t.DialRetryFrequency = rate.Every(100 * time.Millisecond)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Please consider this small improvement: ```rafthttp.streamReader``` dial timeout was hardcoded to 100ms which may be too frequent for some use-cases of ```rafthttp``` library. I would like to have this setting configurable.
