### PR TITLE
mvcc: don't use pointer for storeTxnRead in storeTxnWrite

### DIFF
--- a/mvcc/kvstore_bench_test.go
+++ b/mvcc/kvstore_bench_test.go
@@ -95,6 +95,7 @@ func BenchmarkStoreTxnPut(b *testing.B) {
 	vals := createBytesSlice(bytesN, b.N)
 
 	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		txn := s.Write()
 		txn.Put(keys[i], vals[i], lease.NoLease)

--- a/mvcc/kvstore_txn.go
+++ b/mvcc/kvstore_txn.go
@@ -51,7 +51,7 @@ func (tr *storeTxnRead) End() {
 }
 
 type storeTxnWrite struct {
-	*storeTxnRead
+	storeTxnRead
 	tx backend.BatchTx
 	// beginRev is the revision where the txn begins; it will write to the next revision.
 	beginRev int64
@@ -63,7 +63,7 @@ func (s *store) Write() TxnWrite {
 	tx := s.b.BatchTx()
 	tx.Lock()
 	tw := &storeTxnWrite{
-		storeTxnRead: &storeTxnRead{s, tx, 0, 0},
+		storeTxnRead: storeTxnRead{s, tx, 0, 0},
 		tx:           tx,
 		beginRev:     s.currentRev,
 		changes:      make([]mvccpb.KeyValue, 0, 4),


### PR DESCRIPTION
Saves an allocation when creating a storeTxnWrite.

Before:
```
BenchmarkStoreTxnPut-4            	  200000	      7728 ns/op	    1515 B/op	      16 allocs/op
BenchmarkWatchableStoreTxnPut-4   	  200000	      7934 ns/op	    1580 B/op	      18 allocs/op
```

After:
```
BenchmarkStoreTxnPut-4            	  200000	      7319 ns/op	    1498 B/op	      15 allocs/op
BenchmarkWatchableStoreTxnPut-4   	  200000	      7558 ns/op	    1565 B/op	      17 allocs/op
```