### PR TITLE
mvcc: fix TestHashKVWhenCompacting hash mismatch

### DIFF
--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -522,7 +522,7 @@ func TestHashKVWhenCompacting(t *testing.T) {
 	s := NewStore(b, &lease.FakeLessor{}, nil)
 	defer os.Remove(tmpPath)
 
-	rev := 1000
+	rev := 10000
 	for i := 2; i <= rev; i++ {
 		s.Put([]byte("foo"), []byte(fmt.Sprintf("bar%d", i)), lease.NoLease)
 	}
@@ -558,7 +558,7 @@ func TestHashKVWhenCompacting(t *testing.T) {
 				revHash[r.compactRev] = r.hash
 			}
 			if r.hash != revHash[r.compactRev] {
-				t.Fatalf("Hashes differ (current %v) != (saved %v)", r.hash, revHash[r.compactRev])
+				t.Fatalf("hashes differ (current %v) != (saved %v) at %v", r.hash, revHash[r.compactRev], r.compactRev)
 			}
 		}
 	}()


### PR DESCRIPTION
This pr adds a check in compaction to ensure that setting keep to nil only if this is the latest compaction in queue.

Suppose that HashKV() starts after compact(A) and compact(B) has scheduled and after
completion of compact(A) but before the completion of compact(B).

Before this PR:
Completion of compact(A) sets keep to nil to indicate that there are no ongoing compactions.
This assumption causes HashKV to hash all mvcc keys including keys that 
hasn't been deleted by compact(B) up to a rev. Hence, HashKV again after completion of compact(B) returns
a different Hash that during compact(B).

After this PR:
Completion of compact(A) sets keep to nil if current compactRev == compactRev(compact(A)).
Since calling compact(B) changes current compactRev, then current compactRev != compactRev(compact(A)).
Then HashKV will base on the keep set during compact(B) instead of nil which return the correct hash
during compact(B).

fixes  #8311
