### PR TITLE
raft: (re-)introduce TestRecvMsgPreVote

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -1361,6 +1361,10 @@ func TestRecvMsgVote(t *testing.T) {
 	testRecvMsgVote(t, pb.MsgVote)
 }
 
+func TestRecvMsgPreVote(t *testing.T) {
+	testRecvMsgVote(t, pb.MsgPreVote)
+}
+
 func testRecvMsgVote(t *testing.T, msgType pb.MessageType) {
 	tests := []struct {
 		state          StateType


### PR DESCRIPTION
TestRecvMsgPreVote was intended to be introduced in https://github.com/coreos/etcd/pull/6624 but was uncapitalized (search for testRecvMsgPreVote instead) and then subsequently removed due to it being unused.