### PR TITLE
Documentation, op-guide: reorganize etcd operation section

### DIFF
--- a/Documentation/docs.md
+++ b/Documentation/docs.md
@@ -22,33 +22,46 @@ The easiest way to get started using etcd as a distributed key-value store is to
 
 ## Operating etcd clusters
 
-Administrators who need to create reliable and scalable key-value stores for the developers they support should begin with a [cluster on multiple machines][clustering].
+Administrators who need a fault-tolerant etcd cluster for either development or production should begin with a [cluster on multiple machines][clustering].
 
- - [Setting up etcd clusters][clustering]
- - [Setting up etcd gateways][gateway]
- - [Setting up etcd gRPC proxy][grpc_proxy]
+### Setting up etcd
+
+ - [Configuration flags][conf]
+ - [Multi-member cluster][clustering]
+ - [gRPC proxy][grpc_proxy]
+ - [L4 gateway][gateway]
+
+### System configuration
+
+ - [Supported systems][supported_platforms]
  - [Hardware recommendations][hardware]
- - [Configuration][conf]
- - [Security][security]
- - [Authentication][authentication]
- - [Monitoring][monitoring]
- - [Maintenance][maintenance]
- - [Understand failures][failures]
- - [Disaster recovery][recovery]
- - [Performance][performance]
- - [Versioning][versioning]
+ - [Performance benchmarking][performance]
+ - [Tuning][tuning]
 
 ### Platform guides
 
- - [Supported systems][supported_platforms]
- - [Docker container][container_docker]
- - [Container Linux, systemd][container_linux_platform]
- - [rkt container][container_rkt]
  - [Amazon Web Services][aws_platform]
+ - [Container Linux, systemd][container_linux_platform]
  - [FreeBSD][freebsd_platform]
+ - [Docker container][container_docker]
+ - [rkt container][container_rkt]
+
+### Security
+
+ - [TLS][security]
+ - [Role-based access control][authentication]
+
+### Maintenance and troubleshooting
+
+ - [Frequently asked questions][faq]
+ - [Monitoring][monitoring]
+ - [Maintenance][maintenance]
+ - [Failure modes][failures]
+ - [Disaster recovery][recovery]
 
 ### Upgrading and compatibility
 
+ - [Version numbers][versioning]
  - [Migrate applications from using API v2 to API v3][v2_migration]
  - [Upgrading a v2.3 cluster to v3.0][v3_upgrade]
  - [Upgrading a v3.0 cluster to v3.1][v31_upgrade]
@@ -65,17 +78,13 @@ To learn more about the concepts and internals behind etcd, read the following p
  - Internals
    - [Auth subsystem][auth_design]
 
-## Frequently Asked Questions (FAQ)
-
-Answers to [common questions] about etcd.
-
 [api_ref]: dev-guide/api_reference_v3.md
 [api_concurrency_ref]: dev-guide/api_concurrency_reference_v3.md
 [api_grpc_gateway]: dev-guide/api_grpc_gateway.md
 [clustering]: op-guide/clustering.md
 [conf]: op-guide/configuration.md
 [system-limit]: dev-guide/limit.md
-[common questions]: faq.md
+[faq]: faq.md
 [why]: learning/why.md
 [data_model]: learning/data_model.md
 [demo]: demo.md
@@ -111,3 +120,4 @@ Answers to [common questions] about etcd.
 [v32_upgrade]: upgrades/upgrade_3_2.md
 [authentication]: op-guide/authentication.md
 [auth_design]: learning/auth_design.md
+[tuning]: tuning.md

--- a/Documentation/op-guide/authentication.md
+++ b/Documentation/op-guide/authentication.md
@@ -1,8 +1,8 @@
-# Authentication Guide
+# Role-based access control
 
 ## Overview
 
-Authentication was added in etcd 2.1. The etcd v3 API slightly modified the authentication feature's API and user interface to better fit the new data model. This guide is intended to help users set up basic authentication in etcd v3.
+Authentication was added in etcd 2.1. The etcd v3 API slightly modified the authentication feature's API and user interface to better fit the new data model. This guide is intended to help users set up basic authentication and role-based access control in etcd v3.
 
 ## Special users and roles
 

--- a/Documentation/op-guide/failures.md
+++ b/Documentation/op-guide/failures.md
@@ -1,4 +1,4 @@
-# Understand failures
+# Failure modes
 
 Failures are common in a large deployment of machines. A machine fails when its hardware or software malfunctions. Multiple machines fail together when there are power failures or network issues. Multiple kinds of failures can also happen at once; it is almost impossible to enumerate all possible failure cases. 
 

--- a/Documentation/op-guide/recovery.md
+++ b/Documentation/op-guide/recovery.md
@@ -1,4 +1,4 @@
-## Disaster recovery
+# Disaster recovery
 
 etcd is designed to withstand machine failures. An etcd cluster automatically recovers from temporary failures (e.g., machine reboots) and tolerates up to *(N-1)/2* permanent failures for a cluster of N members. When a member permanently fails, whether due to hardware failure or disk corruption, it loses access to the cluster. If the cluster permanently loses more than *(N-1)/2* members then it disastrously fails, irrevocably losing quorum. Once quorum is lost, the cluster cannot reach consensus and therefore cannot continue accepting updates.
 
