### PR TITLE
etcdserver: add leaseExpired metrics

### DIFF
--- a/etcdserver/metrics.go
+++ b/etcdserver/metrics.go
@@ -58,6 +58,12 @@ var (
 		Name:      "proposals_failed_total",
 		Help:      "The total number of failed proposals seen.",
 	})
+	leaseExpired = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "server",
+		Name:      "lease_expired_total",
+		Help:      "The total number of expired leases.",
+	})
 )
 
 func init() {
@@ -67,6 +73,7 @@ func init() {
 	prometheus.MustRegister(proposalsApplied)
 	prometheus.MustRegister(proposalsPending)
 	prometheus.MustRegister(proposalsFailed)
+	prometheus.MustRegister(leaseExpired)
 }
 
 func monitorFileDescriptor(done <-chan struct{}) {

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -749,6 +749,7 @@ func (s *EtcdServer) run() {
 					s.goAttach(func() {
 						ctx := s.authStore.WithRoot(s.ctx)
 						s.LeaseRevoke(ctx, &pb.LeaseRevokeRequest{ID: int64(lid)})
+						leaseExpired.Inc()
 						<-c
 					})
 				}


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/8050.

e.g.

```
curl -L http://localhost:2379/metrics | grep lease

etcd_debugging_server_lease_expired_total 3
```