### PR TITLE
auth: replace NewContext with NewOutgoingContext

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -1098,7 +1098,7 @@ func (as *authStore) WithRoot(ctx context.Context) context.Context {
 		"token": token,
 	}
 	tokenMD := metadata.New(mdMap)
-	return metadata.NewContext(ctx, tokenMD)
+	return metadata.NewOutgoingContext(ctx, tokenMD)
 }
 
 func (as *authStore) HasRole(user, role string) bool {


### PR DESCRIPTION
This was missed in last gRPC bump-up.

c.f. https://github.com/grpc/grpc-go/commit/596a6acc87c73c3bc398a60ef0089976491ca060