### PR TITLE
mvcc: set db size metric on restore

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -1,0 +1,37 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/coreos/etcd/pkg/testutil"
+)
+
+// TestMetricDbSize checks that the db size metric is set on boot.
+func TestMetricDbSize(t *testing.T) {
+	defer testutil.AfterTest(t)
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	v, err := clus.Members[0].Metric("etcd_debugging_mvcc_db_total_size_in_bytes")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v == "0" {
+		t.Fatalf("expected non-zero, got %q", v)
+	}
+}

--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -260,6 +260,9 @@ func (s *store) restore() error {
 	// restore index
 	tx := s.b.BatchTx()
 	tx.Lock()
+
+	dbTotalSize.Set(float64(s.b.Size()))
+
 	_, finishedCompactBytes := tx.UnsafeRange(metaBucketName, finishedCompactKeyName, nil, 0)
 	if len(finishedCompactBytes) != 0 {
 		s.compactMainRev = bytesToRev(finishedCompactBytes[0]).main


### PR DESCRIPTION
Fixes #8080