### PR TITLE
client: handle cleared event index for watch

### DIFF
--- a/client/keys.go
+++ b/client/keys.go
@@ -463,6 +463,9 @@ func (hw *httpWatcher) Next(ctx context.Context) (*Response, error) {
 			if err == ErrEmptyBody {
 				continue
 			}
+			if er, ok := err.(Error); ok && er.Code == ErrorCodeEventIndexCleared {
+				hw.nextWait.WaitIndex = er.Index + 1
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Ref: https://github.com/coreos/etcd/blob/master/Documentation/v2/api.md#watch-from-cleared-event-index

```
401: The event in requested index is outdated and cleared (the requested history has been cleared [2280149175/2280148930]) [2280150174]
```
It may lead to an infinite loop if this error isn't handled.

**BTW:** This error still happens on my server after this patch is applied, but less frequent.