### PR TITLE
transport: accept connection if matched IP SAN but no DNS match

### DIFF
--- a/pkg/transport/listener_tls.go
+++ b/pkg/transport/listener_tls.go
@@ -197,7 +197,11 @@ func checkCertSAN(ctx context.Context, cert *x509.Certificate, remoteAddr string
 		return herr
 	}
 	if len(cert.IPAddresses) > 0 {
-		if cerr := cert.VerifyHostname(h); cerr != nil && len(cert.DNSNames) == 0 {
+		cerr := cert.VerifyHostname(h)
+		if cerr == nil {
+			return nil
+		}
+		if len(cert.DNSNames) == 0 {
 			return cerr
 		}
 	}


### PR DESCRIPTION
The IP SAN check would always do a DNS SAN check if DNS is given
and the connection's IP is verified. Instead, don't check DNS
entries if there's a matching iP.

Fixes #8206