### PR TITLE
mvcc: don't allocate end revision while computing range

### DIFF
--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -445,16 +445,3 @@ func appendMarkTombstone(b []byte) []byte {
 func isTombstone(b []byte) bool {
 	return len(b) == markedRevBytesLen && b[markBytePosition] == markTombstone
 }
-
-// revBytesRange returns the range of revision bytes at
-// the given revision.
-func revBytesRange(rev revision) (start, end []byte) {
-	start = newRevBytes()
-	revToBytes(rev, start)
-
-	end = newRevBytes()
-	endRev := revision{main: rev.main, sub: rev.sub + 1}
-	revToBytes(endRev, end)
-
-	return start, end
-}

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -217,9 +217,10 @@ func TestStoreRange(t *testing.T) {
 			t.Errorf("#%d: rev = %d, want %d", i, ret.Rev, wrev)
 		}
 
-		wstart, wend := revBytesRange(tt.idxr.revs[0])
+		wstart := newRevBytes()
+		revToBytes(tt.idxr.revs[0], wstart)
 		wact := []testutil.Action{
-			{"range", []interface{}{keyBucketName, wstart, wend, int64(0)}},
+			{"range", []interface{}{keyBucketName, wstart, []byte(nil), int64(0)}},
 		}
 		if g := b.tx.Action(); !reflect.DeepEqual(g, wact) {
 			t.Errorf("#%d: tx action = %+v, want %+v", i, g, wact)


### PR DESCRIPTION
Use 'nil' since it's only reading a single key. Also preallocates
the result slice based on limit / number of revisions fetched.

Fixes #8208 

Slight throughput improvement on serialized benchmarks for large ranges (tested with 1k small keys), but larger stddev. Observed worse performance without the preallocation, possibly due to GC effects.