### PR TITLE
clientv3: unify receiver name for Election.

### DIFF
--- a/clientv3/concurrency/election.go
+++ b/clientv3/concurrency/election.go
@@ -240,4 +240,4 @@ func (e *Election) Key() string { return e.leaderKey }
 func (e *Election) Rev() int64 { return e.leaderRev }
 
 // Header is the response header from the last successful election proposal.
-func (m *Election) Header() *pb.ResponseHeader { return m.hdr }
+func (e *Election) Header() *pb.ResponseHeader { return e.hdr }


### PR DESCRIPTION
Fix receiver name not unified in Election.