### PR TITLE
Default stm isolation level is serializable snapshot isolation

### DIFF
--- a/clientv3/concurrency/stm.go
+++ b/clientv3/concurrency/stm.go
@@ -85,7 +85,7 @@ func WithPrefetch(keys ...string) stmOption {
 	return func(so *stmOptions) { so.prefetch = append(so.prefetch, keys...) }
 }
 
-// NewSTM initiates a new STM instance, using snapshot isolation by default.
+// NewSTM initiates a new STM instance, using serializable snapshot isolation by default.
 func NewSTM(c *v3.Client, apply func(STM) error, so ...stmOption) (*v3.TxnResponse, error) {
 	opts := &stmOptions{ctx: c.Ctx()}
 	for _, f := range so {


### PR DESCRIPTION
Update the comment of NewSTM function

Signed-off-by: Hui Kang <kangh@us.ibm.com>

# Contributing guidelines

Please read our [contribution workflow][contributing] before submitting a pull request.

[contributing]: https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow
