### PR TITLE
client: fix TestHTTPClusterClientSyncUnpinEndpoint

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -670,8 +670,15 @@ func (r *redirectedHTTPAction) HTTPRequest(ep url.URL) *http.Request {
 }
 
 func shuffleEndpoints(r *rand.Rand, eps []url.URL) []url.URL {
-	p := r.Perm(len(eps))
-	neps := make([]url.URL, len(eps))
+	// copied from Go 1.9<= rand.Rand.Perm
+	n := len(eps)
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		j := r.Intn(i + 1)
+		p[i] = p[j]
+		p[j] = i
+	}
+	neps := make([]url.URL, n)
 	for i, k := range p {
 		neps[i] = eps[k]
 	}


### PR DESCRIPTION
client uses math.rand.Perm, and now Perm works like Shuffle
in go math package (https://github.com/golang/go/commit/caae0917bff12751019cb4240e99874fa692e770#diff-d4a72c5ba8515eae95a093e0aec62635).

Fixes client test breakage in Go tip.

```
--- FAIL: TestHTTPClusterClientSyncUnpinEndpoint (0.00s)
	client_test.go:988: #0: pinned endpoint = {http  <nil> 127.0.0.1:4001   false  }, want http://127.0.0.1:2379
	client_test.go:988: #2: pinned endpoint = {http  <nil> 127.0.0.1:4001   false  }, want http://127.0.0.1:4002
--- FAIL: TestHTTPClusterClientSyncUnpinEndpoint (0.00s)
	client_test.go:988: #0: pinned endpoint = {http  <nil> 127.0.0.1:4001   false  }, want http://127.0.0.1:2379
	client_test.go:988: #2: pinned endpoint = {http  <nil> 127.0.0.1:4001   false  }, want http://127.0.0.1:4002
--- FAIL: TestHTTPClusterClientSyncUnpinEndpoint (0.00s)
	client_test.go:988: #0: pinned endpoint = {http  <nil> 127.0.0.1:4001   false  }, want http://127.0.0.1:2379
	client_test.go:988: #2: pinned endpoint = {http  <nil> 127.0.0.1:4001   false  }, want http://127.0.0.1:4002
```