### PR TITLE
testutil: whitelist os.(*file).close

### DIFF
--- a/pkg/testutil/leak.go
+++ b/pkg/testutil/leak.go
@@ -119,6 +119,7 @@ func interestingGoroutines() (gs []string) {
 		stack := strings.TrimSpace(sl[1])
 		if stack == "" ||
 			strings.Contains(stack, "sync.(*WaitGroup).Done") ||
+			strings.Contains(stack, "os.(*file).close") ||
 			strings.Contains(stack, "created by os/signal.init") ||
 			strings.Contains(stack, "runtime/panic.go") ||
 			strings.Contains(stack, "created by testing.RunTests") ||


### PR DESCRIPTION
Leak detector is catching goroutines trying to close files which appear
runtime related:

1 instances of:
syscall.Syscall(...)
	/usr/local/golang/1.8.3/go/src/syscall/asm_linux_386.s:20 +0x5
syscall.Close(...)
	/usr/local/golang/1.8.3/go/src/syscall/zsyscall_linux_386.go:296 +0x3d
os.(*file).close(...)
	/usr/local/golang/1.8.3/go/src/os/file_unix.go:140 +0x62

It's unlikely a user goroutine will leak on file close; whitelist it.