### PR TITLE
clientv3: when a endpoint is unavailable, switch it in retry

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -119,6 +119,13 @@ func (c *Client) SetEndpoints(eps ...string) {
 	c.balancer.updateAddrs(eps)
 }
 
+// TrySwitchEndpoint try to make balancer change it's fix endpoint.
+// It may do nothing while their is only one endpoint, or switch has just happened
+// It is called when the endpoint now is not available, like network partition happens
+func (c *Client) TrySwitchEndpoint() {
+	c.balancer.trySwitchEndpoint()
+}
+
 // Sync synchronizes client's endpoints with the known endpoints from the etcd membership.
 func (c *Client) Sync(ctx context.Context) error {
 	mresp, err := c.MemberList(ctx)

--- a/clientv3/retry.go
+++ b/clientv3/retry.go
@@ -45,6 +45,9 @@ func (c *Client) newRetryWrapper(isStop retryStopErrFunc) retryRpcFunc {
 	return func(rpcCtx context.Context, f rpcFunc) error {
 		for {
 			if err := f(rpcCtx); err == nil || isStop(err) {
+				if grpc.Code(err) == codes.Unavailable {
+					c.TrySwitchEndpoint()
+				}
 				return err
 			}
 			select {


### PR DESCRIPTION
    clientv3: balancer.go and retry.go

    when a endpoint is unavailable, switch it in retry

    fix: #8326
