### PR TITLE
netutil: don't resolve unix socket URLs when comparing URLs

### DIFF
--- a/e2e/etcd_config_test.go
+++ b/e2e/etcd_config_test.go
@@ -84,3 +84,32 @@ func TestEtcdMultiPeer(t *testing.T) {
 		}
 	}
 }
+
+// TestEtcdUnixPeers checks that etcd will boot with unix socket peers.
+func TestEtcdUnixPeers(t *testing.T) {
+	d, err := ioutil.TempDir("", "e1.etcd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(d)
+	proc, err := spawnCmd(
+		[]string{
+			binDir + "/etcd",
+			"--data-dir", d,
+			"--name", "e1",
+			"--listen-peer-urls", "unix://etcd.unix:1",
+			"--initial-advertise-peer-urls", "unix://etcd.unix:1",
+			"--initial-cluster", "e1=unix://etcd.unix:1",
+		},
+	)
+	defer os.Remove("etcd.unix:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = waitReadyExpectProc(proc, etcdServerReadyLines); err != nil {
+		t.Fatal(err)
+	}
+	if err = proc.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
etcd would fail to bootstrap:
```
../bin/etcd-1358: 2017-08-17 11:48:48.526669 I | etcdmain: setting maximum number of CPUs to 8, total number of available CPUs is 8
../bin/etcd-1358: 2017-08-17 11:48:48.526804 I | embed: listening for peers on unix://etcd.unix:1
../bin/etcd-1358: 2017-08-17 11:48:48.527042 I | embed: listening for client requests on localhost:2379
../bin/etcd-1358: 2017-08-17 11:48:49.061660 W | pkg/netutil: failed resolving host etcd.unix:1 (lookup etcd.unix on 75.75.75.75:53: no such host); retrying in 1s
../bin/etcd-1358: 2017-08-17 11:48:50.093301 W | pkg/netutil: failed resolving host etcd.unix:1 (lookup etcd.unix on 75.75.75.75:53: no such host); retrying in 1s
../bin/etcd-1358: 2017-08-17 11:48:51.122967 W | pkg/netutil: failed resolving host etcd.unix:1 (lookup etcd.unix on 75.75.75.75:53: no such host); retrying in 1s
```