### PR TITLE
clientv3: use Endpoints[0] to initialize grpc creds

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -322,7 +322,7 @@ func (c *Client) dial(endpoint string, dopts ...grpc.DialOption) (*grpc.ClientCo
 
 	opts = append(opts, c.cfg.DialOptions...)
 
-	conn, err := grpc.Dial(host, opts...)
+	conn, err := grpc.DialContext(c.ctx, host, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +367,9 @@ func newClient(cfg *Config) (*Client, error) {
 	}
 
 	client.balancer = newSimpleBalancer(cfg.Endpoints)
-	conn, err := client.dial("", grpc.WithBalancer(client.balancer))
+	// use Endpoints[0] so that for https:// without any tls config given, then
+	// grpc will assume the ServerName is in the endpoint.
+	conn, err := client.dial(cfg.Endpoints[0], grpc.WithBalancer(client.balancer))
 	if err != nil {
 		client.cancel()
 		client.balancer.Close()

--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -182,7 +182,7 @@ func parseEndpoint(endpoint string) (proto string, host string, scheme string) {
 	host = url.Host
 	switch url.Scheme {
 	case "http", "https":
-	case "unix":
+	case "unix", "unixs":
 		proto = "unix"
 		host = url.Host + url.Path
 	default:
@@ -197,7 +197,7 @@ func (c *Client) processCreds(scheme string) (creds *credentials.TransportCreden
 	case "unix":
 	case "http":
 		creds = nil
-	case "https":
+	case "https", "unixs":
 		if creds != nil {
 			break
 		}

--- a/clientv3/integration/dial_test.go
+++ b/clientv3/integration/dial_test.go
@@ -66,6 +66,22 @@ func TestDialTLSExpired(t *testing.T) {
 	}
 }
 
+// TestDialTLSNoConfig ensures the client fails to dial / times out
+// when TLS endpoints (https, unixs) are given but no tls config.
+func TestDialTLSNoConfig(t *testing.T) {
+	defer testutil.AfterTest(t)
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1, ClientTLS: &testTLSInfo})
+	defer clus.Terminate(t)
+	// expect 'signed by unknown authority'
+	_, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{clus.Members[0].GRPCAddr()},
+		DialTimeout: time.Second,
+	})
+	if err != grpc.ErrClientConnTimeout {
+		t.Fatalf("expected %v, got %v", grpc.ErrClientConnTimeout, err)
+	}
+}
+
 // TestDialSetEndpoints ensures SetEndpoints can replace unavailable endpoints with available ones.
 func TestDialSetEndpointsBeforeFail(t *testing.T) {
 	testDialSetEndpoints(t, true)

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -569,7 +569,7 @@ func (m *member) listenGRPC() error {
 		l.Close()
 		return err
 	}
-	m.grpcAddr = m.grpcBridge.URL()
+	m.grpcAddr = schemeFromTLSInfo(m.ClientTLSInfo) + "://" + m.grpcBridge.inaddr
 	m.grpcListener = l
 	return nil
 }


### PR DESCRIPTION
Dialing out without specifying TLS creds but giving https uses some
default behavior that depends on passing an endpoint with https to
Dial(), so it's not enough to completely rely on the balancer to supply
endpoints.

Fixes #8008