### PR TITLE
raft: conf change proposals buffer

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -844,6 +844,7 @@ func stepLeader(r *raft, m pb.Message) {
 		for i, e := range m.Entries {
 			if e.Type == pb.EntryConfChange {
 				if r.pendingConf {
+					// FIXME: should this be refactored as an impossible case?
 					r.logger.Infof("propose conf %s ignored since pending unapplied configuration", e.String())
 					m.Entries[i] = pb.Entry{Type: pb.EntryNormal}
 				}


### PR DESCRIPTION
Please review this proof of concept patch that is supposed to avoid the situation when Raft ignores conf change proposals when there is yet unapplied one (from [here](https://github.com/coreos/etcd/blob/master/raft/raft.go#L847)):

```
 propose conf Type:EntryConfChange Data:"\010\001\020\000\030\302\334\240\205\271\201\321\302\r\"\026http://localhost:10744"  ignored since pending unapplied configuration
```
In my opinion, this behavior may cause problems when the cluster membership updates overtake the Raft leader's progress (e. g. at the moment of new peers spawning at the cluster startup, or massive peer loss due to network problems). In these edge cases conf change proposals may be ignored and lost. 

This patch introduces a buffer within a Raft node which prevents it from sending the conf change proposals too frequently.