### PR TITLE
etcdctl: add ttl flag for lock command

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -832,9 +832,13 @@ echo ${transferee_id}
 
 ## Concurrency commands
 
-### LOCK \<lockname\> [command arg1 arg2 ...]
+### LOCK [options] \<lockname\> [command arg1 arg2 ...]
 
 LOCK acquires a distributed named mutex with a given name. Once the lock is acquired, it will be held until etcdctl is terminated.
+
+#### Options
+
+- ttl - time out in seconds of lock session.
 
 #### Output
 

--- a/etcdctl/ctlv3/command/lock_command.go
+++ b/etcdctl/ctlv3/command/lock_command.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+var lockTTL = 10
+
 // NewLockCommand returns the cobra command for "lock".
 func NewLockCommand() *cobra.Command {
 	c := &cobra.Command{
@@ -35,6 +37,7 @@ func NewLockCommand() *cobra.Command {
 		Short: "Acquires a named lock",
 		Run:   lockCommandFunc,
 	}
+	c.Flags().IntVarP(&lockTTL, "ttl", "", lockTTL, "timeout for session")
 	return c
 }
 
@@ -49,7 +52,7 @@ func lockCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func lockUntilSignal(c *clientv3.Client, lockname string, cmdArgs []string) error {
-	s, err := concurrency.NewSession(c)
+	s, err := concurrency.NewSession(c, concurrency.WithTTL(lockTTL))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1, add session ttl for lock cmd
2, set default session ttl to 10 seconds
@xiang90 @heyitsanthony 
please buddy check and  suggest if it is a better way to set the ttl as a gloabal flag ?
