### PR TITLE
vendor: upgrade grpc-go to 1.4.2

### DIFF
--- a/cmd/vendor/google.golang.org/grpc/rpc_util.go
+++ b/cmd/vendor/google.golang.org/grpc/rpc_util.go
@@ -528,6 +528,6 @@ func getMaxSize(mcMax, doptMax *int, defaultVal int) *int {
 const SupportPackageIsVersion4 = true
 
 // Version is the current grpc version.
-const Version = "1.4.1"
+const Version = "1.4.2"
 
 const grpcUA = "grpc-go/" + Version

--- a/cmd/vendor/google.golang.org/grpc/transport/http2_client.go
+++ b/cmd/vendor/google.golang.org/grpc/transport/http2_client.go
@@ -541,7 +541,9 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 			return nil, connectionErrorf(true, err, "transport: %v", err)
 		}
 	}
+	s.mu.Lock()
 	s.bytesSent = true
+	s.mu.Unlock()
 
 	if t.statsHandler != nil {
 		outHeader := &stats.OutHeader{
@@ -1024,7 +1026,9 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 	if !ok {
 		return
 	}
+	s.mu.Lock()
 	s.bytesReceived = true
+	s.mu.Unlock()
 	var state decodeState
 	if err := state.decodeResponseHeader(frame); err != nil {
 		s.mu.Lock()

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7c7ebb812829e2942acb8481e4e9412576b4290a53edea7f30e7e14ac86033a8
-updated: 2017-06-16T11:43:37.376823012-07:00
+hash: 1c01233ff3c05df62210db3ec7bd51114f9b22401187e8e749a3ee5ea99f8594
+updated: 2017-06-22T14:26:04.148865868-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -144,7 +144,7 @@ imports:
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 42c095b6c9bdd80d4435b064508c398afdb0ec99
+  version: b15215fb911b24a5d61d57feec4233d610530464
   subpackages:
   - codes
   - credentials

--- a/glide.yaml
+++ b/glide.yaml
@@ -97,7 +97,7 @@ import:
   subpackages:
   - rate
 - package: google.golang.org/grpc
-  version: v1.4.1
+  version: v1.4.2
   subpackages:
   - codes
   - credentials


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/8141.