### PR TITLE
srv: if a host matches a peer, only use if url schemes match

### DIFF
--- a/pkg/srv/srv.go
+++ b/pkg/srv/srv.go
@@ -71,9 +71,10 @@ func GetCluster(service, name, dns string, apurls types.URLs) ([]string, error) 
 			// SRV records have a trailing dot but URL shouldn't.
 			shortHost := strings.TrimSuffix(srv.Target, ".")
 			urlHost := net.JoinHostPort(shortHost, port)
-			stringParts = append(stringParts, fmt.Sprintf("%s=%s://%s", n, scheme, urlHost))
 			if ok && url.Scheme != scheme {
 				err = fmt.Errorf("bootstrap at %s from DNS for %s has scheme mismatch with expected peer %s", scheme+"://"+urlHost, service, url.String())
+			} else {
+				stringParts = append(stringParts, fmt.Sprintf("%s=%s://%s", n, scheme, urlHost))
 			}
 		}
 		if len(stringParts) == 0 {

--- a/pkg/srv/srv_test.go
+++ b/pkg/srv/srv_test.go
@@ -86,7 +86,14 @@ func TestSRVGetCluster(t *testing.T) {
 
 			"dnsClusterTest=https://1.example.com:2480,0=https://2.example.com:2480,1=https://3.example.com:2480",
 		},
-		// invalid
+		// reject if apurls are TLS but SRV is only http
+		{
+			nil,
+			srvAll,
+			[]string{"https://10.0.0.1:2480"},
+
+			"0=http://2.example.com:2480,1=http://3.example.com:2480",
+		},
 	}
 
 	resolveTCPAddr = func(network, addr string) (*net.TCPAddr, error) {


### PR DESCRIPTION
The https scheme for a peer advertise URL was ignored when resolving through
SRV records.