### PR TITLE
v2http: put back /v2/machines and mark as non-deprecated

### DIFF
--- a/etcdserver/api/v2http/client_test.go
+++ b/etcdserver/api/v2http/client_test.go
@@ -1220,6 +1220,56 @@ func TestWriteEvent(t *testing.T) {
 	}
 }
 
+func TestV2DMachinesEndpoint(t *testing.T) {
+	tests := []struct {
+		method string
+		wcode  int
+	}{
+		{"GET", http.StatusOK},
+		{"HEAD", http.StatusOK},
+		{"POST", http.StatusMethodNotAllowed},
+	}
+
+	m := &machinesHandler{cluster: &fakeCluster{}}
+	s := httptest.NewServer(m)
+	defer s.Close()
+
+	for _, tt := range tests {
+		req, err := http.NewRequest(tt.method, s.URL+machinesPrefix, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.StatusCode != tt.wcode {
+			t.Errorf("StatusCode = %d, expected %d", resp.StatusCode, tt.wcode)
+		}
+	}
+}
+
+func TestServeMachines(t *testing.T) {
+	cluster := &fakeCluster{
+		clientURLs: []string{"http://localhost:8080", "http://localhost:8081", "http://localhost:8082"},
+	}
+	writer := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &machinesHandler{cluster: cluster}
+	h.ServeHTTP(writer, req)
+	w := "http://localhost:8080, http://localhost:8081, http://localhost:8082"
+	if g := writer.Body.String(); g != w {
+		t.Errorf("body = %s, want %s", g, w)
+	}
+	if writer.Code != http.StatusOK {
+		t.Errorf("code = %d, want %d", writer.Code, http.StatusOK)
+	}
+}
+
 func TestGetID(t *testing.T) {
 	tests := []struct {
 		path string


### PR DESCRIPTION
This reverts commit 2bb33181b6c8fbe8109fc668a19ce4ab46c605ec. python-etcd
seems to depend on /v2/machines and the maintainer vanished. Plus, it is
prefixed with /v2/ so it probably can't be deprecated anyway.

/cc @xiang90 