### PR TITLE
grpcproxy: don’t serve SSL when using upstream TLS auth

### DIFF
--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -190,8 +190,7 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 		Handler: httpmux,
 	}
 
-	var httpl net.Listener
-	httpl = m.Match(cmux.HTTP1())
+	httpl := m.Match(cmux.HTTP1())
 	go func() { errc <- srvhttp.Serve(httpl) }()
 
 	go func() { errc <- m.Serve() }()

--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -15,7 +15,6 @@
 package etcdmain
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -192,12 +191,7 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 	}
 
 	var httpl net.Listener
-	if cfg.TLS != nil {
-		srvhttp.TLSConfig = cfg.TLS
-		httpl = tls.NewListener(m.Match(cmux.Any()), cfg.TLS)
-	} else {
-		httpl = m.Match(cmux.HTTP1())
-	}
+	httpl = m.Match(cmux.HTTP1())
 	go func() { errc <- srvhttp.Serve(httpl) }()
 
 	go func() { errc <- m.Serve() }()


### PR DESCRIPTION
right now, the grpc-proxy in the 3.2 branch confusingly enables TLS on its HTTP1 muxer (i.e. HTTPS) if you specify upstream client certificates. this stops that from happening.