### PR TITLE
clientv3: do not launch cluster on go test without explicit -run

### DIFF
--- a/clientv3/main_test.go
+++ b/clientv3/main_test.go
@@ -32,14 +32,20 @@ func init() { auth.BcryptCost = bcrypt.MinCost }
 
 // TestMain sets up an etcd cluster if running the examples.
 func TestMain(m *testing.M) {
-	useCluster := true // default to running all tests
+	useCluster, hasRunArg := false, false // default to running only Test*
 	for _, arg := range os.Args {
 		if strings.HasPrefix(arg, "-test.run=") {
 			exp := strings.Split(arg, "=")[1]
 			match, err := regexp.MatchString(exp, "Example")
 			useCluster = (err == nil && match) || strings.Contains(exp, "Example")
+			hasRunArg = true
 			break
 		}
+	}
+	if !hasRunArg {
+		// force only running Test* if no args given to avoid leak false
+		// positives from having a long-running cluster for the examples.
+		os.Args = append(os.Args, "-test.run=Test")
 	}
 
 	v := 0


### PR DESCRIPTION
There's a workaround by running -run=Test but this periodically
comes up as an issue, so have `go test` only run Test* to stem
the complaints.

Fixes #8000