### PR TITLE
dev-guide: update experimental APIs

### DIFF
--- a/Documentation/dev-guide/experimental_apis.md
+++ b/Documentation/dev-guide/experimental_apis.md
@@ -4,8 +4,4 @@ For the most part, the etcd project is stable, but we are still moving fast! We 
 
 ## The current experimental API/features are:
 
-- [gateway][gateway]: beta, to be stable in 3.2 release
-- [gRPC proxy][grpc-proxy]: alpha, to be stable in 3.2 release
-
-[gateway]: ../op-guide/gateway.md
-[grpc-proxy]: ../op-guide/grpc_proxy.md
+(none currently)


### PR DESCRIPTION
No experimental APIs at the moment.

Fixes #8212

/cc @xiang90 