### PR TITLE
integration: check all members agree on leader in waitLeader

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -303,10 +303,11 @@ func (c *cluster) removeMember(t *testing.T, id uint64) error {
 	cc := MustNewHTTPClient(t, c.URLs(), c.cfg.ClientTLS)
 	ma := client.NewMembersAPI(cc)
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	if err := ma.Remove(ctx, types.ID(id).String()); err != nil {
+	err := ma.Remove(ctx, types.ID(id).String())
+	cancel()
+	if err != nil {
 		return err
 	}
-	cancel()
 	newMembers := make([]*member, 0)
 	for _, m := range c.Members {
 		if uint64(m.s.ID()) != id {


### PR DESCRIPTION
Could reproduce via
```sh
while [ 1 ]; do date; nice go test -v -run=Decrease -cpu=1,2,4 -count=5 >out.txt 2>&1 || break; done
```

Fixes #8225