@@ -6,7 +6,7 @@ To recover from disastrous failure, etcd v3 provides snapshot and restore facili
 
 [v2_recover]: ../v2/admin_guide.md#disaster-recovery
 
-### Snapshotting the keyspace
+## Snapshotting the keyspace
 
 Recovering a cluster first needs a snapshot of the keyspace from an etcd member. A snapshot may either be taken from a live member with the `etcdctl snapshot save` command or by copying the `member/snap/db` file from an etcd data directory. For example, the following command snapshots the keyspace served by `$ENDPOINT` to the file `snapshot.db`:
 
@@ -14,7 +14,7 @@ Recovering a cluster first needs a snapshot of the keyspace from an etcd member.
 $ ETCDCTL_API=3 etcdctl --endpoints $ENDPOINT snapshot save snapshot.db
 ```
 
-### Restoring a cluster
+## Restoring a cluster
 
 To restore a cluster, all that is needed is a single snapshot "db" file. A cluster restore with `etcdctl snapshot restore` creates new etcd data directories; all members should restore using the same snapshot. Restoring overwrites some snapshot metadata (specifically, the member ID and cluster ID); the member loses its former identity. This metadata overwrite prevents the new member from inadvertently joining an existing cluster. Therefore in order to start a cluster from a snapshot, the restore must start a new logical cluster.
 

--- a/Documentation/op-guide/security.md
+++ b/Documentation/op-guide/security.md
@@ -1,4 +1,4 @@
-# Security model
+# Transport security model
 
 etcd supports automatic TLS as well as authentication through client certificates for both clients to server as well as peer (server to server / cluster) communication.
 

--- a/Documentation/op-guide/supported-platform.md
+++ b/Documentation/op-guide/supported-platform.md
@@ -1,8 +1,8 @@
-## Supported platforms
+# Supported systems
 
-### Current support
+## Current support
 
-The following table lists etcd support status for common architectures and operating systems,
+The following table lists etcd support status for common architectures and operating systems:
 
 | Architecture | Operating System | Status       | Maintainers                 |
 | ------------ | ---------------- | ------------ | --------------------------- |
@@ -18,7 +18,7 @@ The following table lists etcd support status for common architectures and opera
 
 Experimental platforms appear to work in practice and have some platform specific code in etcd, but do not fully conform to the stable support policy. Unstable platforms have been lightly tested, but less than experimental. Unlisted architecture and operating system pairs are currently unsupported; caveat emptor.
 
-### Supporting a new platform
+## Supporting a new system platform
 
 For etcd to officially support a new platform as stable, a few requirements are necessary to ensure acceptable quality:
 
@@ -28,7 +28,7 @@ For etcd to officially support a new platform as stable, a few requirements are 
 4. Set up CI (TravisCI, SemaphoreCI or Jenkins) for running integration tests; etcd must pass intensive tests.
 5. (Optional) Set up a functional testing cluster; an etcd cluster should survive stress testing.
 
-### 32-bit and other unsupported systems
+## 32-bit and other unsupported systems
 
 etcd has known issues on 32-bit systems due to a bug in the Go runtime. See the [Go issue][go-issue] and [atomic package][go-atomic] for more information.
 

--- a/Documentation/op-guide/versioning.md
+++ b/Documentation/op-guide/versioning.md
@@ -1,6 +1,6 @@
-## Versioning
+# Versioning
 
-### Service versioning
+## Service versioning
 
 etcd uses [semantic versioning](http://semver.org)
 New minor versions may add additional features to the API.
@@ -11,7 +11,7 @@ Get the running etcd cluster version with `etcdctl`:
 ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 endpoint status
 ```
 
-### API versioning
+## API versioning
 
 The `v3` API responses should not change after the 3.0.0 release but new features will be added over time.
 

--- a/Documentation/platforms/aws.md
+++ b/Documentation/platforms/aws.md
@@ -1,4 +1,4 @@
-## Introduction
+# Amazon Web Services
 
 This guide assumes operational knowledge of Amazon Web Services (AWS), specifically Amazon Elastic Compute Cloud (EC2). This guide provides an introduction to design considerations when designing an etcd deployment on AWS EC2 and how AWS specific features may be utilized in that context.
 

--- a/Documentation/platforms/container-linux-systemd.md
+++ b/Documentation/platforms/container-linux-systemd.md
@@ -1,4 +1,4 @@
-# Run etcd on Container Linux with systemd
+# Container Linux with systemd
 
 The following guide shows how to run etcd with [systemd][systemd-docs] under [Container Linux][container-linux-docs].
 


### PR DESCRIPTION
Reorganizes sections in README.md, slightly changes some titles, puts
sections at a consistent depth.