### PR TITLE
Update interacting_v3.md - v2 keys to v3 API incompatability

### DIFF
--- a/Documentation/dev-guide/interacting_v3.md
+++ b/Documentation/dev-guide/interacting_v3.md
@@ -2,13 +2,12 @@
 
 Users mostly interact with etcd by putting or getting the value of a key. This section describes how to do that by using etcdctl, a command line tool for interacting with etcd server. The concepts described here should apply to the gRPC APIs or client library APIs.
 
-By default, etcdctl talks to the etcd server with the v2 API for backward compatibility. For etcdctl to speak to etcd using the v3 API, the API version must be set to version 3 via the `ETCDCTL_API` environment variable.
+By default, etcdctl talks to the etcd server with the v2 API for backward compatibility. For etcdctl to speak to etcd using the v3 API, the API version must be set to version 3 via the `ETCDCTL_API` environment variable. However note that any key that was created using the v2 API will not be able to be queried via the v3 API.  A v3 API ```etcdctl get``` of a v2 key will exit with 0 and no key data, this is the expected behaviour.
+
 
 ```bash
 export ETCDCTL_API=3
 ```
-
-**However note** that any key that was created using the v2 API will not be able to be queried via the v3 API.  A v3 API ```etcdctl get``` of a v2 key will exit with 0 and no key data, this is the expected behaviour.
 
 ## Find versions
 

--- a/Documentation/dev-guide/interacting_v3.md
+++ b/Documentation/dev-guide/interacting_v3.md
@@ -8,6 +8,8 @@ By default, etcdctl talks to the etcd server with the v2 API for backward compat
 export ETCDCTL_API=3
 ```
 
+**However note** that any key that was created using the v2 API will not be able to be queried via the v3 API.  A v3 API ```etcdctl get``` of a v2 key will exit with 0 and no key data, this is the expected behaviour.
+
 ## Find versions
 
 etcdctl version and Server API version can be useful in finding the appropriate commands to be used for performing various operations on etcd.


### PR DESCRIPTION
Making it clear to the user that keys created via the v2 API are not readable by the etcdctl with the v3 API.  A etcdctl v3 get of a v2 key key exits with 0 and no data, which is quite confusing, hopefully this just makes that it a bit clearer if the user upgraded etcd to 3.x in the past (and forget some of the 2.3 to 3.0 to 3.1 to 3.2 upgrade details) but never updated the API they used as v2 was the default and they happen to trying to figure out wtf, this is a further reminder of that backward incompatibility.