### PR TITLE
raft: fix bullet point indentation in README

### DIFF
--- a/raft/README.md
+++ b/raft/README.md
@@ -25,12 +25,12 @@ This raft implementation is a full feature implementation of Raft protocol. Feat
 - Membership changes
 - Leadership transfer extension
 - Efficient linearizable read-only queries served by both the leader and followers
- - leader checks with quorum and bypasses Raft log before processing read-only queries
- - followers asks leader to get a safe read index before processing read-only queries
+  - leader checks with quorum and bypasses Raft log before processing read-only queries
+  - followers asks leader to get a safe read index before processing read-only queries
 - More efficient lease-based linearizable read-only queries served by both the leader and followers
- - leader bypasses Raft log and processing read-only queries locally
- - followers asks leader to get a safe read index before processing read-only queries
- - this approach relies on the clock of the all the machines in raft group
+  - leader bypasses Raft log and processing read-only queries locally
+  - followers asks leader to get a safe read index before processing read-only queries
+  - this approach relies on the clock of the all the machines in raft group
 
 This raft implementation also includes a few optional enhancements:
 


### PR DESCRIPTION
Before this change:

<img width="790" alt="screen shot 2017-09-18 at 4 08 50 pm" src="https://user-images.githubusercontent.com/7085343/30562247-c20959ba-9c8b-11e7-825f-fe82b63d9876.png">

After this change:

<img width="793" alt="screen shot 2017-09-18 at 4 08 57 pm" src="https://user-images.githubusercontent.com/7085343/30562253-c60da7aa-9c8b-11e7-9462-a1fd99b310a3.png">
