### PR TITLE
test: sync with etcd-agent start in functional_pass

### DIFF
--- a/test
+++ b/test
@@ -101,13 +101,21 @@ function functional_pass {
 		agent_pids="${agent_pids} $pid"
 	done
 
+	for a in 1 2 3; do
+		echo "Waiting for 'etcd-agent' on ${a}9027..."
+		while ! nc -z localhost ${a}9027; do
+			sleep 1
+		done
+	done
+
+	echo "Starting 'etcd-tester'"
 	./bin/etcd-tester \
 		-agent-endpoints "127.0.0.1:19027,127.0.0.1:29027,127.0.0.1:39027" \
 		-client-ports 12379,22379,32379 \
 		-peer-ports 12380,22380,32380 \
 		-limit 1 \
 		-schedule-cases "0 1 2 3 4 5" \
-		-exit-on-failure
+		-exit-on-failure && echo "'etcd-tester' succeeded"
 	ETCD_TESTER_EXIT_CODE=$?
 	echo "ETCD_TESTER_EXIT_CODE:" ${ETCD_TESTER_EXIT_CODE}
 


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/8211.

tester started before agent starts listening. This patch syncs
with agent listener starts.