### PR TITLE
Documentation, scripts: update RPC API docs

### DIFF
--- a/Documentation/dev-guide/api_reference_v3.md
+++ b/Documentation/dev-guide/api_reference_v3.md
@@ -790,6 +790,7 @@ From google paxosdb paper: Our implementation hinges around a powerful primitive
 | created | created is set to true if the response is for a create watch request. The client should record the watch_id and expect to receive events for the created watcher from the same stream. All events sent to the created watcher will attach with the same watch_id. | bool |
 | canceled | canceled is set to true if the response is for a cancel watch request. No further events will be sent to the canceled watcher. | bool |
 | compact_revision | compact_revision is set to the minimum index if a watcher tries to watch at a compacted index.  This happens when creating a watcher at a compacted revision or the watcher cannot catch up with the progress of the key-value store.  The client should treat the watcher as canceled and should not try to create any watcher with the same start_revision again. | int64 |
+| cancel_reason | cancel_reason indicates the reason for canceling the watcher. | string |
 | events |  | (slice of) mvccpb.Event |
 
 

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -107,7 +107,7 @@ rm -rf Documentation/dev-guide/apispec/swagger/etcdserver/
 if [ "$1" = "-g" ]; then
 	echo "protodoc is auto-generating grpc API reference documentation..."
 	go get -v -u github.com/coreos/protodoc
-	SHA_PROTODOC="e901a6d4fa64c815acf117864521a8dadb11390f"
+	SHA_PROTODOC="4372ee725035a208404e2d5465ba921469decc32"
 	PROTODOC_PATH="${GOPATH}/src/github.com/coreos/protodoc"
 	pushd "${PROTODOC_PATH}"
 		git reset --hard "${SHA_PROTODOC}"


### PR DESCRIPTION
Was missing the new cancel_reason field. Also includes updated protodoc
sha to fix generating documentation for upcoming txn compare range patchset.

Split into a separate PR from the txn compare range one so it's easier to backport into 3.2.0