### PR TITLE
pkg/flags: warns on shadowed environment variable flags

### DIFF
--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -80,9 +80,7 @@ func SetFlagsFromEnv(prefix string, fs *flag.FlagSet) error {
 	fs.VisitAll(func(f *flag.Flag) {
 		err = setFlagFromEnv(fs, prefix, f.Name, usedEnvKey, alreadySet, true)
 	})
-
 	verifyEnv(prefix, usedEnvKey, alreadySet)
-
 	return err
 }
 
@@ -100,6 +98,7 @@ func SetPflagsFromEnv(prefix string, fs *pflag.FlagSet) error {
 			err = serr
 		}
 	})
+	verifyEnv(prefix, usedEnvKey, alreadySet)
 	return err
 }
 
@@ -118,7 +117,8 @@ func verifyEnv(prefix string, usedEnvKey, alreadySet map[string]bool) {
 			continue
 		}
 		if alreadySet[kv[0]] {
-			plog.Infof("recognized environment variable %s, but unused: shadowed by corresponding flag ", kv[0])
+			// TODO: exit with error in v3.4
+			plog.Warningf("recognized environment variable %s, but unused: shadowed by corresponding flag", kv[0])
 			continue
 		}
 		if strings.HasPrefix(env, prefix+"_") {


### PR DESCRIPTION
Address https://github.com/coreos/etcd/issues/8380.

```
export ETCD_NAME=aaaaa
./bin/etcd --name bbb
2017-08-09 14:18:11.061895 W | etcdmain: recognized environment variable ETCD_NAME, but unused: shadowed by corresponding flag

export ETCDCTL_ENDPOINTS=aaaaa.com
ETCDCTL_API=3 ./bin/etcdctl endpoint health --endpoints=bbb.com
2017-08-09 14:18:11.061895 W | pkg/flags: recognized environment variable ETCDCTL_ENDPOINTS, but unused: shadowed by corresponding flag
```
