### PR TITLE
test, osutil: disable setting SIG_DFL on linux if built with cov tag

### DIFF
--- a/pkg/osutil/signal.go
+++ b/pkg/osutil/signal.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !linux
+// +build !linux cov
 
 package osutil
 

--- a/pkg/osutil/signal_linux.go
+++ b/pkg/osutil/signal_linux.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux
+// +build linux,!cov
 
 package osutil
 

--- a/test
+++ b/test
@@ -377,7 +377,7 @@ function dep_pass {
 function build_cov_pass {
 	out="bin"
 	if [ -n "${BINDIR}" ]; then out="${BINDIR}"; fi
-	go test -c -covermode=set -coverpkg=$PKGS_COMMA -o ${out}/etcd_test
+	go test -tags cov -c -covermode=set -coverpkg=$PKGS_COMMA -o ${out}/etcd_test
 	go test -tags cov -c -covermode=set -coverpkg=$PKGS_COMMA -o ${out}/etcdctl_test ${REPO_PATH}/etcdctl
 }
 


### PR DESCRIPTION
Was causing etcd to terminate before finishing writing its coverage profile.