### PR TITLE
Documentation/learning/why: Update link to CockroachDB

### DIFF
--- a/Documentation/learning/why.md
+++ b/Documentation/learning/why.md
@@ -107,7 +107,7 @@ For distributed coordination, choosing etcd can help prevent operational headach
 [etcd-rbac]: ../op-guide/authentication.md#working-with-roles
 [zk-acl]: https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_ZooKeeperAccessControl
 [consul-acl]: https://www.consul.io/docs/internals/acl.html
-[cockroach-grant]: https://www.cockroachlabs.com/docs/grant.html
+[cockroach-grant]: https://www.cockroachlabs.com/docs/stable/grant.html
 [spanner-roles]: https://cloud.google.com/spanner/docs/iam#roles
 [zk-bindings]: https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#ch_bindings
 [container-linux]: https://coreos.com/why


### PR DESCRIPTION
Since we implemented docs versioning, the default url is
https://cockroachlabs.com/docs/stable instead of
https://cockroachlabs.com/docs. We have a redirect in place
from /docs to /docs/stable, so existing links aren't broken,
but it's a better user experience to bypass the redirect.