### PR TITLE
concurrency: fix typo in Serializable godoc

### DIFF
--- a/clientv3/concurrency/stm.go
+++ b/clientv3/concurrency/stm.go
@@ -46,7 +46,7 @@ const (
 	// SerializableSnapshot provides serializable isolation and also checks
 	// for write conflicts.
 	SerializableSnapshot Isolation = iota
-	// Serializable reads within the same transactiona attempt return data
+	// Serializable reads within the same transaction attempt return data
 	// from the at the revision of the first read.
 	Serializable
 	// RepeatableReads reads within the same transaction attempt always


### PR DESCRIPTION
concurrency: fix typo in Serializable godoc