### PR TITLE
etcdctl/ctlv3: remove unnecessary 'return'

### DIFF
--- a/etcdctl/ctlv3/command/compaction_command.go
+++ b/etcdctl/ctlv3/command/compaction_command.go
@@ -57,7 +57,6 @@ func compactionCommandFunc(cmd *cobra.Command, args []string) {
 	cancel()
 	if cerr != nil {
 		ExitWithError(ExitError, cerr)
-		return
 	}
 	fmt.Println("compacted revision", rev)
 }


### PR DESCRIPTION
Found via https://github.com/coreos/etcd/pull/8153/commits/9a7a9f4de6e4a60245a6ee0e098a1568ce810bd4#r123566851.