### PR TITLE
scripts, Documentation: fix swagger generation

### DIFF
--- a/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
+++ b/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
@@ -2179,6 +2179,10 @@
           "format": "int64",
           "description": "compact_revision is set to the minimum index if a watcher tries to watch\nat a compacted index.\n\nThis happens when creating a watcher at a compacted revision or the watcher cannot\ncatch up with the progress of the key-value store. \n\nThe client should treat the watcher as canceled and should not try to create any\nwatcher with the same start_revision again."
         },
+        "cancel_reason": {
+          "type": "string",
+          "description": "cancel_reason indicates the reason for canceling the watcher."
+        },
         "events": {
           "type": "array",
           "items": {

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -68,6 +68,8 @@ for dir in ${DIRS}; do
 	popd
 done
 
+# remove old swagger files so it's obvious whether the files fail to generate
+rm -rf Documentation/dev-guide/apispec/swagger/*json
 for pb in etcdserverpb/rpc api/v3lock/v3lockpb/v3lock api/v3election/v3electionpb/v3election; do
 	protobase="etcdserver/${pb}"
 	protoc -I. \
@@ -93,8 +95,9 @@ for pb in etcdserverpb/rpc api/v3lock/v3lockpb/v3lock api/v3election/v3electionp
 	go fmt ${gwfile}
 	mv ${gwfile} ${pkgpath}/gw/
 	rm -f ./etcdserver/${pb}*.bak
+	swaggerName=`basename ${pb}`
 	mv	Documentation/dev-guide/apispec/swagger/etcdserver/${pb}.swagger.json \
-		Documentation/dev-guide/apispec/swagger/${name}.swagger.json
+		Documentation/dev-guide/apispec/swagger/${swaggerName}.swagger.json
 done
 rm -rf Documentation/dev-guide/apispec/swagger/etcdserver/
 


### PR DESCRIPTION
Changes to the genproto to support splitting out the grpc-gateway broke
swagger generation.