### PR TITLE
build-aci: Fix ACI image name

### DIFF
--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -36,6 +36,7 @@ fi
 acbuild --debug begin
 
 TMPHOSTS="$(mktemp)"
+ACI_ARCH="$(go2aci ${GOARCH})"
 
 acbuildEnd() {
     rm "$TMPHOSTS"
@@ -71,7 +72,7 @@ acbuild --debug port add peer tcp 2380
 
 acbuild --debug copy "$TMPHOSTS" /etc/hosts
 
-acbuild --debug label add arch "$(go2aci ${GOARCH})"
+acbuild --debug label add arch "${ACI_ARCH}"
 
 # mkdir default data-dir
 mkdir -p .acbuild/currentaci/rootfs/var/lib/etcd
@@ -80,4 +81,4 @@ mkdir -p .acbuild/currentaci/rootfs/var/lib/etcd
 ln -s ./usr/local/bin/etcd .acbuild/currentaci/rootfs/etcd
 ln -s ./usr/local/bin/etcdctl .acbuild/currentaci/rootfs/etcdctl
 
-acbuild --debug write --overwrite $BUILDDIR/etcd-${1}-linux-${GOARCH}.aci
+acbuild --debug write --overwrite $BUILDDIR/etcd-${1}-linux-${ACI_ARCH}.aci


### PR DESCRIPTION
The appc discovery spec states that the architecture specifier in the ACI
image file name will be an ACI architecture value.  Our build scripts were
using GOARCH in the image name, which is incorrect for arm64/aarch64.
See: https://github.com/appc/spec/blob/master/spec/discovery.md
