### PR TITLE
etcdctl: unset ETCDCTL_ARGS on cov builds

### DIFF
--- a/etcdctl/ctlv3/ctl_cov.go
+++ b/etcdctl/ctlv3/ctl_cov.go
@@ -27,6 +27,7 @@ func Start() {
 	// ETCDCTL_ARGS=etcdctl_test arg1 arg2...
 	// SetArgs() takes arg1 arg2...
 	rootCmd.SetArgs(strings.Split(os.Getenv("ETCDCTL_ARGS"), "\xe7\xcd")[1:])
+	os.Unsetenv("ETCDCTL_ARGS")
 	if err := rootCmd.Execute(); err != nil {
 		command.ExitWithError(command.ExitError, err)
 	}


### PR DESCRIPTION
The stricter warnings on pkg/flags generates extra output that
break coverage tests. Unset the ETCDCTL_ARGS environment variable
so the warnings aren't printed.