### PR TITLE
v3rpc: use map for translating errors to grpc errors

### DIFF
--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -25,79 +25,50 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+var toGRPCErrorMap = map[error]error{
+	membership.ErrIDRemoved:               rpctypes.ErrGRPCMemberNotFound,
+	membership.ErrIDNotFound:              rpctypes.ErrGRPCMemberNotFound,
+	membership.ErrIDExists:                rpctypes.ErrGRPCMemberExist,
+	membership.ErrPeerURLexists:           rpctypes.ErrGRPCPeerURLExist,
+	etcdserver.ErrNotEnoughStartedMembers: rpctypes.ErrMemberNotEnoughStarted,
+
+	mvcc.ErrCompacted:             rpctypes.ErrGRPCCompacted,
+	mvcc.ErrFutureRev:             rpctypes.ErrGRPCFutureRev,
+	etcdserver.ErrRequestTooLarge: rpctypes.ErrGRPCRequestTooLarge,
+	etcdserver.ErrNoSpace:         rpctypes.ErrGRPCNoSpace,
+	etcdserver.ErrTooManyRequests: rpctypes.ErrTooManyRequests,
+
+	etcdserver.ErrNoLeader:                   rpctypes.ErrGRPCNoLeader,
+	etcdserver.ErrStopped:                    rpctypes.ErrGRPCStopped,
+	etcdserver.ErrTimeout:                    rpctypes.ErrGRPCTimeout,
+	etcdserver.ErrTimeoutDueToLeaderFail:     rpctypes.ErrGRPCTimeoutDueToLeaderFail,
+	etcdserver.ErrTimeoutDueToConnectionLost: rpctypes.ErrGRPCTimeoutDueToConnectionLost,
+	etcdserver.ErrUnhealthy:                  rpctypes.ErrGRPCUnhealthy,
+	etcdserver.ErrKeyNotFound:                rpctypes.ErrGRPCKeyNotFound,
+
+	lease.ErrLeaseNotFound: rpctypes.ErrGRPCLeaseNotFound,
+	lease.ErrLeaseExists:   rpctypes.ErrGRPCLeaseExist,
+
+	auth.ErrRootUserNotExist:     rpctypes.ErrGRPCRootUserNotExist,
+	auth.ErrRootRoleNotExist:     rpctypes.ErrGRPCRootRoleNotExist,
+	auth.ErrUserAlreadyExist:     rpctypes.ErrGRPCUserAlreadyExist,
+	auth.ErrUserEmpty:            rpctypes.ErrGRPCUserEmpty,
+	auth.ErrUserNotFound:         rpctypes.ErrGRPCUserNotFound,
+	auth.ErrRoleAlreadyExist:     rpctypes.ErrGRPCRoleAlreadyExist,
+	auth.ErrRoleNotFound:         rpctypes.ErrGRPCRoleNotFound,
+	auth.ErrAuthFailed:           rpctypes.ErrGRPCAuthFailed,
+	auth.ErrPermissionDenied:     rpctypes.ErrGRPCPermissionDenied,
+	auth.ErrRoleNotGranted:       rpctypes.ErrGRPCRoleNotGranted,
+	auth.ErrPermissionNotGranted: rpctypes.ErrGRPCPermissionNotGranted,
+	auth.ErrAuthNotEnabled:       rpctypes.ErrGRPCAuthNotEnabled,
+	auth.ErrInvalidAuthToken:     rpctypes.ErrGRPCInvalidAuthToken,
+	auth.ErrInvalidAuthMgmt:      rpctypes.ErrGRPCInvalidAuthMgmt,
+}
+
 func togRPCError(err error) error {
-	switch err {
-	case membership.ErrIDRemoved:
-		return rpctypes.ErrGRPCMemberNotFound
-	case membership.ErrIDNotFound:
-		return rpctypes.ErrGRPCMemberNotFound
-	case membership.ErrIDExists:
-		return rpctypes.ErrGRPCMemberExist
-	case membership.ErrPeerURLexists:
-		return rpctypes.ErrGRPCPeerURLExist
-	case etcdserver.ErrNotEnoughStartedMembers:
-		return rpctypes.ErrMemberNotEnoughStarted
-
-	case mvcc.ErrCompacted:
-		return rpctypes.ErrGRPCCompacted
-	case mvcc.ErrFutureRev:
-		return rpctypes.ErrGRPCFutureRev
-	case etcdserver.ErrRequestTooLarge:
-		return rpctypes.ErrGRPCRequestTooLarge
-	case etcdserver.ErrNoSpace:
-		return rpctypes.ErrGRPCNoSpace
-	case etcdserver.ErrTooManyRequests:
-		return rpctypes.ErrTooManyRequests
-
-	case etcdserver.ErrNoLeader:
-		return rpctypes.ErrGRPCNoLeader
-	case etcdserver.ErrStopped:
-		return rpctypes.ErrGRPCStopped
-	case etcdserver.ErrTimeout:
-		return rpctypes.ErrGRPCTimeout
-	case etcdserver.ErrTimeoutDueToLeaderFail:
-		return rpctypes.ErrGRPCTimeoutDueToLeaderFail
-	case etcdserver.ErrTimeoutDueToConnectionLost:
-		return rpctypes.ErrGRPCTimeoutDueToConnectionLost
-	case etcdserver.ErrUnhealthy:
-		return rpctypes.ErrGRPCUnhealthy
-	case etcdserver.ErrKeyNotFound:
-		return rpctypes.ErrGRPCKeyNotFound
-
-	case lease.ErrLeaseNotFound:
-		return rpctypes.ErrGRPCLeaseNotFound
-	case lease.ErrLeaseExists:
-		return rpctypes.ErrGRPCLeaseExist
-
-	case auth.ErrRootUserNotExist:
-		return rpctypes.ErrGRPCRootUserNotExist
-	case auth.ErrRootRoleNotExist:
-		return rpctypes.ErrGRPCRootRoleNotExist
-	case auth.ErrUserAlreadyExist:
-		return rpctypes.ErrGRPCUserAlreadyExist
-	case auth.ErrUserEmpty:
-		return rpctypes.ErrGRPCUserEmpty
-	case auth.ErrUserNotFound:
-		return rpctypes.ErrGRPCUserNotFound
-	case auth.ErrRoleAlreadyExist:
-		return rpctypes.ErrGRPCRoleAlreadyExist
-	case auth.ErrRoleNotFound:
-		return rpctypes.ErrGRPCRoleNotFound
-	case auth.ErrAuthFailed:
-		return rpctypes.ErrGRPCAuthFailed
-	case auth.ErrPermissionDenied:
-		return rpctypes.ErrGRPCPermissionDenied
-	case auth.ErrRoleNotGranted:
-		return rpctypes.ErrGRPCRoleNotGranted
-	case auth.ErrPermissionNotGranted:
-		return rpctypes.ErrGRPCPermissionNotGranted
-	case auth.ErrAuthNotEnabled:
-		return rpctypes.ErrGRPCAuthNotEnabled
-	case auth.ErrInvalidAuthToken:
-		return rpctypes.ErrGRPCInvalidAuthToken
-	case auth.ErrInvalidAuthMgmt:
-		return rpctypes.ErrGRPCInvalidAuthMgmt
-	default:
+	grpcErr, ok := toGRPCErrorMap[err]
+	if !ok {
 		return grpc.Errorf(codes.Unknown, err.Error())
 	}
+	return grpcErr
 }


### PR DESCRIPTION
Switch statement had poor coverage, use a map instead