### PR TITLE
*: configure server keepalive, optimize client balancer with health check

### DIFF
--- a/.words
+++ b/.words
@@ -1,7 +1,9 @@
 RPC
 RPCs
+blackholed
 cancelable
 cancelation
+cluster_proxy
 defragment
 defragmenting
 etcd
@@ -20,5 +22,7 @@ prefetching
 protobuf
 serializable
 teardown
+too_many_pings
 uncontended
 unprefixed
+unlisting

--- a/clientv3/balancer.go
+++ b/clientv3/balancer.go
@@ -17,8 +17,10 @@ package clientv3
 import (
 	"context"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -33,7 +35,9 @@ var ErrNoAddrAvilable = grpc.Errorf(codes.Unavailable, "there is no address avai
 // to the grpc reconnection code path
 type simpleBalancer struct {
 	// addrs are the client's endpoints for grpc
-	addrs []grpc.Address
+	addrs       []grpc.Address
+	healthCheck func(ep string) (bool, error)
+
 	// notifyCh notifies grpc of the set of addresses for connecting
 	notifyCh chan []grpc.Address
 
@@ -43,6 +47,9 @@ type simpleBalancer struct {
 
 	// mu protects all fields below.
 	mu sync.RWMutex
+
+	// failed records last failed time of endpoints.
+	failed map[string]time.Time
 
 	// upc closes when pinAddr transitions from empty to non-empty or the balancer closes.
 	upc chan struct{}
@@ -71,7 +78,7 @@ type simpleBalancer struct {
 	closed bool
 }
 
-func newSimpleBalancer(eps []string) *simpleBalancer {
+func newSimpleBalancer(eps []string, dialTimeout time.Duration, healthCheck func(ep string) (bool, error)) *simpleBalancer {
 	notifyCh := make(chan []grpc.Address, 1)
 	addrs := make([]grpc.Address, len(eps))
 	for i := range eps {
@@ -79,7 +86,9 @@ func newSimpleBalancer(eps []string) *simpleBalancer {
 	}
 	sb := &simpleBalancer{
 		addrs:        addrs,
+		healthCheck:  healthCheck,
 		notifyCh:     notifyCh,
+		failed:       make(map[string]time.Time),
 		readyc:       make(chan struct{}),
 		upc:          make(chan struct{}),
 		stopc:        make(chan struct{}),
@@ -90,6 +99,7 @@ func newSimpleBalancer(eps []string) *simpleBalancer {
 	}
 	close(sb.downc)
 	go sb.updateNotifyLoop()
+	go sb.updateFailed(dialTimeout)
 	return sb
 }
 
@@ -137,10 +147,21 @@ func (b *simpleBalancer) updateAddrs(eps []string) {
 	b.host2ep = np
 
 	addrs := make([]grpc.Address, 0, len(eps))
+	all := make(map[string]struct{}, len(eps))
 	for i := range eps {
-		addrs = append(addrs, grpc.Address{Addr: getHost(eps[i])})
+		addr := grpc.Address{Addr: getHost(eps[i])}
+		addrs = append(addrs, addr)
+		all[addr.Addr] = struct{}{}
 	}
 	b.addrs = addrs
+
+	failed := b.failed
+	for k := range failed {
+		if _, ok := all[k]; !ok {
+			delete(failed, k)
+		}
+	}
+	b.failed = failed
 
 	// updating notifyCh can trigger new connections,
 	// only update addrs if all connections are down
@@ -219,9 +240,65 @@ func (b *simpleBalancer) updateNotifyLoop() {
 	}
 }
 
+func (b *simpleBalancer) updateFailed(timeout time.Duration) {
+	if timeout < 3*time.Second {
+		timeout = 3 * time.Second
+	}
+	for {
+		select {
+		case <-time.After(timeout):
+			b.mu.Lock()
+			for k, v := range b.failed {
+				if time.Since(v) > timeout {
+					delete(b.failed, k)
+				}
+			}
+			b.mu.Unlock()
+		case <-b.stopc:
+			return
+		}
+	}
+}
+
+type addrConn struct {
+	addr   grpc.Address
+	failed time.Time
+}
+
 func (b *simpleBalancer) notifyAddrs() {
 	b.mu.RLock()
-	addrs := b.addrs
+	var addrs []grpc.Address
+	if len(b.addrs) == 1 ||
+		len(b.failed) == 0 ||
+		b.healthCheck == nil { // single-endpoint, or no failure
+		addrs = b.addrs
+	} else if len(b.failed) > 0 { // last pinned failing temporarily
+		all := make(map[string]grpc.Address)
+		for _, addr := range b.addrs {
+			all[addr.Addr] = addr
+			if _, ok := b.failed[addr.Addr]; ok {
+				continue
+			}
+			ok, err := b.healthCheck(addr.Addr)
+			if ok && err == nil {
+				addrs = append(addrs, addr)
+			}
+		}
+		if len(addrs) == 0 { // no better alternative found
+			addrs = b.addrs
+		} else { // sort that latest failed be at the end
+			addrConns := make([]addrConn, 0, len(b.failed))
+			for k, v := range b.failed {
+				addrConns = append(addrConns, addrConn{addr: all[k], failed: v})
+			}
+			sort.Slice(addrConns, func(i, j int) bool {
+				return addrConns[i].failed.Before(addrConns[j].failed)
+			})
+			for _, a := range addrConns {
+				addrs = append(addrs, a.addr)
+			}
+		}
+	}
 	b.mu.RUnlock()
 	select {
 	case b.notifyCh <- addrs:
@@ -229,6 +306,57 @@ func (b *simpleBalancer) notifyAddrs() {
 	}
 }
 
+func (b *simpleBalancer) shouldPin(addr grpc.Address) bool {
+	if len(b.addrs) == 1 {
+		return true
+	}
+
+	if _, ok := b.failed[addr.Addr]; !ok { // did not fail
+		if b.healthCheck != nil {
+			healthy, err := b.healthCheck(addr.Addr)
+			if healthy && err == nil { // confirmed healthy
+				return true
+			}
+			b.failed[addr.Addr] = time.Now()
+			return false
+		}
+		return true
+	}
+	if b.healthCheck == nil {
+		return true
+	}
+
+	// failing temporarily
+	healthy, err := b.healthCheck(addr.Addr)
+	if healthy && err == nil { // recovered
+		delete(b.failed, addr.Addr)
+		return true
+	}
+
+	// failing still
+	for _, other := range b.addrs {
+		if other.Addr == addr.Addr {
+			continue
+		}
+		healthy, err := b.healthCheck(other.Addr)
+		if healthy && err == nil { // found better alternative
+			return false
+		}
+	}
+
+	// no better alternatives found; keep retrying
+	return true
+}
+
+// Up is part of the balancer interface, simpleBalancer implements the interface.
+// Balancer notifies a set of endpoints and pin whichever endpoint gRPC
+// Balancer.Up first and closes other endpoints. Client could get stuck
+// retrying blackholed endpoints, because gRPC marks network I/O errors
+// as transient, retrying until success; it takes several seconds
+// to find healthy one in next tries. Same applies when server is stopped.
+// To avoid wasting retries, gray-list unhealthy endpoints on notifyAddrs,
+// unlisting them after dial timeouts, and double-checks endpoint health
+// with gRPC health API.
 func (b *simpleBalancer) Up(addr grpc.Address) func(error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -247,6 +375,9 @@ func (b *simpleBalancer) Up(addr grpc.Address) func(error) {
 	if b.pinAddr != "" {
 		return func(err error) {}
 	}
+	if !b.shouldPin(addr) {
+		return func(err error) {}
+	}
 	// notify waiting Get()s and pin first connected address
 	close(b.upc)
 	b.downc = make(chan struct{})
@@ -255,6 +386,7 @@ func (b *simpleBalancer) Up(addr grpc.Address) func(error) {
 	b.readyOnce.Do(func() { close(b.readyc) })
 	return func(err error) {
 		b.mu.Lock()
+		b.failed[addr.Addr] = time.Now()
 		b.upc = make(chan struct{})
 		close(b.downc)
 		b.pinAddr = ""

--- a/clientv3/balancer_test.go
+++ b/clientv3/balancer_test.go
@@ -33,7 +33,7 @@ var (
 )
 
 func TestBalancerGetUnblocking(t *testing.T) {
-	sb := newSimpleBalancer(endpoints)
+	sb := newSimpleBalancer(endpoints, 0, nil)
 	defer sb.Close()
 	if addrs := <-sb.Notify(); len(addrs) != len(endpoints) {
 		t.Errorf("Initialize newSimpleBalancer should have triggered Notify() chan, but it didn't")
@@ -77,7 +77,7 @@ func TestBalancerGetUnblocking(t *testing.T) {
 }
 
 func TestBalancerGetBlocking(t *testing.T) {
-	sb := newSimpleBalancer(endpoints)
+	sb := newSimpleBalancer(endpoints, 0, nil)
 	defer sb.Close()
 	if addrs := <-sb.Notify(); len(addrs) != len(endpoints) {
 		t.Errorf("Initialize newSimpleBalancer should have triggered Notify() chan, but it didn't")
@@ -143,7 +143,7 @@ func TestBalancerDoNotBlockOnClose(t *testing.T) {
 	defer kcl.close()
 
 	for i := 0; i < 5; i++ {
-		sb := newSimpleBalancer(kcl.endpoints())
+		sb := newSimpleBalancer(kcl.endpoints(), 0, nil)
 		conn, err := grpc.Dial("", grpc.WithInsecure(), grpc.WithBalancer(sb))
 		if err != nil {
 			t.Fatal(err)

--- a/clientv3/integration/watch_keepalive_test.go
+++ b/clientv3/integration/watch_keepalive_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !cluster_proxy
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/integration"
+	"github.com/coreos/etcd/pkg/testutil"
+
+	"golang.org/x/net/context"
+)
+
+// TestWatchKeepAlive tests when watch discovers it cannot talk to
+// blackholed endpoint, client balancer switches to healthy one.
+// TODO: test with '-tags cluster_proxy'
+func TestWatchKeepAlive(t *testing.T) {
+	defer testutil.AfterTest(t)
+
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{
+		Size:                  3,
+		GRPCKeepAliveMinTime:  time.Millisecond, // avoid too_many_pings
+		GRPCKeepAliveInterval: 2 * time.Second,  // server-to-client ping
+		GRPCKeepAliveTimeout:  2 * time.Second,
+	})
+	defer clus.Terminate(t)
+
+	ccfg := clientv3.Config{
+		Endpoints:            []string{clus.Members[0].GRPCAddr()},
+		DialTimeout:          3 * time.Second,
+		DialKeepAliveTime:    2 * time.Second,
+		DialKeepAliveTimeout: 2 * time.Second,
+	}
+	cli, err := clientv3.New(ccfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	wch := cli.Watch(context.Background(), "foo", clientv3.WithCreatedNotify())
+	if _, ok := <-wch; !ok {
+		t.Fatalf("watch failed on creation")
+	}
+
+	clus.Members[0].Blackhole()
+
+	// expects endpoint switch to ep[1]
+	cli.SetEndpoints(clus.Members[0].GRPCAddr(), clus.Members[1].GRPCAddr())
+
+	// ep[0] keepalive time-out after DialKeepAliveTime + DialKeepAliveTimeout
+	// wait extra for processing network error for endpoint switching
+	timeout := ccfg.DialKeepAliveTime + ccfg.DialKeepAliveTimeout + ccfg.DialTimeout
+	time.Sleep(timeout)
+
+	if _, err = clus.Client(1).Put(context.TODO(), "foo", "bar"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-wch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("took too long to receive events")
+	}
+
+	clus.Members[0].Unblackhole()
+	clus.Members[1].Blackhole()
+	defer clus.Members[1].Unblackhole()
+
+	// wait for ep[0] recover, ep[1] fail
+	time.Sleep(timeout)
+
+	if _, err = clus.Client(0).Put(context.TODO(), "foo", "bar"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-wch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("took too long to receive events")
+	}
+}

--- a/embed/config.go
+++ b/embed/config.go
@@ -93,6 +93,24 @@ type Config struct {
 	MaxTxnOps         uint  `json:"max-txn-ops"`
 	MaxRequestBytes   uint  `json:"max-request-bytes"`
 
+	// gRPC server options
+
+	// GRPCKeepAliveMinTime is the minimum interval that a client should
+	// wait before pinging server.
+	// When client pings "too fast", server sends goaway and closes the
+	// connection (errors: too_many_pings, http2.ErrCodeEnhanceYourCalm).
+	// When too slow, nothing happens.
+	// Server expects client pings only when there is any active streams
+	// by setting 'PermitWithoutStream' false.
+	GRPCKeepAliveMinTime time.Duration `json:"grpc-keepalive-min-time"`
+	// GRPCKeepAliveInterval is the frequency of server-to-client ping
+	// to check if a connection is alive. Close a non-responsive connection
+	// after an additional duration of Timeout.
+	GRPCKeepAliveInterval time.Duration `json:"grpc-keepalive-interval"`
+	// GRPCKeepAliveTimeout is the additional duration of wait
+	// before closing a non-responsive connection.
+	GRPCKeepAliveTimeout time.Duration `json:"grpc-keepalive-timeout"`
+
 	// clustering
 
 	APUrls, ACUrls      []url.URL
@@ -181,25 +199,26 @@ func NewConfig() *Config {
 	lcurl, _ := url.Parse(DefaultListenClientURLs)
 	acurl, _ := url.Parse(DefaultAdvertiseClientURLs)
 	cfg := &Config{
-		CorsInfo:            &cors.CORSInfo{},
-		MaxSnapFiles:        DefaultMaxSnapshots,
-		MaxWalFiles:         DefaultMaxWALs,
-		Name:                DefaultName,
-		SnapCount:           etcdserver.DefaultSnapCount,
-		MaxTxnOps:           DefaultMaxTxnOps,
-		MaxRequestBytes:     DefaultMaxRequestBytes,
-		TickMs:              100,
-		ElectionMs:          1000,
-		LPUrls:              []url.URL{*lpurl},
-		LCUrls:              []url.URL{*lcurl},
-		APUrls:              []url.URL{*apurl},
-		ACUrls:              []url.URL{*acurl},
-		ClusterState:        ClusterStateFlagNew,
-		InitialClusterToken: "etcd-cluster",
-		StrictReconfigCheck: true,
-		Metrics:             "basic",
-		EnableV2:            true,
-		AuthToken:           "simple",
+		CorsInfo:             &cors.CORSInfo{},
+		MaxSnapFiles:         DefaultMaxSnapshots,
+		MaxWalFiles:          DefaultMaxWALs,
+		Name:                 DefaultName,
+		SnapCount:            etcdserver.DefaultSnapCount,
+		MaxTxnOps:            DefaultMaxTxnOps,
+		MaxRequestBytes:      DefaultMaxRequestBytes,
+		GRPCKeepAliveMinTime: 5 * time.Second,
+		TickMs:               100,
+		ElectionMs:           1000,
+		LPUrls:               []url.URL{*lpurl},
+		LCUrls:               []url.URL{*lcurl},
+		APUrls:               []url.URL{*apurl},
+		ACUrls:               []url.URL{*acurl},
+		ClusterState:         ClusterStateFlagNew,
+		InitialClusterToken:  "etcd-cluster",
+		StrictReconfigCheck:  true,
+		Metrics:              "basic",
+		EnableV2:             true,
+		AuthToken:            "simple",
 	}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	return cfg

--- a/embed/serve.go
+++ b/embed/serve.go
@@ -66,7 +66,12 @@ func newServeCtx() *serveCtx {
 // serve accepts incoming connections on the listener l,
 // creating a new service goroutine for each. The service goroutines
 // read requests and then call handler to reply to them.
-func (sctx *serveCtx) serve(s *etcdserver.EtcdServer, tlsinfo *transport.TLSInfo, handler http.Handler, errHandler func(error)) error {
+func (sctx *serveCtx) serve(
+	s *etcdserver.EtcdServer,
+	tlsinfo *transport.TLSInfo,
+	handler http.Handler,
+	errHandler func(error),
+	gopts ...grpc.ServerOption) error {
 	logger := defaultLog.New(ioutil.Discard, "etcdhttp", 0)
 	<-s.ReadyNotify()
 	plog.Info("ready to serve client requests")
@@ -77,7 +82,7 @@ func (sctx *serveCtx) serve(s *etcdserver.EtcdServer, tlsinfo *transport.TLSInfo
 	servLock := v3lock.NewLockServer(v3c)
 
 	if sctx.insecure {
-		gs := v3rpc.Server(s, nil)
+		gs := v3rpc.Server(s, nil, gopts...)
 		sctx.grpcServerC <- gs
 		v3electionpb.RegisterElectionServer(gs, servElection)
 		v3lockpb.RegisterLockServer(gs, servLock)
@@ -111,7 +116,7 @@ func (sctx *serveCtx) serve(s *etcdserver.EtcdServer, tlsinfo *transport.TLSInfo
 		if tlsErr != nil {
 			return tlsErr
 		}
-		gs := v3rpc.Server(s, tlscfg)
+		gs := v3rpc.Server(s, tlscfg, gopts...)
 		sctx.grpcServerC <- gs
 		v3electionpb.RegisterElectionServer(gs, servElection)
 		v3lockpb.RegisterLockServer(gs, servLock)

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/coreos/etcd/embed"
 	"github.com/coreos/etcd/pkg/flags"
@@ -143,6 +144,9 @@ func newConfig() *config {
 	fs.Int64Var(&cfg.QuotaBackendBytes, "quota-backend-bytes", cfg.QuotaBackendBytes, "Raise alarms when backend size exceeds the given quota. 0 means use the default quota.")
 	fs.UintVar(&cfg.MaxTxnOps, "max-txn-ops", cfg.MaxTxnOps, "Maximum number of operations permitted in a transaction.")
 	fs.UintVar(&cfg.MaxRequestBytes, "max-request-bytes", cfg.MaxRequestBytes, "Maximum client request size in bytes the server will accept.")
+	fs.DurationVar(&cfg.GRPCKeepAliveMinTime, "grpc-keepalive-min-time", cfg.Config.GRPCKeepAliveMinTime, "Minimum interval duration that a client should wait before pinging server.")
+	fs.DurationVar(&cfg.GRPCKeepAliveInterval, "grpc-keepalive-interval", time.Duration(0), "Frequency duration of server-to-client ping to check if a connection is alive.")
+	fs.DurationVar(&cfg.GRPCKeepAliveTimeout, "grpc-keepalive-timeout", time.Duration(0), "Additional duration of wait before closing a non-responsive connection.")
 
 	// clustering
 	fs.Var(flags.NewURLsValue(embed.DefaultInitialAdvertisePeerURLs), "initial-advertise-peer-urls", "List of this member's peer URLs to advertise to the rest of the cluster.")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -70,6 +70,12 @@ member flags:
 		maximum number of operations permitted in a transaction.
 	--max-request-bytes '1572864'
 		maximum client request size in bytes the server will accept.
+	--grpc-keepalive-min-time '5s'
+		minimum duration interval that a client should wait before pinging server.
+	--grpc-keepalive-interval '0s'
+		frequency duration of server-to-client ping to check if a connection is alive.
+	--grpc-keepalive-timeout '0s'
+		additional duration of wait before closing a non-responsive connection.
 
 clustering flags:
 

--- a/etcdserver/api/v3rpc/grpc.go
+++ b/etcdserver/api/v3rpc/grpc.go
@@ -38,7 +38,7 @@ func init() {
 	grpclog.SetLogger(plog)
 }
 
-func Server(s *etcdserver.EtcdServer, tls *tls.Config) *grpc.Server {
+func Server(s *etcdserver.EtcdServer, tls *tls.Config, gopts ...grpc.ServerOption) *grpc.Server {
 	var opts []grpc.ServerOption
 	opts = append(opts, grpc.CustomCodec(&codec{}))
 	if tls != nil {
@@ -49,7 +49,7 @@ func Server(s *etcdserver.EtcdServer, tls *tls.Config) *grpc.Server {
 	opts = append(opts, grpc.MaxRecvMsgSize(int(s.Cfg.MaxRequestBytes+grpcOverheadBytes)))
 	opts = append(opts, grpc.MaxSendMsgSize(maxSendBytes))
 	opts = append(opts, grpc.MaxConcurrentStreams(maxStreams))
-	grpcServer := grpc.NewServer(opts...)
+	grpcServer := grpc.NewServer(append(opts, gopts...)...)
 
 	pb.RegisterKVServer(grpcServer, NewQuotaKVServer(s))
 	pb.RegisterWatchServer(grpcServer, NewWatchServer(s))

--- a/integration/bridge.go
+++ b/integration/bridge.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"sync"
 
@@ -31,9 +32,10 @@ type bridge struct {
 	l       net.Listener
 	conns   map[*bridgeConn]struct{}
 
-	stopc  chan struct{}
-	pausec chan struct{}
-	wg     sync.WaitGroup
+	stopc      chan struct{}
+	pausec     chan struct{}
+	blackholec chan struct{}
+	wg         sync.WaitGroup
 
 	mu sync.Mutex
 }
@@ -41,11 +43,12 @@ type bridge struct {
 func newBridge(addr string) (*bridge, error) {
 	b := &bridge{
 		// bridge "port" is ("%05d%05d0", port, pid) since go1.8 expects the port to be a number
-		inaddr:  addr + "0",
-		outaddr: addr,
-		conns:   make(map[*bridgeConn]struct{}),
-		stopc:   make(chan struct{}),
-		pausec:  make(chan struct{}),
+		inaddr:     addr + "0",
+		outaddr:    addr,
+		conns:      make(map[*bridgeConn]struct{}),
+		stopc:      make(chan struct{}),
+		pausec:     make(chan struct{}),
+		blackholec: make(chan struct{}),
 	}
 	close(b.pausec)
 
@@ -152,12 +155,12 @@ func (b *bridge) serveConn(bc *bridgeConn) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		io.Copy(bc.out, bc.in)
+		b.ioCopy(bc, bc.out, bc.in)
 		bc.close()
 		wg.Done()
 	}()
 	go func() {
-		io.Copy(bc.in, bc.out)
+		b.ioCopy(bc, bc.in, bc.out)
 		bc.close()
 		wg.Done()
 	}()
@@ -178,4 +181,48 @@ func (bc *bridgeConn) Close() {
 func (bc *bridgeConn) close() {
 	bc.in.Close()
 	bc.out.Close()
+}
+
+func (b *bridge) Blackhole() {
+	b.mu.Lock()
+	close(b.blackholec)
+	b.mu.Unlock()
+}
+
+func (b *bridge) Unblackhole() {
+	b.mu.Lock()
+	for bc := range b.conns {
+		bc.Close()
+	}
+	b.conns = make(map[*bridgeConn]struct{})
+	b.blackholec = make(chan struct{})
+	b.mu.Unlock()
+}
+
+// ref. https://github.com/golang/go/blob/master/src/io/io.go copyBuffer
+func (b *bridge) ioCopy(bc *bridgeConn, dst io.Writer, src io.Reader) (err error) {
+	buf := make([]byte, 32*1024)
+	for {
+		select {
+		case <-b.blackholec:
+			io.Copy(ioutil.Discard, src)
+			return nil
+		default:
+		}
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[0:nr])
+			if ew != nil {
+				return ew
+			}
+			if nr != nw {
+				return io.ErrShortWrite
+			}
+		}
+		if er != nil {
+			err = er
+			break
+		}
+	}
+	return
 }

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -1,0 +1,41 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/pkg/testutil"
+
+	"golang.org/x/net/context"
+)
+
+func TestBlackhole(t *testing.T) {
+	defer testutil.AfterTest(t)
+
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	clus.Members[0].Blackhole()
+	time.Sleep(time.Second)
+
+	clus.Members[0].Unblackhole()
+	time.Sleep(time.Second)
+
+	if _, err := clus.Client(0).Put(context.Background(), "foo", "bar"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -588,6 +588,8 @@ func (m *member) ID() types.ID { return m.s.ID() }
 func (m *member) DropConnections()    { m.grpcBridge.Reset() }
 func (m *member) PauseConnections()   { m.grpcBridge.Pause() }
 func (m *member) UnpauseConnections() { m.grpcBridge.Unpause() }
+func (m *member) Blackhole()          { m.grpcBridge.Blackhole() }
+func (m *member) Unblackhole()        { m.grpcBridge.Unblackhole() }
 
 // NewClientV3 creates a new grpc client connection to the member
 func NewClientV3(m *member) (*clientv3.Client, error) {


### PR DESCRIPTION
1. Configure server gRPC keepalive parameters
2. Optimize client endpoint switch by gray-listing transient-failed nodes

keepalive timed-out is 'connectivity.TransientFailure'
in gRPC; it keeps retrying (calling 'Balancer.Up') until
success. This is problematic in multi-endpoint balancer
with an endpoint being blackholed. Balancer can get stuck
retrying blackholed endpoint, taking several seconds to
find healthy ones.

Also gray-listing(https://github.com/coreos/etcd/pull/8463) endpoints doesn't work in following case:

```
# TestKVGetResetLoneEndpoint

CODE / CURRENT PINNED ADDRESS
01. clientv3.New(ep1, ep2) / NONE
02. notifyAddrs(ep1, ep2) / NONE
03. grpc.lbWatcher receives ep1, ep2 from Notify() / NONE
04. grpc.lbWatcher ADD calls resetAddrConn ep1 / NONE
05. grpc.lbWatcher ADD calls resetAddrConn ep2 / NONE

06. grpc calls resetTransport Up(ep1) / NONE
07. clientv3.Balancer Up pins ep1 / ep1

08. grpc calls resetTransport Up(ep2) / ep1
09. clientv3.Balancer Up DOES NOT pin ep2 / ep1

10. updateNotifyLoop sends b.notifyCh <- pinned ep1 / ep1

11. Stop(ep1) / ep1

12. grpc.lbWatcher receives ep1 from Notify() / ep1
13. grpc.lbWatcher DEL calls tearDown(errConnDrain) ep2 / ep1

14. Stop(ep2) / ep1

15. clientv3.Balancer Up down network I/O error on ep1 / NONE
16. Gray-list ep1

# ep1 is gray-listed, so only notify ep2
# but ep2 is also stopped
# this makes balancer stuck with ep2
17. notifyAddrs(ep2) / NONE
18. notifyAddrs(ep2) / NONE
19. grpc.lbWatcher receives ep2 from Notify() / NONE
20. grpc.lbWatcher ADD calls resetAddrConn ep2 / NONE
21. grpc.lbWatcher DEL calls tearDown(errConnDrain) ep1 / NONE
22. grpc.lbWatcher receives ep2 from Notify() / NONE

23. Restart(ep1) / NONE

24. Get(ep1,ep2) timed out / NONE
```

At step 17 above, we should instead notify both ep1 and ep2.
If we exclude gray-listed ep1, balancer gets stuck with stopped endpoint ep2.

Problem is:
1. ep2 was never pinned
2. ep2 is also stopped
3. So gRPC fails to connect to ep2 with error `"transport: Error while dialing dial unix ep2: connect: no such file or directory"`
4. There's no way to check if ep2 is down.

This PR adds additional health-check API call to discover endpoint status on endpoint notify.