### PR TITLE
fileutil: return immediately if preallocating 0 bytes

### DIFF
--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -127,6 +127,11 @@ func TestZeroToEnd(t *testing.T) {
 	}
 	defer f.Close()
 
+	// Ensure 0 size is a nop so zero-to-end on an empty file won't give EINVAL.
+	if err = ZeroToEnd(f); err != nil {
+		t.Fatal(err)
+	}
+
 	b := make([]byte, 1024)
 	for i := range b {
 		b[i] = 12

--- a/pkg/fileutil/preallocate.go
+++ b/pkg/fileutil/preallocate.go
@@ -25,6 +25,10 @@ import (
 // If the operation is unsupported, no error will be returned.
 // Otherwise, the error encountered will be returned.
 func Preallocate(f *os.File, sizeInBytes int64, extendFile bool) error {
+	if sizeInBytes == 0 {
+		// fallocate will return EINVAL if length is 0; skip
+		return nil
+	}
 	if extendFile {
 		return preallocExtend(f, sizeInBytes)
 	}


### PR DESCRIPTION
fallocate will return EINVAL, causing zeroing to the end of a
0 byte file to fail.

Fixes #8045