### PR TITLE
rafthttp: permit very large v2 snapshots

### DIFF
--- a/rafthttp/http.go
+++ b/rafthttp/http.go
@@ -183,7 +183,8 @@ func (h *snapshotHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dec := &messageDecoder{r: r.Body}
-	m, err := dec.decode()
+	// let snapshots be very large since they can exceed 512MB for large installations
+	m, err := dec.decodeLimit(uint64(1 << 63))
 	if err != nil {
 		msg := fmt.Sprintf("failed to decode raft message (%v)", err)
 		plog.Errorf(msg)

--- a/rafthttp/msg_codec.go
+++ b/rafthttp/msg_codec.go
@@ -48,12 +48,16 @@ var (
 )
 
 func (dec *messageDecoder) decode() (raftpb.Message, error) {
+	return dec.decodeLimit(readBytesLimit)
+}
+
+func (dec *messageDecoder) decodeLimit(numBytes uint64) (raftpb.Message, error) {
 	var m raftpb.Message
 	var l uint64
 	if err := binary.Read(dec.r, binary.BigEndian, &l); err != nil {
 		return m, err
 	}
-	if l > readBytesLimit {
+	if l > numBytes {
 		return m, ErrExceedSizeLimit
 	}
 	buf := make([]byte, int(l))


### PR DESCRIPTION
v2 snapshots were hitting the 512MB message decode limit, causing
sending snapshots to new members to fail for being too big.