### PR TITLE
raft: don't ack MsgPreVotes when it cannot succeed

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -789,7 +789,11 @@ func (r *raft) Step(m pb.Message) error {
 	case pb.MsgVote, pb.MsgPreVote:
 		// The m.Term > r.Term clause is for MsgPreVote. For MsgVote m.Term should
 		// always equal r.Term.
-		if (r.Vote == None || m.Term > r.Term || r.Vote == m.From) && r.raftLog.isUpToDate(m.Index, m.LogTerm) {
+		if m.Type == pb.MsgVote && m.Term != r.Term {
+			panic(fmt.Sprintf("m.Type == pb.MsgVote && m.Term != r.Term: %d != %d", m.Term, r.Term))
+		}
+
+		if (r.Vote == None || r.Vote == m.From || (m.Type == pb.MsgPreVote && m.Term > r.Term)) && r.raftLog.isUpToDate(m.Index, m.LogTerm) {
 			r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] cast %s for %x [logterm: %d, index: %d] at term %d",
 				r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term)
 			// When responding to Msg{Pre,}Vote messages we include the term

--- a/raft/rawnode_test.go
+++ b/raft/rawnode_test.go
@@ -31,12 +31,11 @@ func TestRawNodeStep(t *testing.T) {
 			t.Fatal(err)
 		}
 		msgt := raftpb.MessageType(i)
-		err = rawNode.Step(raftpb.Message{Type: msgt})
+		err = rawNode.Step(raftpb.Message{Type: msgt, Term: 1})
 		// LocalMsg should be ignored.
-		if IsLocalMsg(msgt) {
-			if err != ErrStepLocalMsg {
-				t.Errorf("%d: step should ignore %s", msgt, msgn)
-			}
+		if IsLocalMsg(msgt) && err != ErrStepLocalMsg {
+			t.Errorf("%d: step should ignore %s", msgt, msgn)
+			return
 		}
 	}
 }


### PR DESCRIPTION
replace https://github.com/coreos/etcd/pull/8517.

i added a test, which illustrate what problem this pr tries to address.  

/cc @bdarnell @javaforfun 
