### PR TITLE
Dockerfile-test: add test image with Go 1.9

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,29 @@
+FROM golang:1.9-stretch
+
+RUN apt-get -y update
+RUN apt-get -y install \
+  netcat \
+  libaspell-dev \
+  libhunspell-dev \
+  hunspell-en-us \
+  aspell-en \
+  shellcheck
+
+RUN mkdir -p ${GOPATH}/src/github.com/coreos/etcd
+WORKDIR ${GOPATH}/src/github.com/coreos/etcd
+
+ADD ./scripts/install-marker.sh ./scripts/install-marker.sh
+
+RUN go get -v -u -tags spell github.com/chzchzchz/goword \
+  && go get -v -u github.com/coreos/license-bill-of-materials \
+  && go get -v -u honnef.co/go/tools/cmd/gosimple \
+  && go get -v -u honnef.co/go/tools/cmd/unused \
+  && go get -v -u honnef.co/go/tools/cmd/staticcheck \
+  && go get -v -u github.com/wadey/gocovmerge \
+  && ./scripts/install-marker.sh amd64
+
+# e.g.
+# docker build --tag etcd-test --file ./Dockerfile-test .
+# docker run --volume=`pwd`:/go/src/github.com/coreos/etcd etcd-test \
+#  /bin/sh -c "INTEGRATION=y PASSES='build integration_e2e' ./test"
+


### PR DESCRIPTION
While Semaphore CI does not support Go 1.9 yet, we can do:

```
docker build --tag etcd-test --file ./Dockerfile-test .
# Or serve this image in registry

docker run \
  --volume=`pwd`:/go/src/github.com/coreos/etcd \
  etcd-test \
  /bin/sh -c "RELEASE_TEST=y INTEGRATION=y PASSES='build unit release integration_e2e functional' ./test 2>&1 | tee test.log"
```