### PR TITLE
*: fix shellcheck warnings

### DIFF
--- a/build
+++ b/build
@@ -4,7 +4,7 @@
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/etcd"
 
-GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
+GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 if [ ! -z "$FAILPOINTS" ]; then
 	GIT_SHA="$GIT_SHA"-FAILPOINTS
 fi
@@ -14,10 +14,9 @@ GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/cmd/vendor/${REPO_PATH}/version.GitSHA=$
 
 # enable/disable failpoints
 toggle_failpoints() {
-	FAILPKGS="etcdserver/ mvcc/backend/"
 	mode="$1"
 	if which gofail >/dev/null 2>&1; then
-		gofail "$mode" $FAILPKGS
+		gofail "$mode" etcdserver/ mvcc/backend/
 	elif [ "$mode" != "disable" ]; then
 		echo "FAILPOINTS set but gofail not found"
 		exit 1
@@ -34,9 +33,12 @@ etcd_build() {
 	out="bin"
 	if [ -n "${BINDIR}" ]; then out="${BINDIR}"; fi
 	toggle_failpoints_default
-	# Static compilation is useful when etcd is run in a container
-	CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "$GO_LDFLAGS" -o ${out}/etcd ${REPO_PATH}/cmd/etcd || return
-	CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "$GO_LDFLAGS" -o ${out}/etcdctl ${REPO_PATH}/cmd/etcdctl || return
+	# Static compilation is useful when etcd is run in a container. $GO_BUILD_FLAGS is OK
+
+	# shellcheck disable=SC2086
+	CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "$GO_LDFLAGS" -o "${out}/etcd" ${REPO_PATH}/cmd/etcd || return
+	# shellcheck disable=SC2086
+	CGO_ENABLED=0 go build $GO_BUILD_FLAGS -installsuffix cgo -ldflags "$GO_LDFLAGS" -o "${out}/etcdctl" ${REPO_PATH}/cmd/etcdctl || return
 }
 
 etcd_setup_gopath() {
@@ -49,9 +51,9 @@ etcd_setup_gopath() {
 		GOPATH=":$GOPATH"
 	fi
 	export GOPATH=${etcdGOPATH}$GOPATH
-	rm -rf ${etcdGOPATH}/src
-	mkdir -p ${etcdGOPATH}
-	ln -s ${CDIR}/cmd/vendor ${etcdGOPATH}/src
+	rm -rf "${etcdGOPATH}/src"
+	mkdir -p "${etcdGOPATH}"
+	ln -s "${CDIR}/cmd/vendor" "${etcdGOPATH}/src"
 }
 
 toggle_failpoints_default

--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -18,12 +18,12 @@ go2aci() {
 	esac
 }
 
-if ! command -v $ACBUILD >/dev/null; then
+if ! command -v "${ACBUILD}" >/dev/null; then
     echo "acbuild ($ACBUILD) is not executable"
     exit 1
 fi
 
-if [ ! -x $BINARYDIR/etcd ] ; then
+if [ ! -x "${BINARYDIR}"/etcd ] ; then
     echo "$BINARYDIR/etcd not found. Is it compiled?"
     exit 1
 fi
@@ -36,7 +36,7 @@ fi
 acbuild --debug begin
 
 TMPHOSTS="$(mktemp)"
-ACI_ARCH="$(go2aci ${GOARCH})"
+ACI_ARCH=$(go2aci "${GOARCH}")
 
 acbuildEnd() {
     rm "$TMPHOSTS"
@@ -45,15 +45,15 @@ acbuildEnd() {
 }
 trap acbuildEnd EXIT
 
-cat <<DF > $TMPHOSTS
+cat <<DF > "$TMPHOSTS"
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 DF
 
 acbuild --debug set-name coreos.com/etcd
 acbuild --debug annotation add appc.io/executor/supports-systemd-notify true
 
-acbuild --debug copy $BINARYDIR/etcd /usr/local/bin/etcd
-acbuild --debug copy $BINARYDIR/etcdctl /usr/local/bin/etcdctl
+acbuild --debug copy "${BINARYDIR}"/etcd /usr/local/bin/etcd
+acbuild --debug copy "${BINARYDIR}"/etcdctl /usr/local/bin/etcdctl
 
 acbuild --debug copy README.md README.md
 acbuild --debug copy etcdctl/README.md README-etcdctl.md
@@ -81,4 +81,4 @@ mkdir -p .acbuild/currentaci/rootfs/var/lib/etcd
 ln -s ./usr/local/bin/etcd .acbuild/currentaci/rootfs/etcd
 ln -s ./usr/local/bin/etcdctl .acbuild/currentaci/rootfs/etcdctl
 
-acbuild --debug write --overwrite $BUILDDIR/etcd-${1}-linux-${ACI_ARCH}.aci
+acbuild --debug write --overwrite "${BUILDDIR}/etcd-${1}-linux-${ACI_ARCH}.aci"

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -16,15 +16,15 @@ function setup_env {
 	local proj=${1}
 	local ver=${2}
 
-	if [ ! -d ${proj} ]; then
-		git clone https://github.com/coreos/${proj}
+	if [ ! -d "${proj}" ]; then
+		git clone https://github.com/coreos/"${proj}"
 	fi
 
-	pushd ${proj} >/dev/null
+	pushd "${proj}" >/dev/null
 		git checkout master
 		git fetch --all
 		git reset --hard origin/master
-		git checkout $ver
+		git checkout "${ver}"
 	popd >/dev/null
 }
 
@@ -34,28 +34,28 @@ function package {
 	local srcdir="${2}/bin"
 
 	local ccdir="${srcdir}/${GOOS}_${GOARCH}"
-	if [ -d ${ccdir} ]; then
-		srcdir=${ccdir}
+	if [ -d "${ccdir}" ]; then
+		srcdir="${ccdir}"
 	fi
 	local ext=""
-	if [ ${GOOS} == "windows" ]; then
+	if [ "${GOOS}" == "windows" ]; then
 		ext=".exe"
 	fi
 	for bin in etcd etcdctl; do
-		cp ${srcdir}/${bin} ${target}/${bin}${ext}
+		cp "${srcdir}/${bin}" "${target}/${bin}${ext}"
 	done
 
-	cp etcd/README.md ${target}/README.md
-	cp etcd/etcdctl/README.md ${target}/README-etcdctl.md
-	cp etcd/etcdctl/READMEv2.md ${target}/READMEv2-etcdctl.md
+	cp etcd/README.md "${target}"/README.md
+	cp etcd/etcdctl/README.md "${target}"/README-etcdctl.md
+	cp etcd/etcdctl/READMEv2.md "${target}"/READMEv2-etcdctl.md
 
-	cp -R etcd/Documentation ${target}/Documentation
+	cp -R etcd/Documentation "${target}"/Documentation
 }
 
 function main {
 	mkdir release
 	cd release
-	setup_env ${PROJ} ${VER}
+	setup_env "${PROJ}" "${VER}"
 
 	for os in darwin windows linux; do
 		export GOOS=${os}
@@ -74,14 +74,14 @@ function main {
 			popd >/dev/null
 
 			TARGET="etcd-${VER}-${GOOS}-${GOARCH}"
-			mkdir ${TARGET}
-			package ${TARGET} ${PROJ}
+			mkdir "${TARGET}"
+			package "${TARGET}" "${PROJ}"
 
 			if [ ${GOOS} == "linux" ]; then
-				tar cfz ${TARGET}.tar.gz ${TARGET}
+				tar cfz "${TARGET}.tar.gz" "${TARGET}"
 				echo "Wrote release/${TARGET}.tar.gz"
 			else
-				zip -qr ${TARGET}.zip ${TARGET}
+				zip -qr "${TARGET}.zip" "${TARGET}"
 				echo "Wrote release/${TARGET}.zip"
 			fi
 		done

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -10,21 +10,21 @@ fi
 VERSION=${1}
 ARCH=$(go env GOARCH)
 DOCKERFILE="Dockerfile-release"
-: ${TAG:="quay.io/coreos/etcd"}
+if [ -z "$TAG" ]; then TAG="quay.io/coreos/etcd"; fi
 
-if [ -z ${BINARYDIR} ]; then
-	RELEASE="etcd-${1}"-`go env GOOS`-`go env GOARCH`
+if [ -z "${BINARYDIR}" ]; then
+	RELEASE="etcd-${1}"-$(go env GOOS)-$(go env GOARCH)
 	BINARYDIR="${RELEASE}"
 	TARFILE="${RELEASE}.tar.gz"
 	TARURL="https://github.com/coreos/etcd/releases/download/${1}/${TARFILE}"
-	if ! curl -f -L -o ${TARFILE} ${TARURL} ; then
+	if ! curl -f -L -o "${TARFILE}" "${TARURL}" ; then
 		echo "Failed to download ${TARURL}."
 		exit 1
 	fi
-	tar -zvxf ${TARFILE}
+	tar -zvxf "${TARFILE}"
 fi
 
-if [ ${ARCH} != "amd64" ]; then
+if [ "${ARCH}" != "amd64" ]; then
 	DOCKERFILE+=".${ARCH}"
 	VERSION+="-${ARCH}"
 fi
@@ -34,10 +34,10 @@ BUILDDIR=${BUILDDIR:-.}
 
 IMAGEDIR=${BUILDDIR}/image-docker
 
-mkdir -p ${IMAGEDIR}/var/etcd
-mkdir -p ${IMAGEDIR}/var/lib/etcd
-cp ${BINARYDIR}/etcd ${BINARYDIR}/etcdctl ${IMAGEDIR}
+mkdir -p "${IMAGEDIR}"/var/etcd
+mkdir -p "${IMAGEDIR}"/var/lib/etcd
+cp "${BINARYDIR}"/etcd "${BINARYDIR}"/etcdctl "${IMAGEDIR}"
 
-cat ./${DOCKERFILE} > ${IMAGEDIR}/Dockerfile
+cat ./"${DOCKERFILE}" > "${IMAGEDIR}"/Dockerfile
 
-docker build -t ${TAG}:${VERSION} ${IMAGEDIR}
+docker build -t "${TAG}:${VERSION}" "${IMAGEDIR}"

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -5,12 +5,12 @@
 #
 set -e
 
-if ! [[ "$0" =~ "scripts/genproto.sh" ]]; then
+if ! [[ "$0" =~ scripts/genproto.sh ]]; then
 	echo "must be run from repository root"
 	exit 255
 fi
 
-if ! [[ $(protoc --version) =~ "3.3.0" ]]; then
+if [[ $(protoc --version | cut -f2 -d' ') != "3.3.0" ]]; then
 	echo "could not find protoc 3.3.0, is it installed + in PATH?"
 	exit 255
 fi
@@ -57,16 +57,16 @@ pushd "${GRPC_GATEWAY_ROOT}"
 popd
 
 for dir in ${DIRS}; do
-	pushd ${dir}
-		protoc --gofast_out=plugins=grpc,import_prefix=github.com/coreos/:. -I=".:${GOGOPROTO_PATH}:${COREOS_ROOT}:${GRPC_GATEWAY_ROOT}/third_party/googleapis" *.proto
-		sed -i.bak -E "s/github\.com\/coreos\/(gogoproto|github\.com|golang\.org|google\.golang\.org)/\1/g" *.pb.go
-		sed -i.bak -E 's/github\.com\/coreos\/(errors|fmt|io)/\1/g' *.pb.go
-		sed -i.bak -E 's/import _ \"gogoproto\"//g' *.pb.go
-		sed -i.bak -E 's/import fmt \"fmt\"//g' *.pb.go
-		sed -i.bak -E 's/import _ \"github\.com\/coreos\/google\/api\"//g' *.pb.go
-		sed -i.bak -E 's/import _ \"google\.golang\.org\/genproto\/googleapis\/api\/annotations\"//g' *.pb.go
-		rm -f *.bak
-		goimports -w *.pb.go
+	pushd "${dir}"
+		protoc --gofast_out=plugins=grpc,import_prefix=github.com/coreos/:. -I=".:${GOGOPROTO_PATH}:${COREOS_ROOT}:${GRPC_GATEWAY_ROOT}/third_party/googleapis" ./*.proto
+		sed -i.bak -E "s/github\.com\/coreos\/(gogoproto|github\.com|golang\.org|google\.golang\.org)/\1/g" ./*.pb.go
+		sed -i.bak -E 's/github\.com\/coreos\/(errors|fmt|io)/\1/g' ./*.pb.go
+		sed -i.bak -E 's/import _ \"gogoproto\"//g' ./*.pb.go
+		sed -i.bak -E 's/import fmt \"fmt\"//g' ./*.pb.go
+		sed -i.bak -E 's/import _ \"github\.com\/coreos\/google\/api\"//g' ./*.pb.go
+		sed -i.bak -E 's/import _ \"google\.golang\.org\/genproto\/googleapis\/api\/annotations\"//g' ./*.pb.go
+		rm -f ./*.bak
+		goimports -w ./*.pb.go
 	popd
 done
 
@@ -75,15 +75,15 @@ rm -rf Documentation/dev-guide/apispec/swagger/*json
 for pb in etcdserverpb/rpc api/v3lock/v3lockpb/v3lock api/v3election/v3electionpb/v3election; do
 	protobase="etcdserver/${pb}"
 	protoc -I. \
-	    -I${GRPC_GATEWAY_ROOT}/third_party/googleapis \
-	    -I${GOGOPROTO_PATH} \
-	    -I${COREOS_ROOT} \
+	    -I"${GRPC_GATEWAY_ROOT}"/third_party/googleapis \
+	    -I"${GOGOPROTO_PATH}" \
+	    -I"${COREOS_ROOT}" \
 	    --grpc-gateway_out=logtostderr=true:. \
 	    --swagger_out=logtostderr=true:./Documentation/dev-guide/apispec/swagger/. \
 	    ${protobase}.proto
 	# hack to move gw files around so client won't include them
-	pkgpath=`dirname ${protobase}`
-	pkg=`basename ${pkgpath}`
+	pkgpath=$(dirname "${protobase}")
+	pkg=$(basename "${pkgpath}")
 	gwfile="${protobase}.pb.gw.go"
 	sed -i.bak -E "s/package $pkg/package gw/g" ${gwfile}
 	sed -i.bak -E "s/protoReq /&$pkg\./g" ${gwfile}
@@ -93,13 +93,13 @@ for pb in etcdserverpb/rpc api/v3lock/v3lockpb/v3lock api/v3election/v3electionp
 	sed -i.bak -E "s/New[A-Za-z]*Client/${pkg}.&/" ${gwfile}
 	# darwin doesn't like newlines in sed...
 	sed -i.bak -E "s|import \(|& \"github.com/coreos/etcd/${pkgpath}\"|" ${gwfile}
-	mkdir -p  ${pkgpath}/gw/
+	mkdir -p  "${pkgpath}"/gw/
 	go fmt ${gwfile}
-	mv ${gwfile} ${pkgpath}/gw/
+	mv ${gwfile} "${pkgpath}/gw/"
 	rm -f ./etcdserver/${pb}*.bak
-	swaggerName=`basename ${pb}`
+	swaggerName=$(basename ${pb})
 	mv	Documentation/dev-guide/apispec/swagger/etcdserver/${pb}.swagger.json \
-		Documentation/dev-guide/apispec/swagger/${swaggerName}.swagger.json
+		Documentation/dev-guide/apispec/swagger/"${swaggerName}".swagger.json
 done
 rm -rf Documentation/dev-guide/apispec/swagger/etcdserver/
 

--- a/scripts/install-marker.sh
+++ b/scripts/install-marker.sh
@@ -15,7 +15,7 @@ if [ ${ARCH} == "darwin" ]; then
 fi
 
 echo "Installing marker"
-curl -L ${MARKER_URL} -o ${GOPATH}/bin/marker
-chmod 755 ${GOPATH}/bin/marker
+curl -L "${MARKER_URL}" -o "${GOPATH}"/bin/marker
+chmod 755 "${GOPATH}"/bin/marker
 
-${GOPATH}/bin/marker --version
+"${GOPATH}"/bin/marker --version

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,18 +23,18 @@ fi
 
 ETCD_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-pushd ${ETCD_ROOT} >/dev/null
+pushd "${ETCD_ROOT}" >/dev/null
 	echo Building etcd binary...
-	./scripts/build-binary ${VERSION}
+	./scripts/build-binary "${VERSION}"
 
 	# ppc64le not yet supported by acbuild.
 	for TARGET_ARCH in "amd64" "arm64"; do
 		echo Building ${TARGET_ARCH} aci image...
-		GOARCH=${TARGET_ARCH} BINARYDIR=release/etcd-${VERSION}-linux-${TARGET_ARCH} BUILDDIR=release ./scripts/build-aci ${VERSION}
+		GOARCH=${TARGET_ARCH} BINARYDIR=release/etcd-${VERSION}-linux-${TARGET_ARCH} BUILDDIR=release ./scripts/build-aci "${VERSION}"
 	done
 
 	for TARGET_ARCH in "amd64" "arm64" "ppc64le"; do
 		echo Building ${TARGET_ARCH} docker image...
-		GOARCH=${TARGET_ARCH} BINARYDIR=release/etcd-${VERSION}-linux-${TARGET_ARCH} BUILDDIR=release ./scripts/build-docker ${VERSION}
+		GOARCH=${TARGET_ARCH} BINARYDIR=release/etcd-${VERSION}-linux-${TARGET_ARCH} BUILDDIR=release ./scripts/build-docker "${VERSION}"
 	done
 popd >/dev/null

--- a/scripts/updatebom.sh
+++ b/scripts/updatebom.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if ! [[ "$0" =~ "scripts/updatebom.sh" ]]; then
+if ! [[ "$0" =~ scripts/updatebom.sh ]]; then
 	echo "must be run from repository root"
 	exit 255
 fi
@@ -16,7 +16,7 @@ mkdir ./gopath
 mv ./cmd/vendor ./gopath/src
 
 echo "generating bill-of-materials.json"
-GOPATH=`pwd`/gopath license-bill-of-materials \
+GOPATH=$(pwd)/gopath license-bill-of-materials \
     --override-file ./bill-of-materials.override.json \
     github.com/coreos/etcd github.com/coreos/etcd/etcdctl > bill-of-materials.json
 

--- a/scripts/updatedep.sh
+++ b/scripts/updatedep.sh
@@ -14,7 +14,7 @@
 #        ./scripts/updatedep.sh github.com/USER/PROJECT#9b772b54b3bf0be1eec083c9669766a56332559a
 # 2. make sure glide.yaml and glide.lock are updated
 
-if ! [[ "$0" =~ "scripts/updatedep.sh" ]]; then
+if ! [[ "$0" =~ scripts/updatedep.sh ]]; then
 	echo "must be run from repository root"
 	exit 255
 fi
@@ -44,13 +44,13 @@ popd
 
 if [ -n "$1" ]; then
 	echo "glide get on $1"
-	matches=`grep "name: $1" glide.lock`
+	matches=$(grep "name: $1" glide.lock)
 	if [ ! -z "$matches" ]; then
 		echo "glide update on $1"
-		glide update --strip-vendor $1
+		glide update --strip-vendor "$1"
 	else
 		echo "glide get on $1"
-		glide get --strip-vendor $1
+		glide get --strip-vendor "$1"
 	fi
 else
 	echo "glide update on *"

--- a/test
+++ b/test
@@ -38,13 +38,13 @@ IGNORE_PKGS="(cmd/|etcdserverpb|rafttest|gopath.proto|v3lockpb|v3electionpb)"
 INTEGRATION_PKGS="(integration|e2e|contrib|functional-tester)"
 
 # all github.com/coreos/etcd/whatever pkgs that are not auto-generated / tools
-PKGS=`find . -name \*.go | while read a; do dirname $a; done | sort | uniq | egrep -v "$IGNORE_PKGS" | egrep -v "(tools/|contrib/|e2e|pb)" | sed "s|\.|${REPO_PATH}|g" | xargs echo`
+PKGS=$(find . -name \*.go | while read -r a; do dirname "$a"; done | sort | uniq | egrep -v "$IGNORE_PKGS" | egrep -v "(tools/|contrib/|e2e|pb)" | sed "s|\.|${REPO_PATH}|g" | xargs echo)
 # pkg1,pkg2,pkg3
 PKGS_COMMA=${PKGS// /,}
 
-TEST_PKGS=`find . -name \*_test.go | while read a; do dirname $a; done | sort | uniq | egrep -v "$IGNORE_PKGS" | sed "s|\./||g"`
-FORMATTABLE=`find . -name \*.go | while read a; do echo "$(dirname $a)/*.go"; done | sort | uniq | egrep -v "$IGNORE_PKGS" | sed "s|\./||g"`
-TESTABLE_AND_FORMATTABLE=`echo "$TEST_PKGS" | egrep -v "$INTEGRATION_PKGS"`
+TEST_PKGS=$(find . -name \*_test.go | while read -r a; do dirname "$a"; done | sort | uniq | egrep -v "$IGNORE_PKGS" | sed "s|\./||g")
+FORMATTABLE=$(find . -name \*.go | while read -r a; do echo "$(dirname "$a")/*.go"; done | sort | uniq | egrep -v "$IGNORE_PKGS" | sed "s|\./||g")
+TESTABLE_AND_FORMATTABLE=$(echo "$TEST_PKGS" | egrep -v "$INTEGRATION_PKGS")
 
 # check if user provided PKG override
 if [ -z "${USERPKG}" ]; then
@@ -58,20 +58,22 @@ else
 	# only run gofmt on packages provided by user
 	FMT="$TEST"
 fi
+FMT=($FMT)
 
 # prepend REPO_PATH to each local package
 split=$TEST
 TEST=""
 for a in $split; do TEST="$TEST ${REPO_PATH}/${a}"; done
+TEST=($TEST)
 
 # TODO: 'client' pkg fails with gosimple from generated files
 # TODO: 'rafttest' is failing with unused
-STATIC_ANALYSIS_PATHS=`find . -name \*.go | while read a; do dirname $a; done | sort | uniq | egrep -v "$IGNORE_PKGS" | grep -v 'client'`
+STATIC_ANALYSIS_PATHS=$(find . -name \*.go | while read -r a; do dirname "$a"; done | sort | uniq | egrep -v "$IGNORE_PKGS" | grep -v 'client')
+STATIC_ANALYSIS_PATHS=($STATIC_ANALYSIS_PATHS)
 
 if [ -z "$GOARCH" ]; then
 	GOARCH=$(go env GOARCH);
 fi
-
 
 # determine whether target supports race detection
 if [ "$GOARCH" == "amd64" ]; then
@@ -81,21 +83,21 @@ fi
 function unit_pass {
 	echo "Running unit tests..."
 	# only -run=Test so examples can run in integration tests
-	go test -timeout 3m ${COVER} ${RACE} -cpu 1,2,4 -run=Test $@ ${TEST}
+	go test -timeout 3m "${COVER}" ${RACE} -cpu 1,2,4 -run=Test "$@" "${TEST[@]}"
 }
 
 function integration_pass {
 	echo "Running integration tests..."
-	go test -timeout 15m -v -cpu 1,2,4 $@ ${REPO_PATH}/integration
-	integration_extra $@
+	go test -timeout 15m -v -cpu 1,2,4 "$@" "${REPO_PATH}/integration"
+	integration_extra "$@"
 }
 
 function integration_extra {
-	go test -timeout 1m -v ${RACE} -cpu 1,2,4 $@ ${REPO_PATH}/client/integration
-	go test -timeout 15m -v ${RACE} -cpu 1,2,4 $@ ${REPO_PATH}/clientv3/integration
-	go test -timeout 1m -v -cpu 1,2,4 $@ ${REPO_PATH}/contrib/raftexample
-	go test -timeout 1m -v ${RACE} -cpu 1,2,4 -run=Example $@ ${TEST}
-	go test -timeout 5m -v ${RACE} -tags v2v3 $@ ${REPO_PATH}/store
+	go test -timeout 1m -v ${RACE} -cpu 1,2,4 "$@" "${REPO_PATH}/client/integration"
+	go test -timeout 15m -v ${RACE} -cpu 1,2,4 "$@" "${REPO_PATH}/clientv3/integration"
+	go test -timeout 1m -v -cpu 1,2,4 "$@" "${REPO_PATH}/contrib/raftexample"
+	go test -timeout 5m -v ${RACE} -tags v2v3 "$@" "${REPO_PATH}/store"
+	go test -timeout 1m -v ${RACE} -cpu 1,2,4 -run=Example "$@" "${TEST[@]}"
 }
 
 function functional_pass {
@@ -125,8 +127,9 @@ function functional_pass {
 	echo "ETCD_TESTER_EXIT_CODE:" ${ETCD_TESTER_EXIT_CODE}
 
 	echo "Waiting for processes to exit"
-	kill -s TERM ${agent_pids}
-	for a in ${agent_pids}; do wait $a || true; done
+	agent_pids=($agent_pids)
+	kill -s TERM "${agent_pids[@]}"
+	for a in "${agent_pids[@]}"; do wait "$a" || true; done
 	rm -rf ./agent-*
 
 	if [[ "${ETCD_TESTER_EXIT_CODE}" -ne "0" ]]; then
@@ -157,38 +160,39 @@ function cov_pass {
 	mkdir -p "$COVERDIR"
 
 	# run code coverage for unit and integration tests
-	GOCOVFLAGS="-covermode=set -coverpkg $PKGS_COMMA -v -timeout 15m"
+	GOCOVFLAGS="-covermode=set -coverpkg ${PKGS_COMMA} -v -timeout 15m"
+	GOCOVFLAGS=($GOCOVFLGS)
 	failed=""
-	for t in `echo "${TEST_PKGS}" | egrep -v "(e2e|functional-tester)"`; do
-		tf=`echo $t | tr / _`
+	for t in $(echo "${TEST_PKGS}" | egrep -v "(e2e|functional-tester)"); do
+		tf=$(echo "$t" | tr / _)
 		# cache package compilation data for faster repeated builds
-		go test $GOCOVFLAGS -i ${REPO_PATH}/$t || true
+		go test "${GOCOVFLAGS[@]}" -i "${REPO_PATH}/$t" || true
 		# uses -run=Test to skip examples because clientv3/ example tests will leak goroutines
-		go test $GOCOVFLAGS -run=Test -coverprofile "$COVERDIR/${tf}.coverprofile"  ${REPO_PATH}/$t || failed="$failed $t"
+		go test "${GOCOVFLAGS[@]}" -run=Test -coverprofile "$COVERDIR/${tf}.coverprofile"  "${REPO_PATH}/$t" || failed="$failed $t"
 	done
 
 	# v2v3 tests
-	go test -tags v2v3 $GOCOVFLAGS -coverprofile "$COVERDIR/store-v2v3.coverprofile" ${REPO_PATH}/clientv3/integration || failed="$failed store-v2v3"
+	go test -tags v2v3 "${GOCOVFLAGS[@]}" -coverprofile "$COVERDIR/store-v2v3.coverprofile" "${REPO_PATH}/clientv3/integration" || failed="$failed store-v2v3"
 
 	# proxy tests
-	go test -tags cluster_proxy $GOCOVFLAGS -coverprofile "$COVERDIR/proxy_integration.coverprofile" ${REPO_PATH}/integration || failed="$failed proxy-integration"
-	go test -tags cluster_proxy $GOCOVFLAGS -coverprofile "$COVERDIR/proxy_clientv3.coverprofile" ${REPO_PATH}/clientv3/integration || failed="$failed proxy-clientv3/integration"
+	go test -tags cluster_proxy "${GOCOVFLAGS[@]}" -coverprofile "$COVERDIR/proxy_integration.coverprofile" "${REPO_PATH}/integration" || failed="$failed proxy-integration"
+	go test -tags cluster_proxy "${GOCOVFLAGS[@]}" -coverprofile "$COVERDIR/proxy_clientv3.coverprofile" "${REPO_PATH}/clientv3/integration" || failed="$failed proxy-clientv3/integration"
 
 	# run code coverage for e2e tests
 	# use 30m timeout because e2e coverage takes longer
 	# due to many tests cause etcd process to wait
 	# on leadership transfer timeout during gracefully shutdown
 	echo Testing e2e without proxy...
-	go test -tags cov -timeout 30m -v ${REPO_PATH}"/e2e" || failed="$failed e2e"
+	go test -tags cov -timeout 30m -v "${REPO_PATH}/e2e" || failed="$failed e2e"
 	echo Testing e2e with proxy...
-	go test -tags "cov cluster_proxy" -timeout 30m -v ${REPO_PATH}"/e2e" || failed="$failed e2e-proxy"
+	go test -tags "cov cluster_proxy" -timeout 30m -v "${REPO_PATH}/e2e" || failed="$failed e2e-proxy"
 
 	# incrementally merge to get coverage data even if some coverage files are corrupted
 	# optimistically assume etcdserver package's coverage file is OK since gocovmerge
 	# expects to start with a non-empty file
 	cp "$COVERDIR"/etcdserver.coverprofile "$COVERDIR"/cover.out
 	for f in "$COVERDIR"/*.coverprofile; do
-		gocovmerge $f "$COVERDIR"/cover.out  >"$COVERDIR"/cover.tmp || failed="$failed $f"
+		gocovmerge "$f" "$COVERDIR"/cover.out  >"$COVERDIR"/cover.tmp || failed="$failed $f"
 		if [ -s "$COVERDIR"/cover.tmp ]; then
 			mv "$COVERDIR"/cover.tmp "$COVERDIR"/cover.out
 		fi
@@ -199,7 +203,7 @@ function cov_pass {
 	# held failures to generate the full coverage file, now fail
 	if [ -n "$failed" ]; then
 		for f in $failed; do
-			echo FAIL $f
+			echo FAIL "$f"
 		done
 		exit 255
 	fi
@@ -207,25 +211,25 @@ function cov_pass {
 
 function e2e_pass {
 	echo "Running e2e tests..."
-	go test -timeout 15m -v -cpu 1,2,4 $@ ${REPO_PATH}/e2e
+	go test -timeout 15m -v -cpu 1,2,4 "$@" "${REPO_PATH}/e2e"
 }
 
 function integration_e2e_pass {
 	echo "Running integration and e2e tests..."
 
-	go test -timeout 15m -v -cpu 1,2,4 $@ ${REPO_PATH}/e2e &
+	go test -timeout 15m -v -cpu 1,2,4 "$@" "${REPO_PATH}/e2e" &
 	e2epid="$!"
-	go test -timeout 15m -v -cpu 1,2,4 $@ ${REPO_PATH}/integration &
+	go test -timeout 15m -v -cpu 1,2,4 "$@" "${REPO_PATH}/integration" &
 	intpid="$!"
 	wait $e2epid
 	wait $intpid
-	integration_extra $@
+	integration_extra "$@"
 }
 
 function grpcproxy_pass {
-	go test -timeout 20m -v ${RACE} -tags cluster_proxy -cpu 1,2,4 $@ ${REPO_PATH}/integration
-	go test -timeout 20m -v ${RACE} -tags cluster_proxy -cpu 1,2,4 $@ ${REPO_PATH}/clientv3/integration
-	go test -timeout 15m -v -tags cluster_proxy $@ ${REPO_PATH}/e2e
+	go test -timeout 20m -v ${RACE} -tags cluster_proxy -cpu 1,2,4 "$@" "${REPO_PATH}/integration"
+	go test -timeout 20m -v ${RACE} -tags cluster_proxy -cpu 1,2,4 "$@" "${REPO_PATH}/clientv3/integration"
+	go test -timeout 15m -v -tags cluster_proxy "$@" "${REPO_PATH}/e2e"
 }
 
 function release_pass {
@@ -245,7 +249,7 @@ function release_pass {
 	echo "Downloading $file"
 
 	set +e
-	curl --fail -L https://github.com/coreos/etcd/releases/download/$UPGRADE_VER/$file -o /tmp/$file
+	curl --fail -L "https://github.com/coreos/etcd/releases/download/$UPGRADE_VER/$file" -o "/tmp/$file"
 	local result=$?
 	set -e
 	case $result in
@@ -255,7 +259,7 @@ function release_pass {
 			;;
 	esac
 
-	tar xzvf /tmp/$file -C /tmp/ --strip-components=1
+	tar xzvf "/tmp/$file" -C /tmp/ --strip-components=1
 	mkdir -p ./bin
 	mv /tmp/etcd ./bin/etcd-last-release
 }
@@ -264,22 +268,23 @@ function fmt_pass {
 	toggle_failpoints disable
 
 	echo "Checking gofmt..."
-	fmtRes=$(gofmt -l -s -d $FMT)
+	fmtRes=$(gofmt -l -s -d "${FMT[@]}")
 	if [ -n "${fmtRes}" ]; then
 		echo -e "gofmt checking failed:\n${fmtRes}"
 		exit 255
 	fi
 
 	echo "Checking govet..."
-	vetRes=$(go vet $TEST)
+	vetRes=$(go vet "${TEST[@]}")
 	if [ -n "${vetRes}" ]; then
 		echo -e "govet checking failed:\n${vetRes}"
 		exit 255
 	fi
 
 	echo "Checking 'go tool vet -all -shadow'..."
-	fmtpkgs=$(for a in $FMT; do dirname "$a"; done | sort | uniq | grep -v "\\.")
-	vetRes=$(go tool vet -all -shadow ${fmtpkgs} 2>&1 | grep -v '/gw/' || true)
+	fmtpkgs=$(for a in "${FMT[@]}"; do dirname "$a"; done | sort | uniq | grep -v "\\.")
+	fmtpkgs=($fmtpkgs)
+	vetRes=$(go tool vet -all -shadow "${fmtpkgs[@]}" 2>&1 | grep -v '/gw/' || true)
 	if [ -n "${vetRes}" ]; then
 		echo -e "govet -all -shadow checking failed:\n${vetRes}"
 		exit 255
@@ -289,21 +294,14 @@ function fmt_pass {
 		echo "Checking shellcheck..."
 		shellcheckResult=$(shellcheck -fgcc build test scripts/* 2>&1 || true)
 		if [ -n "${shellcheckResult}" ]; then
-			# mask the most common ones; fix later
-			SHELLCHECK_MASK="SC(2086|2006|2068|2196|2035|2162|2076)"
-			errs=$(echo "${shellcheckResult}" | egrep -v "${SHELLCHECK_MASK}" || true)
-			if [ -n "${errs}" ]; then
-				echo -e "shellcheck checking failed:\n${shellcheckResult}\n===\nFailed:\n${errs}"
-				exit 255
-			fi
-			suppressed=$(echo "${shellcheckResult}" | cut -f4- -d':' | sort | uniq -c | sort -n)
-			echo -e "shellcheck suppressed warnings:\n${suppressed}"
+			echo -e "shellcheck checking failed:\n${shellcheckResult}"
+			exit 255
 		fi
 	fi
 
 	echo "Checking documentation style..."
 	# eschew you
-	yous=`find . -name \*.md -exec egrep --color "[Yy]ou[r]?[ '.,;]" {} + | grep -v /v2/ || true`
+	yous=$(find . -name \*.md -exec egrep --color "[Yy]ou[r]?[ '.,;]" {} + | grep -v /v2/ || true)
 	if [ ! -z "$yous" ]; then
 		echo -e "found 'you' in documentation:\n${yous}"
 		exit 255
@@ -312,7 +310,7 @@ function fmt_pass {
 	# TODO: check other markdown files when marker handles headers with '[]'
 	if which marker >/dev/null; then
 		echo "Checking marker to find broken links..."
-		markerResult=`marker --skip-http --root ./Documentation 2>&1 || true`
+		markerResult=$(marker --skip-http --root ./Documentation 2>&1 || true)
 		if [ -n "${markerResult}" ]; then
 			echo -e "marker checking failed:\n${markerResult}"
 			exit 255
@@ -324,11 +322,13 @@ function fmt_pass {
 	if which goword >/dev/null; then
 		echo "Checking goword..."
 		# get all go files to process
-		gofiles=`find $FMT -iname '*.go' 2>/dev/null`
+		gofiles=$(find "${FMT[@]}" -iname '*.go' 2>/dev/null)
+		gofiles_all=($gofiles)
 		# ignore tests and protobuf files
-		gofiles=`echo ${gofiles} | sort | uniq | sed "s/ /\n/g" | egrep -v "(\\_test.go|\\.pb\\.go)"`
+		gofiles=$(echo "${gofiles_all[@]}" | sort | uniq | sed "s/ /\n/g" | egrep -v "(\\_test.go|\\.pb\\.go)")
+		gofiles=($gofiles)
 		# only check for broken exported godocs
-		gowordRes=`goword -use-spell=false ${gofiles} | grep godoc-export | sort`
+		gowordRes=$(goword -use-spell=false "${gofiles[@]}" | grep godoc-export | sort)
 		if [ ! -z "$gowordRes" ]; then
 			echo -e "goword checking failed:\n${gowordRes}"
 			exit 255
@@ -339,7 +339,7 @@ function fmt_pass {
 
 	if which gosimple >/dev/null; then
 		echo "Checking gosimple..."
-		gosimpleResult=`gosimple ${STATIC_ANALYSIS_PATHS} 2>&1 || true`
+		gosimpleResult=$(gosimple "${STATIC_ANALYSIS_PATHS[@]}" 2>&1 || true)
 		if [ -n "${gosimpleResult}" ]; then
 			# TODO: resolve these after go1.8 migration
 			SIMPLE_CHECK_MASK="S(1024)"
@@ -356,7 +356,7 @@ function fmt_pass {
 
 	if which unused >/dev/null; then
 		echo "Checking unused..."
-		unusedResult=`unused ${STATIC_ANALYSIS_PATHS} 2>&1 || true`
+		unusedResult=$(unused "${STATIC_ANALYSIS_PATHS[@]}" 2>&1 || true)
 		if [ -n "${unusedResult}" ]; then
 			echo -e "unused checking failed:\n${unusedResult}"
 			exit 255
@@ -367,7 +367,7 @@ function fmt_pass {
 
 	if which staticcheck >/dev/null; then
 		echo "Checking staticcheck..."
-		staticcheckResult=`staticcheck ${STATIC_ANALYSIS_PATHS} 2>&1 || true`
+		staticcheckResult=$(staticcheck "${STATIC_ANALYSIS_PATHS[@]}" 2>&1 || true)
 		if [ -n "${staticcheckResult}" ]; then
 			# TODO: resolve these after go1.8 migration
 			# See https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck
@@ -376,7 +376,7 @@ function fmt_pass {
 				echo -e "staticcheck checking failed:\n${staticcheckResult}"
 				exit 255
 			else
-				suppressed=`echo "${staticcheckResult}" | sed 's/ /\n/g' | grep "(SA" | sort | uniq -c`
+				suppressed=$(echo "${staticcheckResult}" | sed 's/ /\n/g' | grep "(SA" | sort | uniq -c)
 				echo -e "staticcheck suppressed warnings:\n${suppressed}"
 			fi
 		fi
@@ -398,8 +398,8 @@ function fmt_pass {
 	fi
 
 	echo "Checking commit titles..."
-	git log --oneline "$(git merge-base HEAD master)"...HEAD | while read l; do
-		commitMsg=`echo "$l" | cut -f2- -d' '`
+	git log --oneline "$(git merge-base HEAD master)"...HEAD | while read -r l; do
+		commitMsg=$(echo "$l" | cut -f2- -d' ')
 		if [[ "$commitMsg" == Merge* ]]; then
 			# ignore "Merge pull" commits
 			continue
@@ -409,10 +409,10 @@ function fmt_pass {
 			continue
 		fi
 
-		pkgPrefix=`echo "$commitMsg" | cut -f1 -d':'`
-		spaceCommas=`echo "$commitMsg" | sed 's/ /\n/g' | grep -c ',$' || echo 0`
-		commaSpaces=`echo "$commitMsg" | sed 's/,/\n/g' | grep -c '^ ' || echo 0`
-		if [[ `echo $commitMsg | grep -c ":..*"` == 0 || "$commitMsg" == "$pkgPrefix" || "$spaceCommas" != "$commaSpaces" ]]; then
+		pkgPrefix=$(echo "$commitMsg" | cut -f1 -d':')
+		spaceCommas=$(echo "$commitMsg" | sed 's/ /\n/g' | grep -c ',$' || echo 0)
+		commaSpaces=$(echo "$commitMsg" | sed 's/,/\n/g' | grep -c '^ ' || echo 0)
+		if [[ $(echo "$commitMsg" | grep -c ":..*") == 0 || "$commitMsg" == "$pkgPrefix" || "$spaceCommas" != "$commaSpaces" ]]; then
     			echo "$l"...
 			echo "Expected commit title format '<package>{\", \"<package>}: <description>'"
 			echo "Got: $l"
@@ -441,7 +441,7 @@ function dep_pass {
 	# don't pull in etcdserver package
 	pushd clientv3 >/dev/null
 	badpkg="(etcdserver$|mvcc$|backend$|grpc-gateway)"
-	deps=`go list -f '{{ .Deps }}'  | sed 's/ /\n/g' | egrep "${badpkg}" || echo ""`
+	deps=$(go list -f '{{ .Deps }}'  | sed 's/ /\n/g' | egrep "${badpkg}" || echo "")
 	popd >/dev/null
 	if [ ! -z "$deps" ]; then
 		echo -e "clientv3 has masked dependencies:\n${deps}"
@@ -452,8 +452,8 @@ function dep_pass {
 function build_cov_pass {
 	out="bin"
 	if [ -n "${BINDIR}" ]; then out="${BINDIR}"; fi
-	go test -tags cov -c -covermode=set -coverpkg=$PKGS_COMMA -o ${out}/etcd_test
-	go test -tags cov -c -covermode=set -coverpkg=$PKGS_COMMA -o ${out}/etcdctl_test ${REPO_PATH}/etcdctl
+	go test -tags cov -c -covermode=set -coverpkg="$PKGS_COMMA" -o "${out}/etcd_test"
+	go test -tags cov -c -covermode=set -coverpkg="$PKGS_COMMA" -o "${out}/etcdctl_test" "${REPO_PATH}/etcdctl"
 }
 
 function compile_pass {
@@ -468,7 +468,7 @@ function build_pass {
 
 for pass in $PASSES; do
 	echo "Starting '$pass' pass at $(date)"
-	${pass}_pass $@
+	"${pass}"_pass "$@"
 	echo "Finished '$pass' pass at $(date)"
 done
 


### PR DESCRIPTION
* regexp warnings
* use ./*glob* so names don't become options
* use $(..) instead of legacy `..`
* read with -r to avoid mangling backslashes
* double quote to prevent globbing and word splitting