### PR TITLE
bridge: make pass-through the default

### DIFF
--- a/tools/local-tester/Procfile
+++ b/tools/local-tester/Procfile
@@ -1,14 +1,14 @@
 # Use goreman to run `go get github.com/mattn/goreman`
 
 # peer bridges
-pbridge1: tools/local-tester/bridge/bridge 127.0.0.1:11111 127.0.0.1:12380
-pbridge2: tools/local-tester/bridge/bridge 127.0.0.1:22222 127.0.0.1:22380
-pbridge3: tools/local-tester/bridge/bridge 127.0.0.1:33333 127.0.0.1:32380
+pbridge1: tools/local-tester/bridge.sh 127.0.0.1:11111 127.0.0.1:12380
+pbridge2: tools/local-tester/bridge.sh 127.0.0.1:22222 127.0.0.1:22380
+pbridge3: tools/local-tester/bridge.sh 127.0.0.1:33333 127.0.0.1:32380
 
 # client bridges
-cbridge1: tools/local-tester/bridge/bridge 127.0.0.1:2379 127.0.0.1:11119
-cbridge2: tools/local-tester/bridge/bridge 127.0.0.1:22379 127.0.0.1:22229
-cbridge3: tools/local-tester/bridge/bridge 127.0.0.1:32379 127.0.0.1:33339
+cbridge1: tools/local-tester/bridge.sh 127.0.0.1:2379 127.0.0.1:11119
+cbridge2: tools/local-tester/bridge.sh 127.0.0.1:22379 127.0.0.1:22229
+cbridge3: tools/local-tester/bridge.sh 127.0.0.1:32379 127.0.0.1:33339
 
 faults: tools/local-tester/faults.sh
 

--- a/tools/local-tester/bridge.sh
+++ b/tools/local-tester/bridge.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+exec tools/local-tester/bridge/bridge \
+	-delay-accept		\
+	-reset-listen		\
+	-conn-fault-rate=0.25	\
+	-immediate-close	\
+	-blackhole		\
+	-time-close		\
+	-write-remote-only	\
+	-read-remote-only	\
+	-random-blackhole	\
+	-corrupt-receive	\
+	-corrupt-send		\
+	-reorder		\
+	$@

--- a/tools/local-tester/bridge/bridge.go
+++ b/tools/local-tester/bridge/bridge.go
@@ -193,19 +193,19 @@ type connFaultFunc func(*bridgeConn)
 func main() {
 	var cfg config
 
-	flag.BoolVar(&cfg.delayAccept, "delay-accept", true, "delays accepting new connections")
-	flag.BoolVar(&cfg.resetListen, "reset-listen", true, "resets the listening port")
+	flag.BoolVar(&cfg.delayAccept, "delay-accept", false, "delays accepting new connections")
+	flag.BoolVar(&cfg.resetListen, "reset-listen", false, "resets the listening port")
 
-	flag.Float64Var(&cfg.connFaultRate, "conn-fault-rate", 0.25, "rate of faulty connections")
-	flag.BoolVar(&cfg.immediateClose, "immediate-close", true, "close after accept")
-	flag.BoolVar(&cfg.blackhole, "blackhole", true, "reads nothing, writes go nowhere")
-	flag.BoolVar(&cfg.timeClose, "time-close", true, "close after random time")
-	flag.BoolVar(&cfg.writeRemoteOnly, "write-remote-only", true, "only write, no read")
-	flag.BoolVar(&cfg.readRemoteOnly, "read-remote-only", true, "only read, no write")
-	flag.BoolVar(&cfg.randomBlackhole, "random-blackhole", true, "blackhole after data xfer")
-	flag.BoolVar(&cfg.corruptReceive, "corrupt-receive", true, "corrupt packets received from destination")
-	flag.BoolVar(&cfg.corruptSend, "corrupt-send", true, "corrupt packets sent to destination")
-	flag.BoolVar(&cfg.reorder, "reorder", true, "reorder packet delivery")
+	flag.Float64Var(&cfg.connFaultRate, "conn-fault-rate", 0.0, "rate of faulty connections")
+	flag.BoolVar(&cfg.immediateClose, "immediate-close", false, "close after accept")
+	flag.BoolVar(&cfg.blackhole, "blackhole", false, "reads nothing, writes go nowhere")
+	flag.BoolVar(&cfg.timeClose, "time-close", false, "close after random time")
+	flag.BoolVar(&cfg.writeRemoteOnly, "write-remote-only", false, "only write, no read")
+	flag.BoolVar(&cfg.readRemoteOnly, "read-remote-only", false, "only read, no write")
+	flag.BoolVar(&cfg.randomBlackhole, "random-blackhole", false, "blackhole after data xfer")
+	flag.BoolVar(&cfg.corruptReceive, "corrupt-receive", false, "corrupt packets received from destination")
+	flag.BoolVar(&cfg.corruptSend, "corrupt-send", false, "corrupt packets sent to destination")
+	flag.BoolVar(&cfg.reorder, "reorder", false, "reorder packet delivery")
 
 	flag.StringVar(&cfg.txDelay, "tx-delay", "0", "duration to delay client transmission to server")
 	flag.StringVar(&cfg.rxDelay, "rx-delay", "0", "duration to delay client receive from server")
@@ -287,6 +287,10 @@ func main() {
 		connFaults = append(connFaults, f)
 	}
 
+	if len(connFaults) > 1 && cfg.connFaultRate == 0 {
+		log.Fatal("connection faults defined but conn-fault-rate=0")
+	}
+
 	var disp dispatcher
 	if cfg.reorder {
 		disp = newDispatcherPool()
@@ -302,7 +306,7 @@ func main() {
 		}
 
 		r := rand.Intn(len(connFaults))
-		if rand.Intn(100) > int(100.0*cfg.connFaultRate) {
+		if rand.Intn(100) >= int(100.0*cfg.connFaultRate) {
 			r = 0
 		}
 


### PR DESCRIPTION
Setting only latency options is a pain since every fault must
be disabled on the command line. Instead, by default start
as a standard bridge without any fault injection.