### PR TITLE
fileutil: test some fallback functionality

### DIFF
--- a/pkg/fileutil/lock_linux_test.go
+++ b/pkg/fileutil/lock_linux_test.go
@@ -1,0 +1,29 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package fileutil
+
+import "testing"
+
+// TestLockAndUnlockSyscallFlock tests the fallback flock using the flock syscall.
+func TestLockAndUnlockSyscallFlock(t *testing.T) {
+	oldTryLock, oldLock := linuxTryLockFile, linuxLockFile
+	defer func() {
+		linuxTryLockFile, linuxLockFile = oldTryLock, oldLock
+	}()
+	linuxTryLockFile, linuxLockFile = flockTryLockFile, flockLockFile
+	TestLockAndUnlock(t)
+}

--- a/pkg/fileutil/preallocate_test.go
+++ b/pkg/fileutil/preallocate_test.go
@@ -20,10 +20,20 @@ import (
 	"testing"
 )
 
-func TestPreallocateExtend(t *testing.T) { runPreallocTest(t, testPreallocateExtend) }
-func testPreallocateExtend(t *testing.T, f *os.File) {
+func TestPreallocateExtend(t *testing.T) {
+	pf := func(f *os.File, sz int64) error { return Preallocate(f, sz, true) }
+	tf := func(t *testing.T, f *os.File) { testPreallocateExtend(t, f, pf) }
+	runPreallocTest(t, tf)
+}
+
+func TestPreallocateExtendTrunc(t *testing.T) {
+	tf := func(t *testing.T, f *os.File) { testPreallocateExtend(t, f, preallocExtendTrunc) }
+	runPreallocTest(t, tf)
+}
+
+func testPreallocateExtend(t *testing.T, f *os.File, pf func(*os.File, int64) error) {
 	size := int64(64 * 1000)
-	if err := Preallocate(f, size, true); err != nil {
+	if err := pf(f, size); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
syscall.Flock fallback and preallocExtendTrunc

via codecov:
https://codecov.io/gh/coreos/etcd/src/fb086ef13f6ef78d497c2aec6b6070781e2d0543/pkg/fileutil/preallocate.go
https://codecov.io/gh/coreos/etcd/src/fb086ef13f6ef78d497c2aec6b6070781e2d0543/pkg/fileutil/lock_flock.go