### PR TITLE
etcdserver: better warning when initial-cluster doesn't match advertise urls

### DIFF
--- a/etcdserver/config_test.go
+++ b/etcdserver/config_test.go
@@ -109,6 +109,14 @@ func TestConfigVerifyLocalMember(t *testing.T) {
 		},
 		{
 			// Advertised peer URLs must match those in cluster-state
+			"node1=http://localhost:12345",
+			[]string{"http://localhost:2380", "http://localhost:12345"},
+			true,
+
+			true,
+		},
+		{
+			// Advertised peer URLs must match those in cluster-state
 			"node1=http://localhost:2380",
 			[]string{},
 			true,


### PR DESCRIPTION
The old error was not clear about what URLs needed to be added, sometimes
truncating the list. To make it clearer, print out the missing entries
for --initial-cluster and print the full list of initial advertise peers.

Fixes #8079 and #7927

Old output:
```
etcdmain: --initial-cluster must include etcd01=http://172.28.0.4:2380 given --initial-advertise-peer-urls=http://172.28.0.4:2380
```

New output:
```
etcdmain: --initial-cluster has etcd01=http://172.28.0.2:2380 but missing from --initial-advertise-peer-urls=http://172.28.0.4:2380
```