### PR TITLE
contrib/raftexample: use bytes.Buffer.String (no 'string()')

### DIFF
--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -58,7 +58,7 @@ func (s *kvstore) Propose(k string, v string) {
 	if err := gob.NewEncoder(&buf).Encode(kv{k, v}); err != nil {
 		log.Fatal(err)
 	}
-	s.proposeC <- string(buf.Bytes())
+	s.proposeC <- buf.String()
 }
 
 func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {


### PR DESCRIPTION
Fix travis CI breakage.