### PR TITLE
raft: check whether it's leader PRC request when recv message with higher term 

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -1755,6 +1755,13 @@ func TestFreeStuckCandidateWithCheckQuorum(t *testing.T) {
 	if c.Term != a.Term {
 		t.Errorf("term = %d, want %d", c.Term, a.Term)
 	}
+
+	// Vote again, should become leader this time
+	nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
+
+	if c.state != StateLeader {
+		t.Errorf("peer 3 state: %s, want %s", c.state, StateLeader)
+	}
 }
 
 func TestNonPromotableVoterWithCheckQuorum(t *testing.T) {


### PR DESCRIPTION
raft: currently when raft recv message with higher term, it set leader to that node.  If raft recv a MsgAppResp with higher term, it could not know whether remote node is leader or not. it's confusing.

So for message with higher term, only reset raft.lead when it's leader RPC request. Those messages are MsgApp, MsgHeartbeat, MsgSnap.