### PR TITLE
integration: check concurrent auth ops don't cause old rev errors

### DIFF
--- a/integration/v3_auth_test.go
+++ b/integration/v3_auth_test.go
@@ -15,6 +15,8 @@
 package integration
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -291,4 +293,42 @@ func TestV3AuthNonAuthorizedRPCs(t *testing.T) {
 	if !eqErrGRPC(err, rpctypes.ErrGRPCUserEmpty) {
 		t.Fatalf("could put key (%v), it should cause an error of permission denied", respput)
 	}
+}
+
+func TestV3AuthOldRevConcurrent(t *testing.T) {
+	defer testutil.AfterTest(t)
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	authSetupRoot(t, toGRPC(clus.Client(0)).Auth)
+
+	c, cerr := clientv3.New(clientv3.Config{
+		Endpoints:   clus.Client(0).Endpoints(),
+		DialTimeout: 5 * time.Second,
+		Username:    "root",
+		Password:    "123",
+	})
+	testutil.AssertNil(t, cerr)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	f := func(i int) {
+		defer wg.Done()
+		role, user := fmt.Sprintf("test-role-%d", i), fmt.Sprintf("test-user-%d", i)
+		_, err := c.RoleAdd(context.TODO(), role)
+		testutil.AssertNil(t, err)
+		_, err = c.RoleGrantPermission(context.TODO(), role, "", clientv3.GetPrefixRangeEnd(""), clientv3.PermissionType(clientv3.PermReadWrite))
+		testutil.AssertNil(t, err)
+		_, err = c.UserAdd(context.TODO(), user, "123")
+		testutil.AssertNil(t, err)
+		_, err = c.Put(context.TODO(), "a", "b")
+		testutil.AssertNil(t, err)
+	}
+	// needs concurrency to trigger
+	numRoles := 2
+	wg.Add(numRoles)
+	for i := 0; i < numRoles; i++ {
+		go f(i)
+	}
+	wg.Wait()
 }

--- a/pkg/testutil/assert.go
+++ b/pkg/testutil/assert.go
@@ -54,5 +54,9 @@ func AssertFalse(t *testing.T, v bool, msg ...string) {
 }
 
 func isNil(v interface{}) bool {
-	return v == nil || reflect.ValueOf(v).IsNil()
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	return rv.Kind() != reflect.Struct && rv.IsNil()
 }


### PR DESCRIPTION
Fixes #8406 

Should be backported along with 478ba2c