### PR TITLE
proxy: don't inc a cache miss count in a case of linearizable range

### DIFF
--- a/proxy/grpcproxy/kv.go
+++ b/proxy/grpcproxy/kv.go
@@ -48,8 +48,9 @@ func (p *kvProxy) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRespo
 			cacheHits.Inc()
 			return nil, err
 		}
+
+		cachedMisses.Inc()
 	}
-	cachedMisses.Inc()
 
 	resp, err := p.kv.Do(ctx, RangeRequestToOp(r))
 	if err != nil {


### PR DESCRIPTION
Requests of linearizable range don't touch the cache of grpcproxy. So
incrementing the miss count wouldn't be meaningful.
