### PR TITLE
protecting lease revoking with auth

### DIFF
--- a/auth/simple_token.go
+++ b/auth/simple_token.go
@@ -118,6 +118,8 @@ func (t *tokenSimple) genTokenPrefix() (string, error) {
 
 func (t *tokenSimple) assignSimpleTokenToUser(username, token string) {
 	t.simpleTokensMu.Lock()
+	defer t.simpleTokensMu.Unlock()
+
 	_, ok := t.simpleTokens[token]
 	if ok {
 		plog.Panicf("token %s is alredy used", token)
@@ -125,7 +127,6 @@ func (t *tokenSimple) assignSimpleTokenToUser(username, token string) {
 
 	t.simpleTokens[token] = username
 	t.simpleTokenKeeper.addSimpleToken(token)
-	t.simpleTokensMu.Unlock()
 }
 
 func (t *tokenSimple) invalidateUser(username string) {

--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -84,6 +84,7 @@ func (s *EtcdServer) newApplierV3() applierV3 {
 	return newAuthApplierV3(
 		s.AuthStore(),
 		newQuotaApplierV3(s, &applierV3backend{s}),
+		s.lessor,
 	)
 }
 

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -747,7 +747,8 @@ func (s *EtcdServer) run() {
 					}
 					lid := lease.ID
 					s.goAttach(func() {
-						s.LeaseRevoke(s.ctx, &pb.LeaseRevokeRequest{ID: int64(lid)})
+						ctx := s.authStore.WithRoot(s.ctx)
+						s.LeaseRevoke(ctx, &pb.LeaseRevokeRequest{ID: int64(lid)})
 						<-c
 					})
 				}

--- a/integration/v3_auth_test.go
+++ b/integration/v3_auth_test.go
@@ -20,6 +20,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/coreos/etcd/auth/authpb"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
@@ -104,16 +105,167 @@ func TestV3AuthRevision(t *testing.T) {
 	}
 }
 
+type user struct {
+	name     string
+	password string
+	role     string
+	key      string
+	end      string
+}
+
+func TestV3AuthWithLeaseRevoke(t *testing.T) {
+	defer testutil.AfterTest(t)
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	users := []user{
+		{
+			name:     "user1",
+			password: "user1-123",
+			role:     "role1",
+			key:      "k1",
+			end:      "k2",
+		},
+	}
+	authSetupUsers(t, toGRPC(clus.Client(0)).Auth, users)
+
+	authSetupRoot(t, toGRPC(clus.Client(0)).Auth)
+
+	rootc, cerr := clientv3.New(clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "root", Password: "123"})
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	defer rootc.Close()
+
+	leaseResp, err := rootc.Grant(context.TODO(), 90)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaseID := leaseResp.ID
+	// permission of k3 isn't granted to user1
+	_, err = rootc.Put(context.TODO(), "k3", "val", clientv3.WithLease(leaseID))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userc, cerr := clientv3.New(clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	defer userc.Close()
+	_, err = userc.Revoke(context.TODO(), leaseID)
+	if err == nil {
+		t.Fatal("revoking from user1 should be failed with permission denied")
+	}
+}
+
+func TestV3AuthWithLeaseAttach(t *testing.T) {
+	defer testutil.AfterTest(t)
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	users := []user{
+		{
+			name:     "user1",
+			password: "user1-123",
+			role:     "role1",
+			key:      "k1",
+			end:      "k3",
+		},
+		{
+			name:     "user2",
+			password: "user2-123",
+			role:     "role2",
+			key:      "k2",
+			end:      "k4",
+		},
+	}
+	authSetupUsers(t, toGRPC(clus.Client(0)).Auth, users)
+
+	authSetupRoot(t, toGRPC(clus.Client(0)).Auth)
+
+	user1c, cerr := clientv3.New(clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	defer user1c.Close()
+
+	user2c, cerr := clientv3.New(clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user2", Password: "user2-123"})
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	defer user2c.Close()
+
+	leaseResp, err := user1c.Grant(context.TODO(), 90)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaseID := leaseResp.ID
+	// permission of k2 is also granted to user2
+	_, err = user1c.Put(context.TODO(), "k2", "val", clientv3.WithLease(leaseID))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = user2c.Revoke(context.TODO(), leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leaseResp, err = user1c.Grant(context.TODO(), 90)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaseID = leaseResp.ID
+	// permission of k1 isn't granted to user2
+	_, err = user1c.Put(context.TODO(), "k1", "val", clientv3.WithLease(leaseID))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = user2c.Revoke(context.TODO(), leaseID)
+	if err == nil {
+		t.Fatal("revoking from user2 should be failed with permission denied")
+	}
+}
+
+func authSetupUsers(t *testing.T, auth pb.AuthClient, users []user) {
+	for _, user := range users {
+		if _, err := auth.UserAdd(context.TODO(), &pb.AuthUserAddRequest{Name: user.name, Password: user.password}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := auth.RoleAdd(context.TODO(), &pb.AuthRoleAddRequest{Name: user.role}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := auth.UserGrantRole(context.TODO(), &pb.AuthUserGrantRoleRequest{User: user.name, Role: user.role}); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(user.key) == 0 {
+			continue
+		}
+
+		perm := &authpb.Permission{
+			PermType: authpb.READWRITE,
+			Key:      []byte(user.key),
+			RangeEnd: []byte(user.end),
+		}
+		if _, err := auth.RoleGrantPermission(context.TODO(), &pb.AuthRoleGrantPermissionRequest{Name: user.role, Perm: perm}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func authSetupRoot(t *testing.T, auth pb.AuthClient) {
-	if _, err := auth.UserAdd(context.TODO(), &pb.AuthUserAddRequest{Name: "root", Password: "123"}); err != nil {
-		t.Fatal(err)
+	root := []user{
+		{
+			name:     "root",
+			password: "123",
+			role:     "root",
+			key:      "",
+		},
 	}
-	if _, err := auth.RoleAdd(context.TODO(), &pb.AuthRoleAddRequest{Name: "root"}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := auth.UserGrantRole(context.TODO(), &pb.AuthUserGrantRoleRequest{User: "root", Role: "root"}); err != nil {
-		t.Fatal(err)
-	}
+	authSetupUsers(t, auth, root)
 	if _, err := auth.AuthEnable(context.TODO(), &pb.AuthEnableRequest{}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Current leases can be revoked by anyone. This PR limits the users who can revoke leases. If the user isn't granted write permission of keys which are attached the lease, the revoking request will be denied.

/cc @yudai 
