### PR TITLE
e2e: make CtlV2GetRoleUser non-quorum

### DIFF
--- a/e2e/ctl_v2_test.go
+++ b/e2e/ctl_v2_test.go
@@ -163,7 +163,7 @@ func TestCtlV2GetRoleUserWithProxy(t *testing.T) { testCtlV2GetRoleUser(t, &conf
 func testCtlV2GetRoleUser(t *testing.T, cfg *etcdProcessClusterConfig) {
 	defer testutil.AfterTest(t)
 
-	epc := setupEtcdctlTest(t, cfg, true)
+	epc := setupEtcdctlTest(t, cfg, false)
 	defer func() {
 		if err := epc.Close(); err != nil {
 			t.Fatalf("error closing etcd processes (%v)", err)


### PR DESCRIPTION
GetUser doesn't go through quorum, so issuing a user get
to any member of a cluster get stale data from a slow member.
Instead, use a single member cluster for the test.

Fixes #7993