### PR TITLE
mvcc: remove allocation from Put path in tree index

### DIFF
--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -35,6 +35,8 @@ type index interface {
 type treeIndex struct {
 	sync.RWMutex
 	tree *btree.BTree
+	// used to avoid allocation while searching tree under lock
+	keyPtr keyIndex
 }
 
 func newTreeIndex() index {
@@ -44,14 +46,14 @@ func newTreeIndex() index {
 }
 
 func (ti *treeIndex) Put(key []byte, rev revision) {
-	keyi := &keyIndex{key: key}
-
 	ti.Lock()
 	defer ti.Unlock()
-	item := ti.tree.Get(keyi)
+
+	ti.keyPtr = keyIndex{key: key}
+	item := ti.tree.Get(&ti.keyPtr)
 	if item == nil {
-		keyi.put(rev.main, rev.sub)
-		ti.tree.ReplaceOrInsert(keyi)
+		ti.keyPtr.put(rev.main, rev.sub)
+		ti.tree.ReplaceOrInsert(&ti.keyPtr)
 		return
 	}
 	okeyi := item.(*keyIndex)
@@ -105,11 +107,11 @@ func (ti *treeIndex) Range(key, end []byte, atRev int64) (keys [][]byte, revs []
 }
 
 func (ti *treeIndex) Tombstone(key []byte, rev revision) error {
-	keyi := &keyIndex{key: key}
-
 	ti.Lock()
 	defer ti.Unlock()
-	item := ti.tree.Get(keyi)
+
+	ti.keyPtr = keyIndex{key: key}
+	item := ti.tree.Get(&ti.keyPtr)
 	if item == nil {
 		return ErrRevisionNotFound
 	}


### PR DESCRIPTION
Before
```
BenchmarkStorePut-4                               200000              6853 ns/op
BenchmarkStorePutUpdate-4                         200000              6102 ns/op
BenchmarkStoreTxnPut-4                            200000              6794 ns/op            1490 B/op         15 allocs/op
BenchmarkWatchableStorePut-4                      200000              6743 ns/op            1550 B/op         15 allocs/op
BenchmarkWatchableStoreTxnPut-4                   200000              7341 ns/op            1563 B/op         17 allocs/op
BenchmarkWatchableStoreWatchSyncPut-4             200000              6057 ns/op             275 B/op          2 allocs/op
PASS
ok      _/Users/anthony/go/src/github.com/coreos/etcd/mvcc      17.834s
```

After
```
BenchmarkStorePut-4                               300000              3461 ns/op
BenchmarkStorePutUpdate-4                         200000              6256 ns/op
BenchmarkStoreTxnPut-4                            300000              3353 ns/op            1393 B/op         14 allocs/op
BenchmarkWatchableStorePut-4                      500000              3315 ns/op            1436 B/op         14 allocs/op
BenchmarkWatchableStoreTxnPut-4                   300000              3631 ns/op            1454 B/op         16 allocs/op
BenchmarkWatchableStoreWatchSyncPut-4             200000              5916 ns/op             271 B/op          2 allocs/op
PASS
ok      _/Users/anthony/go/src/github.com/coreos/etcd/mvcc      26.034s
```