### PR TITLE
etcdserver: use RecorderStream for TestSyncTimeout to avoid missing action

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1577,7 +1577,7 @@ type nodeProposalBlockerRecorder struct {
 }
 
 func newProposalBlockerRecorder() *nodeProposalBlockerRecorder {
-	return &nodeProposalBlockerRecorder{*newNodeRecorder()}
+	return &nodeProposalBlockerRecorder{*newNodeRecorderStream()}
 }
 
 func (n *nodeProposalBlockerRecorder) Propose(ctx context.Context, data []byte) error {


### PR DESCRIPTION
via https://travis-ci.org/coreos/etcd/jobs/243406529, fixes
```
--- FAIL: TestSyncTimeout (0.02s)
	server_test.go:837: action = [], want [{Propose blocked []}]
```
