### PR TITLE
raft: reset votes when becomePreCandidate

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -611,6 +611,7 @@ func (r *raft) becomePreCandidate() {
 	// but doesn't change anything else. In particular it does not increase
 	// r.Term or change r.Vote.
 	r.step = stepCandidate
+	r.votes = make(map[uint64]bool)
 	r.tick = r.tickElection
 	r.state = StatePreCandidate
 	r.logger.Infof("%x became pre-candidate at term %d", r.id, r.Term)


### PR DESCRIPTION
raft: reset votes when becomePreCandidate.  because the [poll method](../blob/master/raft/raft.go#L690) wouldn't update grant state when key exists.

here is a case:  
1.  cluster with three node [A, B, C],  all term are 2, with leader A and all logs are replicated.
2.  node A down.   B and C start election at the same time (split votes), both become pre-candidate.
3.  C grant B's pre-vote,  and B grant C's pre-vote.  So, both B and C become candidate, with term 3.
4.  C reject B's vote, and B reject C's vote.  So, B and C are still candidate.   B record votes like (B, true) (C, false),   C record votes like (B, false)  (C, true)
5.  B election-timeout first, start pre-vote.  C grant B's pre-vote.
6.  when B check poll state，it's still (B, true) (C, false).     So, election will continue, and no one will win.