### PR TITLE
allow users to know their roles and permissions

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -165,6 +165,9 @@ type AuthStore interface {
 
 	// WithRoot generates and installs a token that can be used as a root credential
 	WithRoot(ctx context.Context) context.Context
+
+	// HasRole checks that user has role
+	HasRole(user, role string) bool
 }
 
 type TokenProvider interface {
@@ -1096,4 +1099,24 @@ func (as *authStore) WithRoot(ctx context.Context) context.Context {
 	}
 	tokenMD := metadata.New(mdMap)
 	return metadata.NewContext(ctx, tokenMD)
+}
+
+func (as *authStore) HasRole(user, role string) bool {
+	tx := as.be.BatchTx()
+	tx.Lock()
+	defer tx.Unlock()
+
+	u := getUser(tx, user)
+	if u == nil {
+		plog.Warningf("tried to check user %s has role %s, but user %s doesn't exist", user, role, user)
+		return false
+	}
+
+	for _, r := range u.Roles {
+		if role == r {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
This PR adds a new option `--all-readable` to `etcdctl get`. If the option is passed, etcdctl tries to get all read granted keys from a user specified with `--user`.

For doing it, the first commit changes the semantics of `UserGet()` and `RoleGet()` semantics. Now they can be called by non admin users if the information belongs to the user itself.

Fix https://github.com/coreos/etcd/issues/8157

@hzektser @japhar81 could you check that this is what you want?

/cc @heyitsanthony I'll add e2e test cases for the changes until earlier next week.