### PR TITLE
embed: connect json gateway with user-provided listen address

### DIFF
--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -328,6 +328,9 @@ func startClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
 		if sctx.l, err = net.Listen(proto, addr); err != nil {
 			return nil, err
 		}
+		// net.Listener will rewrite ipv4 0.0.0.0 to ipv6 [::], breaking
+		// hosts that disable ipv6. So, use the address given by the user.
+		sctx.addr = addr
 
 		if fdLimit, fderr := runtimeutil.FDLimit(); fderr == nil {
 			if fdLimit <= reservedInternalFDNum {

--- a/embed/serve.go
+++ b/embed/serve.go
@@ -44,6 +44,7 @@ import (
 
 type serveCtx struct {
 	l        net.Listener
+	addr     string
 	secure   bool
 	insecure bool
 
@@ -171,7 +172,7 @@ type registerHandlerFunc func(context.Context, *gw.ServeMux, *grpc.ClientConn) e
 
 func (sctx *serveCtx) registerGateway(opts []grpc.DialOption) (*gw.ServeMux, error) {
 	ctx := sctx.ctx
-	conn, err := grpc.DialContext(ctx, sctx.l.Addr().String(), opts...)
+	conn, err := grpc.DialContext(ctx, sctx.addr, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
net.Listener says its address is [::] when given 0.0.0.0, breaking
hosts that have ipv6 disabled.

Fixes #8151
Fixes #7961