### PR TITLE
test: 'FAIL' on release binary download failure

### DIFF
--- a/test
+++ b/test
@@ -185,6 +185,10 @@ function release_pass {
 		# in case, we need to test against different version
 		UPGRADE_VER=$MANUAL_VER
 	fi
+	if [[ -z ${UPGRADE_VER} ]]; then
+		UPGRADE_VER="v3.2.0"
+		echo "fallback to" ${UPGRADE_VER}
+	fi
 
 	local file="etcd-$UPGRADE_VER-linux-$GOARCH.tar.gz"
 	echo "Downloading $file"
@@ -195,9 +199,8 @@ function release_pass {
 	set -e
 	case $result in
 		0)	;;
-		22)	return 0
-			;;
-		*)	exit $result
+		*)	echo "FAIL with" ${result}
+			exit $result
 			;;
 	esac
 


### PR DESCRIPTION
This fixes bash syntax on '[[ -n ${VAR} ]]', which is
always true. Replacing with '[[ ${VAR} ]]'.

I also see CI is failing to download release binaries
but exit code doesn't trigger CI job failure.

We need 'FAIL' string.

It' failing here https://semaphoreci.com/coreos/etcd/branches/pull-request-8133/builds/2

```
Downloading etcd--linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                           Dload  U   ploadTotal         Spent    Left  Speed

  0     0    0     0    0     0    0        0 --:--:-----::- -- --:--:   0
    --0     0        0 0       0    0    0      0 --:--:-- --:--:-- --:--:-0
  -   cu: rl(22) T rheueeqsted URL ruretned erro 4r:04 Not Found
FAIL with 22
```