### PR TITLE
release: use gcr.io as default registry

### DIFF
--- a/Documentation/dev-internal/release.md
+++ b/Documentation/dev-internal/release.md
@@ -90,6 +90,17 @@ The public key for GPG signing can be found at [CoreOS Application Signing Key](
 - Select whether it is a pre-release.
 - Publish the release!
 
+## Publish docker image to gcr.io
+
+- Push docker image:
+
+```
+gcloud docker -- login -u _json_key -p "$(cat $KEY_PATH)" https://gcr.io
+gcloud docker -- push gcr.io/etcd-development/etcd:latest
+```
+
+- Add `latest` tag to the new image on [gcr.io](https://gcr.io/etcd-development/etcd) if this is a stable release.
+
 ## Publish docker image in Quay.io
 
 - Push docker image:

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -10,7 +10,7 @@ fi
 VERSION=${1}
 ARCH=$(go env GOARCH)
 DOCKERFILE="Dockerfile-release"
-: ${TAG:="quay.io/coreos/etcd"}
+: ${TAG:="gcr.io/etcd-development/etcd"}
 
 if [ -z ${BINARYDIR} ]; then
 	RELEASE="etcd-${1}"-`go env GOOS`-`go env GOARCH`


### PR DESCRIPTION
Let's use gcr.io as default registry for next release (3.3).
We can still push images to quay with `TAG` flag to release script.

Plus, quay S3 issue with AWS has been blocking us for functional testing dashboard.
I would like to switch them all to gcr.io.

I test pushed to https://gcr.io/etcd-development/etcd and confirm that it works.