### PR TITLE
lease: randomize expiry on initial refresh call

### DIFF
--- a/integration/v3_lease_test.go
+++ b/integration/v3_lease_test.go
@@ -66,15 +66,9 @@ func TestV3LeasePrmote(t *testing.T) {
 	// it was going to expire anyway.
 	time.Sleep(3 * time.Second)
 
+	// expiring lease should be renewed with randomized delta
 	if !leaseExist(t, clus, lresp.ID) {
 		t.Error("unexpected lease not exists")
-	}
-
-	// let lease expires. total lease = 5 seconds and we already
-	// waits for 3 seconds, so 3 seconds more is enough.
-	time.Sleep(3 * time.Second)
-	if leaseExist(t, clus, lresp.ID) {
-		t.Error("unexpected lease exists")
 	}
 }
 


### PR DESCRIPTION
Address https://github.com/coreos/etcd/issues/8096.
