### PR TITLE
integration: clean up resources in error paths of TestV3WatchFromCurr…

### DIFF
--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -223,20 +223,24 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 		cresp, err := wStream.Recv()
 		if err != nil {
 			t.Errorf("#%d: wStream.Recv error: %v", i, err)
+			clus.Terminate(t)
 			continue
 		}
 		if !cresp.Created {
 			t.Errorf("#%d: did not create watchid, got %+v", i, cresp)
+			clus.Terminate(t)
 			continue
 		}
 		if cresp.Canceled {
 			t.Errorf("#%d: canceled watcher on create %+v", i, cresp)
+			clus.Terminate(t)
 			continue
 		}
 
 		createdWatchId := cresp.WatchId
 		if cresp.Header == nil || cresp.Header.Revision != 1 {
 			t.Errorf("#%d: header revision got +%v, wanted revison 1", i, cresp)
+			clus.Terminate(t)
 			continue
 		}
 


### PR DESCRIPTION
…entRevision

Current error paths of TestV3WatchFromCurrentRevision don't clean the
used resources including goroutines. Because go's tests are executed
continuously in a single process, the leaked goroutines makes error
logs bloated like the below case:
https://jenkins-etcd-public.prod.coreos.systems/job/etcd-coverage/2143/

This commit lets the error paths clean the resources.
