### PR TITLE
mvcc: Revisions() method for index to avoid key allocation

### DIFF
--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -24,6 +24,7 @@ import (
 type index interface {
 	Get(key []byte, atRev int64) (rev, created revision, ver int64, err error)
 	Range(key, end []byte, atRev int64) ([][]byte, []revision)
+	Revisions(key, end []byte, atRev int64) []revision
 	Put(key []byte, rev revision)
 	Tombstone(key []byte, rev revision) error
 	RangeSince(key, end []byte, rev int64) []revision
@@ -82,6 +83,18 @@ func (ti *treeIndex) keyIndex(keyi *keyIndex) *keyIndex {
 		return item.(*keyIndex)
 	}
 	return nil
+}
+
+func (ti *treeIndex) Revisions(key, end []byte, atRev int64) (revs []revision) {
+	if end == nil {
+		rev, _, _, err := ti.Get(key, atRev)
+		if err != nil {
+			return nil
+		}
+		return []revision{rev}
+	}
+	_, rev := ti.Range(key, end, atRev)
+	return rev
 }
 
 func (ti *treeIndex) Range(key, end []byte, atRev int64) (keys [][]byte, revs []revision) {

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -741,6 +741,11 @@ type fakeIndex struct {
 	indexCompactRespc     chan map[revision]struct{}
 }
 
+func (i *fakeIndex) Revisions(key, end []byte, atRev int64) []revision {
+	_, rev := i.Range(key, end, atRev)
+	return rev
+}
+
 func (i *fakeIndex) Get(key []byte, atRev int64) (rev, created revision, ver int64, err error) {
 	i.Recorder.Record(testutil.Action{Name: "get", Params: []interface{}{key, atRev}})
 	r := <-i.indexGetRespc

--- a/mvcc/kvstore_txn.go
+++ b/mvcc/kvstore_txn.go
@@ -120,7 +120,7 @@ func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions
 		return &RangeResult{KVs: nil, Count: -1, Rev: 0}, ErrCompacted
 	}
 
-	_, revpairs := tr.s.kvindex.Range(key, end, int64(rev))
+	revpairs := tr.s.kvindex.Revisions(key, end, int64(rev))
 	if len(revpairs) == 0 {
 		return &RangeResult{KVs: nil, Count: 0, Rev: curRev}, nil
 	}


### PR DESCRIPTION
Save another alloc on the one key path.

master:
```
$ go test -bench=OneKey -run=OneKey -count=4 
BenchmarkStoreRangeOneKey-8      1000000              1883 ns/op             610 B/op         14 allocs/op
BenchmarkStoreRangeOneKey-8      1000000              1807 ns/op             609 B/op         14 allocs/op
BenchmarkStoreRangeOneKey-8      1000000              1861 ns/op             610 B/op         14 allocs/op
BenchmarkStoreRangeOneKey-8      1000000              1850 ns/op             610 B/op         14 allocs/op
```

branch:
```
$ go test -bench=OneKey -run=OneKey -count=4
BenchmarkStoreRangeOneKey-8      1000000              1808 ns/op             578 B/op         13 allocs/op
BenchmarkStoreRangeOneKey-8      1000000              1766 ns/op             578 B/op         13 allocs/op
BenchmarkStoreRangeOneKey-8      1000000              1800 ns/op             577 B/op         13 allocs/op
BenchmarkStoreRangeOneKey-8      1000000              1758 ns/op             578 B/op         13 allocs/op
```