### PR TITLE
raft: don't ack MsgPreVotes when it cannot succeed

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -782,9 +782,11 @@ func (r *raft) Step(m pb.Message) error {
 	case pb.MsgVote, pb.MsgPreVote:
 		// The m.Term > r.Term clause is for MsgPreVote. For MsgVote m.Term should
 		// always equal r.Term.
-		if (r.Vote == None || m.Term > r.Term || r.Vote == m.From) && r.raftLog.isUpToDate(m.Index, m.LogTerm) {
-			r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] cast %s for %x [logterm: %d, index: %d] at term %d",
-				r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term)
+		if m.Type == pb.MsgVote && m.Term != r.Term {
+			panic(fmt.Sprintf("m.Type == pb.MsgVote && m.Term != r.Term: %d != %d", m.Term, r.Term))
+		}
+		if (r.Vote == None || r.Vote == m.From || (m.Type == pb.MsgPreVote && m.Term > r.Term)) &&
+			r.raftLog.isUpToDate(m.Index, m.LogTerm) {
 			// When responding to Msg{Pre,}Vote messages we include the term
 			// from the message, not the local term. To see why consider the
 			// case where a single node was previously partitioned away and
@@ -794,6 +796,8 @@ func (r *raft) Step(m pb.Message) error {
 			// the message (it ignores all out of date messages).
 			// The term in the original message and current local term are the
 			// same in the case of regular votes, but different for pre-votes.
+			r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] cast %s for %x [logterm: %d, index: %d] at term %d",
+				r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term)
 			r.send(pb.Message{To: m.From, Term: m.Term, Type: voteRespMsgType(m.Type)})
 			if m.Type == pb.MsgVote {
 				// Only record real votes.

--- a/raft/rawnode_test.go
+++ b/raft/rawnode_test.go
@@ -31,12 +31,11 @@ func TestRawNodeStep(t *testing.T) {
 			t.Fatal(err)
 		}
 		msgt := raftpb.MessageType(i)
-		err = rawNode.Step(raftpb.Message{Type: msgt})
+		err = rawNode.Step(raftpb.Message{Type: msgt, Term: 1})
 		// LocalMsg should be ignored.
-		if IsLocalMsg(msgt) {
-			if err != ErrStepLocalMsg {
-				t.Errorf("%d: step should ignore %s", msgt, msgn)
-			}
+		if IsLocalMsg(msgt) && err != ErrStepLocalMsg {
+			t.Errorf("%d: step should ignore %s", msgt, msgn)
+			return
 		}
 	}
 }


### PR DESCRIPTION
The changeset tightens the constraint around granted `PreVote`s.
Previously `PreVote` requests of the same term as the node's current term
would be granted despite there being no way for it to succeed
(`MsgPreVotes` currently specify the next term, if the next term of the requesting
node is the same as our current term, when subsequently calling for an
election it will fail). In this case we will now simply reject the vote.

---

While here we add a panic for a comment specified-constraint.

    // The m.Term > r.Term clause is for MsgPreVote. For MsgVote m.Term
    // should always equal r.Term.

TestRawNodeStep was in violation of this by sending in Msg{Pre,}Vote
messages with unspecified terms (defaulting to 0) when the recipient
node was at a higher term.

+cc @bdarnell @xiang90 