### PR TITLE
client: regenerate sources for etcd/client with new ugorji/go changes

### DIFF
--- a/client/keys.generated.go
+++ b/client/keys.generated.go
@@ -37,10 +37,10 @@ var (
 type codecSelfer1819 struct{}
 
 func init() {
-	if codec1978.GenVersion != 5 {
+	if codec1978.GenVersion != 6 {
 		_, file, _, _ := runtime.Caller(0)
 		err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v",
-			5, codec1978.GenVersion, file)
+			6, codec1978.GenVersion, file)
 		panic(err)
 	}
 	if false { // reference the types, but skip this branch at build/run time
@@ -189,7 +189,7 @@ func (x *Response) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1819)
-		yys3Slc = r.DecodeBytes(yys3Slc, true, true)
+		yys3Slc = r.DecodeStringAsBytes()
 		yys3 := string(yys3Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1819)
 		switch yys3 {
@@ -601,7 +601,7 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		}
 		z.DecSendContainerState(codecSelfer_containerMapKey1819)
-		yys3Slc = r.DecodeBytes(yys3Slc, true, true)
+		yys3Slc = r.DecodeStringAsBytes()
 		yys3 := string(yys3Slc)
 		z.DecSendContainerState(codecSelfer_containerMapValue1819)
 		switch yys3 {
@@ -982,79 +982,45 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 			yyv1 = yyv1[:0]
 			yyc1 = true
 		}
-	} else if yyl1 > 0 {
-		var yyrr1, yyrl1 int
-		var yyrt1 bool
-		_, _ = yyrl1, yyrt1
-		yyrr1 = yyl1 // len(yyv1)
-		if yyl1 > cap(yyv1) {
-
-			yyrg1 := len(yyv1) > 0
-			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 8)
-			if yyrt1 {
+	} else {
+		yyhl1 := yyl1 > 0
+		var yyrl1 int
+		if yyhl1 {
+			if yyl1 > cap(yyv1) {
+				yyrl1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 8)
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]
 				} else {
 					yyv1 = make([]*Node, yyrl1)
 				}
-			} else {
-				yyv1 = make([]*Node, yyrl1)
-			}
-			yyc1 = true
-			yyrr1 = len(yyv1)
-			if yyrg1 {
-				copy(yyv1, yyv21)
-			}
-		} else if yyl1 != len(yyv1) {
-			yyv1 = yyv1[:yyl1]
-			yyc1 = true
-		}
-		yyj1 := 0
-		for ; yyj1 < yyrr1; yyj1++ {
-			yyh1.ElemContainerState(yyj1)
-			if r.TryDecodeAsNil() {
-				if yyv1[yyj1] != nil {
-					*yyv1[yyj1] = Node{}
-				}
-			} else {
-				if yyv1[yyj1] == nil {
-					yyv1[yyj1] = new(Node)
-				}
-				yyw2 := yyv1[yyj1]
-				yyw2.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt1 {
-			for ; yyj1 < yyl1; yyj1++ {
-				yyv1 = append(yyv1, nil)
-				yyh1.ElemContainerState(yyj1)
-				if r.TryDecodeAsNil() {
-					if yyv1[yyj1] != nil {
-						*yyv1[yyj1] = Node{}
-					}
-				} else {
-					if yyv1[yyj1] == nil {
-						yyv1[yyj1] = new(Node)
-					}
-					yyw3 := yyv1[yyj1]
-					yyw3.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		yyj1 := 0
-		for ; !r.CheckBreak(); yyj1++ {
-
-			if yyj1 >= len(yyv1) {
-				yyv1 = append(yyv1, nil) // var yyz1 *Node
+				yyc1 = true
+			} else if yyl1 != len(yyv1) {
+				yyv1 = yyv1[:yyl1]
 				yyc1 = true
 			}
+		}
+		yyj1 := 0
+		for ; (yyhl1 && yyj1 < yyl1) || !(yyhl1 || r.CheckBreak()); yyj1++ {
+			if yyj1 == 0 && len(yyv1) == 0 {
+				if yyhl1 {
+					yyrl1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 8)
+				} else {
+					yyrl1 = 8
+				}
+				yyv1 = make([]*Node, yyrl1)
+				yyc1 = true
+			}
+			// if indefinite, etc, then expand the slice if necessary
+			var yydb1 bool
+			if yyj1 >= len(yyv1) {
+				yyv1 = append(yyv1, nil)
+				yyc1 = true
+
+			}
 			yyh1.ElemContainerState(yyj1)
-			if yyj1 < len(yyv1) {
+			if yydb1 {
+				z.DecSwallow()
+			} else {
 				if r.TryDecodeAsNil() {
 					if yyv1[yyj1] != nil {
 						*yyv1[yyj1] = Node{}
@@ -1063,20 +1029,17 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 					if yyv1[yyj1] == nil {
 						yyv1[yyj1] = new(Node)
 					}
-					yyw4 := yyv1[yyj1]
-					yyw4.CodecDecodeSelf(d)
+					yyw2 := yyv1[yyj1]
+					yyw2.CodecDecodeSelf(d)
 				}
 
-			} else {
-				z.DecSwallow()
 			}
-
 		}
 		if yyj1 < len(yyv1) {
 			yyv1 = yyv1[:yyj1]
 			yyc1 = true
 		} else if yyj1 == 0 && yyv1 == nil {
-			yyv1 = []*Node{}
+			yyv1 = make([]*Node, 0)
 			yyc1 = true
 		}
 	}
@@ -1084,4 +1047,5 @@ func (x codecSelfer1819) decNodes(v *Nodes, d *codec1978.Decoder) {
 	if yyc1 {
 		*v = yyv1
 	}
+
 }

--- a/cmd/vendor/github.com/ugorji/go/codec/0doc.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/0doc.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a MIT license found in the LICENSE file.
 
 /*
-High Performance, Feature-Rich Idiomatic Go codec/encoding library for 
-binc, msgpack, cbor, json.
+High Performance, Feature-Rich Idiomatic Go 1.4+ codec/encoding library for
+binc, msgpack, cbor, json
 
 Supported Serialization formats are:
 
@@ -11,21 +11,17 @@ Supported Serialization formats are:
   - binc:    http://github.com/ugorji/binc
   - cbor:    http://cbor.io http://tools.ietf.org/html/rfc7049
   - json:    http://json.org http://tools.ietf.org/html/rfc7159
-  - simple: 
+  - simple:
 
 To install:
 
     go get github.com/ugorji/go/codec
 
-This package understands the 'unsafe' tag, to allow using unsafe semantics:
-
-  - When decoding into a struct, you need to read the field name as a string 
-    so you can find the struct field it is mapped to.
-    Using `unsafe` will bypass the allocation and copying overhead of []byte->string conversion.
-
-To install using unsafe, pass the 'unsafe' tag:
-
-    go get -tags=unsafe github.com/ugorji/go/codec
+This package will carefully use 'unsafe' for performance reasons in specific places.
+You can build without unsafe use by passing the safe or appengine tag
+i.e. 'go install -tags=safe ...'. Note that unsafe is only supported for the last 3
+go sdk versions e.g. current go release is go 1.9, so we support unsafe use only from
+go 1.7+ . This is because supporting unsafe requires knowledge of implementation details.
 
 For detailed usage information, read the primer at http://ugorji.net/blog/go-codec-primer .
 
@@ -38,9 +34,9 @@ Rich Feature Set includes:
   - Very High Performance.
     Our extensive benchmarks show us outperforming Gob, Json, Bson, etc by 2-4X.
   - Multiple conversions:
-    Package coerces types where appropriate 
+    Package coerces types where appropriate
     e.g. decode an int in the stream into a float, etc.
-  - Corner Cases: 
+  - Corner Cases:
     Overflows, nil maps/slices, nil values in streams are handled correctly
   - Standard field renaming via tags
   - Support for omitting empty fields during an encoding
@@ -56,7 +52,7 @@ Rich Feature Set includes:
   - Fast (no-reflection) encoding/decoding of common maps and slices
   - Code-generation for faster performance.
   - Support binary (e.g. messagepack, cbor) and text (e.g. json) formats
-  - Support indefinite-length formats to enable true streaming 
+  - Support indefinite-length formats to enable true streaming
     (for formats which support it e.g. json, cbor)
   - Support canonical encoding, where a value is ALWAYS encoded as same sequence of bytes.
     This mostly applies to maps, where iteration order is non-deterministic.
@@ -68,12 +64,12 @@ Rich Feature Set includes:
   - Encode/Decode from/to chan types (for iterative streaming support)
   - Drop-in replacement for encoding/json. `json:` key in struct tag supported.
   - Provides a RPC Server and Client Codec for net/rpc communication protocol.
-  - Handle unique idiosyncrasies of codecs e.g. 
-    - For messagepack, configure how ambiguities in handling raw bytes are resolved 
-    - For messagepack, provide rpc server/client codec to support 
+  - Handle unique idiosyncrasies of codecs e.g.
+    - For messagepack, configure how ambiguities in handling raw bytes are resolved
+    - For messagepack, provide rpc server/client codec to support
       msgpack-rpc protocol defined at:
       https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md
-  
+
 Extension Support
 
 Users can register a function to handle the encoding or decoding of

--- a/cmd/vendor/github.com/ugorji/go/codec/binc.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/binc.go
@@ -356,6 +356,9 @@ func (d *bincDecDriver) uncacheRead() {
 }
 
 func (d *bincDecDriver) ContainerType() (vt valueType) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
 	if d.vd == bincVdSpecial && d.vs == bincSpNil {
 		return valueTypeNil
 	} else if d.vd == bincVdByteArray {
@@ -580,6 +583,9 @@ func (d *bincDecDriver) DecodeBool() (b bool) {
 }
 
 func (d *bincDecDriver) ReadMapStart() (length int) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
 	if d.vd != bincVdMap {
 		d.d.errorf("Invalid d.vd for map. Expecting 0x%x. Got: 0x%x", bincVdMap, d.vd)
 		return
@@ -590,6 +596,9 @@ func (d *bincDecDriver) ReadMapStart() (length int) {
 }
 
 func (d *bincDecDriver) ReadArrayStart() (length int) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
 	if d.vd != bincVdArray {
 		d.d.errorf("Invalid d.vd for array. Expecting 0x%x. Got: 0x%x", bincVdArray, d.vd)
 		return
@@ -639,12 +648,12 @@ func (d *bincDecDriver) decStringAndBytes(bs []byte, withString, zerocopy bool) 
 			if d.br {
 				bs2 = d.r.readx(slen)
 			} else if len(bs) == 0 {
-				bs2 = decByteSlice(d.r, slen, d.b[:])
+				bs2 = decByteSlice(d.r, slen, d.d.h.MaxInitLen, d.b[:])
 			} else {
-				bs2 = decByteSlice(d.r, slen, bs)
+				bs2 = decByteSlice(d.r, slen, d.d.h.MaxInitLen, bs)
 			}
 		} else {
-			bs2 = decByteSlice(d.r, slen, bs)
+			bs2 = decByteSlice(d.r, slen, d.d.h.MaxInitLen, bs)
 		}
 		if withString {
 			s = string(bs2)
@@ -696,7 +705,7 @@ func (d *bincDecDriver) decStringAndBytes(bs []byte, withString, zerocopy bool) 
 			// since using symbols, do not store any part of
 			// the parameter bs in the map, as it might be a shared buffer.
 			// bs2 = decByteSlice(d.r, slen, bs)
-			bs2 = decByteSlice(d.r, slen, nil)
+			bs2 = decByteSlice(d.r, slen, d.d.h.MaxInitLen, nil)
 			if withString {
 				s = string(bs2)
 			}
@@ -719,11 +728,12 @@ func (d *bincDecDriver) DecodeString() (s string) {
 	return
 }
 
-func (d *bincDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
-	if isstring {
-		bsOut, _ = d.decStringAndBytes(bs, false, zerocopy)
-		return
-	}
+func (d *bincDecDriver) DecodeStringAsBytes() (s []byte) {
+	s, _ = d.decStringAndBytes(d.b[:], false, true)
+	return
+}
+
+func (d *bincDecDriver) DecodeBytes(bs []byte, zerocopy bool) (bsOut []byte) {
 	if !d.bdRead {
 		d.readNextBd()
 	}
@@ -747,7 +757,7 @@ func (d *bincDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut [
 			bs = d.b[:]
 		}
 	}
-	return decByteSlice(d.r, clen, bs)
+	return decByteSlice(d.r, clen, d.d.h.MaxInitLen, bs)
 }
 
 func (d *bincDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxtag uint64) {
@@ -780,7 +790,7 @@ func (d *bincDecDriver) decodeExtV(verifyTag bool, tag byte) (xtag byte, xbs []b
 		}
 		xbs = d.r.readx(l)
 	} else if d.vd == bincVdByteArray {
-		xbs = d.DecodeBytes(nil, false, true)
+		xbs = d.DecodeBytes(nil, true)
 	} else {
 		d.d.errorf("Invalid d.vd for extensions (Expecting extensions or byte array). Got: 0x%x", d.vd)
 		return
@@ -849,7 +859,7 @@ func (d *bincDecDriver) DecodeNaked() {
 		n.s = d.DecodeString()
 	case bincVdByteArray:
 		n.v = valueTypeBytes
-		n.l = d.DecodeBytes(nil, false, false)
+		n.l = d.DecodeBytes(nil, false)
 	case bincVdTimestamp:
 		n.v = valueTypeTimestamp
 		tt, err := decodeTime(d.r.readx(int(d.vs)))
@@ -910,7 +920,7 @@ func (h *BincHandle) newEncDriver(e *Encoder) encDriver {
 }
 
 func (h *BincHandle) newDecDriver(d *Decoder) decDriver {
-	return &bincDecDriver{d: d, r: d.r, h: h, br: d.bytes}
+	return &bincDecDriver{d: d, h: h, r: d.r, br: d.bytes}
 }
 
 func (e *bincEncDriver) reset() {
@@ -920,7 +930,7 @@ func (e *bincEncDriver) reset() {
 }
 
 func (d *bincDecDriver) reset() {
-	d.r = d.d.r
+	d.r, d.br = d.d.r, d.d.bytes
 	d.s = nil
 	d.bd, d.bdRead, d.vd, d.vs = 0, false, 0, 0
 }

--- a/cmd/vendor/github.com/ugorji/go/codec/fast-path.generated.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/fast-path.generated.go
@@ -86,7 +86,7 @@ func init() {
 	i := 0
 	fn := func(v interface{}, fe func(*encFnInfo, reflect.Value), fd func(*decFnInfo, reflect.Value)) (f fastpathE) {
 		xrt := reflect.TypeOf(v)
-		xptr := reflect.ValueOf(xrt).Pointer()
+		xptr := rt2id(xrt)
 		fastpathAV[i] = fastpathE{xptr, xrt, fe, fd}
 		i++
 		return
@@ -3115,9 +3115,9 @@ func fastpathEncodeTypeSwitchMap(iv interface{}, e *Encoder) bool {
 
 func (f *encFnInfo) fastpathEncSliceIntfR(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceIntfV(rv.Interface().([]interface{}), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceIntfV(rv2i(rv).([]interface{}), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceIntfV(rv.Interface().([]interface{}), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceIntfV(rv2i(rv).([]interface{}), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceIntfV(v []interface{}, checkNil bool, e *Encoder) {
@@ -3168,9 +3168,9 @@ func (_ fastpathT) EncAsMapSliceIntfV(v []interface{}, checkNil bool, e *Encoder
 
 func (f *encFnInfo) fastpathEncSliceStringR(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceStringV(rv.Interface().([]string), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceStringV(rv2i(rv).([]string), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceStringV(rv.Interface().([]string), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceStringV(rv2i(rv).([]string), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceStringV(v []string, checkNil bool, e *Encoder) {
@@ -3221,9 +3221,9 @@ func (_ fastpathT) EncAsMapSliceStringV(v []string, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceFloat32R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceFloat32V(rv.Interface().([]float32), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceFloat32V(rv2i(rv).([]float32), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceFloat32V(rv.Interface().([]float32), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceFloat32V(rv2i(rv).([]float32), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceFloat32V(v []float32, checkNil bool, e *Encoder) {
@@ -3274,9 +3274,9 @@ func (_ fastpathT) EncAsMapSliceFloat32V(v []float32, checkNil bool, e *Encoder)
 
 func (f *encFnInfo) fastpathEncSliceFloat64R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceFloat64V(rv.Interface().([]float64), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceFloat64V(rv2i(rv).([]float64), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceFloat64V(rv.Interface().([]float64), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceFloat64V(rv2i(rv).([]float64), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceFloat64V(v []float64, checkNil bool, e *Encoder) {
@@ -3327,9 +3327,9 @@ func (_ fastpathT) EncAsMapSliceFloat64V(v []float64, checkNil bool, e *Encoder)
 
 func (f *encFnInfo) fastpathEncSliceUintR(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceUintV(rv.Interface().([]uint), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceUintV(rv2i(rv).([]uint), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceUintV(rv.Interface().([]uint), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceUintV(rv2i(rv).([]uint), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceUintV(v []uint, checkNil bool, e *Encoder) {
@@ -3380,9 +3380,9 @@ func (_ fastpathT) EncAsMapSliceUintV(v []uint, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceUint16R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceUint16V(rv.Interface().([]uint16), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceUint16V(rv2i(rv).([]uint16), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceUint16V(rv.Interface().([]uint16), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceUint16V(rv2i(rv).([]uint16), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceUint16V(v []uint16, checkNil bool, e *Encoder) {
@@ -3433,9 +3433,9 @@ func (_ fastpathT) EncAsMapSliceUint16V(v []uint16, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceUint32R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceUint32V(rv.Interface().([]uint32), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceUint32V(rv2i(rv).([]uint32), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceUint32V(rv.Interface().([]uint32), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceUint32V(rv2i(rv).([]uint32), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceUint32V(v []uint32, checkNil bool, e *Encoder) {
@@ -3486,9 +3486,9 @@ func (_ fastpathT) EncAsMapSliceUint32V(v []uint32, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceUint64R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceUint64V(rv.Interface().([]uint64), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceUint64V(rv2i(rv).([]uint64), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceUint64V(rv.Interface().([]uint64), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceUint64V(rv2i(rv).([]uint64), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceUint64V(v []uint64, checkNil bool, e *Encoder) {
@@ -3539,9 +3539,9 @@ func (_ fastpathT) EncAsMapSliceUint64V(v []uint64, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceUintptrR(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceUintptrV(rv.Interface().([]uintptr), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceUintptrV(rv2i(rv).([]uintptr), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceUintptrV(rv.Interface().([]uintptr), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceUintptrV(rv2i(rv).([]uintptr), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceUintptrV(v []uintptr, checkNil bool, e *Encoder) {
@@ -3592,9 +3592,9 @@ func (_ fastpathT) EncAsMapSliceUintptrV(v []uintptr, checkNil bool, e *Encoder)
 
 func (f *encFnInfo) fastpathEncSliceIntR(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceIntV(rv.Interface().([]int), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceIntV(rv2i(rv).([]int), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceIntV(rv.Interface().([]int), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceIntV(rv2i(rv).([]int), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceIntV(v []int, checkNil bool, e *Encoder) {
@@ -3645,9 +3645,9 @@ func (_ fastpathT) EncAsMapSliceIntV(v []int, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceInt8R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceInt8V(rv.Interface().([]int8), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceInt8V(rv2i(rv).([]int8), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceInt8V(rv.Interface().([]int8), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceInt8V(rv2i(rv).([]int8), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceInt8V(v []int8, checkNil bool, e *Encoder) {
@@ -3698,9 +3698,9 @@ func (_ fastpathT) EncAsMapSliceInt8V(v []int8, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceInt16R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceInt16V(rv.Interface().([]int16), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceInt16V(rv2i(rv).([]int16), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceInt16V(rv.Interface().([]int16), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceInt16V(rv2i(rv).([]int16), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceInt16V(v []int16, checkNil bool, e *Encoder) {
@@ -3751,9 +3751,9 @@ func (_ fastpathT) EncAsMapSliceInt16V(v []int16, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceInt32R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceInt32V(rv.Interface().([]int32), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceInt32V(rv2i(rv).([]int32), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceInt32V(rv.Interface().([]int32), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceInt32V(rv2i(rv).([]int32), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceInt32V(v []int32, checkNil bool, e *Encoder) {
@@ -3804,9 +3804,9 @@ func (_ fastpathT) EncAsMapSliceInt32V(v []int32, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceInt64R(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceInt64V(rv.Interface().([]int64), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceInt64V(rv2i(rv).([]int64), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceInt64V(rv.Interface().([]int64), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceInt64V(rv2i(rv).([]int64), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceInt64V(v []int64, checkNil bool, e *Encoder) {
@@ -3857,9 +3857,9 @@ func (_ fastpathT) EncAsMapSliceInt64V(v []int64, checkNil bool, e *Encoder) {
 
 func (f *encFnInfo) fastpathEncSliceBoolR(rv reflect.Value) {
 	if f.ti.mbs {
-		fastpathTV.EncAsMapSliceBoolV(rv.Interface().([]bool), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncAsMapSliceBoolV(rv2i(rv).([]bool), fastpathCheckNilFalse, f.e)
 	} else {
-		fastpathTV.EncSliceBoolV(rv.Interface().([]bool), fastpathCheckNilFalse, f.e)
+		fastpathTV.EncSliceBoolV(rv2i(rv).([]bool), fastpathCheckNilFalse, f.e)
 	}
 }
 func (_ fastpathT) EncSliceBoolV(v []bool, checkNil bool, e *Encoder) {
@@ -3909,7 +3909,7 @@ func (_ fastpathT) EncAsMapSliceBoolV(v []bool, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapIntfIntfR(rv reflect.Value) {
-	fastpathTV.EncMapIntfIntfV(rv.Interface().(map[interface{}]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfIntfV(rv2i(rv).(map[interface{}]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfIntfV(v map[interface{}]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -3962,7 +3962,7 @@ func (_ fastpathT) EncMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 }
 
 func (f *encFnInfo) fastpathEncMapIntfStringR(rv reflect.Value) {
-	fastpathTV.EncMapIntfStringV(rv.Interface().(map[interface{}]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfStringV(rv2i(rv).(map[interface{}]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfStringV(v map[interface{}]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4015,7 +4015,7 @@ func (_ fastpathT) EncMapIntfStringV(v map[interface{}]string, checkNil bool, e 
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUintR(rv reflect.Value) {
-	fastpathTV.EncMapIntfUintV(rv.Interface().(map[interface{}]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfUintV(rv2i(rv).(map[interface{}]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUintV(v map[interface{}]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4068,7 +4068,7 @@ func (_ fastpathT) EncMapIntfUintV(v map[interface{}]uint, checkNil bool, e *Enc
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUint8R(rv reflect.Value) {
-	fastpathTV.EncMapIntfUint8V(rv.Interface().(map[interface{}]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfUint8V(rv2i(rv).(map[interface{}]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUint8V(v map[interface{}]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4121,7 +4121,7 @@ func (_ fastpathT) EncMapIntfUint8V(v map[interface{}]uint8, checkNil bool, e *E
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUint16R(rv reflect.Value) {
-	fastpathTV.EncMapIntfUint16V(rv.Interface().(map[interface{}]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfUint16V(rv2i(rv).(map[interface{}]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUint16V(v map[interface{}]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4174,7 +4174,7 @@ func (_ fastpathT) EncMapIntfUint16V(v map[interface{}]uint16, checkNil bool, e 
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUint32R(rv reflect.Value) {
-	fastpathTV.EncMapIntfUint32V(rv.Interface().(map[interface{}]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfUint32V(rv2i(rv).(map[interface{}]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUint32V(v map[interface{}]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4227,7 +4227,7 @@ func (_ fastpathT) EncMapIntfUint32V(v map[interface{}]uint32, checkNil bool, e 
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUint64R(rv reflect.Value) {
-	fastpathTV.EncMapIntfUint64V(rv.Interface().(map[interface{}]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfUint64V(rv2i(rv).(map[interface{}]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUint64V(v map[interface{}]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4280,7 +4280,7 @@ func (_ fastpathT) EncMapIntfUint64V(v map[interface{}]uint64, checkNil bool, e 
 }
 
 func (f *encFnInfo) fastpathEncMapIntfUintptrR(rv reflect.Value) {
-	fastpathTV.EncMapIntfUintptrV(rv.Interface().(map[interface{}]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfUintptrV(rv2i(rv).(map[interface{}]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4333,7 +4333,7 @@ func (_ fastpathT) EncMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, 
 }
 
 func (f *encFnInfo) fastpathEncMapIntfIntR(rv reflect.Value) {
-	fastpathTV.EncMapIntfIntV(rv.Interface().(map[interface{}]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfIntV(rv2i(rv).(map[interface{}]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfIntV(v map[interface{}]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4386,7 +4386,7 @@ func (_ fastpathT) EncMapIntfIntV(v map[interface{}]int, checkNil bool, e *Encod
 }
 
 func (f *encFnInfo) fastpathEncMapIntfInt8R(rv reflect.Value) {
-	fastpathTV.EncMapIntfInt8V(rv.Interface().(map[interface{}]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfInt8V(rv2i(rv).(map[interface{}]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfInt8V(v map[interface{}]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4439,7 +4439,7 @@ func (_ fastpathT) EncMapIntfInt8V(v map[interface{}]int8, checkNil bool, e *Enc
 }
 
 func (f *encFnInfo) fastpathEncMapIntfInt16R(rv reflect.Value) {
-	fastpathTV.EncMapIntfInt16V(rv.Interface().(map[interface{}]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfInt16V(rv2i(rv).(map[interface{}]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfInt16V(v map[interface{}]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4492,7 +4492,7 @@ func (_ fastpathT) EncMapIntfInt16V(v map[interface{}]int16, checkNil bool, e *E
 }
 
 func (f *encFnInfo) fastpathEncMapIntfInt32R(rv reflect.Value) {
-	fastpathTV.EncMapIntfInt32V(rv.Interface().(map[interface{}]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfInt32V(rv2i(rv).(map[interface{}]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfInt32V(v map[interface{}]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4545,7 +4545,7 @@ func (_ fastpathT) EncMapIntfInt32V(v map[interface{}]int32, checkNil bool, e *E
 }
 
 func (f *encFnInfo) fastpathEncMapIntfInt64R(rv reflect.Value) {
-	fastpathTV.EncMapIntfInt64V(rv.Interface().(map[interface{}]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfInt64V(rv2i(rv).(map[interface{}]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfInt64V(v map[interface{}]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4598,7 +4598,7 @@ func (_ fastpathT) EncMapIntfInt64V(v map[interface{}]int64, checkNil bool, e *E
 }
 
 func (f *encFnInfo) fastpathEncMapIntfFloat32R(rv reflect.Value) {
-	fastpathTV.EncMapIntfFloat32V(rv.Interface().(map[interface{}]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfFloat32V(rv2i(rv).(map[interface{}]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfFloat32V(v map[interface{}]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4651,7 +4651,7 @@ func (_ fastpathT) EncMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 }
 
 func (f *encFnInfo) fastpathEncMapIntfFloat64R(rv reflect.Value) {
-	fastpathTV.EncMapIntfFloat64V(rv.Interface().(map[interface{}]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfFloat64V(rv2i(rv).(map[interface{}]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfFloat64V(v map[interface{}]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4704,7 +4704,7 @@ func (_ fastpathT) EncMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 }
 
 func (f *encFnInfo) fastpathEncMapIntfBoolR(rv reflect.Value) {
-	fastpathTV.EncMapIntfBoolV(rv.Interface().(map[interface{}]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntfBoolV(rv2i(rv).(map[interface{}]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntfBoolV(v map[interface{}]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4757,7 +4757,7 @@ func (_ fastpathT) EncMapIntfBoolV(v map[interface{}]bool, checkNil bool, e *Enc
 }
 
 func (f *encFnInfo) fastpathEncMapStringIntfR(rv reflect.Value) {
-	fastpathTV.EncMapStringIntfV(rv.Interface().(map[string]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringIntfV(rv2i(rv).(map[string]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringIntfV(v map[string]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4812,7 +4812,7 @@ func (_ fastpathT) EncMapStringIntfV(v map[string]interface{}, checkNil bool, e 
 }
 
 func (f *encFnInfo) fastpathEncMapStringStringR(rv reflect.Value) {
-	fastpathTV.EncMapStringStringV(rv.Interface().(map[string]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringStringV(rv2i(rv).(map[string]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringStringV(v map[string]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4867,7 +4867,7 @@ func (_ fastpathT) EncMapStringStringV(v map[string]string, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapStringUintR(rv reflect.Value) {
-	fastpathTV.EncMapStringUintV(rv.Interface().(map[string]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringUintV(rv2i(rv).(map[string]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUintV(v map[string]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4922,7 +4922,7 @@ func (_ fastpathT) EncMapStringUintV(v map[string]uint, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapStringUint8R(rv reflect.Value) {
-	fastpathTV.EncMapStringUint8V(rv.Interface().(map[string]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringUint8V(rv2i(rv).(map[string]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUint8V(v map[string]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -4977,7 +4977,7 @@ func (_ fastpathT) EncMapStringUint8V(v map[string]uint8, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapStringUint16R(rv reflect.Value) {
-	fastpathTV.EncMapStringUint16V(rv.Interface().(map[string]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringUint16V(rv2i(rv).(map[string]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUint16V(v map[string]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5032,7 +5032,7 @@ func (_ fastpathT) EncMapStringUint16V(v map[string]uint16, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapStringUint32R(rv reflect.Value) {
-	fastpathTV.EncMapStringUint32V(rv.Interface().(map[string]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringUint32V(rv2i(rv).(map[string]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUint32V(v map[string]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5087,7 +5087,7 @@ func (_ fastpathT) EncMapStringUint32V(v map[string]uint32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapStringUint64R(rv reflect.Value) {
-	fastpathTV.EncMapStringUint64V(rv.Interface().(map[string]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringUint64V(rv2i(rv).(map[string]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUint64V(v map[string]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5142,7 +5142,7 @@ func (_ fastpathT) EncMapStringUint64V(v map[string]uint64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapStringUintptrR(rv reflect.Value) {
-	fastpathTV.EncMapStringUintptrV(rv.Interface().(map[string]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringUintptrV(rv2i(rv).(map[string]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringUintptrV(v map[string]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5197,7 +5197,7 @@ func (_ fastpathT) EncMapStringUintptrV(v map[string]uintptr, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapStringIntR(rv reflect.Value) {
-	fastpathTV.EncMapStringIntV(rv.Interface().(map[string]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringIntV(rv2i(rv).(map[string]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringIntV(v map[string]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5252,7 +5252,7 @@ func (_ fastpathT) EncMapStringIntV(v map[string]int, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapStringInt8R(rv reflect.Value) {
-	fastpathTV.EncMapStringInt8V(rv.Interface().(map[string]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringInt8V(rv2i(rv).(map[string]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringInt8V(v map[string]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5307,7 +5307,7 @@ func (_ fastpathT) EncMapStringInt8V(v map[string]int8, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapStringInt16R(rv reflect.Value) {
-	fastpathTV.EncMapStringInt16V(rv.Interface().(map[string]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringInt16V(rv2i(rv).(map[string]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringInt16V(v map[string]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5362,7 +5362,7 @@ func (_ fastpathT) EncMapStringInt16V(v map[string]int16, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapStringInt32R(rv reflect.Value) {
-	fastpathTV.EncMapStringInt32V(rv.Interface().(map[string]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringInt32V(rv2i(rv).(map[string]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringInt32V(v map[string]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5417,7 +5417,7 @@ func (_ fastpathT) EncMapStringInt32V(v map[string]int32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapStringInt64R(rv reflect.Value) {
-	fastpathTV.EncMapStringInt64V(rv.Interface().(map[string]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringInt64V(rv2i(rv).(map[string]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringInt64V(v map[string]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5472,7 +5472,7 @@ func (_ fastpathT) EncMapStringInt64V(v map[string]int64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapStringFloat32R(rv reflect.Value) {
-	fastpathTV.EncMapStringFloat32V(rv.Interface().(map[string]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringFloat32V(rv2i(rv).(map[string]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringFloat32V(v map[string]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5527,7 +5527,7 @@ func (_ fastpathT) EncMapStringFloat32V(v map[string]float32, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapStringFloat64R(rv reflect.Value) {
-	fastpathTV.EncMapStringFloat64V(rv.Interface().(map[string]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringFloat64V(rv2i(rv).(map[string]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringFloat64V(v map[string]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5582,7 +5582,7 @@ func (_ fastpathT) EncMapStringFloat64V(v map[string]float64, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapStringBoolR(rv reflect.Value) {
-	fastpathTV.EncMapStringBoolV(rv.Interface().(map[string]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapStringBoolV(rv2i(rv).(map[string]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapStringBoolV(v map[string]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5637,7 +5637,7 @@ func (_ fastpathT) EncMapStringBoolV(v map[string]bool, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32IntfR(rv reflect.Value) {
-	fastpathTV.EncMapFloat32IntfV(rv.Interface().(map[float32]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32IntfV(rv2i(rv).(map[float32]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32IntfV(v map[float32]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5683,7 +5683,7 @@ func (_ fastpathT) EncMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32StringR(rv reflect.Value) {
-	fastpathTV.EncMapFloat32StringV(rv.Interface().(map[float32]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32StringV(rv2i(rv).(map[float32]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32StringV(v map[float32]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5729,7 +5729,7 @@ func (_ fastpathT) EncMapFloat32StringV(v map[float32]string, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32UintR(rv reflect.Value) {
-	fastpathTV.EncMapFloat32UintV(rv.Interface().(map[float32]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32UintV(rv2i(rv).(map[float32]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32UintV(v map[float32]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5775,7 +5775,7 @@ func (_ fastpathT) EncMapFloat32UintV(v map[float32]uint, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Uint8V(rv.Interface().(map[float32]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Uint8V(rv2i(rv).(map[float32]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Uint8V(v map[float32]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5821,7 +5821,7 @@ func (_ fastpathT) EncMapFloat32Uint8V(v map[float32]uint8, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Uint16V(rv.Interface().(map[float32]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Uint16V(rv2i(rv).(map[float32]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Uint16V(v map[float32]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5867,7 +5867,7 @@ func (_ fastpathT) EncMapFloat32Uint16V(v map[float32]uint16, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Uint32V(rv.Interface().(map[float32]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Uint32V(rv2i(rv).(map[float32]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Uint32V(v map[float32]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5913,7 +5913,7 @@ func (_ fastpathT) EncMapFloat32Uint32V(v map[float32]uint32, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Uint64V(rv.Interface().(map[float32]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Uint64V(rv2i(rv).(map[float32]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Uint64V(v map[float32]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -5959,7 +5959,7 @@ func (_ fastpathT) EncMapFloat32Uint64V(v map[float32]uint64, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapFloat32UintptrV(rv.Interface().(map[float32]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32UintptrV(rv2i(rv).(map[float32]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6005,7 +6005,7 @@ func (_ fastpathT) EncMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32IntR(rv reflect.Value) {
-	fastpathTV.EncMapFloat32IntV(rv.Interface().(map[float32]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32IntV(rv2i(rv).(map[float32]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32IntV(v map[float32]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6051,7 +6051,7 @@ func (_ fastpathT) EncMapFloat32IntV(v map[float32]int, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Int8R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Int8V(rv.Interface().(map[float32]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Int8V(rv2i(rv).(map[float32]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Int8V(v map[float32]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6097,7 +6097,7 @@ func (_ fastpathT) EncMapFloat32Int8V(v map[float32]int8, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Int16R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Int16V(rv.Interface().(map[float32]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Int16V(rv2i(rv).(map[float32]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Int16V(v map[float32]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6143,7 +6143,7 @@ func (_ fastpathT) EncMapFloat32Int16V(v map[float32]int16, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Int32R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Int32V(rv.Interface().(map[float32]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Int32V(rv2i(rv).(map[float32]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Int32V(v map[float32]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6189,7 +6189,7 @@ func (_ fastpathT) EncMapFloat32Int32V(v map[float32]int32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Int64R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Int64V(rv.Interface().(map[float32]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Int64V(rv2i(rv).(map[float32]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Int64V(v map[float32]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6235,7 +6235,7 @@ func (_ fastpathT) EncMapFloat32Int64V(v map[float32]int64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Float32R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Float32V(rv.Interface().(map[float32]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Float32V(rv2i(rv).(map[float32]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Float32V(v map[float32]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6281,7 +6281,7 @@ func (_ fastpathT) EncMapFloat32Float32V(v map[float32]float32, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32Float64R(rv reflect.Value) {
-	fastpathTV.EncMapFloat32Float64V(rv.Interface().(map[float32]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32Float64V(rv2i(rv).(map[float32]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32Float64V(v map[float32]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6327,7 +6327,7 @@ func (_ fastpathT) EncMapFloat32Float64V(v map[float32]float64, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapFloat32BoolR(rv reflect.Value) {
-	fastpathTV.EncMapFloat32BoolV(rv.Interface().(map[float32]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat32BoolV(rv2i(rv).(map[float32]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat32BoolV(v map[float32]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6373,7 +6373,7 @@ func (_ fastpathT) EncMapFloat32BoolV(v map[float32]bool, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64IntfR(rv reflect.Value) {
-	fastpathTV.EncMapFloat64IntfV(rv.Interface().(map[float64]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64IntfV(rv2i(rv).(map[float64]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64IntfV(v map[float64]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6419,7 +6419,7 @@ func (_ fastpathT) EncMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64StringR(rv reflect.Value) {
-	fastpathTV.EncMapFloat64StringV(rv.Interface().(map[float64]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64StringV(rv2i(rv).(map[float64]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64StringV(v map[float64]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6465,7 +6465,7 @@ func (_ fastpathT) EncMapFloat64StringV(v map[float64]string, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64UintR(rv reflect.Value) {
-	fastpathTV.EncMapFloat64UintV(rv.Interface().(map[float64]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64UintV(rv2i(rv).(map[float64]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64UintV(v map[float64]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6511,7 +6511,7 @@ func (_ fastpathT) EncMapFloat64UintV(v map[float64]uint, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Uint8V(rv.Interface().(map[float64]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Uint8V(rv2i(rv).(map[float64]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Uint8V(v map[float64]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6557,7 +6557,7 @@ func (_ fastpathT) EncMapFloat64Uint8V(v map[float64]uint8, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Uint16V(rv.Interface().(map[float64]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Uint16V(rv2i(rv).(map[float64]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Uint16V(v map[float64]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6603,7 +6603,7 @@ func (_ fastpathT) EncMapFloat64Uint16V(v map[float64]uint16, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Uint32V(rv.Interface().(map[float64]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Uint32V(rv2i(rv).(map[float64]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Uint32V(v map[float64]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6649,7 +6649,7 @@ func (_ fastpathT) EncMapFloat64Uint32V(v map[float64]uint32, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Uint64V(rv.Interface().(map[float64]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Uint64V(rv2i(rv).(map[float64]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Uint64V(v map[float64]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6695,7 +6695,7 @@ func (_ fastpathT) EncMapFloat64Uint64V(v map[float64]uint64, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapFloat64UintptrV(rv.Interface().(map[float64]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64UintptrV(rv2i(rv).(map[float64]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6741,7 +6741,7 @@ func (_ fastpathT) EncMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64IntR(rv reflect.Value) {
-	fastpathTV.EncMapFloat64IntV(rv.Interface().(map[float64]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64IntV(rv2i(rv).(map[float64]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64IntV(v map[float64]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6787,7 +6787,7 @@ func (_ fastpathT) EncMapFloat64IntV(v map[float64]int, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Int8R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Int8V(rv.Interface().(map[float64]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Int8V(rv2i(rv).(map[float64]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Int8V(v map[float64]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6833,7 +6833,7 @@ func (_ fastpathT) EncMapFloat64Int8V(v map[float64]int8, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Int16R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Int16V(rv.Interface().(map[float64]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Int16V(rv2i(rv).(map[float64]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Int16V(v map[float64]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6879,7 +6879,7 @@ func (_ fastpathT) EncMapFloat64Int16V(v map[float64]int16, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Int32R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Int32V(rv.Interface().(map[float64]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Int32V(rv2i(rv).(map[float64]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Int32V(v map[float64]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6925,7 +6925,7 @@ func (_ fastpathT) EncMapFloat64Int32V(v map[float64]int32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Int64R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Int64V(rv.Interface().(map[float64]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Int64V(rv2i(rv).(map[float64]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Int64V(v map[float64]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -6971,7 +6971,7 @@ func (_ fastpathT) EncMapFloat64Int64V(v map[float64]int64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Float32R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Float32V(rv.Interface().(map[float64]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Float32V(rv2i(rv).(map[float64]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Float32V(v map[float64]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7017,7 +7017,7 @@ func (_ fastpathT) EncMapFloat64Float32V(v map[float64]float32, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64Float64R(rv reflect.Value) {
-	fastpathTV.EncMapFloat64Float64V(rv.Interface().(map[float64]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64Float64V(rv2i(rv).(map[float64]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64Float64V(v map[float64]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7063,7 +7063,7 @@ func (_ fastpathT) EncMapFloat64Float64V(v map[float64]float64, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapFloat64BoolR(rv reflect.Value) {
-	fastpathTV.EncMapFloat64BoolV(rv.Interface().(map[float64]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapFloat64BoolV(rv2i(rv).(map[float64]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapFloat64BoolV(v map[float64]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7109,7 +7109,7 @@ func (_ fastpathT) EncMapFloat64BoolV(v map[float64]bool, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUintIntfR(rv reflect.Value) {
-	fastpathTV.EncMapUintIntfV(rv.Interface().(map[uint]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintIntfV(rv2i(rv).(map[uint]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintIntfV(v map[uint]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7155,7 +7155,7 @@ func (_ fastpathT) EncMapUintIntfV(v map[uint]interface{}, checkNil bool, e *Enc
 }
 
 func (f *encFnInfo) fastpathEncMapUintStringR(rv reflect.Value) {
-	fastpathTV.EncMapUintStringV(rv.Interface().(map[uint]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintStringV(rv2i(rv).(map[uint]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintStringV(v map[uint]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7201,7 +7201,7 @@ func (_ fastpathT) EncMapUintStringV(v map[uint]string, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUintUintR(rv reflect.Value) {
-	fastpathTV.EncMapUintUintV(rv.Interface().(map[uint]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintUintV(rv2i(rv).(map[uint]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUintV(v map[uint]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7247,7 +7247,7 @@ func (_ fastpathT) EncMapUintUintV(v map[uint]uint, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapUintUint8R(rv reflect.Value) {
-	fastpathTV.EncMapUintUint8V(rv.Interface().(map[uint]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintUint8V(rv2i(rv).(map[uint]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUint8V(v map[uint]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7293,7 +7293,7 @@ func (_ fastpathT) EncMapUintUint8V(v map[uint]uint8, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUintUint16R(rv reflect.Value) {
-	fastpathTV.EncMapUintUint16V(rv.Interface().(map[uint]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintUint16V(rv2i(rv).(map[uint]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUint16V(v map[uint]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7339,7 +7339,7 @@ func (_ fastpathT) EncMapUintUint16V(v map[uint]uint16, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUintUint32R(rv reflect.Value) {
-	fastpathTV.EncMapUintUint32V(rv.Interface().(map[uint]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintUint32V(rv2i(rv).(map[uint]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUint32V(v map[uint]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7385,7 +7385,7 @@ func (_ fastpathT) EncMapUintUint32V(v map[uint]uint32, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUintUint64R(rv reflect.Value) {
-	fastpathTV.EncMapUintUint64V(rv.Interface().(map[uint]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintUint64V(rv2i(rv).(map[uint]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUint64V(v map[uint]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7431,7 +7431,7 @@ func (_ fastpathT) EncMapUintUint64V(v map[uint]uint64, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUintUintptrR(rv reflect.Value) {
-	fastpathTV.EncMapUintUintptrV(rv.Interface().(map[uint]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintUintptrV(rv2i(rv).(map[uint]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintUintptrV(v map[uint]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7477,7 +7477,7 @@ func (_ fastpathT) EncMapUintUintptrV(v map[uint]uintptr, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUintIntR(rv reflect.Value) {
-	fastpathTV.EncMapUintIntV(rv.Interface().(map[uint]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintIntV(rv2i(rv).(map[uint]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintIntV(v map[uint]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7523,7 +7523,7 @@ func (_ fastpathT) EncMapUintIntV(v map[uint]int, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapUintInt8R(rv reflect.Value) {
-	fastpathTV.EncMapUintInt8V(rv.Interface().(map[uint]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintInt8V(rv2i(rv).(map[uint]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintInt8V(v map[uint]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7569,7 +7569,7 @@ func (_ fastpathT) EncMapUintInt8V(v map[uint]int8, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapUintInt16R(rv reflect.Value) {
-	fastpathTV.EncMapUintInt16V(rv.Interface().(map[uint]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintInt16V(rv2i(rv).(map[uint]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintInt16V(v map[uint]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7615,7 +7615,7 @@ func (_ fastpathT) EncMapUintInt16V(v map[uint]int16, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUintInt32R(rv reflect.Value) {
-	fastpathTV.EncMapUintInt32V(rv.Interface().(map[uint]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintInt32V(rv2i(rv).(map[uint]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintInt32V(v map[uint]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7661,7 +7661,7 @@ func (_ fastpathT) EncMapUintInt32V(v map[uint]int32, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUintInt64R(rv reflect.Value) {
-	fastpathTV.EncMapUintInt64V(rv.Interface().(map[uint]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintInt64V(rv2i(rv).(map[uint]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintInt64V(v map[uint]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7707,7 +7707,7 @@ func (_ fastpathT) EncMapUintInt64V(v map[uint]int64, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUintFloat32R(rv reflect.Value) {
-	fastpathTV.EncMapUintFloat32V(rv.Interface().(map[uint]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintFloat32V(rv2i(rv).(map[uint]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintFloat32V(v map[uint]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7753,7 +7753,7 @@ func (_ fastpathT) EncMapUintFloat32V(v map[uint]float32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUintFloat64R(rv reflect.Value) {
-	fastpathTV.EncMapUintFloat64V(rv.Interface().(map[uint]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintFloat64V(rv2i(rv).(map[uint]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintFloat64V(v map[uint]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7799,7 +7799,7 @@ func (_ fastpathT) EncMapUintFloat64V(v map[uint]float64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUintBoolR(rv reflect.Value) {
-	fastpathTV.EncMapUintBoolV(rv.Interface().(map[uint]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintBoolV(rv2i(rv).(map[uint]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintBoolV(v map[uint]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7845,7 +7845,7 @@ func (_ fastpathT) EncMapUintBoolV(v map[uint]bool, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapUint8IntfR(rv reflect.Value) {
-	fastpathTV.EncMapUint8IntfV(rv.Interface().(map[uint8]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8IntfV(rv2i(rv).(map[uint8]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8IntfV(v map[uint8]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7891,7 +7891,7 @@ func (_ fastpathT) EncMapUint8IntfV(v map[uint8]interface{}, checkNil bool, e *E
 }
 
 func (f *encFnInfo) fastpathEncMapUint8StringR(rv reflect.Value) {
-	fastpathTV.EncMapUint8StringV(rv.Interface().(map[uint8]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8StringV(rv2i(rv).(map[uint8]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8StringV(v map[uint8]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7937,7 +7937,7 @@ func (_ fastpathT) EncMapUint8StringV(v map[uint8]string, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint8UintR(rv reflect.Value) {
-	fastpathTV.EncMapUint8UintV(rv.Interface().(map[uint8]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8UintV(rv2i(rv).(map[uint8]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8UintV(v map[uint8]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -7983,7 +7983,7 @@ func (_ fastpathT) EncMapUint8UintV(v map[uint8]uint, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Uint8V(rv.Interface().(map[uint8]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Uint8V(rv2i(rv).(map[uint8]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Uint8V(v map[uint8]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8029,7 +8029,7 @@ func (_ fastpathT) EncMapUint8Uint8V(v map[uint8]uint8, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Uint16V(rv.Interface().(map[uint8]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Uint16V(rv2i(rv).(map[uint8]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Uint16V(v map[uint8]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8075,7 +8075,7 @@ func (_ fastpathT) EncMapUint8Uint16V(v map[uint8]uint16, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Uint32V(rv.Interface().(map[uint8]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Uint32V(rv2i(rv).(map[uint8]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Uint32V(v map[uint8]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8121,7 +8121,7 @@ func (_ fastpathT) EncMapUint8Uint32V(v map[uint8]uint32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Uint64V(rv.Interface().(map[uint8]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Uint64V(rv2i(rv).(map[uint8]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Uint64V(v map[uint8]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8167,7 +8167,7 @@ func (_ fastpathT) EncMapUint8Uint64V(v map[uint8]uint64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint8UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapUint8UintptrV(rv.Interface().(map[uint8]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8UintptrV(rv2i(rv).(map[uint8]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8213,7 +8213,7 @@ func (_ fastpathT) EncMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint8IntR(rv reflect.Value) {
-	fastpathTV.EncMapUint8IntV(rv.Interface().(map[uint8]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8IntV(rv2i(rv).(map[uint8]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8IntV(v map[uint8]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8259,7 +8259,7 @@ func (_ fastpathT) EncMapUint8IntV(v map[uint8]int, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Int8R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Int8V(rv.Interface().(map[uint8]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Int8V(rv2i(rv).(map[uint8]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Int8V(v map[uint8]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8305,7 +8305,7 @@ func (_ fastpathT) EncMapUint8Int8V(v map[uint8]int8, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Int16R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Int16V(rv.Interface().(map[uint8]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Int16V(rv2i(rv).(map[uint8]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Int16V(v map[uint8]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8351,7 +8351,7 @@ func (_ fastpathT) EncMapUint8Int16V(v map[uint8]int16, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Int32R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Int32V(rv.Interface().(map[uint8]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Int32V(rv2i(rv).(map[uint8]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Int32V(v map[uint8]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8397,7 +8397,7 @@ func (_ fastpathT) EncMapUint8Int32V(v map[uint8]int32, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Int64R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Int64V(rv.Interface().(map[uint8]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Int64V(rv2i(rv).(map[uint8]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Int64V(v map[uint8]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8443,7 +8443,7 @@ func (_ fastpathT) EncMapUint8Int64V(v map[uint8]int64, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Float32R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Float32V(rv.Interface().(map[uint8]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Float32V(rv2i(rv).(map[uint8]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Float32V(v map[uint8]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8489,7 +8489,7 @@ func (_ fastpathT) EncMapUint8Float32V(v map[uint8]float32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint8Float64R(rv reflect.Value) {
-	fastpathTV.EncMapUint8Float64V(rv.Interface().(map[uint8]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8Float64V(rv2i(rv).(map[uint8]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8Float64V(v map[uint8]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8535,7 +8535,7 @@ func (_ fastpathT) EncMapUint8Float64V(v map[uint8]float64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint8BoolR(rv reflect.Value) {
-	fastpathTV.EncMapUint8BoolV(rv.Interface().(map[uint8]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint8BoolV(rv2i(rv).(map[uint8]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint8BoolV(v map[uint8]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8581,7 +8581,7 @@ func (_ fastpathT) EncMapUint8BoolV(v map[uint8]bool, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUint16IntfR(rv reflect.Value) {
-	fastpathTV.EncMapUint16IntfV(rv.Interface().(map[uint16]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16IntfV(rv2i(rv).(map[uint16]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16IntfV(v map[uint16]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8627,7 +8627,7 @@ func (_ fastpathT) EncMapUint16IntfV(v map[uint16]interface{}, checkNil bool, e 
 }
 
 func (f *encFnInfo) fastpathEncMapUint16StringR(rv reflect.Value) {
-	fastpathTV.EncMapUint16StringV(rv.Interface().(map[uint16]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16StringV(rv2i(rv).(map[uint16]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16StringV(v map[uint16]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8673,7 +8673,7 @@ func (_ fastpathT) EncMapUint16StringV(v map[uint16]string, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint16UintR(rv reflect.Value) {
-	fastpathTV.EncMapUint16UintV(rv.Interface().(map[uint16]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16UintV(rv2i(rv).(map[uint16]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16UintV(v map[uint16]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8719,7 +8719,7 @@ func (_ fastpathT) EncMapUint16UintV(v map[uint16]uint, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Uint8V(rv.Interface().(map[uint16]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Uint8V(rv2i(rv).(map[uint16]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Uint8V(v map[uint16]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8765,7 +8765,7 @@ func (_ fastpathT) EncMapUint16Uint8V(v map[uint16]uint8, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Uint16V(rv.Interface().(map[uint16]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Uint16V(rv2i(rv).(map[uint16]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Uint16V(v map[uint16]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8811,7 +8811,7 @@ func (_ fastpathT) EncMapUint16Uint16V(v map[uint16]uint16, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Uint32V(rv.Interface().(map[uint16]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Uint32V(rv2i(rv).(map[uint16]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Uint32V(v map[uint16]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8857,7 +8857,7 @@ func (_ fastpathT) EncMapUint16Uint32V(v map[uint16]uint32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Uint64V(rv.Interface().(map[uint16]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Uint64V(rv2i(rv).(map[uint16]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Uint64V(v map[uint16]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8903,7 +8903,7 @@ func (_ fastpathT) EncMapUint16Uint64V(v map[uint16]uint64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint16UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapUint16UintptrV(rv.Interface().(map[uint16]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16UintptrV(rv2i(rv).(map[uint16]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8949,7 +8949,7 @@ func (_ fastpathT) EncMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint16IntR(rv reflect.Value) {
-	fastpathTV.EncMapUint16IntV(rv.Interface().(map[uint16]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16IntV(rv2i(rv).(map[uint16]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16IntV(v map[uint16]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -8995,7 +8995,7 @@ func (_ fastpathT) EncMapUint16IntV(v map[uint16]int, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Int8R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Int8V(rv.Interface().(map[uint16]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Int8V(rv2i(rv).(map[uint16]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Int8V(v map[uint16]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9041,7 +9041,7 @@ func (_ fastpathT) EncMapUint16Int8V(v map[uint16]int8, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Int16R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Int16V(rv.Interface().(map[uint16]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Int16V(rv2i(rv).(map[uint16]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Int16V(v map[uint16]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9087,7 +9087,7 @@ func (_ fastpathT) EncMapUint16Int16V(v map[uint16]int16, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Int32R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Int32V(rv.Interface().(map[uint16]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Int32V(rv2i(rv).(map[uint16]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Int32V(v map[uint16]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9133,7 +9133,7 @@ func (_ fastpathT) EncMapUint16Int32V(v map[uint16]int32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Int64R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Int64V(rv.Interface().(map[uint16]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Int64V(rv2i(rv).(map[uint16]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Int64V(v map[uint16]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9179,7 +9179,7 @@ func (_ fastpathT) EncMapUint16Int64V(v map[uint16]int64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Float32R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Float32V(rv.Interface().(map[uint16]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Float32V(rv2i(rv).(map[uint16]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Float32V(v map[uint16]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9225,7 +9225,7 @@ func (_ fastpathT) EncMapUint16Float32V(v map[uint16]float32, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint16Float64R(rv reflect.Value) {
-	fastpathTV.EncMapUint16Float64V(rv.Interface().(map[uint16]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16Float64V(rv2i(rv).(map[uint16]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16Float64V(v map[uint16]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9271,7 +9271,7 @@ func (_ fastpathT) EncMapUint16Float64V(v map[uint16]float64, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint16BoolR(rv reflect.Value) {
-	fastpathTV.EncMapUint16BoolV(rv.Interface().(map[uint16]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint16BoolV(rv2i(rv).(map[uint16]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint16BoolV(v map[uint16]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9317,7 +9317,7 @@ func (_ fastpathT) EncMapUint16BoolV(v map[uint16]bool, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint32IntfR(rv reflect.Value) {
-	fastpathTV.EncMapUint32IntfV(rv.Interface().(map[uint32]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32IntfV(rv2i(rv).(map[uint32]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32IntfV(v map[uint32]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9363,7 +9363,7 @@ func (_ fastpathT) EncMapUint32IntfV(v map[uint32]interface{}, checkNil bool, e 
 }
 
 func (f *encFnInfo) fastpathEncMapUint32StringR(rv reflect.Value) {
-	fastpathTV.EncMapUint32StringV(rv.Interface().(map[uint32]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32StringV(rv2i(rv).(map[uint32]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32StringV(v map[uint32]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9409,7 +9409,7 @@ func (_ fastpathT) EncMapUint32StringV(v map[uint32]string, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint32UintR(rv reflect.Value) {
-	fastpathTV.EncMapUint32UintV(rv.Interface().(map[uint32]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32UintV(rv2i(rv).(map[uint32]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32UintV(v map[uint32]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9455,7 +9455,7 @@ func (_ fastpathT) EncMapUint32UintV(v map[uint32]uint, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Uint8V(rv.Interface().(map[uint32]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Uint8V(rv2i(rv).(map[uint32]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Uint8V(v map[uint32]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9501,7 +9501,7 @@ func (_ fastpathT) EncMapUint32Uint8V(v map[uint32]uint8, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Uint16V(rv.Interface().(map[uint32]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Uint16V(rv2i(rv).(map[uint32]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Uint16V(v map[uint32]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9547,7 +9547,7 @@ func (_ fastpathT) EncMapUint32Uint16V(v map[uint32]uint16, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Uint32V(rv.Interface().(map[uint32]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Uint32V(rv2i(rv).(map[uint32]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Uint32V(v map[uint32]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9593,7 +9593,7 @@ func (_ fastpathT) EncMapUint32Uint32V(v map[uint32]uint32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Uint64V(rv.Interface().(map[uint32]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Uint64V(rv2i(rv).(map[uint32]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Uint64V(v map[uint32]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9639,7 +9639,7 @@ func (_ fastpathT) EncMapUint32Uint64V(v map[uint32]uint64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint32UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapUint32UintptrV(rv.Interface().(map[uint32]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32UintptrV(rv2i(rv).(map[uint32]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9685,7 +9685,7 @@ func (_ fastpathT) EncMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint32IntR(rv reflect.Value) {
-	fastpathTV.EncMapUint32IntV(rv.Interface().(map[uint32]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32IntV(rv2i(rv).(map[uint32]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32IntV(v map[uint32]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9731,7 +9731,7 @@ func (_ fastpathT) EncMapUint32IntV(v map[uint32]int, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Int8R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Int8V(rv.Interface().(map[uint32]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Int8V(rv2i(rv).(map[uint32]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Int8V(v map[uint32]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9777,7 +9777,7 @@ func (_ fastpathT) EncMapUint32Int8V(v map[uint32]int8, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Int16R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Int16V(rv.Interface().(map[uint32]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Int16V(rv2i(rv).(map[uint32]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Int16V(v map[uint32]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9823,7 +9823,7 @@ func (_ fastpathT) EncMapUint32Int16V(v map[uint32]int16, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Int32R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Int32V(rv.Interface().(map[uint32]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Int32V(rv2i(rv).(map[uint32]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Int32V(v map[uint32]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9869,7 +9869,7 @@ func (_ fastpathT) EncMapUint32Int32V(v map[uint32]int32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Int64R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Int64V(rv.Interface().(map[uint32]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Int64V(rv2i(rv).(map[uint32]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Int64V(v map[uint32]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9915,7 +9915,7 @@ func (_ fastpathT) EncMapUint32Int64V(v map[uint32]int64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Float32R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Float32V(rv.Interface().(map[uint32]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Float32V(rv2i(rv).(map[uint32]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Float32V(v map[uint32]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -9961,7 +9961,7 @@ func (_ fastpathT) EncMapUint32Float32V(v map[uint32]float32, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint32Float64R(rv reflect.Value) {
-	fastpathTV.EncMapUint32Float64V(rv.Interface().(map[uint32]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32Float64V(rv2i(rv).(map[uint32]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32Float64V(v map[uint32]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10007,7 +10007,7 @@ func (_ fastpathT) EncMapUint32Float64V(v map[uint32]float64, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint32BoolR(rv reflect.Value) {
-	fastpathTV.EncMapUint32BoolV(rv.Interface().(map[uint32]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint32BoolV(rv2i(rv).(map[uint32]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint32BoolV(v map[uint32]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10053,7 +10053,7 @@ func (_ fastpathT) EncMapUint32BoolV(v map[uint32]bool, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint64IntfR(rv reflect.Value) {
-	fastpathTV.EncMapUint64IntfV(rv.Interface().(map[uint64]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64IntfV(rv2i(rv).(map[uint64]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64IntfV(v map[uint64]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10099,7 +10099,7 @@ func (_ fastpathT) EncMapUint64IntfV(v map[uint64]interface{}, checkNil bool, e 
 }
 
 func (f *encFnInfo) fastpathEncMapUint64StringR(rv reflect.Value) {
-	fastpathTV.EncMapUint64StringV(rv.Interface().(map[uint64]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64StringV(rv2i(rv).(map[uint64]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64StringV(v map[uint64]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10145,7 +10145,7 @@ func (_ fastpathT) EncMapUint64StringV(v map[uint64]string, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint64UintR(rv reflect.Value) {
-	fastpathTV.EncMapUint64UintV(rv.Interface().(map[uint64]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64UintV(rv2i(rv).(map[uint64]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64UintV(v map[uint64]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10191,7 +10191,7 @@ func (_ fastpathT) EncMapUint64UintV(v map[uint64]uint, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Uint8V(rv.Interface().(map[uint64]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Uint8V(rv2i(rv).(map[uint64]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Uint8V(v map[uint64]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10237,7 +10237,7 @@ func (_ fastpathT) EncMapUint64Uint8V(v map[uint64]uint8, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Uint16V(rv.Interface().(map[uint64]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Uint16V(rv2i(rv).(map[uint64]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Uint16V(v map[uint64]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10283,7 +10283,7 @@ func (_ fastpathT) EncMapUint64Uint16V(v map[uint64]uint16, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Uint32V(rv.Interface().(map[uint64]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Uint32V(rv2i(rv).(map[uint64]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Uint32V(v map[uint64]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10329,7 +10329,7 @@ func (_ fastpathT) EncMapUint64Uint32V(v map[uint64]uint32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Uint64V(rv.Interface().(map[uint64]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Uint64V(rv2i(rv).(map[uint64]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Uint64V(v map[uint64]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10375,7 +10375,7 @@ func (_ fastpathT) EncMapUint64Uint64V(v map[uint64]uint64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUint64UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapUint64UintptrV(rv.Interface().(map[uint64]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64UintptrV(rv2i(rv).(map[uint64]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10421,7 +10421,7 @@ func (_ fastpathT) EncMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint64IntR(rv reflect.Value) {
-	fastpathTV.EncMapUint64IntV(rv.Interface().(map[uint64]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64IntV(rv2i(rv).(map[uint64]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64IntV(v map[uint64]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10467,7 +10467,7 @@ func (_ fastpathT) EncMapUint64IntV(v map[uint64]int, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Int8R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Int8V(rv.Interface().(map[uint64]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Int8V(rv2i(rv).(map[uint64]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Int8V(v map[uint64]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10513,7 +10513,7 @@ func (_ fastpathT) EncMapUint64Int8V(v map[uint64]int8, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Int16R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Int16V(rv.Interface().(map[uint64]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Int16V(rv2i(rv).(map[uint64]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Int16V(v map[uint64]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10559,7 +10559,7 @@ func (_ fastpathT) EncMapUint64Int16V(v map[uint64]int16, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Int32R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Int32V(rv.Interface().(map[uint64]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Int32V(rv2i(rv).(map[uint64]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Int32V(v map[uint64]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10605,7 +10605,7 @@ func (_ fastpathT) EncMapUint64Int32V(v map[uint64]int32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Int64R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Int64V(rv.Interface().(map[uint64]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Int64V(rv2i(rv).(map[uint64]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Int64V(v map[uint64]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10651,7 +10651,7 @@ func (_ fastpathT) EncMapUint64Int64V(v map[uint64]int64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Float32R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Float32V(rv.Interface().(map[uint64]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Float32V(rv2i(rv).(map[uint64]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Float32V(v map[uint64]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10697,7 +10697,7 @@ func (_ fastpathT) EncMapUint64Float32V(v map[uint64]float32, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint64Float64R(rv reflect.Value) {
-	fastpathTV.EncMapUint64Float64V(rv.Interface().(map[uint64]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64Float64V(rv2i(rv).(map[uint64]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64Float64V(v map[uint64]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10743,7 +10743,7 @@ func (_ fastpathT) EncMapUint64Float64V(v map[uint64]float64, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUint64BoolR(rv reflect.Value) {
-	fastpathTV.EncMapUint64BoolV(rv.Interface().(map[uint64]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUint64BoolV(rv2i(rv).(map[uint64]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUint64BoolV(v map[uint64]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10789,7 +10789,7 @@ func (_ fastpathT) EncMapUint64BoolV(v map[uint64]bool, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrIntfR(rv reflect.Value) {
-	fastpathTV.EncMapUintptrIntfV(rv.Interface().(map[uintptr]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrIntfV(rv2i(rv).(map[uintptr]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10835,7 +10835,7 @@ func (_ fastpathT) EncMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, 
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrStringR(rv reflect.Value) {
-	fastpathTV.EncMapUintptrStringV(rv.Interface().(map[uintptr]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrStringV(rv2i(rv).(map[uintptr]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrStringV(v map[uintptr]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10881,7 +10881,7 @@ func (_ fastpathT) EncMapUintptrStringV(v map[uintptr]string, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUintR(rv reflect.Value) {
-	fastpathTV.EncMapUintptrUintV(rv.Interface().(map[uintptr]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrUintV(rv2i(rv).(map[uintptr]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrUintV(v map[uintptr]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10927,7 +10927,7 @@ func (_ fastpathT) EncMapUintptrUintV(v map[uintptr]uint, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUint8R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrUint8V(rv.Interface().(map[uintptr]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrUint8V(rv2i(rv).(map[uintptr]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -10973,7 +10973,7 @@ func (_ fastpathT) EncMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUint16R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrUint16V(rv.Interface().(map[uintptr]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrUint16V(rv2i(rv).(map[uintptr]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11019,7 +11019,7 @@ func (_ fastpathT) EncMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUint32R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrUint32V(rv.Interface().(map[uintptr]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrUint32V(rv2i(rv).(map[uintptr]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11065,7 +11065,7 @@ func (_ fastpathT) EncMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUint64R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrUint64V(rv.Interface().(map[uintptr]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrUint64V(rv2i(rv).(map[uintptr]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11111,7 +11111,7 @@ func (_ fastpathT) EncMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, e *
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrUintptrR(rv reflect.Value) {
-	fastpathTV.EncMapUintptrUintptrV(rv.Interface().(map[uintptr]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrUintptrV(rv2i(rv).(map[uintptr]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11157,7 +11157,7 @@ func (_ fastpathT) EncMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrIntR(rv reflect.Value) {
-	fastpathTV.EncMapUintptrIntV(rv.Interface().(map[uintptr]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrIntV(rv2i(rv).(map[uintptr]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrIntV(v map[uintptr]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11203,7 +11203,7 @@ func (_ fastpathT) EncMapUintptrIntV(v map[uintptr]int, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrInt8R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrInt8V(rv.Interface().(map[uintptr]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrInt8V(rv2i(rv).(map[uintptr]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrInt8V(v map[uintptr]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11249,7 +11249,7 @@ func (_ fastpathT) EncMapUintptrInt8V(v map[uintptr]int8, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrInt16R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrInt16V(rv.Interface().(map[uintptr]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrInt16V(rv2i(rv).(map[uintptr]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrInt16V(v map[uintptr]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11295,7 +11295,7 @@ func (_ fastpathT) EncMapUintptrInt16V(v map[uintptr]int16, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrInt32R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrInt32V(rv.Interface().(map[uintptr]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrInt32V(rv2i(rv).(map[uintptr]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrInt32V(v map[uintptr]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11341,7 +11341,7 @@ func (_ fastpathT) EncMapUintptrInt32V(v map[uintptr]int32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrInt64R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrInt64V(rv.Interface().(map[uintptr]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrInt64V(rv2i(rv).(map[uintptr]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrInt64V(v map[uintptr]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11387,7 +11387,7 @@ func (_ fastpathT) EncMapUintptrInt64V(v map[uintptr]int64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrFloat32R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrFloat32V(rv.Interface().(map[uintptr]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrFloat32V(rv2i(rv).(map[uintptr]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11433,7 +11433,7 @@ func (_ fastpathT) EncMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrFloat64R(rv reflect.Value) {
-	fastpathTV.EncMapUintptrFloat64V(rv.Interface().(map[uintptr]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrFloat64V(rv2i(rv).(map[uintptr]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11479,7 +11479,7 @@ func (_ fastpathT) EncMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, e
 }
 
 func (f *encFnInfo) fastpathEncMapUintptrBoolR(rv reflect.Value) {
-	fastpathTV.EncMapUintptrBoolV(rv.Interface().(map[uintptr]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapUintptrBoolV(rv2i(rv).(map[uintptr]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapUintptrBoolV(v map[uintptr]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11525,7 +11525,7 @@ func (_ fastpathT) EncMapUintptrBoolV(v map[uintptr]bool, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapIntIntfR(rv reflect.Value) {
-	fastpathTV.EncMapIntIntfV(rv.Interface().(map[int]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntIntfV(rv2i(rv).(map[int]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntIntfV(v map[int]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11571,7 +11571,7 @@ func (_ fastpathT) EncMapIntIntfV(v map[int]interface{}, checkNil bool, e *Encod
 }
 
 func (f *encFnInfo) fastpathEncMapIntStringR(rv reflect.Value) {
-	fastpathTV.EncMapIntStringV(rv.Interface().(map[int]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntStringV(rv2i(rv).(map[int]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntStringV(v map[int]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11617,7 +11617,7 @@ func (_ fastpathT) EncMapIntStringV(v map[int]string, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapIntUintR(rv reflect.Value) {
-	fastpathTV.EncMapIntUintV(rv.Interface().(map[int]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntUintV(rv2i(rv).(map[int]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUintV(v map[int]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11663,7 +11663,7 @@ func (_ fastpathT) EncMapIntUintV(v map[int]uint, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapIntUint8R(rv reflect.Value) {
-	fastpathTV.EncMapIntUint8V(rv.Interface().(map[int]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntUint8V(rv2i(rv).(map[int]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUint8V(v map[int]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11709,7 +11709,7 @@ func (_ fastpathT) EncMapIntUint8V(v map[int]uint8, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapIntUint16R(rv reflect.Value) {
-	fastpathTV.EncMapIntUint16V(rv.Interface().(map[int]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntUint16V(rv2i(rv).(map[int]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUint16V(v map[int]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11755,7 +11755,7 @@ func (_ fastpathT) EncMapIntUint16V(v map[int]uint16, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapIntUint32R(rv reflect.Value) {
-	fastpathTV.EncMapIntUint32V(rv.Interface().(map[int]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntUint32V(rv2i(rv).(map[int]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUint32V(v map[int]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11801,7 +11801,7 @@ func (_ fastpathT) EncMapIntUint32V(v map[int]uint32, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapIntUint64R(rv reflect.Value) {
-	fastpathTV.EncMapIntUint64V(rv.Interface().(map[int]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntUint64V(rv2i(rv).(map[int]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUint64V(v map[int]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11847,7 +11847,7 @@ func (_ fastpathT) EncMapIntUint64V(v map[int]uint64, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapIntUintptrR(rv reflect.Value) {
-	fastpathTV.EncMapIntUintptrV(rv.Interface().(map[int]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntUintptrV(rv2i(rv).(map[int]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntUintptrV(v map[int]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11893,7 +11893,7 @@ func (_ fastpathT) EncMapIntUintptrV(v map[int]uintptr, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapIntIntR(rv reflect.Value) {
-	fastpathTV.EncMapIntIntV(rv.Interface().(map[int]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntIntV(rv2i(rv).(map[int]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntIntV(v map[int]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11939,7 +11939,7 @@ func (_ fastpathT) EncMapIntIntV(v map[int]int, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapIntInt8R(rv reflect.Value) {
-	fastpathTV.EncMapIntInt8V(rv.Interface().(map[int]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntInt8V(rv2i(rv).(map[int]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntInt8V(v map[int]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -11985,7 +11985,7 @@ func (_ fastpathT) EncMapIntInt8V(v map[int]int8, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapIntInt16R(rv reflect.Value) {
-	fastpathTV.EncMapIntInt16V(rv.Interface().(map[int]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntInt16V(rv2i(rv).(map[int]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntInt16V(v map[int]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12031,7 +12031,7 @@ func (_ fastpathT) EncMapIntInt16V(v map[int]int16, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapIntInt32R(rv reflect.Value) {
-	fastpathTV.EncMapIntInt32V(rv.Interface().(map[int]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntInt32V(rv2i(rv).(map[int]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntInt32V(v map[int]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12077,7 +12077,7 @@ func (_ fastpathT) EncMapIntInt32V(v map[int]int32, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapIntInt64R(rv reflect.Value) {
-	fastpathTV.EncMapIntInt64V(rv.Interface().(map[int]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntInt64V(rv2i(rv).(map[int]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntInt64V(v map[int]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12123,7 +12123,7 @@ func (_ fastpathT) EncMapIntInt64V(v map[int]int64, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapIntFloat32R(rv reflect.Value) {
-	fastpathTV.EncMapIntFloat32V(rv.Interface().(map[int]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntFloat32V(rv2i(rv).(map[int]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntFloat32V(v map[int]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12169,7 +12169,7 @@ func (_ fastpathT) EncMapIntFloat32V(v map[int]float32, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapIntFloat64R(rv reflect.Value) {
-	fastpathTV.EncMapIntFloat64V(rv.Interface().(map[int]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntFloat64V(rv2i(rv).(map[int]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntFloat64V(v map[int]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12215,7 +12215,7 @@ func (_ fastpathT) EncMapIntFloat64V(v map[int]float64, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapIntBoolR(rv reflect.Value) {
-	fastpathTV.EncMapIntBoolV(rv.Interface().(map[int]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapIntBoolV(rv2i(rv).(map[int]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapIntBoolV(v map[int]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12261,7 +12261,7 @@ func (_ fastpathT) EncMapIntBoolV(v map[int]bool, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapInt8IntfR(rv reflect.Value) {
-	fastpathTV.EncMapInt8IntfV(rv.Interface().(map[int8]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8IntfV(rv2i(rv).(map[int8]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8IntfV(v map[int8]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12307,7 +12307,7 @@ func (_ fastpathT) EncMapInt8IntfV(v map[int8]interface{}, checkNil bool, e *Enc
 }
 
 func (f *encFnInfo) fastpathEncMapInt8StringR(rv reflect.Value) {
-	fastpathTV.EncMapInt8StringV(rv.Interface().(map[int8]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8StringV(rv2i(rv).(map[int8]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8StringV(v map[int8]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12353,7 +12353,7 @@ func (_ fastpathT) EncMapInt8StringV(v map[int8]string, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt8UintR(rv reflect.Value) {
-	fastpathTV.EncMapInt8UintV(rv.Interface().(map[int8]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8UintV(rv2i(rv).(map[int8]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8UintV(v map[int8]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12399,7 +12399,7 @@ func (_ fastpathT) EncMapInt8UintV(v map[int8]uint, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Uint8V(rv.Interface().(map[int8]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Uint8V(rv2i(rv).(map[int8]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Uint8V(v map[int8]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12445,7 +12445,7 @@ func (_ fastpathT) EncMapInt8Uint8V(v map[int8]uint8, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Uint16V(rv.Interface().(map[int8]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Uint16V(rv2i(rv).(map[int8]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Uint16V(v map[int8]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12491,7 +12491,7 @@ func (_ fastpathT) EncMapInt8Uint16V(v map[int8]uint16, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Uint32V(rv.Interface().(map[int8]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Uint32V(rv2i(rv).(map[int8]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Uint32V(v map[int8]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12537,7 +12537,7 @@ func (_ fastpathT) EncMapInt8Uint32V(v map[int8]uint32, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Uint64V(rv.Interface().(map[int8]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Uint64V(rv2i(rv).(map[int8]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Uint64V(v map[int8]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12583,7 +12583,7 @@ func (_ fastpathT) EncMapInt8Uint64V(v map[int8]uint64, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt8UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapInt8UintptrV(rv.Interface().(map[int8]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8UintptrV(rv2i(rv).(map[int8]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8UintptrV(v map[int8]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12629,7 +12629,7 @@ func (_ fastpathT) EncMapInt8UintptrV(v map[int8]uintptr, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt8IntR(rv reflect.Value) {
-	fastpathTV.EncMapInt8IntV(rv.Interface().(map[int8]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8IntV(rv2i(rv).(map[int8]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8IntV(v map[int8]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12675,7 +12675,7 @@ func (_ fastpathT) EncMapInt8IntV(v map[int8]int, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Int8R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Int8V(rv.Interface().(map[int8]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Int8V(rv2i(rv).(map[int8]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Int8V(v map[int8]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12721,7 +12721,7 @@ func (_ fastpathT) EncMapInt8Int8V(v map[int8]int8, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Int16R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Int16V(rv.Interface().(map[int8]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Int16V(rv2i(rv).(map[int8]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Int16V(v map[int8]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12767,7 +12767,7 @@ func (_ fastpathT) EncMapInt8Int16V(v map[int8]int16, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Int32R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Int32V(rv.Interface().(map[int8]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Int32V(rv2i(rv).(map[int8]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Int32V(v map[int8]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12813,7 +12813,7 @@ func (_ fastpathT) EncMapInt8Int32V(v map[int8]int32, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Int64R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Int64V(rv.Interface().(map[int8]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Int64V(rv2i(rv).(map[int8]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Int64V(v map[int8]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12859,7 +12859,7 @@ func (_ fastpathT) EncMapInt8Int64V(v map[int8]int64, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Float32R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Float32V(rv.Interface().(map[int8]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Float32V(rv2i(rv).(map[int8]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Float32V(v map[int8]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12905,7 +12905,7 @@ func (_ fastpathT) EncMapInt8Float32V(v map[int8]float32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt8Float64R(rv reflect.Value) {
-	fastpathTV.EncMapInt8Float64V(rv.Interface().(map[int8]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8Float64V(rv2i(rv).(map[int8]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8Float64V(v map[int8]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12951,7 +12951,7 @@ func (_ fastpathT) EncMapInt8Float64V(v map[int8]float64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt8BoolR(rv reflect.Value) {
-	fastpathTV.EncMapInt8BoolV(rv.Interface().(map[int8]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt8BoolV(rv2i(rv).(map[int8]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt8BoolV(v map[int8]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -12997,7 +12997,7 @@ func (_ fastpathT) EncMapInt8BoolV(v map[int8]bool, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapInt16IntfR(rv reflect.Value) {
-	fastpathTV.EncMapInt16IntfV(rv.Interface().(map[int16]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16IntfV(rv2i(rv).(map[int16]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16IntfV(v map[int16]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13043,7 +13043,7 @@ func (_ fastpathT) EncMapInt16IntfV(v map[int16]interface{}, checkNil bool, e *E
 }
 
 func (f *encFnInfo) fastpathEncMapInt16StringR(rv reflect.Value) {
-	fastpathTV.EncMapInt16StringV(rv.Interface().(map[int16]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16StringV(rv2i(rv).(map[int16]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16StringV(v map[int16]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13089,7 +13089,7 @@ func (_ fastpathT) EncMapInt16StringV(v map[int16]string, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt16UintR(rv reflect.Value) {
-	fastpathTV.EncMapInt16UintV(rv.Interface().(map[int16]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16UintV(rv2i(rv).(map[int16]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16UintV(v map[int16]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13135,7 +13135,7 @@ func (_ fastpathT) EncMapInt16UintV(v map[int16]uint, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Uint8V(rv.Interface().(map[int16]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Uint8V(rv2i(rv).(map[int16]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Uint8V(v map[int16]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13181,7 +13181,7 @@ func (_ fastpathT) EncMapInt16Uint8V(v map[int16]uint8, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Uint16V(rv.Interface().(map[int16]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Uint16V(rv2i(rv).(map[int16]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Uint16V(v map[int16]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13227,7 +13227,7 @@ func (_ fastpathT) EncMapInt16Uint16V(v map[int16]uint16, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Uint32V(rv.Interface().(map[int16]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Uint32V(rv2i(rv).(map[int16]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Uint32V(v map[int16]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13273,7 +13273,7 @@ func (_ fastpathT) EncMapInt16Uint32V(v map[int16]uint32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Uint64V(rv.Interface().(map[int16]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Uint64V(rv2i(rv).(map[int16]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Uint64V(v map[int16]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13319,7 +13319,7 @@ func (_ fastpathT) EncMapInt16Uint64V(v map[int16]uint64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt16UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapInt16UintptrV(rv.Interface().(map[int16]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16UintptrV(rv2i(rv).(map[int16]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16UintptrV(v map[int16]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13365,7 +13365,7 @@ func (_ fastpathT) EncMapInt16UintptrV(v map[int16]uintptr, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt16IntR(rv reflect.Value) {
-	fastpathTV.EncMapInt16IntV(rv.Interface().(map[int16]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16IntV(rv2i(rv).(map[int16]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16IntV(v map[int16]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13411,7 +13411,7 @@ func (_ fastpathT) EncMapInt16IntV(v map[int16]int, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Int8R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Int8V(rv.Interface().(map[int16]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Int8V(rv2i(rv).(map[int16]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Int8V(v map[int16]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13457,7 +13457,7 @@ func (_ fastpathT) EncMapInt16Int8V(v map[int16]int8, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Int16R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Int16V(rv.Interface().(map[int16]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Int16V(rv2i(rv).(map[int16]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Int16V(v map[int16]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13503,7 +13503,7 @@ func (_ fastpathT) EncMapInt16Int16V(v map[int16]int16, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Int32R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Int32V(rv.Interface().(map[int16]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Int32V(rv2i(rv).(map[int16]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Int32V(v map[int16]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13549,7 +13549,7 @@ func (_ fastpathT) EncMapInt16Int32V(v map[int16]int32, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Int64R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Int64V(rv.Interface().(map[int16]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Int64V(rv2i(rv).(map[int16]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Int64V(v map[int16]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13595,7 +13595,7 @@ func (_ fastpathT) EncMapInt16Int64V(v map[int16]int64, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Float32R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Float32V(rv.Interface().(map[int16]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Float32V(rv2i(rv).(map[int16]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Float32V(v map[int16]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13641,7 +13641,7 @@ func (_ fastpathT) EncMapInt16Float32V(v map[int16]float32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt16Float64R(rv reflect.Value) {
-	fastpathTV.EncMapInt16Float64V(rv.Interface().(map[int16]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16Float64V(rv2i(rv).(map[int16]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16Float64V(v map[int16]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13687,7 +13687,7 @@ func (_ fastpathT) EncMapInt16Float64V(v map[int16]float64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt16BoolR(rv reflect.Value) {
-	fastpathTV.EncMapInt16BoolV(rv.Interface().(map[int16]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt16BoolV(rv2i(rv).(map[int16]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt16BoolV(v map[int16]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13733,7 +13733,7 @@ func (_ fastpathT) EncMapInt16BoolV(v map[int16]bool, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt32IntfR(rv reflect.Value) {
-	fastpathTV.EncMapInt32IntfV(rv.Interface().(map[int32]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32IntfV(rv2i(rv).(map[int32]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32IntfV(v map[int32]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13779,7 +13779,7 @@ func (_ fastpathT) EncMapInt32IntfV(v map[int32]interface{}, checkNil bool, e *E
 }
 
 func (f *encFnInfo) fastpathEncMapInt32StringR(rv reflect.Value) {
-	fastpathTV.EncMapInt32StringV(rv.Interface().(map[int32]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32StringV(rv2i(rv).(map[int32]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32StringV(v map[int32]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13825,7 +13825,7 @@ func (_ fastpathT) EncMapInt32StringV(v map[int32]string, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt32UintR(rv reflect.Value) {
-	fastpathTV.EncMapInt32UintV(rv.Interface().(map[int32]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32UintV(rv2i(rv).(map[int32]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32UintV(v map[int32]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13871,7 +13871,7 @@ func (_ fastpathT) EncMapInt32UintV(v map[int32]uint, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Uint8V(rv.Interface().(map[int32]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Uint8V(rv2i(rv).(map[int32]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Uint8V(v map[int32]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13917,7 +13917,7 @@ func (_ fastpathT) EncMapInt32Uint8V(v map[int32]uint8, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Uint16V(rv.Interface().(map[int32]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Uint16V(rv2i(rv).(map[int32]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Uint16V(v map[int32]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -13963,7 +13963,7 @@ func (_ fastpathT) EncMapInt32Uint16V(v map[int32]uint16, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Uint32V(rv.Interface().(map[int32]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Uint32V(rv2i(rv).(map[int32]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Uint32V(v map[int32]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14009,7 +14009,7 @@ func (_ fastpathT) EncMapInt32Uint32V(v map[int32]uint32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Uint64V(rv.Interface().(map[int32]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Uint64V(rv2i(rv).(map[int32]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Uint64V(v map[int32]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14055,7 +14055,7 @@ func (_ fastpathT) EncMapInt32Uint64V(v map[int32]uint64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt32UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapInt32UintptrV(rv.Interface().(map[int32]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32UintptrV(rv2i(rv).(map[int32]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32UintptrV(v map[int32]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14101,7 +14101,7 @@ func (_ fastpathT) EncMapInt32UintptrV(v map[int32]uintptr, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt32IntR(rv reflect.Value) {
-	fastpathTV.EncMapInt32IntV(rv.Interface().(map[int32]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32IntV(rv2i(rv).(map[int32]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32IntV(v map[int32]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14147,7 +14147,7 @@ func (_ fastpathT) EncMapInt32IntV(v map[int32]int, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Int8R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Int8V(rv.Interface().(map[int32]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Int8V(rv2i(rv).(map[int32]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Int8V(v map[int32]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14193,7 +14193,7 @@ func (_ fastpathT) EncMapInt32Int8V(v map[int32]int8, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Int16R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Int16V(rv.Interface().(map[int32]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Int16V(rv2i(rv).(map[int32]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Int16V(v map[int32]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14239,7 +14239,7 @@ func (_ fastpathT) EncMapInt32Int16V(v map[int32]int16, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Int32R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Int32V(rv.Interface().(map[int32]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Int32V(rv2i(rv).(map[int32]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Int32V(v map[int32]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14285,7 +14285,7 @@ func (_ fastpathT) EncMapInt32Int32V(v map[int32]int32, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Int64R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Int64V(rv.Interface().(map[int32]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Int64V(rv2i(rv).(map[int32]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Int64V(v map[int32]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14331,7 +14331,7 @@ func (_ fastpathT) EncMapInt32Int64V(v map[int32]int64, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Float32R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Float32V(rv.Interface().(map[int32]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Float32V(rv2i(rv).(map[int32]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Float32V(v map[int32]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14377,7 +14377,7 @@ func (_ fastpathT) EncMapInt32Float32V(v map[int32]float32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt32Float64R(rv reflect.Value) {
-	fastpathTV.EncMapInt32Float64V(rv.Interface().(map[int32]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32Float64V(rv2i(rv).(map[int32]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32Float64V(v map[int32]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14423,7 +14423,7 @@ func (_ fastpathT) EncMapInt32Float64V(v map[int32]float64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt32BoolR(rv reflect.Value) {
-	fastpathTV.EncMapInt32BoolV(rv.Interface().(map[int32]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt32BoolV(rv2i(rv).(map[int32]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt32BoolV(v map[int32]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14469,7 +14469,7 @@ func (_ fastpathT) EncMapInt32BoolV(v map[int32]bool, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt64IntfR(rv reflect.Value) {
-	fastpathTV.EncMapInt64IntfV(rv.Interface().(map[int64]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64IntfV(rv2i(rv).(map[int64]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64IntfV(v map[int64]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14515,7 +14515,7 @@ func (_ fastpathT) EncMapInt64IntfV(v map[int64]interface{}, checkNil bool, e *E
 }
 
 func (f *encFnInfo) fastpathEncMapInt64StringR(rv reflect.Value) {
-	fastpathTV.EncMapInt64StringV(rv.Interface().(map[int64]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64StringV(rv2i(rv).(map[int64]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64StringV(v map[int64]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14561,7 +14561,7 @@ func (_ fastpathT) EncMapInt64StringV(v map[int64]string, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt64UintR(rv reflect.Value) {
-	fastpathTV.EncMapInt64UintV(rv.Interface().(map[int64]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64UintV(rv2i(rv).(map[int64]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64UintV(v map[int64]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14607,7 +14607,7 @@ func (_ fastpathT) EncMapInt64UintV(v map[int64]uint, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Uint8R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Uint8V(rv.Interface().(map[int64]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Uint8V(rv2i(rv).(map[int64]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Uint8V(v map[int64]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14653,7 +14653,7 @@ func (_ fastpathT) EncMapInt64Uint8V(v map[int64]uint8, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Uint16R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Uint16V(rv.Interface().(map[int64]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Uint16V(rv2i(rv).(map[int64]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Uint16V(v map[int64]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14699,7 +14699,7 @@ func (_ fastpathT) EncMapInt64Uint16V(v map[int64]uint16, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Uint32R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Uint32V(rv.Interface().(map[int64]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Uint32V(rv2i(rv).(map[int64]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Uint32V(v map[int64]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14745,7 +14745,7 @@ func (_ fastpathT) EncMapInt64Uint32V(v map[int64]uint32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Uint64R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Uint64V(rv.Interface().(map[int64]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Uint64V(rv2i(rv).(map[int64]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Uint64V(v map[int64]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14791,7 +14791,7 @@ func (_ fastpathT) EncMapInt64Uint64V(v map[int64]uint64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapInt64UintptrR(rv reflect.Value) {
-	fastpathTV.EncMapInt64UintptrV(rv.Interface().(map[int64]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64UintptrV(rv2i(rv).(map[int64]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64UintptrV(v map[int64]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14837,7 +14837,7 @@ func (_ fastpathT) EncMapInt64UintptrV(v map[int64]uintptr, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt64IntR(rv reflect.Value) {
-	fastpathTV.EncMapInt64IntV(rv.Interface().(map[int64]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64IntV(rv2i(rv).(map[int64]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64IntV(v map[int64]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14883,7 +14883,7 @@ func (_ fastpathT) EncMapInt64IntV(v map[int64]int, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Int8R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Int8V(rv.Interface().(map[int64]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Int8V(rv2i(rv).(map[int64]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Int8V(v map[int64]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14929,7 +14929,7 @@ func (_ fastpathT) EncMapInt64Int8V(v map[int64]int8, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Int16R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Int16V(rv.Interface().(map[int64]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Int16V(rv2i(rv).(map[int64]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Int16V(v map[int64]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -14975,7 +14975,7 @@ func (_ fastpathT) EncMapInt64Int16V(v map[int64]int16, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Int32R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Int32V(rv.Interface().(map[int64]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Int32V(rv2i(rv).(map[int64]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Int32V(v map[int64]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15021,7 +15021,7 @@ func (_ fastpathT) EncMapInt64Int32V(v map[int64]int32, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Int64R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Int64V(rv.Interface().(map[int64]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Int64V(rv2i(rv).(map[int64]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Int64V(v map[int64]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15067,7 +15067,7 @@ func (_ fastpathT) EncMapInt64Int64V(v map[int64]int64, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Float32R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Float32V(rv.Interface().(map[int64]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Float32V(rv2i(rv).(map[int64]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Float32V(v map[int64]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15113,7 +15113,7 @@ func (_ fastpathT) EncMapInt64Float32V(v map[int64]float32, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt64Float64R(rv reflect.Value) {
-	fastpathTV.EncMapInt64Float64V(rv.Interface().(map[int64]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64Float64V(rv2i(rv).(map[int64]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64Float64V(v map[int64]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15159,7 +15159,7 @@ func (_ fastpathT) EncMapInt64Float64V(v map[int64]float64, checkNil bool, e *En
 }
 
 func (f *encFnInfo) fastpathEncMapInt64BoolR(rv reflect.Value) {
-	fastpathTV.EncMapInt64BoolV(rv.Interface().(map[int64]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapInt64BoolV(rv2i(rv).(map[int64]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapInt64BoolV(v map[int64]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15205,7 +15205,7 @@ func (_ fastpathT) EncMapInt64BoolV(v map[int64]bool, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapBoolIntfR(rv reflect.Value) {
-	fastpathTV.EncMapBoolIntfV(rv.Interface().(map[bool]interface{}), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolIntfV(rv2i(rv).(map[bool]interface{}), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolIntfV(v map[bool]interface{}, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15251,7 +15251,7 @@ func (_ fastpathT) EncMapBoolIntfV(v map[bool]interface{}, checkNil bool, e *Enc
 }
 
 func (f *encFnInfo) fastpathEncMapBoolStringR(rv reflect.Value) {
-	fastpathTV.EncMapBoolStringV(rv.Interface().(map[bool]string), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolStringV(rv2i(rv).(map[bool]string), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolStringV(v map[bool]string, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15297,7 +15297,7 @@ func (_ fastpathT) EncMapBoolStringV(v map[bool]string, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUintR(rv reflect.Value) {
-	fastpathTV.EncMapBoolUintV(rv.Interface().(map[bool]uint), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolUintV(rv2i(rv).(map[bool]uint), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUintV(v map[bool]uint, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15343,7 +15343,7 @@ func (_ fastpathT) EncMapBoolUintV(v map[bool]uint, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUint8R(rv reflect.Value) {
-	fastpathTV.EncMapBoolUint8V(rv.Interface().(map[bool]uint8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolUint8V(rv2i(rv).(map[bool]uint8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUint8V(v map[bool]uint8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15389,7 +15389,7 @@ func (_ fastpathT) EncMapBoolUint8V(v map[bool]uint8, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUint16R(rv reflect.Value) {
-	fastpathTV.EncMapBoolUint16V(rv.Interface().(map[bool]uint16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolUint16V(rv2i(rv).(map[bool]uint16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUint16V(v map[bool]uint16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15435,7 +15435,7 @@ func (_ fastpathT) EncMapBoolUint16V(v map[bool]uint16, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUint32R(rv reflect.Value) {
-	fastpathTV.EncMapBoolUint32V(rv.Interface().(map[bool]uint32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolUint32V(rv2i(rv).(map[bool]uint32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUint32V(v map[bool]uint32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15481,7 +15481,7 @@ func (_ fastpathT) EncMapBoolUint32V(v map[bool]uint32, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUint64R(rv reflect.Value) {
-	fastpathTV.EncMapBoolUint64V(rv.Interface().(map[bool]uint64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolUint64V(rv2i(rv).(map[bool]uint64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUint64V(v map[bool]uint64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15527,7 +15527,7 @@ func (_ fastpathT) EncMapBoolUint64V(v map[bool]uint64, checkNil bool, e *Encode
 }
 
 func (f *encFnInfo) fastpathEncMapBoolUintptrR(rv reflect.Value) {
-	fastpathTV.EncMapBoolUintptrV(rv.Interface().(map[bool]uintptr), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolUintptrV(rv2i(rv).(map[bool]uintptr), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolUintptrV(v map[bool]uintptr, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15573,7 +15573,7 @@ func (_ fastpathT) EncMapBoolUintptrV(v map[bool]uintptr, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapBoolIntR(rv reflect.Value) {
-	fastpathTV.EncMapBoolIntV(rv.Interface().(map[bool]int), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolIntV(rv2i(rv).(map[bool]int), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolIntV(v map[bool]int, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15619,7 +15619,7 @@ func (_ fastpathT) EncMapBoolIntV(v map[bool]int, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapBoolInt8R(rv reflect.Value) {
-	fastpathTV.EncMapBoolInt8V(rv.Interface().(map[bool]int8), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolInt8V(rv2i(rv).(map[bool]int8), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolInt8V(v map[bool]int8, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15665,7 +15665,7 @@ func (_ fastpathT) EncMapBoolInt8V(v map[bool]int8, checkNil bool, e *Encoder) {
 }
 
 func (f *encFnInfo) fastpathEncMapBoolInt16R(rv reflect.Value) {
-	fastpathTV.EncMapBoolInt16V(rv.Interface().(map[bool]int16), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolInt16V(rv2i(rv).(map[bool]int16), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolInt16V(v map[bool]int16, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15711,7 +15711,7 @@ func (_ fastpathT) EncMapBoolInt16V(v map[bool]int16, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapBoolInt32R(rv reflect.Value) {
-	fastpathTV.EncMapBoolInt32V(rv.Interface().(map[bool]int32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolInt32V(rv2i(rv).(map[bool]int32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolInt32V(v map[bool]int32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15757,7 +15757,7 @@ func (_ fastpathT) EncMapBoolInt32V(v map[bool]int32, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapBoolInt64R(rv reflect.Value) {
-	fastpathTV.EncMapBoolInt64V(rv.Interface().(map[bool]int64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolInt64V(rv2i(rv).(map[bool]int64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolInt64V(v map[bool]int64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15803,7 +15803,7 @@ func (_ fastpathT) EncMapBoolInt64V(v map[bool]int64, checkNil bool, e *Encoder)
 }
 
 func (f *encFnInfo) fastpathEncMapBoolFloat32R(rv reflect.Value) {
-	fastpathTV.EncMapBoolFloat32V(rv.Interface().(map[bool]float32), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolFloat32V(rv2i(rv).(map[bool]float32), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolFloat32V(v map[bool]float32, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15849,7 +15849,7 @@ func (_ fastpathT) EncMapBoolFloat32V(v map[bool]float32, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapBoolFloat64R(rv reflect.Value) {
-	fastpathTV.EncMapBoolFloat64V(rv.Interface().(map[bool]float64), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolFloat64V(rv2i(rv).(map[bool]float64), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolFloat64V(v map[bool]float64, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -15895,7 +15895,7 @@ func (_ fastpathT) EncMapBoolFloat64V(v map[bool]float64, checkNil bool, e *Enco
 }
 
 func (f *encFnInfo) fastpathEncMapBoolBoolR(rv reflect.Value) {
-	fastpathTV.EncMapBoolBoolV(rv.Interface().(map[bool]bool), fastpathCheckNilFalse, f.e)
+	fastpathTV.EncMapBoolBoolV(rv2i(rv).(map[bool]bool), fastpathCheckNilFalse, f.e)
 }
 func (_ fastpathT) EncMapBoolBoolV(v map[bool]bool, checkNil bool, e *Encoder) {
 	ee := e.e
@@ -18126,13 +18126,13 @@ func fastpathDecodeTypeSwitch(iv interface{}, d *Decoder) bool {
 func (f *decFnInfo) fastpathDecSliceIntfR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]interface{})
+		vp := rv2i(rv.Addr()).(*[]interface{})
 		v, changed := fastpathTV.DecSliceIntfV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]interface{})
+		v := rv2i(rv).([]interface{})
 		fastpathTV.DecSliceIntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -18152,7 +18152,6 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -18167,89 +18166,57 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]interface{}, xlen)
-					}
-				} else {
-					v = make([]interface{}, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 16)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]interface{}, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			d.decode(&v[j])
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, nil)
-				slh.ElemContainerState(j)
-				d.decode(&v[j])
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []interface{}{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]interface{}, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, nil)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				d.decode(&v[j])
-
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 16)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]interface{}, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, nil)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			d.decode(&v[j])
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]interface{}, 0)
 			changed = true
 		}
 	}
@@ -18260,13 +18227,13 @@ func (_ fastpathT) DecSliceIntfV(v []interface{}, checkNil bool, canChange bool,
 func (f *decFnInfo) fastpathDecSliceStringR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]string)
+		vp := rv2i(rv.Addr()).(*[]string)
 		v, changed := fastpathTV.DecSliceStringV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]string)
+		v := rv2i(rv).([]string)
 		fastpathTV.DecSliceStringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -18286,7 +18253,6 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool, d 
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -18301,88 +18267,57 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool, d 
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 16)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]string, xlen)
-					}
-				} else {
-					v = make([]string, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 16)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]string, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = dd.DecodeString()
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, "")
-				slh.ElemContainerState(j)
-				v[j] = dd.DecodeString()
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []string{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]string, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, "")
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = dd.DecodeString()
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 16)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]string, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, "")
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = dd.DecodeString()
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]string, 0)
 			changed = true
 		}
 	}
@@ -18393,13 +18328,13 @@ func (_ fastpathT) DecSliceStringV(v []string, checkNil bool, canChange bool, d 
 func (f *decFnInfo) fastpathDecSliceFloat32R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]float32)
+		vp := rv2i(rv.Addr()).(*[]float32)
 		v, changed := fastpathTV.DecSliceFloat32V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]float32)
+		v := rv2i(rv).([]float32)
 		fastpathTV.DecSliceFloat32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -18419,7 +18354,6 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool, 
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -18434,88 +18368,57 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool, 
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]float32, xlen)
-					}
-				} else {
-					v = make([]float32, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]float32, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = float32(dd.DecodeFloat(true))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = float32(dd.DecodeFloat(true))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []float32{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]float32, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = float32(dd.DecodeFloat(true))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 4)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]float32, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = float32(dd.DecodeFloat(true))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]float32, 0)
 			changed = true
 		}
 	}
@@ -18526,13 +18429,13 @@ func (_ fastpathT) DecSliceFloat32V(v []float32, checkNil bool, canChange bool, 
 func (f *decFnInfo) fastpathDecSliceFloat64R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]float64)
+		vp := rv2i(rv.Addr()).(*[]float64)
 		v, changed := fastpathTV.DecSliceFloat64V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]float64)
+		v := rv2i(rv).([]float64)
 		fastpathTV.DecSliceFloat64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -18552,7 +18455,6 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool, 
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -18567,88 +18469,57 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool, 
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]float64, xlen)
-					}
-				} else {
-					v = make([]float64, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]float64, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = dd.DecodeFloat(false)
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = dd.DecodeFloat(false)
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []float64{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]float64, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = dd.DecodeFloat(false)
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]float64, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = dd.DecodeFloat(false)
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]float64, 0)
 			changed = true
 		}
 	}
@@ -18659,13 +18530,13 @@ func (_ fastpathT) DecSliceFloat64V(v []float64, checkNil bool, canChange bool, 
 func (f *decFnInfo) fastpathDecSliceUintR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]uint)
+		vp := rv2i(rv.Addr()).(*[]uint)
 		v, changed := fastpathTV.DecSliceUintV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]uint)
+		v := rv2i(rv).([]uint)
 		fastpathTV.DecSliceUintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -18685,7 +18556,6 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool, d *Dec
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -18700,88 +18570,57 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool, d *Dec
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]uint, xlen)
-					}
-				} else {
-					v = make([]uint, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]uint, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = uint(dd.DecodeUint(uintBitsize))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = uint(dd.DecodeUint(uintBitsize))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []uint{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]uint, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = uint(dd.DecodeUint(uintBitsize))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]uint, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = uint(dd.DecodeUint(uintBitsize))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]uint, 0)
 			changed = true
 		}
 	}
@@ -18792,13 +18631,13 @@ func (_ fastpathT) DecSliceUintV(v []uint, checkNil bool, canChange bool, d *Dec
 func (f *decFnInfo) fastpathDecSliceUint16R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]uint16)
+		vp := rv2i(rv.Addr()).(*[]uint16)
 		v, changed := fastpathTV.DecSliceUint16V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]uint16)
+		v := rv2i(rv).([]uint16)
 		fastpathTV.DecSliceUint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -18818,7 +18657,6 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool, d 
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -18833,88 +18671,57 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool, d 
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]uint16, xlen)
-					}
-				} else {
-					v = make([]uint16, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 2)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]uint16, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = uint16(dd.DecodeUint(16))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = uint16(dd.DecodeUint(16))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []uint16{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]uint16, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = uint16(dd.DecodeUint(16))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 2)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]uint16, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = uint16(dd.DecodeUint(16))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]uint16, 0)
 			changed = true
 		}
 	}
@@ -18925,13 +18732,13 @@ func (_ fastpathT) DecSliceUint16V(v []uint16, checkNil bool, canChange bool, d 
 func (f *decFnInfo) fastpathDecSliceUint32R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]uint32)
+		vp := rv2i(rv.Addr()).(*[]uint32)
 		v, changed := fastpathTV.DecSliceUint32V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]uint32)
+		v := rv2i(rv).([]uint32)
 		fastpathTV.DecSliceUint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -18951,7 +18758,6 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool, d 
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -18966,88 +18772,57 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool, d 
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]uint32, xlen)
-					}
-				} else {
-					v = make([]uint32, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]uint32, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = uint32(dd.DecodeUint(32))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = uint32(dd.DecodeUint(32))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []uint32{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]uint32, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = uint32(dd.DecodeUint(32))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 4)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]uint32, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = uint32(dd.DecodeUint(32))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]uint32, 0)
 			changed = true
 		}
 	}
@@ -19058,13 +18833,13 @@ func (_ fastpathT) DecSliceUint32V(v []uint32, checkNil bool, canChange bool, d 
 func (f *decFnInfo) fastpathDecSliceUint64R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]uint64)
+		vp := rv2i(rv.Addr()).(*[]uint64)
 		v, changed := fastpathTV.DecSliceUint64V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]uint64)
+		v := rv2i(rv).([]uint64)
 		fastpathTV.DecSliceUint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -19084,7 +18859,6 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool, d 
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -19099,88 +18873,57 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool, d 
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]uint64, xlen)
-					}
-				} else {
-					v = make([]uint64, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]uint64, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = dd.DecodeUint(64)
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = dd.DecodeUint(64)
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []uint64{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]uint64, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = dd.DecodeUint(64)
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]uint64, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = dd.DecodeUint(64)
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]uint64, 0)
 			changed = true
 		}
 	}
@@ -19191,13 +18934,13 @@ func (_ fastpathT) DecSliceUint64V(v []uint64, checkNil bool, canChange bool, d 
 func (f *decFnInfo) fastpathDecSliceUintptrR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]uintptr)
+		vp := rv2i(rv.Addr()).(*[]uintptr)
 		v, changed := fastpathTV.DecSliceUintptrV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]uintptr)
+		v := rv2i(rv).([]uintptr)
 		fastpathTV.DecSliceUintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -19217,7 +18960,6 @@ func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool, 
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -19232,88 +18974,57 @@ func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool, 
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]uintptr, xlen)
-					}
-				} else {
-					v = make([]uintptr, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]uintptr, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = uintptr(dd.DecodeUint(uintBitsize))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = uintptr(dd.DecodeUint(uintBitsize))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []uintptr{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]uintptr, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = uintptr(dd.DecodeUint(uintBitsize))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]uintptr, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = uintptr(dd.DecodeUint(uintBitsize))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]uintptr, 0)
 			changed = true
 		}
 	}
@@ -19324,13 +19035,13 @@ func (_ fastpathT) DecSliceUintptrV(v []uintptr, checkNil bool, canChange bool, 
 func (f *decFnInfo) fastpathDecSliceIntR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]int)
+		vp := rv2i(rv.Addr()).(*[]int)
 		v, changed := fastpathTV.DecSliceIntV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]int)
+		v := rv2i(rv).([]int)
 		fastpathTV.DecSliceIntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -19350,7 +19061,6 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool, d *Decod
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -19365,88 +19075,57 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool, d *Decod
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]int, xlen)
-					}
-				} else {
-					v = make([]int, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]int, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = int(dd.DecodeInt(intBitsize))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = int(dd.DecodeInt(intBitsize))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []int{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]int, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = int(dd.DecodeInt(intBitsize))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]int, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = int(dd.DecodeInt(intBitsize))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]int, 0)
 			changed = true
 		}
 	}
@@ -19457,13 +19136,13 @@ func (_ fastpathT) DecSliceIntV(v []int, checkNil bool, canChange bool, d *Decod
 func (f *decFnInfo) fastpathDecSliceInt8R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]int8)
+		vp := rv2i(rv.Addr()).(*[]int8)
 		v, changed := fastpathTV.DecSliceInt8V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]int8)
+		v := rv2i(rv).([]int8)
 		fastpathTV.DecSliceInt8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -19483,7 +19162,6 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool, d *Dec
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -19498,88 +19176,57 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool, d *Dec
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]int8, xlen)
-					}
-				} else {
-					v = make([]int8, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 1)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]int8, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = int8(dd.DecodeInt(8))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = int8(dd.DecodeInt(8))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []int8{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]int8, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = int8(dd.DecodeInt(8))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 1)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]int8, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = int8(dd.DecodeInt(8))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]int8, 0)
 			changed = true
 		}
 	}
@@ -19590,13 +19237,13 @@ func (_ fastpathT) DecSliceInt8V(v []int8, checkNil bool, canChange bool, d *Dec
 func (f *decFnInfo) fastpathDecSliceInt16R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]int16)
+		vp := rv2i(rv.Addr()).(*[]int16)
 		v, changed := fastpathTV.DecSliceInt16V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]int16)
+		v := rv2i(rv).([]int16)
 		fastpathTV.DecSliceInt16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -19616,7 +19263,6 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool, d *D
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -19631,88 +19277,57 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool, d *D
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 2)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]int16, xlen)
-					}
-				} else {
-					v = make([]int16, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 2)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]int16, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = int16(dd.DecodeInt(16))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = int16(dd.DecodeInt(16))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []int16{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]int16, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = int16(dd.DecodeInt(16))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 2)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]int16, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = int16(dd.DecodeInt(16))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]int16, 0)
 			changed = true
 		}
 	}
@@ -19723,13 +19338,13 @@ func (_ fastpathT) DecSliceInt16V(v []int16, checkNil bool, canChange bool, d *D
 func (f *decFnInfo) fastpathDecSliceInt32R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]int32)
+		vp := rv2i(rv.Addr()).(*[]int32)
 		v, changed := fastpathTV.DecSliceInt32V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]int32)
+		v := rv2i(rv).([]int32)
 		fastpathTV.DecSliceInt32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -19749,7 +19364,6 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool, d *D
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -19764,88 +19378,57 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool, d *D
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 4)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]int32, xlen)
-					}
-				} else {
-					v = make([]int32, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 4)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]int32, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = int32(dd.DecodeInt(32))
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = int32(dd.DecodeInt(32))
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []int32{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]int32, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = int32(dd.DecodeInt(32))
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 4)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]int32, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = int32(dd.DecodeInt(32))
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]int32, 0)
 			changed = true
 		}
 	}
@@ -19856,13 +19439,13 @@ func (_ fastpathT) DecSliceInt32V(v []int32, checkNil bool, canChange bool, d *D
 func (f *decFnInfo) fastpathDecSliceInt64R(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]int64)
+		vp := rv2i(rv.Addr()).(*[]int64)
 		v, changed := fastpathTV.DecSliceInt64V(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]int64)
+		v := rv2i(rv).([]int64)
 		fastpathTV.DecSliceInt64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -19882,7 +19465,6 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool, d *D
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -19897,88 +19479,57 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool, d *D
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 8)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]int64, xlen)
-					}
-				} else {
-					v = make([]int64, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]int64, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = dd.DecodeInt(64)
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, 0)
-				slh.ElemContainerState(j)
-				v[j] = dd.DecodeInt(64)
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []int64{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]int64, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, 0)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = dd.DecodeInt(64)
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 8)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]int64, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, 0)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = dd.DecodeInt(64)
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]int64, 0)
 			changed = true
 		}
 	}
@@ -19989,13 +19540,13 @@ func (_ fastpathT) DecSliceInt64V(v []int64, checkNil bool, canChange bool, d *D
 func (f *decFnInfo) fastpathDecSliceBoolR(rv reflect.Value) {
 	array := f.seq == seqTypeArray
 	if !array && rv.CanAddr() {
-		vp := rv.Addr().Interface().(*[]bool)
+		vp := rv2i(rv.Addr()).(*[]bool)
 		v, changed := fastpathTV.DecSliceBoolV(*vp, fastpathCheckNilFalse, !array, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().([]bool)
+		v := rv2i(rv).([]bool)
 		fastpathTV.DecSliceBoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20015,7 +19566,6 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool, d *Dec
 		}
 		return nil, changed
 	}
-
 	slh, containerLenS := d.decSliceHelperStart()
 	if containerLenS == 0 {
 		if canChange {
@@ -20030,88 +19580,57 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool, d *Dec
 		return v, changed
 	}
 
-	if containerLenS > 0 {
-		x2read := containerLenS
-		var xtrunc bool
+	hasLen := containerLenS > 0
+	var xlen int
+	if hasLen && canChange {
 		if containerLenS > cap(v) {
-			if canChange {
-				var xlen int
-				xlen, xtrunc = decInferLen(containerLenS, d.h.MaxInitLen, 1)
-				if xtrunc {
-					if xlen <= cap(v) {
-						v = v[:xlen]
-					} else {
-						v = make([]bool, xlen)
-					}
-				} else {
-					v = make([]bool, xlen)
-				}
-				changed = true
+			xlen = decInferLen(containerLenS, d.h.MaxInitLen, 1)
+			if xlen <= cap(v) {
+				v = v[:xlen]
 			} else {
-				d.arrayCannotExpand(len(v), containerLenS)
+				v = make([]bool, xlen)
 			}
-			x2read = len(v)
+			changed = true
 		} else if containerLenS != len(v) {
-			if canChange {
-				v = v[:containerLenS]
-				changed = true
-			}
-		}
-		j := 0
-		for ; j < x2read; j++ {
-			slh.ElemContainerState(j)
-			v[j] = dd.DecodeBool()
-		}
-		if xtrunc {
-			for ; j < containerLenS; j++ {
-				v = append(v, false)
-				slh.ElemContainerState(j)
-				v[j] = dd.DecodeBool()
-			}
-		} else if !canChange {
-			for ; j < containerLenS; j++ {
-				slh.ElemContainerState(j)
-				d.swallow()
-			}
-		}
-	} else {
-		breakFound := dd.CheckBreak()
-		if breakFound {
-			if canChange {
-				if v == nil {
-					v = []bool{}
-				} else if len(v) != 0 {
-					v = v[:0]
-				}
-				changed = true
-			}
-			slh.End()
-			return v, changed
-		}
-		if cap(v) == 0 {
-			v = make([]bool, 1, 4)
+			v = v[:containerLenS]
 			changed = true
 		}
-		j := 0
-		for ; !breakFound; j++ {
-			if j >= len(v) {
-				if canChange {
-					v = append(v, false)
-					changed = true
-				} else {
-					d.arrayCannotExpand(len(v), j+1)
-				}
-			}
-			slh.ElemContainerState(j)
-			if j < len(v) {
-				v[j] = dd.DecodeBool()
+	}
+	j := 0
+	for ; (hasLen && j < containerLenS) || !(hasLen || dd.CheckBreak()); j++ {
+		if j == 0 && len(v) == 0 {
+			if hasLen {
+				xlen = decInferLen(containerLenS, d.h.MaxInitLen, 1)
 			} else {
-				d.swallow()
+				xlen = 8
 			}
-			breakFound = dd.CheckBreak()
+			v = make([]bool, xlen)
+			changed = true
 		}
-		if canChange && j < len(v) {
+		// if indefinite, etc, then expand the slice if necessary
+		var decodeIntoBlank bool
+		if j >= len(v) {
+			if canChange {
+				v = append(v, false)
+				changed = true
+			} else {
+				d.arrayCannotExpand(len(v), j+1)
+				decodeIntoBlank = true
+			}
+		}
+		slh.ElemContainerState(j)
+		if decodeIntoBlank {
+			d.swallow()
+		} else {
+			v[j] = dd.DecodeBool()
+		}
+	}
+	if canChange {
+		if j < len(v) {
 			v = v[:j]
+			changed = true
+		} else if j == 0 && v == nil {
+			v = make([]bool, 0)
 			changed = true
 		}
 	}
@@ -20121,13 +19640,13 @@ func (_ fastpathT) DecSliceBoolV(v []bool, checkNil bool, canChange bool, d *Dec
 
 func (f *decFnInfo) fastpathDecMapIntfIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]interface{})
+		vp := rv2i(rv.Addr()).(*map[interface{}]interface{})
 		v, changed := fastpathTV.DecMapIntfIntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]interface{})
+		v := rv2i(rv).(map[interface{}]interface{})
 		fastpathTV.DecMapIntfIntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20148,61 +19667,42 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 32)
 		v = make(map[interface{}]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk interface{}
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20213,13 +19713,13 @@ func (_ fastpathT) DecMapIntfIntfV(v map[interface{}]interface{}, checkNil bool,
 
 func (f *decFnInfo) fastpathDecMapIntfStringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]string)
+		vp := rv2i(rv.Addr()).(*map[interface{}]string)
 		v, changed := fastpathTV.DecMapIntfStringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]string)
+		v := rv2i(rv).(map[interface{}]string)
 		fastpathTV.DecMapIntfStringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20240,51 +19740,37 @@ func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, ca
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 32)
 		v = make(map[interface{}]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20295,13 +19781,13 @@ func (_ fastpathT) DecMapIntfStringV(v map[interface{}]string, checkNil bool, ca
 
 func (f *decFnInfo) fastpathDecMapIntfUintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]uint)
+		vp := rv2i(rv.Addr()).(*map[interface{}]uint)
 		v, changed := fastpathTV.DecMapIntfUintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]uint)
+		v := rv2i(rv).(map[interface{}]uint)
 		fastpathTV.DecMapIntfUintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20322,51 +19808,37 @@ func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canCha
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[interface{}]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20377,13 +19849,13 @@ func (_ fastpathT) DecMapIntfUintV(v map[interface{}]uint, checkNil bool, canCha
 
 func (f *decFnInfo) fastpathDecMapIntfUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]uint8)
+		vp := rv2i(rv.Addr()).(*map[interface{}]uint8)
 		v, changed := fastpathTV.DecMapIntfUint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]uint8)
+		v := rv2i(rv).(map[interface{}]uint8)
 		fastpathTV.DecMapIntfUint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20404,51 +19876,37 @@ func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canC
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[interface{}]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20459,13 +19917,13 @@ func (_ fastpathT) DecMapIntfUint8V(v map[interface{}]uint8, checkNil bool, canC
 
 func (f *decFnInfo) fastpathDecMapIntfUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]uint16)
+		vp := rv2i(rv.Addr()).(*map[interface{}]uint16)
 		v, changed := fastpathTV.DecMapIntfUint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]uint16)
+		v := rv2i(rv).(map[interface{}]uint16)
 		fastpathTV.DecMapIntfUint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20486,51 +19944,37 @@ func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, ca
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 18)
 		v = make(map[interface{}]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20541,13 +19985,13 @@ func (_ fastpathT) DecMapIntfUint16V(v map[interface{}]uint16, checkNil bool, ca
 
 func (f *decFnInfo) fastpathDecMapIntfUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]uint32)
+		vp := rv2i(rv.Addr()).(*map[interface{}]uint32)
 		v, changed := fastpathTV.DecMapIntfUint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]uint32)
+		v := rv2i(rv).(map[interface{}]uint32)
 		fastpathTV.DecMapIntfUint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20568,51 +20012,37 @@ func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, ca
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[interface{}]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20623,13 +20053,13 @@ func (_ fastpathT) DecMapIntfUint32V(v map[interface{}]uint32, checkNil bool, ca
 
 func (f *decFnInfo) fastpathDecMapIntfUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]uint64)
+		vp := rv2i(rv.Addr()).(*map[interface{}]uint64)
 		v, changed := fastpathTV.DecMapIntfUint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]uint64)
+		v := rv2i(rv).(map[interface{}]uint64)
 		fastpathTV.DecMapIntfUint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20650,51 +20080,37 @@ func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, ca
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[interface{}]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20705,13 +20121,13 @@ func (_ fastpathT) DecMapIntfUint64V(v map[interface{}]uint64, checkNil bool, ca
 
 func (f *decFnInfo) fastpathDecMapIntfUintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]uintptr)
+		vp := rv2i(rv.Addr()).(*map[interface{}]uintptr)
 		v, changed := fastpathTV.DecMapIntfUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]uintptr)
+		v := rv2i(rv).(map[interface{}]uintptr)
 		fastpathTV.DecMapIntfUintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20732,51 +20148,37 @@ func (_ fastpathT) DecMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, 
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[interface{}]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20787,13 +20189,13 @@ func (_ fastpathT) DecMapIntfUintptrV(v map[interface{}]uintptr, checkNil bool, 
 
 func (f *decFnInfo) fastpathDecMapIntfIntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]int)
+		vp := rv2i(rv.Addr()).(*map[interface{}]int)
 		v, changed := fastpathTV.DecMapIntfIntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]int)
+		v := rv2i(rv).(map[interface{}]int)
 		fastpathTV.DecMapIntfIntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20814,51 +20216,37 @@ func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChang
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[interface{}]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20869,13 +20257,13 @@ func (_ fastpathT) DecMapIntfIntV(v map[interface{}]int, checkNil bool, canChang
 
 func (f *decFnInfo) fastpathDecMapIntfInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]int8)
+		vp := rv2i(rv.Addr()).(*map[interface{}]int8)
 		v, changed := fastpathTV.DecMapIntfInt8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]int8)
+		v := rv2i(rv).(map[interface{}]int8)
 		fastpathTV.DecMapIntfInt8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20896,51 +20284,37 @@ func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canCha
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[interface{}]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -20951,13 +20325,13 @@ func (_ fastpathT) DecMapIntfInt8V(v map[interface{}]int8, checkNil bool, canCha
 
 func (f *decFnInfo) fastpathDecMapIntfInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]int16)
+		vp := rv2i(rv.Addr()).(*map[interface{}]int16)
 		v, changed := fastpathTV.DecMapIntfInt16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]int16)
+		v := rv2i(rv).(map[interface{}]int16)
 		fastpathTV.DecMapIntfInt16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -20978,51 +20352,37 @@ func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canC
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 18)
 		v = make(map[interface{}]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21033,13 +20393,13 @@ func (_ fastpathT) DecMapIntfInt16V(v map[interface{}]int16, checkNil bool, canC
 
 func (f *decFnInfo) fastpathDecMapIntfInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]int32)
+		vp := rv2i(rv.Addr()).(*map[interface{}]int32)
 		v, changed := fastpathTV.DecMapIntfInt32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]int32)
+		v := rv2i(rv).(map[interface{}]int32)
 		fastpathTV.DecMapIntfInt32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21060,51 +20420,37 @@ func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canC
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[interface{}]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21115,13 +20461,13 @@ func (_ fastpathT) DecMapIntfInt32V(v map[interface{}]int32, checkNil bool, canC
 
 func (f *decFnInfo) fastpathDecMapIntfInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]int64)
+		vp := rv2i(rv.Addr()).(*map[interface{}]int64)
 		v, changed := fastpathTV.DecMapIntfInt64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]int64)
+		v := rv2i(rv).(map[interface{}]int64)
 		fastpathTV.DecMapIntfInt64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21142,51 +20488,37 @@ func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canC
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[interface{}]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21197,13 +20529,13 @@ func (_ fastpathT) DecMapIntfInt64V(v map[interface{}]int64, checkNil bool, canC
 
 func (f *decFnInfo) fastpathDecMapIntfFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]float32)
+		vp := rv2i(rv.Addr()).(*map[interface{}]float32)
 		v, changed := fastpathTV.DecMapIntfFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]float32)
+		v := rv2i(rv).(map[interface{}]float32)
 		fastpathTV.DecMapIntfFloat32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21224,51 +20556,37 @@ func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[interface{}]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21279,13 +20597,13 @@ func (_ fastpathT) DecMapIntfFloat32V(v map[interface{}]float32, checkNil bool, 
 
 func (f *decFnInfo) fastpathDecMapIntfFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]float64)
+		vp := rv2i(rv.Addr()).(*map[interface{}]float64)
 		v, changed := fastpathTV.DecMapIntfFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]float64)
+		v := rv2i(rv).(map[interface{}]float64)
 		fastpathTV.DecMapIntfFloat64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21306,51 +20624,37 @@ func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[interface{}]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21361,13 +20665,13 @@ func (_ fastpathT) DecMapIntfFloat64V(v map[interface{}]float64, checkNil bool, 
 
 func (f *decFnInfo) fastpathDecMapIntfBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[interface{}]bool)
+		vp := rv2i(rv.Addr()).(*map[interface{}]bool)
 		v, changed := fastpathTV.DecMapIntfBoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[interface{}]bool)
+		v := rv2i(rv).(map[interface{}]bool)
 		fastpathTV.DecMapIntfBoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21388,51 +20692,37 @@ func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canCha
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[interface{}]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk interface{}
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = nil
-			d.decode(&mk)
-			if bv, bok := mk.([]byte); bok {
-				mk = d.string(bv)
-			}
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = nil
+		d.decode(&mk)
+		if bv, bok := mk.([]byte); bok {
+			mk = d.string(bv)
+		}
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21443,13 +20733,13 @@ func (_ fastpathT) DecMapIntfBoolV(v map[interface{}]bool, checkNil bool, canCha
 
 func (f *decFnInfo) fastpathDecMapStringIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]interface{})
+		vp := rv2i(rv.Addr()).(*map[string]interface{})
 		v, changed := fastpathTV.DecMapStringIntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]interface{})
+		v := rv2i(rv).(map[string]interface{})
 		fastpathTV.DecMapStringIntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21470,53 +20760,38 @@ func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, ca
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 32)
 		v = make(map[string]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk string
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21527,13 +20802,13 @@ func (_ fastpathT) DecMapStringIntfV(v map[string]interface{}, checkNil bool, ca
 
 func (f *decFnInfo) fastpathDecMapStringStringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]string)
+		vp := rv2i(rv.Addr()).(*map[string]string)
 		v, changed := fastpathTV.DecMapStringStringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]string)
+		v := rv2i(rv).(map[string]string)
 		fastpathTV.DecMapStringStringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21554,43 +20829,33 @@ func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 32)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 32)
 		v = make(map[string]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21601,13 +20866,13 @@ func (_ fastpathT) DecMapStringStringV(v map[string]string, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapStringUintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]uint)
+		vp := rv2i(rv.Addr()).(*map[string]uint)
 		v, changed := fastpathTV.DecMapStringUintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]uint)
+		v := rv2i(rv).(map[string]uint)
 		fastpathTV.DecMapStringUintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21628,43 +20893,33 @@ func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[string]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21675,13 +20930,13 @@ func (_ fastpathT) DecMapStringUintV(v map[string]uint, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapStringUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]uint8)
+		vp := rv2i(rv.Addr()).(*map[string]uint8)
 		v, changed := fastpathTV.DecMapStringUint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]uint8)
+		v := rv2i(rv).(map[string]uint8)
 		fastpathTV.DecMapStringUint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21702,43 +20957,33 @@ func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[string]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21749,13 +20994,13 @@ func (_ fastpathT) DecMapStringUint8V(v map[string]uint8, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapStringUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]uint16)
+		vp := rv2i(rv.Addr()).(*map[string]uint16)
 		v, changed := fastpathTV.DecMapStringUint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]uint16)
+		v := rv2i(rv).(map[string]uint16)
 		fastpathTV.DecMapStringUint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21776,43 +21021,33 @@ func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 18)
 		v = make(map[string]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21823,13 +21058,13 @@ func (_ fastpathT) DecMapStringUint16V(v map[string]uint16, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapStringUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]uint32)
+		vp := rv2i(rv.Addr()).(*map[string]uint32)
 		v, changed := fastpathTV.DecMapStringUint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]uint32)
+		v := rv2i(rv).(map[string]uint32)
 		fastpathTV.DecMapStringUint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21850,43 +21085,33 @@ func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[string]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21897,13 +21122,13 @@ func (_ fastpathT) DecMapStringUint32V(v map[string]uint32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapStringUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]uint64)
+		vp := rv2i(rv.Addr()).(*map[string]uint64)
 		v, changed := fastpathTV.DecMapStringUint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]uint64)
+		v := rv2i(rv).(map[string]uint64)
 		fastpathTV.DecMapStringUint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21924,43 +21149,33 @@ func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[string]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -21971,13 +21186,13 @@ func (_ fastpathT) DecMapStringUint64V(v map[string]uint64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapStringUintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]uintptr)
+		vp := rv2i(rv.Addr()).(*map[string]uintptr)
 		v, changed := fastpathTV.DecMapStringUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]uintptr)
+		v := rv2i(rv).(map[string]uintptr)
 		fastpathTV.DecMapStringUintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -21998,43 +21213,33 @@ func (_ fastpathT) DecMapStringUintptrV(v map[string]uintptr, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[string]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22045,13 +21250,13 @@ func (_ fastpathT) DecMapStringUintptrV(v map[string]uintptr, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapStringIntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]int)
+		vp := rv2i(rv.Addr()).(*map[string]int)
 		v, changed := fastpathTV.DecMapStringIntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]int)
+		v := rv2i(rv).(map[string]int)
 		fastpathTV.DecMapStringIntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22072,43 +21277,33 @@ func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[string]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22119,13 +21314,13 @@ func (_ fastpathT) DecMapStringIntV(v map[string]int, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapStringInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]int8)
+		vp := rv2i(rv.Addr()).(*map[string]int8)
 		v, changed := fastpathTV.DecMapStringInt8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]int8)
+		v := rv2i(rv).(map[string]int8)
 		fastpathTV.DecMapStringInt8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22146,43 +21341,33 @@ func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[string]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22193,13 +21378,13 @@ func (_ fastpathT) DecMapStringInt8V(v map[string]int8, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapStringInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]int16)
+		vp := rv2i(rv.Addr()).(*map[string]int16)
 		v, changed := fastpathTV.DecMapStringInt16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]int16)
+		v := rv2i(rv).(map[string]int16)
 		fastpathTV.DecMapStringInt16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22220,43 +21405,33 @@ func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 18)
 		v = make(map[string]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22267,13 +21442,13 @@ func (_ fastpathT) DecMapStringInt16V(v map[string]int16, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapStringInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]int32)
+		vp := rv2i(rv.Addr()).(*map[string]int32)
 		v, changed := fastpathTV.DecMapStringInt32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]int32)
+		v := rv2i(rv).(map[string]int32)
 		fastpathTV.DecMapStringInt32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22294,43 +21469,33 @@ func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[string]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22341,13 +21506,13 @@ func (_ fastpathT) DecMapStringInt32V(v map[string]int32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapStringInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]int64)
+		vp := rv2i(rv.Addr()).(*map[string]int64)
 		v, changed := fastpathTV.DecMapStringInt64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]int64)
+		v := rv2i(rv).(map[string]int64)
 		fastpathTV.DecMapStringInt64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22368,43 +21533,33 @@ func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[string]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22415,13 +21570,13 @@ func (_ fastpathT) DecMapStringInt64V(v map[string]int64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapStringFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]float32)
+		vp := rv2i(rv.Addr()).(*map[string]float32)
 		v, changed := fastpathTV.DecMapStringFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]float32)
+		v := rv2i(rv).(map[string]float32)
 		fastpathTV.DecMapStringFloat32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22442,43 +21597,33 @@ func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[string]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22489,13 +21634,13 @@ func (_ fastpathT) DecMapStringFloat32V(v map[string]float32, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapStringFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]float64)
+		vp := rv2i(rv.Addr()).(*map[string]float64)
 		v, changed := fastpathTV.DecMapStringFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]float64)
+		v := rv2i(rv).(map[string]float64)
 		fastpathTV.DecMapStringFloat64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22516,43 +21661,33 @@ func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[string]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22563,13 +21698,13 @@ func (_ fastpathT) DecMapStringFloat64V(v map[string]float64, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapStringBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[string]bool)
+		vp := rv2i(rv.Addr()).(*map[string]bool)
 		v, changed := fastpathTV.DecMapStringBoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[string]bool)
+		v := rv2i(rv).(map[string]bool)
 		fastpathTV.DecMapStringBoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22590,43 +21725,33 @@ func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[string]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk string
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeString()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeString()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22637,13 +21762,13 @@ func (_ fastpathT) DecMapStringBoolV(v map[string]bool, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapFloat32IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]interface{})
+		vp := rv2i(rv.Addr()).(*map[float32]interface{})
 		v, changed := fastpathTV.DecMapFloat32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]interface{})
+		v := rv2i(rv).(map[float32]interface{})
 		fastpathTV.DecMapFloat32IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22664,53 +21789,38 @@ func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[float32]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk float32
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22721,13 +21831,13 @@ func (_ fastpathT) DecMapFloat32IntfV(v map[float32]interface{}, checkNil bool, 
 
 func (f *decFnInfo) fastpathDecMapFloat32StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]string)
+		vp := rv2i(rv.Addr()).(*map[float32]string)
 		v, changed := fastpathTV.DecMapFloat32StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]string)
+		v := rv2i(rv).(map[float32]string)
 		fastpathTV.DecMapFloat32StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22748,43 +21858,33 @@ func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[float32]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22795,13 +21895,13 @@ func (_ fastpathT) DecMapFloat32StringV(v map[float32]string, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapFloat32UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]uint)
+		vp := rv2i(rv.Addr()).(*map[float32]uint)
 		v, changed := fastpathTV.DecMapFloat32UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]uint)
+		v := rv2i(rv).(map[float32]uint)
 		fastpathTV.DecMapFloat32UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22822,43 +21922,33 @@ func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float32]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22869,13 +21959,13 @@ func (_ fastpathT) DecMapFloat32UintV(v map[float32]uint, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapFloat32Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]uint8)
+		vp := rv2i(rv.Addr()).(*map[float32]uint8)
 		v, changed := fastpathTV.DecMapFloat32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]uint8)
+		v := rv2i(rv).(map[float32]uint8)
 		fastpathTV.DecMapFloat32Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22896,43 +21986,33 @@ func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[float32]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -22943,13 +22023,13 @@ func (_ fastpathT) DecMapFloat32Uint8V(v map[float32]uint8, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapFloat32Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]uint16)
+		vp := rv2i(rv.Addr()).(*map[float32]uint16)
 		v, changed := fastpathTV.DecMapFloat32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]uint16)
+		v := rv2i(rv).(map[float32]uint16)
 		fastpathTV.DecMapFloat32Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -22970,43 +22050,33 @@ func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[float32]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23017,13 +22087,13 @@ func (_ fastpathT) DecMapFloat32Uint16V(v map[float32]uint16, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapFloat32Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]uint32)
+		vp := rv2i(rv.Addr()).(*map[float32]uint32)
 		v, changed := fastpathTV.DecMapFloat32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]uint32)
+		v := rv2i(rv).(map[float32]uint32)
 		fastpathTV.DecMapFloat32Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23044,43 +22114,33 @@ func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[float32]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23091,13 +22151,13 @@ func (_ fastpathT) DecMapFloat32Uint32V(v map[float32]uint32, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapFloat32Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]uint64)
+		vp := rv2i(rv.Addr()).(*map[float32]uint64)
 		v, changed := fastpathTV.DecMapFloat32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]uint64)
+		v := rv2i(rv).(map[float32]uint64)
 		fastpathTV.DecMapFloat32Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23118,43 +22178,33 @@ func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float32]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23165,13 +22215,13 @@ func (_ fastpathT) DecMapFloat32Uint64V(v map[float32]uint64, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapFloat32UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]uintptr)
+		vp := rv2i(rv.Addr()).(*map[float32]uintptr)
 		v, changed := fastpathTV.DecMapFloat32UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]uintptr)
+		v := rv2i(rv).(map[float32]uintptr)
 		fastpathTV.DecMapFloat32UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23192,43 +22242,33 @@ func (_ fastpathT) DecMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float32]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23239,13 +22279,13 @@ func (_ fastpathT) DecMapFloat32UintptrV(v map[float32]uintptr, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapFloat32IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]int)
+		vp := rv2i(rv.Addr()).(*map[float32]int)
 		v, changed := fastpathTV.DecMapFloat32IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]int)
+		v := rv2i(rv).(map[float32]int)
 		fastpathTV.DecMapFloat32IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23266,43 +22306,33 @@ func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float32]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23313,13 +22343,13 @@ func (_ fastpathT) DecMapFloat32IntV(v map[float32]int, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapFloat32Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]int8)
+		vp := rv2i(rv.Addr()).(*map[float32]int8)
 		v, changed := fastpathTV.DecMapFloat32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]int8)
+		v := rv2i(rv).(map[float32]int8)
 		fastpathTV.DecMapFloat32Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23340,43 +22370,33 @@ func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[float32]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23387,13 +22407,13 @@ func (_ fastpathT) DecMapFloat32Int8V(v map[float32]int8, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapFloat32Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]int16)
+		vp := rv2i(rv.Addr()).(*map[float32]int16)
 		v, changed := fastpathTV.DecMapFloat32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]int16)
+		v := rv2i(rv).(map[float32]int16)
 		fastpathTV.DecMapFloat32Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23414,43 +22434,33 @@ func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[float32]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23461,13 +22471,13 @@ func (_ fastpathT) DecMapFloat32Int16V(v map[float32]int16, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapFloat32Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]int32)
+		vp := rv2i(rv.Addr()).(*map[float32]int32)
 		v, changed := fastpathTV.DecMapFloat32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]int32)
+		v := rv2i(rv).(map[float32]int32)
 		fastpathTV.DecMapFloat32Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23488,43 +22498,33 @@ func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[float32]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23535,13 +22535,13 @@ func (_ fastpathT) DecMapFloat32Int32V(v map[float32]int32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapFloat32Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]int64)
+		vp := rv2i(rv.Addr()).(*map[float32]int64)
 		v, changed := fastpathTV.DecMapFloat32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]int64)
+		v := rv2i(rv).(map[float32]int64)
 		fastpathTV.DecMapFloat32Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23562,43 +22562,33 @@ func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float32]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23609,13 +22599,13 @@ func (_ fastpathT) DecMapFloat32Int64V(v map[float32]int64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapFloat32Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]float32)
+		vp := rv2i(rv.Addr()).(*map[float32]float32)
 		v, changed := fastpathTV.DecMapFloat32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]float32)
+		v := rv2i(rv).(map[float32]float32)
 		fastpathTV.DecMapFloat32Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23636,43 +22626,33 @@ func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[float32]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23683,13 +22663,13 @@ func (_ fastpathT) DecMapFloat32Float32V(v map[float32]float32, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapFloat32Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]float64)
+		vp := rv2i(rv.Addr()).(*map[float32]float64)
 		v, changed := fastpathTV.DecMapFloat32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]float64)
+		v := rv2i(rv).(map[float32]float64)
 		fastpathTV.DecMapFloat32Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23710,43 +22690,33 @@ func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float32]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23757,13 +22727,13 @@ func (_ fastpathT) DecMapFloat32Float64V(v map[float32]float64, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapFloat32BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float32]bool)
+		vp := rv2i(rv.Addr()).(*map[float32]bool)
 		v, changed := fastpathTV.DecMapFloat32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float32]bool)
+		v := rv2i(rv).(map[float32]bool)
 		fastpathTV.DecMapFloat32BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23784,43 +22754,33 @@ func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[float32]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float32
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = float32(dd.DecodeFloat(true))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = float32(dd.DecodeFloat(true))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23831,13 +22791,13 @@ func (_ fastpathT) DecMapFloat32BoolV(v map[float32]bool, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapFloat64IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]interface{})
+		vp := rv2i(rv.Addr()).(*map[float64]interface{})
 		v, changed := fastpathTV.DecMapFloat64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]interface{})
+		v := rv2i(rv).(map[float64]interface{})
 		fastpathTV.DecMapFloat64IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23858,53 +22818,38 @@ func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[float64]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk float64
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23915,13 +22860,13 @@ func (_ fastpathT) DecMapFloat64IntfV(v map[float64]interface{}, checkNil bool, 
 
 func (f *decFnInfo) fastpathDecMapFloat64StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]string)
+		vp := rv2i(rv.Addr()).(*map[float64]string)
 		v, changed := fastpathTV.DecMapFloat64StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]string)
+		v := rv2i(rv).(map[float64]string)
 		fastpathTV.DecMapFloat64StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -23942,43 +22887,33 @@ func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[float64]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -23989,13 +22924,13 @@ func (_ fastpathT) DecMapFloat64StringV(v map[float64]string, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapFloat64UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]uint)
+		vp := rv2i(rv.Addr()).(*map[float64]uint)
 		v, changed := fastpathTV.DecMapFloat64UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]uint)
+		v := rv2i(rv).(map[float64]uint)
 		fastpathTV.DecMapFloat64UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24016,43 +22951,33 @@ func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[float64]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24063,13 +22988,13 @@ func (_ fastpathT) DecMapFloat64UintV(v map[float64]uint, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapFloat64Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]uint8)
+		vp := rv2i(rv.Addr()).(*map[float64]uint8)
 		v, changed := fastpathTV.DecMapFloat64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]uint8)
+		v := rv2i(rv).(map[float64]uint8)
 		fastpathTV.DecMapFloat64Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24090,43 +23015,33 @@ func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[float64]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24137,13 +23052,13 @@ func (_ fastpathT) DecMapFloat64Uint8V(v map[float64]uint8, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapFloat64Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]uint16)
+		vp := rv2i(rv.Addr()).(*map[float64]uint16)
 		v, changed := fastpathTV.DecMapFloat64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]uint16)
+		v := rv2i(rv).(map[float64]uint16)
 		fastpathTV.DecMapFloat64Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24164,43 +23079,33 @@ func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[float64]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24211,13 +23116,13 @@ func (_ fastpathT) DecMapFloat64Uint16V(v map[float64]uint16, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapFloat64Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]uint32)
+		vp := rv2i(rv.Addr()).(*map[float64]uint32)
 		v, changed := fastpathTV.DecMapFloat64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]uint32)
+		v := rv2i(rv).(map[float64]uint32)
 		fastpathTV.DecMapFloat64Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24238,43 +23143,33 @@ func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float64]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24285,13 +23180,13 @@ func (_ fastpathT) DecMapFloat64Uint32V(v map[float64]uint32, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapFloat64Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]uint64)
+		vp := rv2i(rv.Addr()).(*map[float64]uint64)
 		v, changed := fastpathTV.DecMapFloat64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]uint64)
+		v := rv2i(rv).(map[float64]uint64)
 		fastpathTV.DecMapFloat64Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24312,43 +23207,33 @@ func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[float64]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24359,13 +23244,13 @@ func (_ fastpathT) DecMapFloat64Uint64V(v map[float64]uint64, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapFloat64UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]uintptr)
+		vp := rv2i(rv.Addr()).(*map[float64]uintptr)
 		v, changed := fastpathTV.DecMapFloat64UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]uintptr)
+		v := rv2i(rv).(map[float64]uintptr)
 		fastpathTV.DecMapFloat64UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24386,43 +23271,33 @@ func (_ fastpathT) DecMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[float64]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24433,13 +23308,13 @@ func (_ fastpathT) DecMapFloat64UintptrV(v map[float64]uintptr, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapFloat64IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]int)
+		vp := rv2i(rv.Addr()).(*map[float64]int)
 		v, changed := fastpathTV.DecMapFloat64IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]int)
+		v := rv2i(rv).(map[float64]int)
 		fastpathTV.DecMapFloat64IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24460,43 +23335,33 @@ func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[float64]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24507,13 +23372,13 @@ func (_ fastpathT) DecMapFloat64IntV(v map[float64]int, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapFloat64Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]int8)
+		vp := rv2i(rv.Addr()).(*map[float64]int8)
 		v, changed := fastpathTV.DecMapFloat64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]int8)
+		v := rv2i(rv).(map[float64]int8)
 		fastpathTV.DecMapFloat64Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24534,43 +23399,33 @@ func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[float64]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24581,13 +23436,13 @@ func (_ fastpathT) DecMapFloat64Int8V(v map[float64]int8, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapFloat64Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]int16)
+		vp := rv2i(rv.Addr()).(*map[float64]int16)
 		v, changed := fastpathTV.DecMapFloat64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]int16)
+		v := rv2i(rv).(map[float64]int16)
 		fastpathTV.DecMapFloat64Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24608,43 +23463,33 @@ func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[float64]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24655,13 +23500,13 @@ func (_ fastpathT) DecMapFloat64Int16V(v map[float64]int16, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapFloat64Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]int32)
+		vp := rv2i(rv.Addr()).(*map[float64]int32)
 		v, changed := fastpathTV.DecMapFloat64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]int32)
+		v := rv2i(rv).(map[float64]int32)
 		fastpathTV.DecMapFloat64Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24682,43 +23527,33 @@ func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float64]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24729,13 +23564,13 @@ func (_ fastpathT) DecMapFloat64Int32V(v map[float64]int32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapFloat64Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]int64)
+		vp := rv2i(rv.Addr()).(*map[float64]int64)
 		v, changed := fastpathTV.DecMapFloat64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]int64)
+		v := rv2i(rv).(map[float64]int64)
 		fastpathTV.DecMapFloat64Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24756,43 +23591,33 @@ func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[float64]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24803,13 +23628,13 @@ func (_ fastpathT) DecMapFloat64Int64V(v map[float64]int64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapFloat64Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]float32)
+		vp := rv2i(rv.Addr()).(*map[float64]float32)
 		v, changed := fastpathTV.DecMapFloat64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]float32)
+		v := rv2i(rv).(map[float64]float32)
 		fastpathTV.DecMapFloat64Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24830,43 +23655,33 @@ func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[float64]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24877,13 +23692,13 @@ func (_ fastpathT) DecMapFloat64Float32V(v map[float64]float32, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapFloat64Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]float64)
+		vp := rv2i(rv.Addr()).(*map[float64]float64)
 		v, changed := fastpathTV.DecMapFloat64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]float64)
+		v := rv2i(rv).(map[float64]float64)
 		fastpathTV.DecMapFloat64Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24904,43 +23719,33 @@ func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[float64]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -24951,13 +23756,13 @@ func (_ fastpathT) DecMapFloat64Float64V(v map[float64]float64, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapFloat64BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[float64]bool)
+		vp := rv2i(rv.Addr()).(*map[float64]bool)
 		v, changed := fastpathTV.DecMapFloat64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[float64]bool)
+		v := rv2i(rv).(map[float64]bool)
 		fastpathTV.DecMapFloat64BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -24978,43 +23783,33 @@ func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[float64]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk float64
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeFloat(false)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeFloat(false)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25025,13 +23820,13 @@ func (_ fastpathT) DecMapFloat64BoolV(v map[float64]bool, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUintIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]interface{})
+		vp := rv2i(rv.Addr()).(*map[uint]interface{})
 		v, changed := fastpathTV.DecMapUintIntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]interface{})
+		v := rv2i(rv).(map[uint]interface{})
 		fastpathTV.DecMapUintIntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25052,53 +23847,38 @@ func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canCha
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[uint]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk uint
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25109,13 +23889,13 @@ func (_ fastpathT) DecMapUintIntfV(v map[uint]interface{}, checkNil bool, canCha
 
 func (f *decFnInfo) fastpathDecMapUintStringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]string)
+		vp := rv2i(rv.Addr()).(*map[uint]string)
 		v, changed := fastpathTV.DecMapUintStringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]string)
+		v := rv2i(rv).(map[uint]string)
 		fastpathTV.DecMapUintStringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25136,43 +23916,33 @@ func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[uint]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25183,13 +23953,13 @@ func (_ fastpathT) DecMapUintStringV(v map[uint]string, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUintUintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]uint)
+		vp := rv2i(rv.Addr()).(*map[uint]uint)
 		v, changed := fastpathTV.DecMapUintUintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]uint)
+		v := rv2i(rv).(map[uint]uint)
 		fastpathTV.DecMapUintUintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25210,43 +23980,33 @@ func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25257,13 +24017,13 @@ func (_ fastpathT) DecMapUintUintV(v map[uint]uint, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapUintUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]uint8)
+		vp := rv2i(rv.Addr()).(*map[uint]uint8)
 		v, changed := fastpathTV.DecMapUintUint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]uint8)
+		v := rv2i(rv).(map[uint]uint8)
 		fastpathTV.DecMapUintUint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25284,43 +24044,33 @@ func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25331,13 +24081,13 @@ func (_ fastpathT) DecMapUintUint8V(v map[uint]uint8, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUintUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]uint16)
+		vp := rv2i(rv.Addr()).(*map[uint]uint16)
 		v, changed := fastpathTV.DecMapUintUint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]uint16)
+		v := rv2i(rv).(map[uint]uint16)
 		fastpathTV.DecMapUintUint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25358,43 +24108,33 @@ func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25405,13 +24145,13 @@ func (_ fastpathT) DecMapUintUint16V(v map[uint]uint16, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUintUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]uint32)
+		vp := rv2i(rv.Addr()).(*map[uint]uint32)
 		v, changed := fastpathTV.DecMapUintUint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]uint32)
+		v := rv2i(rv).(map[uint]uint32)
 		fastpathTV.DecMapUintUint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25432,43 +24172,33 @@ func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25479,13 +24209,13 @@ func (_ fastpathT) DecMapUintUint32V(v map[uint]uint32, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUintUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]uint64)
+		vp := rv2i(rv.Addr()).(*map[uint]uint64)
 		v, changed := fastpathTV.DecMapUintUint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]uint64)
+		v := rv2i(rv).(map[uint]uint64)
 		fastpathTV.DecMapUintUint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25506,43 +24236,33 @@ func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25553,13 +24273,13 @@ func (_ fastpathT) DecMapUintUint64V(v map[uint]uint64, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUintUintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]uintptr)
+		vp := rv2i(rv.Addr()).(*map[uint]uintptr)
 		v, changed := fastpathTV.DecMapUintUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]uintptr)
+		v := rv2i(rv).(map[uint]uintptr)
 		fastpathTV.DecMapUintUintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25580,43 +24300,33 @@ func (_ fastpathT) DecMapUintUintptrV(v map[uint]uintptr, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25627,13 +24337,13 @@ func (_ fastpathT) DecMapUintUintptrV(v map[uint]uintptr, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUintIntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]int)
+		vp := rv2i(rv.Addr()).(*map[uint]int)
 		v, changed := fastpathTV.DecMapUintIntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]int)
+		v := rv2i(rv).(map[uint]int)
 		fastpathTV.DecMapUintIntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25654,43 +24364,33 @@ func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25701,13 +24401,13 @@ func (_ fastpathT) DecMapUintIntV(v map[uint]int, checkNil bool, canChange bool,
 
 func (f *decFnInfo) fastpathDecMapUintInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]int8)
+		vp := rv2i(rv.Addr()).(*map[uint]int8)
 		v, changed := fastpathTV.DecMapUintInt8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]int8)
+		v := rv2i(rv).(map[uint]int8)
 		fastpathTV.DecMapUintInt8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25728,43 +24428,33 @@ func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25775,13 +24465,13 @@ func (_ fastpathT) DecMapUintInt8V(v map[uint]int8, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapUintInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]int16)
+		vp := rv2i(rv.Addr()).(*map[uint]int16)
 		v, changed := fastpathTV.DecMapUintInt16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]int16)
+		v := rv2i(rv).(map[uint]int16)
 		fastpathTV.DecMapUintInt16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25802,43 +24492,33 @@ func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25849,13 +24529,13 @@ func (_ fastpathT) DecMapUintInt16V(v map[uint]int16, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUintInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]int32)
+		vp := rv2i(rv.Addr()).(*map[uint]int32)
 		v, changed := fastpathTV.DecMapUintInt32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]int32)
+		v := rv2i(rv).(map[uint]int32)
 		fastpathTV.DecMapUintInt32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25876,43 +24556,33 @@ func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25923,13 +24593,13 @@ func (_ fastpathT) DecMapUintInt32V(v map[uint]int32, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUintInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]int64)
+		vp := rv2i(rv.Addr()).(*map[uint]int64)
 		v, changed := fastpathTV.DecMapUintInt64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]int64)
+		v := rv2i(rv).(map[uint]int64)
 		fastpathTV.DecMapUintInt64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -25950,43 +24620,33 @@ func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -25997,13 +24657,13 @@ func (_ fastpathT) DecMapUintInt64V(v map[uint]int64, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUintFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]float32)
+		vp := rv2i(rv.Addr()).(*map[uint]float32)
 		v, changed := fastpathTV.DecMapUintFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]float32)
+		v := rv2i(rv).(map[uint]float32)
 		fastpathTV.DecMapUintFloat32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26024,43 +24684,33 @@ func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26071,13 +24721,13 @@ func (_ fastpathT) DecMapUintFloat32V(v map[uint]float32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUintFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]float64)
+		vp := rv2i(rv.Addr()).(*map[uint]float64)
 		v, changed := fastpathTV.DecMapUintFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]float64)
+		v := rv2i(rv).(map[uint]float64)
 		fastpathTV.DecMapUintFloat64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26098,43 +24748,33 @@ func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26145,13 +24785,13 @@ func (_ fastpathT) DecMapUintFloat64V(v map[uint]float64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUintBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint]bool)
+		vp := rv2i(rv.Addr()).(*map[uint]bool)
 		v, changed := fastpathTV.DecMapUintBoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint]bool)
+		v := rv2i(rv).(map[uint]bool)
 		fastpathTV.DecMapUintBoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26172,43 +24812,33 @@ func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26219,13 +24849,13 @@ func (_ fastpathT) DecMapUintBoolV(v map[uint]bool, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapUint8IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]interface{})
+		vp := rv2i(rv.Addr()).(*map[uint8]interface{})
 		v, changed := fastpathTV.DecMapUint8IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]interface{})
+		v := rv2i(rv).(map[uint8]interface{})
 		fastpathTV.DecMapUint8IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26246,53 +24876,38 @@ func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canC
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[uint8]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk uint8
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26303,13 +24918,13 @@ func (_ fastpathT) DecMapUint8IntfV(v map[uint8]interface{}, checkNil bool, canC
 
 func (f *decFnInfo) fastpathDecMapUint8StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]string)
+		vp := rv2i(rv.Addr()).(*map[uint8]string)
 		v, changed := fastpathTV.DecMapUint8StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]string)
+		v := rv2i(rv).(map[uint8]string)
 		fastpathTV.DecMapUint8StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26330,43 +24945,33 @@ func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[uint8]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26377,13 +24982,13 @@ func (_ fastpathT) DecMapUint8StringV(v map[uint8]string, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint8UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]uint)
+		vp := rv2i(rv.Addr()).(*map[uint8]uint)
 		v, changed := fastpathTV.DecMapUint8UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]uint)
+		v := rv2i(rv).(map[uint8]uint)
 		fastpathTV.DecMapUint8UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26404,43 +25009,33 @@ func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint8]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26451,13 +25046,13 @@ func (_ fastpathT) DecMapUint8UintV(v map[uint8]uint, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUint8Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]uint8)
+		vp := rv2i(rv.Addr()).(*map[uint8]uint8)
 		v, changed := fastpathTV.DecMapUint8Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]uint8)
+		v := rv2i(rv).(map[uint8]uint8)
 		fastpathTV.DecMapUint8Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26478,43 +25073,33 @@ func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[uint8]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26525,13 +25110,13 @@ func (_ fastpathT) DecMapUint8Uint8V(v map[uint8]uint8, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint8Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]uint16)
+		vp := rv2i(rv.Addr()).(*map[uint8]uint16)
 		v, changed := fastpathTV.DecMapUint8Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]uint16)
+		v := rv2i(rv).(map[uint8]uint16)
 		fastpathTV.DecMapUint8Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26552,43 +25137,33 @@ func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[uint8]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26599,13 +25174,13 @@ func (_ fastpathT) DecMapUint8Uint16V(v map[uint8]uint16, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint8Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]uint32)
+		vp := rv2i(rv.Addr()).(*map[uint8]uint32)
 		v, changed := fastpathTV.DecMapUint8Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]uint32)
+		v := rv2i(rv).(map[uint8]uint32)
 		fastpathTV.DecMapUint8Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26626,43 +25201,33 @@ func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[uint8]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26673,13 +25238,13 @@ func (_ fastpathT) DecMapUint8Uint32V(v map[uint8]uint32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint8Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]uint64)
+		vp := rv2i(rv.Addr()).(*map[uint8]uint64)
 		v, changed := fastpathTV.DecMapUint8Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]uint64)
+		v := rv2i(rv).(map[uint8]uint64)
 		fastpathTV.DecMapUint8Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26700,43 +25265,33 @@ func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint8]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26747,13 +25302,13 @@ func (_ fastpathT) DecMapUint8Uint64V(v map[uint8]uint64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint8UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]uintptr)
+		vp := rv2i(rv.Addr()).(*map[uint8]uintptr)
 		v, changed := fastpathTV.DecMapUint8UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]uintptr)
+		v := rv2i(rv).(map[uint8]uintptr)
 		fastpathTV.DecMapUint8UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26774,43 +25329,33 @@ func (_ fastpathT) DecMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint8]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26821,13 +25366,13 @@ func (_ fastpathT) DecMapUint8UintptrV(v map[uint8]uintptr, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint8IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]int)
+		vp := rv2i(rv.Addr()).(*map[uint8]int)
 		v, changed := fastpathTV.DecMapUint8IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]int)
+		v := rv2i(rv).(map[uint8]int)
 		fastpathTV.DecMapUint8IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26848,43 +25393,33 @@ func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint8]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26895,13 +25430,13 @@ func (_ fastpathT) DecMapUint8IntV(v map[uint8]int, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapUint8Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]int8)
+		vp := rv2i(rv.Addr()).(*map[uint8]int8)
 		v, changed := fastpathTV.DecMapUint8Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]int8)
+		v := rv2i(rv).(map[uint8]int8)
 		fastpathTV.DecMapUint8Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26922,43 +25457,33 @@ func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[uint8]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -26969,13 +25494,13 @@ func (_ fastpathT) DecMapUint8Int8V(v map[uint8]int8, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUint8Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]int16)
+		vp := rv2i(rv.Addr()).(*map[uint8]int16)
 		v, changed := fastpathTV.DecMapUint8Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]int16)
+		v := rv2i(rv).(map[uint8]int16)
 		fastpathTV.DecMapUint8Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -26996,43 +25521,33 @@ func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[uint8]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27043,13 +25558,13 @@ func (_ fastpathT) DecMapUint8Int16V(v map[uint8]int16, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint8Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]int32)
+		vp := rv2i(rv.Addr()).(*map[uint8]int32)
 		v, changed := fastpathTV.DecMapUint8Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]int32)
+		v := rv2i(rv).(map[uint8]int32)
 		fastpathTV.DecMapUint8Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27070,43 +25585,33 @@ func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[uint8]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27117,13 +25622,13 @@ func (_ fastpathT) DecMapUint8Int32V(v map[uint8]int32, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint8Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]int64)
+		vp := rv2i(rv.Addr()).(*map[uint8]int64)
 		v, changed := fastpathTV.DecMapUint8Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]int64)
+		v := rv2i(rv).(map[uint8]int64)
 		fastpathTV.DecMapUint8Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27144,43 +25649,33 @@ func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint8]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27191,13 +25686,13 @@ func (_ fastpathT) DecMapUint8Int64V(v map[uint8]int64, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint8Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]float32)
+		vp := rv2i(rv.Addr()).(*map[uint8]float32)
 		v, changed := fastpathTV.DecMapUint8Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]float32)
+		v := rv2i(rv).(map[uint8]float32)
 		fastpathTV.DecMapUint8Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27218,43 +25713,33 @@ func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[uint8]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27265,13 +25750,13 @@ func (_ fastpathT) DecMapUint8Float32V(v map[uint8]float32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint8Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]float64)
+		vp := rv2i(rv.Addr()).(*map[uint8]float64)
 		v, changed := fastpathTV.DecMapUint8Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]float64)
+		v := rv2i(rv).(map[uint8]float64)
 		fastpathTV.DecMapUint8Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27292,43 +25777,33 @@ func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint8]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27339,13 +25814,13 @@ func (_ fastpathT) DecMapUint8Float64V(v map[uint8]float64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint8BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint8]bool)
+		vp := rv2i(rv.Addr()).(*map[uint8]bool)
 		v, changed := fastpathTV.DecMapUint8BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint8]bool)
+		v := rv2i(rv).(map[uint8]bool)
 		fastpathTV.DecMapUint8BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27366,43 +25841,33 @@ func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[uint8]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint8
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint8(dd.DecodeUint(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint8(dd.DecodeUint(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27413,13 +25878,13 @@ func (_ fastpathT) DecMapUint8BoolV(v map[uint8]bool, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUint16IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]interface{})
+		vp := rv2i(rv.Addr()).(*map[uint16]interface{})
 		v, changed := fastpathTV.DecMapUint16IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]interface{})
+		v := rv2i(rv).(map[uint16]interface{})
 		fastpathTV.DecMapUint16IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27440,53 +25905,38 @@ func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, ca
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 18)
 		v = make(map[uint16]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk uint16
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27497,13 +25947,13 @@ func (_ fastpathT) DecMapUint16IntfV(v map[uint16]interface{}, checkNil bool, ca
 
 func (f *decFnInfo) fastpathDecMapUint16StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]string)
+		vp := rv2i(rv.Addr()).(*map[uint16]string)
 		v, changed := fastpathTV.DecMapUint16StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]string)
+		v := rv2i(rv).(map[uint16]string)
 		fastpathTV.DecMapUint16StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27524,43 +25974,33 @@ func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 18)
 		v = make(map[uint16]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27571,13 +26011,13 @@ func (_ fastpathT) DecMapUint16StringV(v map[uint16]string, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint16UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]uint)
+		vp := rv2i(rv.Addr()).(*map[uint16]uint)
 		v, changed := fastpathTV.DecMapUint16UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]uint)
+		v := rv2i(rv).(map[uint16]uint)
 		fastpathTV.DecMapUint16UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27598,43 +26038,33 @@ func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint16]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27645,13 +26075,13 @@ func (_ fastpathT) DecMapUint16UintV(v map[uint16]uint, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint16Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]uint8)
+		vp := rv2i(rv.Addr()).(*map[uint16]uint8)
 		v, changed := fastpathTV.DecMapUint16Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]uint8)
+		v := rv2i(rv).(map[uint16]uint8)
 		fastpathTV.DecMapUint16Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27672,43 +26102,33 @@ func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[uint16]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27719,13 +26139,13 @@ func (_ fastpathT) DecMapUint16Uint8V(v map[uint16]uint8, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint16Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]uint16)
+		vp := rv2i(rv.Addr()).(*map[uint16]uint16)
 		v, changed := fastpathTV.DecMapUint16Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]uint16)
+		v := rv2i(rv).(map[uint16]uint16)
 		fastpathTV.DecMapUint16Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27746,43 +26166,33 @@ func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 4)
 		v = make(map[uint16]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27793,13 +26203,13 @@ func (_ fastpathT) DecMapUint16Uint16V(v map[uint16]uint16, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint16Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]uint32)
+		vp := rv2i(rv.Addr()).(*map[uint16]uint32)
 		v, changed := fastpathTV.DecMapUint16Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]uint32)
+		v := rv2i(rv).(map[uint16]uint32)
 		fastpathTV.DecMapUint16Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27820,43 +26230,33 @@ func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[uint16]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27867,13 +26267,13 @@ func (_ fastpathT) DecMapUint16Uint32V(v map[uint16]uint32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint16Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]uint64)
+		vp := rv2i(rv.Addr()).(*map[uint16]uint64)
 		v, changed := fastpathTV.DecMapUint16Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]uint64)
+		v := rv2i(rv).(map[uint16]uint64)
 		fastpathTV.DecMapUint16Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27894,43 +26294,33 @@ func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint16]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -27941,13 +26331,13 @@ func (_ fastpathT) DecMapUint16Uint64V(v map[uint16]uint64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint16UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]uintptr)
+		vp := rv2i(rv.Addr()).(*map[uint16]uintptr)
 		v, changed := fastpathTV.DecMapUint16UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]uintptr)
+		v := rv2i(rv).(map[uint16]uintptr)
 		fastpathTV.DecMapUint16UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -27968,43 +26358,33 @@ func (_ fastpathT) DecMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint16]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28015,13 +26395,13 @@ func (_ fastpathT) DecMapUint16UintptrV(v map[uint16]uintptr, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint16IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]int)
+		vp := rv2i(rv.Addr()).(*map[uint16]int)
 		v, changed := fastpathTV.DecMapUint16IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]int)
+		v := rv2i(rv).(map[uint16]int)
 		fastpathTV.DecMapUint16IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28042,43 +26422,33 @@ func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint16]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28089,13 +26459,13 @@ func (_ fastpathT) DecMapUint16IntV(v map[uint16]int, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUint16Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]int8)
+		vp := rv2i(rv.Addr()).(*map[uint16]int8)
 		v, changed := fastpathTV.DecMapUint16Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]int8)
+		v := rv2i(rv).(map[uint16]int8)
 		fastpathTV.DecMapUint16Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28116,43 +26486,33 @@ func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[uint16]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28163,13 +26523,13 @@ func (_ fastpathT) DecMapUint16Int8V(v map[uint16]int8, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint16Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]int16)
+		vp := rv2i(rv.Addr()).(*map[uint16]int16)
 		v, changed := fastpathTV.DecMapUint16Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]int16)
+		v := rv2i(rv).(map[uint16]int16)
 		fastpathTV.DecMapUint16Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28190,43 +26550,33 @@ func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 4)
 		v = make(map[uint16]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28237,13 +26587,13 @@ func (_ fastpathT) DecMapUint16Int16V(v map[uint16]int16, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint16Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]int32)
+		vp := rv2i(rv.Addr()).(*map[uint16]int32)
 		v, changed := fastpathTV.DecMapUint16Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]int32)
+		v := rv2i(rv).(map[uint16]int32)
 		fastpathTV.DecMapUint16Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28264,43 +26614,33 @@ func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[uint16]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28311,13 +26651,13 @@ func (_ fastpathT) DecMapUint16Int32V(v map[uint16]int32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint16Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]int64)
+		vp := rv2i(rv.Addr()).(*map[uint16]int64)
 		v, changed := fastpathTV.DecMapUint16Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]int64)
+		v := rv2i(rv).(map[uint16]int64)
 		fastpathTV.DecMapUint16Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28338,43 +26678,33 @@ func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint16]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28385,13 +26715,13 @@ func (_ fastpathT) DecMapUint16Int64V(v map[uint16]int64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint16Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]float32)
+		vp := rv2i(rv.Addr()).(*map[uint16]float32)
 		v, changed := fastpathTV.DecMapUint16Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]float32)
+		v := rv2i(rv).(map[uint16]float32)
 		fastpathTV.DecMapUint16Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28412,43 +26742,33 @@ func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[uint16]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28459,13 +26779,13 @@ func (_ fastpathT) DecMapUint16Float32V(v map[uint16]float32, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint16Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]float64)
+		vp := rv2i(rv.Addr()).(*map[uint16]float64)
 		v, changed := fastpathTV.DecMapUint16Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]float64)
+		v := rv2i(rv).(map[uint16]float64)
 		fastpathTV.DecMapUint16Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28486,43 +26806,33 @@ func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint16]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28533,13 +26843,13 @@ func (_ fastpathT) DecMapUint16Float64V(v map[uint16]float64, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint16BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint16]bool)
+		vp := rv2i(rv.Addr()).(*map[uint16]bool)
 		v, changed := fastpathTV.DecMapUint16BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint16]bool)
+		v := rv2i(rv).(map[uint16]bool)
 		fastpathTV.DecMapUint16BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28560,43 +26870,33 @@ func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[uint16]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint16
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint16(dd.DecodeUint(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint16(dd.DecodeUint(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28607,13 +26907,13 @@ func (_ fastpathT) DecMapUint16BoolV(v map[uint16]bool, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint32IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]interface{})
+		vp := rv2i(rv.Addr()).(*map[uint32]interface{})
 		v, changed := fastpathTV.DecMapUint32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]interface{})
+		v := rv2i(rv).(map[uint32]interface{})
 		fastpathTV.DecMapUint32IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28634,53 +26934,38 @@ func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, ca
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[uint32]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk uint32
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28691,13 +26976,13 @@ func (_ fastpathT) DecMapUint32IntfV(v map[uint32]interface{}, checkNil bool, ca
 
 func (f *decFnInfo) fastpathDecMapUint32StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]string)
+		vp := rv2i(rv.Addr()).(*map[uint32]string)
 		v, changed := fastpathTV.DecMapUint32StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]string)
+		v := rv2i(rv).(map[uint32]string)
 		fastpathTV.DecMapUint32StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28718,43 +27003,33 @@ func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[uint32]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28765,13 +27040,13 @@ func (_ fastpathT) DecMapUint32StringV(v map[uint32]string, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint32UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]uint)
+		vp := rv2i(rv.Addr()).(*map[uint32]uint)
 		v, changed := fastpathTV.DecMapUint32UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]uint)
+		v := rv2i(rv).(map[uint32]uint)
 		fastpathTV.DecMapUint32UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28792,43 +27067,33 @@ func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint32]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28839,13 +27104,13 @@ func (_ fastpathT) DecMapUint32UintV(v map[uint32]uint, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint32Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]uint8)
+		vp := rv2i(rv.Addr()).(*map[uint32]uint8)
 		v, changed := fastpathTV.DecMapUint32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]uint8)
+		v := rv2i(rv).(map[uint32]uint8)
 		fastpathTV.DecMapUint32Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28866,43 +27131,33 @@ func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[uint32]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28913,13 +27168,13 @@ func (_ fastpathT) DecMapUint32Uint8V(v map[uint32]uint8, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint32Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]uint16)
+		vp := rv2i(rv.Addr()).(*map[uint32]uint16)
 		v, changed := fastpathTV.DecMapUint32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]uint16)
+		v := rv2i(rv).(map[uint32]uint16)
 		fastpathTV.DecMapUint32Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -28940,43 +27195,33 @@ func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[uint32]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -28987,13 +27232,13 @@ func (_ fastpathT) DecMapUint32Uint16V(v map[uint32]uint16, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint32Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]uint32)
+		vp := rv2i(rv.Addr()).(*map[uint32]uint32)
 		v, changed := fastpathTV.DecMapUint32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]uint32)
+		v := rv2i(rv).(map[uint32]uint32)
 		fastpathTV.DecMapUint32Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29014,43 +27259,33 @@ func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[uint32]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29061,13 +27296,13 @@ func (_ fastpathT) DecMapUint32Uint32V(v map[uint32]uint32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint32Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]uint64)
+		vp := rv2i(rv.Addr()).(*map[uint32]uint64)
 		v, changed := fastpathTV.DecMapUint32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]uint64)
+		v := rv2i(rv).(map[uint32]uint64)
 		fastpathTV.DecMapUint32Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29088,43 +27323,33 @@ func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint32]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29135,13 +27360,13 @@ func (_ fastpathT) DecMapUint32Uint64V(v map[uint32]uint64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint32UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]uintptr)
+		vp := rv2i(rv.Addr()).(*map[uint32]uintptr)
 		v, changed := fastpathTV.DecMapUint32UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]uintptr)
+		v := rv2i(rv).(map[uint32]uintptr)
 		fastpathTV.DecMapUint32UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29162,43 +27387,33 @@ func (_ fastpathT) DecMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint32]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29209,13 +27424,13 @@ func (_ fastpathT) DecMapUint32UintptrV(v map[uint32]uintptr, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint32IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]int)
+		vp := rv2i(rv.Addr()).(*map[uint32]int)
 		v, changed := fastpathTV.DecMapUint32IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]int)
+		v := rv2i(rv).(map[uint32]int)
 		fastpathTV.DecMapUint32IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29236,43 +27451,33 @@ func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint32]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29283,13 +27488,13 @@ func (_ fastpathT) DecMapUint32IntV(v map[uint32]int, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUint32Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]int8)
+		vp := rv2i(rv.Addr()).(*map[uint32]int8)
 		v, changed := fastpathTV.DecMapUint32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]int8)
+		v := rv2i(rv).(map[uint32]int8)
 		fastpathTV.DecMapUint32Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29310,43 +27515,33 @@ func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[uint32]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29357,13 +27552,13 @@ func (_ fastpathT) DecMapUint32Int8V(v map[uint32]int8, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint32Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]int16)
+		vp := rv2i(rv.Addr()).(*map[uint32]int16)
 		v, changed := fastpathTV.DecMapUint32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]int16)
+		v := rv2i(rv).(map[uint32]int16)
 		fastpathTV.DecMapUint32Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29384,43 +27579,33 @@ func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[uint32]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29431,13 +27616,13 @@ func (_ fastpathT) DecMapUint32Int16V(v map[uint32]int16, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint32Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]int32)
+		vp := rv2i(rv.Addr()).(*map[uint32]int32)
 		v, changed := fastpathTV.DecMapUint32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]int32)
+		v := rv2i(rv).(map[uint32]int32)
 		fastpathTV.DecMapUint32Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29458,43 +27643,33 @@ func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[uint32]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29505,13 +27680,13 @@ func (_ fastpathT) DecMapUint32Int32V(v map[uint32]int32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint32Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]int64)
+		vp := rv2i(rv.Addr()).(*map[uint32]int64)
 		v, changed := fastpathTV.DecMapUint32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]int64)
+		v := rv2i(rv).(map[uint32]int64)
 		fastpathTV.DecMapUint32Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29532,43 +27707,33 @@ func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint32]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29579,13 +27744,13 @@ func (_ fastpathT) DecMapUint32Int64V(v map[uint32]int64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint32Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]float32)
+		vp := rv2i(rv.Addr()).(*map[uint32]float32)
 		v, changed := fastpathTV.DecMapUint32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]float32)
+		v := rv2i(rv).(map[uint32]float32)
 		fastpathTV.DecMapUint32Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29606,43 +27771,33 @@ func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[uint32]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29653,13 +27808,13 @@ func (_ fastpathT) DecMapUint32Float32V(v map[uint32]float32, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint32Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]float64)
+		vp := rv2i(rv.Addr()).(*map[uint32]float64)
 		v, changed := fastpathTV.DecMapUint32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]float64)
+		v := rv2i(rv).(map[uint32]float64)
 		fastpathTV.DecMapUint32Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29680,43 +27835,33 @@ func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint32]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29727,13 +27872,13 @@ func (_ fastpathT) DecMapUint32Float64V(v map[uint32]float64, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint32BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint32]bool)
+		vp := rv2i(rv.Addr()).(*map[uint32]bool)
 		v, changed := fastpathTV.DecMapUint32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint32]bool)
+		v := rv2i(rv).(map[uint32]bool)
 		fastpathTV.DecMapUint32BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29754,43 +27899,33 @@ func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[uint32]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint32
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uint32(dd.DecodeUint(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uint32(dd.DecodeUint(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29801,13 +27936,13 @@ func (_ fastpathT) DecMapUint32BoolV(v map[uint32]bool, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint64IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]interface{})
+		vp := rv2i(rv.Addr()).(*map[uint64]interface{})
 		v, changed := fastpathTV.DecMapUint64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]interface{})
+		v := rv2i(rv).(map[uint64]interface{})
 		fastpathTV.DecMapUint64IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29828,53 +27963,38 @@ func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, ca
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[uint64]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk uint64
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29885,13 +28005,13 @@ func (_ fastpathT) DecMapUint64IntfV(v map[uint64]interface{}, checkNil bool, ca
 
 func (f *decFnInfo) fastpathDecMapUint64StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]string)
+		vp := rv2i(rv.Addr()).(*map[uint64]string)
 		v, changed := fastpathTV.DecMapUint64StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]string)
+		v := rv2i(rv).(map[uint64]string)
 		fastpathTV.DecMapUint64StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29912,43 +28032,33 @@ func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[uint64]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -29959,13 +28069,13 @@ func (_ fastpathT) DecMapUint64StringV(v map[uint64]string, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint64UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]uint)
+		vp := rv2i(rv.Addr()).(*map[uint64]uint)
 		v, changed := fastpathTV.DecMapUint64UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]uint)
+		v := rv2i(rv).(map[uint64]uint)
 		fastpathTV.DecMapUint64UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -29986,43 +28096,33 @@ func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint64]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30033,13 +28133,13 @@ func (_ fastpathT) DecMapUint64UintV(v map[uint64]uint, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint64Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]uint8)
+		vp := rv2i(rv.Addr()).(*map[uint64]uint8)
 		v, changed := fastpathTV.DecMapUint64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]uint8)
+		v := rv2i(rv).(map[uint64]uint8)
 		fastpathTV.DecMapUint64Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30060,43 +28160,33 @@ func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint64]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30107,13 +28197,13 @@ func (_ fastpathT) DecMapUint64Uint8V(v map[uint64]uint8, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint64Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]uint16)
+		vp := rv2i(rv.Addr()).(*map[uint64]uint16)
 		v, changed := fastpathTV.DecMapUint64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]uint16)
+		v := rv2i(rv).(map[uint64]uint16)
 		fastpathTV.DecMapUint64Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30134,43 +28224,33 @@ func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint64]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30181,13 +28261,13 @@ func (_ fastpathT) DecMapUint64Uint16V(v map[uint64]uint16, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint64Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]uint32)
+		vp := rv2i(rv.Addr()).(*map[uint64]uint32)
 		v, changed := fastpathTV.DecMapUint64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]uint32)
+		v := rv2i(rv).(map[uint64]uint32)
 		fastpathTV.DecMapUint64Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30208,43 +28288,33 @@ func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint64]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30255,13 +28325,13 @@ func (_ fastpathT) DecMapUint64Uint32V(v map[uint64]uint32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint64Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]uint64)
+		vp := rv2i(rv.Addr()).(*map[uint64]uint64)
 		v, changed := fastpathTV.DecMapUint64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]uint64)
+		v := rv2i(rv).(map[uint64]uint64)
 		fastpathTV.DecMapUint64Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30282,43 +28352,33 @@ func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint64]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30329,13 +28389,13 @@ func (_ fastpathT) DecMapUint64Uint64V(v map[uint64]uint64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUint64UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]uintptr)
+		vp := rv2i(rv.Addr()).(*map[uint64]uintptr)
 		v, changed := fastpathTV.DecMapUint64UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]uintptr)
+		v := rv2i(rv).(map[uint64]uintptr)
 		fastpathTV.DecMapUint64UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30356,43 +28416,33 @@ func (_ fastpathT) DecMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint64]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30403,13 +28453,13 @@ func (_ fastpathT) DecMapUint64UintptrV(v map[uint64]uintptr, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint64IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]int)
+		vp := rv2i(rv.Addr()).(*map[uint64]int)
 		v, changed := fastpathTV.DecMapUint64IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]int)
+		v := rv2i(rv).(map[uint64]int)
 		fastpathTV.DecMapUint64IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30430,43 +28480,33 @@ func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint64]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30477,13 +28517,13 @@ func (_ fastpathT) DecMapUint64IntV(v map[uint64]int, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapUint64Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]int8)
+		vp := rv2i(rv.Addr()).(*map[uint64]int8)
 		v, changed := fastpathTV.DecMapUint64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]int8)
+		v := rv2i(rv).(map[uint64]int8)
 		fastpathTV.DecMapUint64Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30504,43 +28544,33 @@ func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint64]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30551,13 +28581,13 @@ func (_ fastpathT) DecMapUint64Int8V(v map[uint64]int8, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUint64Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]int16)
+		vp := rv2i(rv.Addr()).(*map[uint64]int16)
 		v, changed := fastpathTV.DecMapUint64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]int16)
+		v := rv2i(rv).(map[uint64]int16)
 		fastpathTV.DecMapUint64Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30578,43 +28608,33 @@ func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uint64]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30625,13 +28645,13 @@ func (_ fastpathT) DecMapUint64Int16V(v map[uint64]int16, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint64Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]int32)
+		vp := rv2i(rv.Addr()).(*map[uint64]int32)
 		v, changed := fastpathTV.DecMapUint64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]int32)
+		v := rv2i(rv).(map[uint64]int32)
 		fastpathTV.DecMapUint64Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30652,43 +28672,33 @@ func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint64]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30699,13 +28709,13 @@ func (_ fastpathT) DecMapUint64Int32V(v map[uint64]int32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint64Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]int64)
+		vp := rv2i(rv.Addr()).(*map[uint64]int64)
 		v, changed := fastpathTV.DecMapUint64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]int64)
+		v := rv2i(rv).(map[uint64]int64)
 		fastpathTV.DecMapUint64Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30726,43 +28736,33 @@ func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint64]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30773,13 +28773,13 @@ func (_ fastpathT) DecMapUint64Int64V(v map[uint64]int64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUint64Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]float32)
+		vp := rv2i(rv.Addr()).(*map[uint64]float32)
 		v, changed := fastpathTV.DecMapUint64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]float32)
+		v := rv2i(rv).(map[uint64]float32)
 		fastpathTV.DecMapUint64Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30800,43 +28800,33 @@ func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uint64]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30847,13 +28837,13 @@ func (_ fastpathT) DecMapUint64Float32V(v map[uint64]float32, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint64Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]float64)
+		vp := rv2i(rv.Addr()).(*map[uint64]float64)
 		v, changed := fastpathTV.DecMapUint64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]float64)
+		v := rv2i(rv).(map[uint64]float64)
 		fastpathTV.DecMapUint64Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30874,43 +28864,33 @@ func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uint64]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30921,13 +28901,13 @@ func (_ fastpathT) DecMapUint64Float64V(v map[uint64]float64, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUint64BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uint64]bool)
+		vp := rv2i(rv.Addr()).(*map[uint64]bool)
 		v, changed := fastpathTV.DecMapUint64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uint64]bool)
+		v := rv2i(rv).(map[uint64]bool)
 		fastpathTV.DecMapUint64BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -30948,43 +28928,33 @@ func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uint64]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uint64
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeUint(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeUint(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -30995,13 +28965,13 @@ func (_ fastpathT) DecMapUint64BoolV(v map[uint64]bool, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUintptrIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]interface{})
+		vp := rv2i(rv.Addr()).(*map[uintptr]interface{})
 		v, changed := fastpathTV.DecMapUintptrIntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]interface{})
+		v := rv2i(rv).(map[uintptr]interface{})
 		fastpathTV.DecMapUintptrIntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31022,53 +28992,38 @@ func (_ fastpathT) DecMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, 
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[uintptr]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk uintptr
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31079,13 +29034,13 @@ func (_ fastpathT) DecMapUintptrIntfV(v map[uintptr]interface{}, checkNil bool, 
 
 func (f *decFnInfo) fastpathDecMapUintptrStringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]string)
+		vp := rv2i(rv.Addr()).(*map[uintptr]string)
 		v, changed := fastpathTV.DecMapUintptrStringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]string)
+		v := rv2i(rv).(map[uintptr]string)
 		fastpathTV.DecMapUintptrStringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31106,43 +29061,33 @@ func (_ fastpathT) DecMapUintptrStringV(v map[uintptr]string, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[uintptr]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31153,13 +29098,13 @@ func (_ fastpathT) DecMapUintptrStringV(v map[uintptr]string, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUintptrUintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]uint)
+		vp := rv2i(rv.Addr()).(*map[uintptr]uint)
 		v, changed := fastpathTV.DecMapUintptrUintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]uint)
+		v := rv2i(rv).(map[uintptr]uint)
 		fastpathTV.DecMapUintptrUintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31180,43 +29125,33 @@ func (_ fastpathT) DecMapUintptrUintV(v map[uintptr]uint, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uintptr]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31227,13 +29162,13 @@ func (_ fastpathT) DecMapUintptrUintV(v map[uintptr]uint, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUintptrUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]uint8)
+		vp := rv2i(rv.Addr()).(*map[uintptr]uint8)
 		v, changed := fastpathTV.DecMapUintptrUint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]uint8)
+		v := rv2i(rv).(map[uintptr]uint8)
 		fastpathTV.DecMapUintptrUint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31254,43 +29189,33 @@ func (_ fastpathT) DecMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uintptr]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31301,13 +29226,13 @@ func (_ fastpathT) DecMapUintptrUint8V(v map[uintptr]uint8, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUintptrUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]uint16)
+		vp := rv2i(rv.Addr()).(*map[uintptr]uint16)
 		v, changed := fastpathTV.DecMapUintptrUint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]uint16)
+		v := rv2i(rv).(map[uintptr]uint16)
 		fastpathTV.DecMapUintptrUint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31328,43 +29253,33 @@ func (_ fastpathT) DecMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uintptr]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31375,13 +29290,13 @@ func (_ fastpathT) DecMapUintptrUint16V(v map[uintptr]uint16, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUintptrUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]uint32)
+		vp := rv2i(rv.Addr()).(*map[uintptr]uint32)
 		v, changed := fastpathTV.DecMapUintptrUint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]uint32)
+		v := rv2i(rv).(map[uintptr]uint32)
 		fastpathTV.DecMapUintptrUint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31402,43 +29317,33 @@ func (_ fastpathT) DecMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uintptr]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31449,13 +29354,13 @@ func (_ fastpathT) DecMapUintptrUint32V(v map[uintptr]uint32, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUintptrUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]uint64)
+		vp := rv2i(rv.Addr()).(*map[uintptr]uint64)
 		v, changed := fastpathTV.DecMapUintptrUint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]uint64)
+		v := rv2i(rv).(map[uintptr]uint64)
 		fastpathTV.DecMapUintptrUint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31476,43 +29381,33 @@ func (_ fastpathT) DecMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, can
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uintptr]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31523,13 +29418,13 @@ func (_ fastpathT) DecMapUintptrUint64V(v map[uintptr]uint64, checkNil bool, can
 
 func (f *decFnInfo) fastpathDecMapUintptrUintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]uintptr)
+		vp := rv2i(rv.Addr()).(*map[uintptr]uintptr)
 		v, changed := fastpathTV.DecMapUintptrUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]uintptr)
+		v := rv2i(rv).(map[uintptr]uintptr)
 		fastpathTV.DecMapUintptrUintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31550,43 +29445,33 @@ func (_ fastpathT) DecMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uintptr]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31597,13 +29482,13 @@ func (_ fastpathT) DecMapUintptrUintptrV(v map[uintptr]uintptr, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapUintptrIntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]int)
+		vp := rv2i(rv.Addr()).(*map[uintptr]int)
 		v, changed := fastpathTV.DecMapUintptrIntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]int)
+		v := rv2i(rv).(map[uintptr]int)
 		fastpathTV.DecMapUintptrIntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31624,43 +29509,33 @@ func (_ fastpathT) DecMapUintptrIntV(v map[uintptr]int, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uintptr]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31671,13 +29546,13 @@ func (_ fastpathT) DecMapUintptrIntV(v map[uintptr]int, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapUintptrInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]int8)
+		vp := rv2i(rv.Addr()).(*map[uintptr]int8)
 		v, changed := fastpathTV.DecMapUintptrInt8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]int8)
+		v := rv2i(rv).(map[uintptr]int8)
 		fastpathTV.DecMapUintptrInt8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31698,43 +29573,33 @@ func (_ fastpathT) DecMapUintptrInt8V(v map[uintptr]int8, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uintptr]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31745,13 +29610,13 @@ func (_ fastpathT) DecMapUintptrInt8V(v map[uintptr]int8, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapUintptrInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]int16)
+		vp := rv2i(rv.Addr()).(*map[uintptr]int16)
 		v, changed := fastpathTV.DecMapUintptrInt16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]int16)
+		v := rv2i(rv).(map[uintptr]int16)
 		fastpathTV.DecMapUintptrInt16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31772,43 +29637,33 @@ func (_ fastpathT) DecMapUintptrInt16V(v map[uintptr]int16, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[uintptr]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31819,13 +29674,13 @@ func (_ fastpathT) DecMapUintptrInt16V(v map[uintptr]int16, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUintptrInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]int32)
+		vp := rv2i(rv.Addr()).(*map[uintptr]int32)
 		v, changed := fastpathTV.DecMapUintptrInt32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]int32)
+		v := rv2i(rv).(map[uintptr]int32)
 		fastpathTV.DecMapUintptrInt32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31846,43 +29701,33 @@ func (_ fastpathT) DecMapUintptrInt32V(v map[uintptr]int32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uintptr]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31893,13 +29738,13 @@ func (_ fastpathT) DecMapUintptrInt32V(v map[uintptr]int32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUintptrInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]int64)
+		vp := rv2i(rv.Addr()).(*map[uintptr]int64)
 		v, changed := fastpathTV.DecMapUintptrInt64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]int64)
+		v := rv2i(rv).(map[uintptr]int64)
 		fastpathTV.DecMapUintptrInt64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31920,43 +29765,33 @@ func (_ fastpathT) DecMapUintptrInt64V(v map[uintptr]int64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uintptr]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -31967,13 +29802,13 @@ func (_ fastpathT) DecMapUintptrInt64V(v map[uintptr]int64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapUintptrFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]float32)
+		vp := rv2i(rv.Addr()).(*map[uintptr]float32)
 		v, changed := fastpathTV.DecMapUintptrFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]float32)
+		v := rv2i(rv).(map[uintptr]float32)
 		fastpathTV.DecMapUintptrFloat32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -31994,43 +29829,33 @@ func (_ fastpathT) DecMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[uintptr]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32041,13 +29866,13 @@ func (_ fastpathT) DecMapUintptrFloat32V(v map[uintptr]float32, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapUintptrFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]float64)
+		vp := rv2i(rv.Addr()).(*map[uintptr]float64)
 		v, changed := fastpathTV.DecMapUintptrFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]float64)
+		v := rv2i(rv).(map[uintptr]float64)
 		fastpathTV.DecMapUintptrFloat64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32068,43 +29893,33 @@ func (_ fastpathT) DecMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, c
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[uintptr]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32115,13 +29930,13 @@ func (_ fastpathT) DecMapUintptrFloat64V(v map[uintptr]float64, checkNil bool, c
 
 func (f *decFnInfo) fastpathDecMapUintptrBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[uintptr]bool)
+		vp := rv2i(rv.Addr()).(*map[uintptr]bool)
 		v, changed := fastpathTV.DecMapUintptrBoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[uintptr]bool)
+		v := rv2i(rv).(map[uintptr]bool)
 		fastpathTV.DecMapUintptrBoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32142,43 +29957,33 @@ func (_ fastpathT) DecMapUintptrBoolV(v map[uintptr]bool, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[uintptr]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk uintptr
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = uintptr(dd.DecodeUint(uintBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = uintptr(dd.DecodeUint(uintBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32189,13 +29994,13 @@ func (_ fastpathT) DecMapUintptrBoolV(v map[uintptr]bool, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapIntIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]interface{})
+		vp := rv2i(rv.Addr()).(*map[int]interface{})
 		v, changed := fastpathTV.DecMapIntIntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]interface{})
+		v := rv2i(rv).(map[int]interface{})
 		fastpathTV.DecMapIntIntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32216,53 +30021,38 @@ func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChang
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[int]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk int
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32273,13 +30063,13 @@ func (_ fastpathT) DecMapIntIntfV(v map[int]interface{}, checkNil bool, canChang
 
 func (f *decFnInfo) fastpathDecMapIntStringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]string)
+		vp := rv2i(rv.Addr()).(*map[int]string)
 		v, changed := fastpathTV.DecMapIntStringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]string)
+		v := rv2i(rv).(map[int]string)
 		fastpathTV.DecMapIntStringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32300,43 +30090,33 @@ func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[int]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32347,13 +30127,13 @@ func (_ fastpathT) DecMapIntStringV(v map[int]string, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapIntUintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]uint)
+		vp := rv2i(rv.Addr()).(*map[int]uint)
 		v, changed := fastpathTV.DecMapIntUintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]uint)
+		v := rv2i(rv).(map[int]uint)
 		fastpathTV.DecMapIntUintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32374,43 +30154,33 @@ func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32421,13 +30191,13 @@ func (_ fastpathT) DecMapIntUintV(v map[int]uint, checkNil bool, canChange bool,
 
 func (f *decFnInfo) fastpathDecMapIntUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]uint8)
+		vp := rv2i(rv.Addr()).(*map[int]uint8)
 		v, changed := fastpathTV.DecMapIntUint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]uint8)
+		v := rv2i(rv).(map[int]uint8)
 		fastpathTV.DecMapIntUint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32448,43 +30218,33 @@ func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32495,13 +30255,13 @@ func (_ fastpathT) DecMapIntUint8V(v map[int]uint8, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapIntUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]uint16)
+		vp := rv2i(rv.Addr()).(*map[int]uint16)
 		v, changed := fastpathTV.DecMapIntUint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]uint16)
+		v := rv2i(rv).(map[int]uint16)
 		fastpathTV.DecMapIntUint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32522,43 +30282,33 @@ func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32569,13 +30319,13 @@ func (_ fastpathT) DecMapIntUint16V(v map[int]uint16, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapIntUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]uint32)
+		vp := rv2i(rv.Addr()).(*map[int]uint32)
 		v, changed := fastpathTV.DecMapIntUint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]uint32)
+		v := rv2i(rv).(map[int]uint32)
 		fastpathTV.DecMapIntUint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32596,43 +30346,33 @@ func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32643,13 +30383,13 @@ func (_ fastpathT) DecMapIntUint32V(v map[int]uint32, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapIntUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]uint64)
+		vp := rv2i(rv.Addr()).(*map[int]uint64)
 		v, changed := fastpathTV.DecMapIntUint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]uint64)
+		v := rv2i(rv).(map[int]uint64)
 		fastpathTV.DecMapIntUint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32670,43 +30410,33 @@ func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32717,13 +30447,13 @@ func (_ fastpathT) DecMapIntUint64V(v map[int]uint64, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapIntUintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]uintptr)
+		vp := rv2i(rv.Addr()).(*map[int]uintptr)
 		v, changed := fastpathTV.DecMapIntUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]uintptr)
+		v := rv2i(rv).(map[int]uintptr)
 		fastpathTV.DecMapIntUintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32744,43 +30474,33 @@ func (_ fastpathT) DecMapIntUintptrV(v map[int]uintptr, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32791,13 +30511,13 @@ func (_ fastpathT) DecMapIntUintptrV(v map[int]uintptr, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapIntIntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]int)
+		vp := rv2i(rv.Addr()).(*map[int]int)
 		v, changed := fastpathTV.DecMapIntIntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]int)
+		v := rv2i(rv).(map[int]int)
 		fastpathTV.DecMapIntIntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32818,43 +30538,33 @@ func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32865,13 +30575,13 @@ func (_ fastpathT) DecMapIntIntV(v map[int]int, checkNil bool, canChange bool,
 
 func (f *decFnInfo) fastpathDecMapIntInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]int8)
+		vp := rv2i(rv.Addr()).(*map[int]int8)
 		v, changed := fastpathTV.DecMapIntInt8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]int8)
+		v := rv2i(rv).(map[int]int8)
 		fastpathTV.DecMapIntInt8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32892,43 +30602,33 @@ func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -32939,13 +30639,13 @@ func (_ fastpathT) DecMapIntInt8V(v map[int]int8, checkNil bool, canChange bool,
 
 func (f *decFnInfo) fastpathDecMapIntInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]int16)
+		vp := rv2i(rv.Addr()).(*map[int]int16)
 		v, changed := fastpathTV.DecMapIntInt16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]int16)
+		v := rv2i(rv).(map[int]int16)
 		fastpathTV.DecMapIntInt16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -32966,43 +30666,33 @@ func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33013,13 +30703,13 @@ func (_ fastpathT) DecMapIntInt16V(v map[int]int16, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapIntInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]int32)
+		vp := rv2i(rv.Addr()).(*map[int]int32)
 		v, changed := fastpathTV.DecMapIntInt32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]int32)
+		v := rv2i(rv).(map[int]int32)
 		fastpathTV.DecMapIntInt32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33040,43 +30730,33 @@ func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33087,13 +30767,13 @@ func (_ fastpathT) DecMapIntInt32V(v map[int]int32, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapIntInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]int64)
+		vp := rv2i(rv.Addr()).(*map[int]int64)
 		v, changed := fastpathTV.DecMapIntInt64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]int64)
+		v := rv2i(rv).(map[int]int64)
 		fastpathTV.DecMapIntInt64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33114,43 +30794,33 @@ func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33161,13 +30831,13 @@ func (_ fastpathT) DecMapIntInt64V(v map[int]int64, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapIntFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]float32)
+		vp := rv2i(rv.Addr()).(*map[int]float32)
 		v, changed := fastpathTV.DecMapIntFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]float32)
+		v := rv2i(rv).(map[int]float32)
 		fastpathTV.DecMapIntFloat32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33188,43 +30858,33 @@ func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33235,13 +30895,13 @@ func (_ fastpathT) DecMapIntFloat32V(v map[int]float32, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapIntFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]float64)
+		vp := rv2i(rv.Addr()).(*map[int]float64)
 		v, changed := fastpathTV.DecMapIntFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]float64)
+		v := rv2i(rv).(map[int]float64)
 		fastpathTV.DecMapIntFloat64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33262,43 +30922,33 @@ func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33309,13 +30959,13 @@ func (_ fastpathT) DecMapIntFloat64V(v map[int]float64, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapIntBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int]bool)
+		vp := rv2i(rv.Addr()).(*map[int]bool)
 		v, changed := fastpathTV.DecMapIntBoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int]bool)
+		v := rv2i(rv).(map[int]bool)
 		fastpathTV.DecMapIntBoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33336,43 +30986,33 @@ func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int(dd.DecodeInt(intBitsize))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int(dd.DecodeInt(intBitsize))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33383,13 +31023,13 @@ func (_ fastpathT) DecMapIntBoolV(v map[int]bool, checkNil bool, canChange bool,
 
 func (f *decFnInfo) fastpathDecMapInt8IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]interface{})
+		vp := rv2i(rv.Addr()).(*map[int8]interface{})
 		v, changed := fastpathTV.DecMapInt8IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]interface{})
+		v := rv2i(rv).(map[int8]interface{})
 		fastpathTV.DecMapInt8IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33410,53 +31050,38 @@ func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canCha
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[int8]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk int8
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33467,13 +31092,13 @@ func (_ fastpathT) DecMapInt8IntfV(v map[int8]interface{}, checkNil bool, canCha
 
 func (f *decFnInfo) fastpathDecMapInt8StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]string)
+		vp := rv2i(rv.Addr()).(*map[int8]string)
 		v, changed := fastpathTV.DecMapInt8StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]string)
+		v := rv2i(rv).(map[int8]string)
 		fastpathTV.DecMapInt8StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33494,43 +31119,33 @@ func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[int8]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33541,13 +31156,13 @@ func (_ fastpathT) DecMapInt8StringV(v map[int8]string, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt8UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]uint)
+		vp := rv2i(rv.Addr()).(*map[int8]uint)
 		v, changed := fastpathTV.DecMapInt8UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]uint)
+		v := rv2i(rv).(map[int8]uint)
 		fastpathTV.DecMapInt8UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33568,43 +31183,33 @@ func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int8]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33615,13 +31220,13 @@ func (_ fastpathT) DecMapInt8UintV(v map[int8]uint, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapInt8Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]uint8)
+		vp := rv2i(rv.Addr()).(*map[int8]uint8)
 		v, changed := fastpathTV.DecMapInt8Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]uint8)
+		v := rv2i(rv).(map[int8]uint8)
 		fastpathTV.DecMapInt8Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33642,43 +31247,33 @@ func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[int8]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33689,13 +31284,13 @@ func (_ fastpathT) DecMapInt8Uint8V(v map[int8]uint8, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt8Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]uint16)
+		vp := rv2i(rv.Addr()).(*map[int8]uint16)
 		v, changed := fastpathTV.DecMapInt8Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]uint16)
+		v := rv2i(rv).(map[int8]uint16)
 		fastpathTV.DecMapInt8Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33716,43 +31311,33 @@ func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[int8]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33763,13 +31348,13 @@ func (_ fastpathT) DecMapInt8Uint16V(v map[int8]uint16, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt8Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]uint32)
+		vp := rv2i(rv.Addr()).(*map[int8]uint32)
 		v, changed := fastpathTV.DecMapInt8Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]uint32)
+		v := rv2i(rv).(map[int8]uint32)
 		fastpathTV.DecMapInt8Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33790,43 +31375,33 @@ func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[int8]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33837,13 +31412,13 @@ func (_ fastpathT) DecMapInt8Uint32V(v map[int8]uint32, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt8Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]uint64)
+		vp := rv2i(rv.Addr()).(*map[int8]uint64)
 		v, changed := fastpathTV.DecMapInt8Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]uint64)
+		v := rv2i(rv).(map[int8]uint64)
 		fastpathTV.DecMapInt8Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33864,43 +31439,33 @@ func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int8]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33911,13 +31476,13 @@ func (_ fastpathT) DecMapInt8Uint64V(v map[int8]uint64, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt8UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]uintptr)
+		vp := rv2i(rv.Addr()).(*map[int8]uintptr)
 		v, changed := fastpathTV.DecMapInt8UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]uintptr)
+		v := rv2i(rv).(map[int8]uintptr)
 		fastpathTV.DecMapInt8UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -33938,43 +31503,33 @@ func (_ fastpathT) DecMapInt8UintptrV(v map[int8]uintptr, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int8]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -33985,13 +31540,13 @@ func (_ fastpathT) DecMapInt8UintptrV(v map[int8]uintptr, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt8IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]int)
+		vp := rv2i(rv.Addr()).(*map[int8]int)
 		v, changed := fastpathTV.DecMapInt8IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]int)
+		v := rv2i(rv).(map[int8]int)
 		fastpathTV.DecMapInt8IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34012,43 +31567,33 @@ func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int8]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34059,13 +31604,13 @@ func (_ fastpathT) DecMapInt8IntV(v map[int8]int, checkNil bool, canChange bool,
 
 func (f *decFnInfo) fastpathDecMapInt8Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]int8)
+		vp := rv2i(rv.Addr()).(*map[int8]int8)
 		v, changed := fastpathTV.DecMapInt8Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]int8)
+		v := rv2i(rv).(map[int8]int8)
 		fastpathTV.DecMapInt8Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34086,43 +31631,33 @@ func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[int8]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34133,13 +31668,13 @@ func (_ fastpathT) DecMapInt8Int8V(v map[int8]int8, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapInt8Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]int16)
+		vp := rv2i(rv.Addr()).(*map[int8]int16)
 		v, changed := fastpathTV.DecMapInt8Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]int16)
+		v := rv2i(rv).(map[int8]int16)
 		fastpathTV.DecMapInt8Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34160,43 +31695,33 @@ func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[int8]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34207,13 +31732,13 @@ func (_ fastpathT) DecMapInt8Int16V(v map[int8]int16, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt8Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]int32)
+		vp := rv2i(rv.Addr()).(*map[int8]int32)
 		v, changed := fastpathTV.DecMapInt8Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]int32)
+		v := rv2i(rv).(map[int8]int32)
 		fastpathTV.DecMapInt8Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34234,43 +31759,33 @@ func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[int8]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34281,13 +31796,13 @@ func (_ fastpathT) DecMapInt8Int32V(v map[int8]int32, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt8Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]int64)
+		vp := rv2i(rv.Addr()).(*map[int8]int64)
 		v, changed := fastpathTV.DecMapInt8Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]int64)
+		v := rv2i(rv).(map[int8]int64)
 		fastpathTV.DecMapInt8Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34308,43 +31823,33 @@ func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int8]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34355,13 +31860,13 @@ func (_ fastpathT) DecMapInt8Int64V(v map[int8]int64, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt8Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]float32)
+		vp := rv2i(rv.Addr()).(*map[int8]float32)
 		v, changed := fastpathTV.DecMapInt8Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]float32)
+		v := rv2i(rv).(map[int8]float32)
 		fastpathTV.DecMapInt8Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34382,43 +31887,33 @@ func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[int8]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34429,13 +31924,13 @@ func (_ fastpathT) DecMapInt8Float32V(v map[int8]float32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt8Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]float64)
+		vp := rv2i(rv.Addr()).(*map[int8]float64)
 		v, changed := fastpathTV.DecMapInt8Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]float64)
+		v := rv2i(rv).(map[int8]float64)
 		fastpathTV.DecMapInt8Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34456,43 +31951,33 @@ func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int8]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34503,13 +31988,13 @@ func (_ fastpathT) DecMapInt8Float64V(v map[int8]float64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt8BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int8]bool)
+		vp := rv2i(rv.Addr()).(*map[int8]bool)
 		v, changed := fastpathTV.DecMapInt8BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int8]bool)
+		v := rv2i(rv).(map[int8]bool)
 		fastpathTV.DecMapInt8BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34530,43 +32015,33 @@ func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[int8]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int8
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int8(dd.DecodeInt(8))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int8(dd.DecodeInt(8))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34577,13 +32052,13 @@ func (_ fastpathT) DecMapInt8BoolV(v map[int8]bool, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapInt16IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]interface{})
+		vp := rv2i(rv.Addr()).(*map[int16]interface{})
 		v, changed := fastpathTV.DecMapInt16IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]interface{})
+		v := rv2i(rv).(map[int16]interface{})
 		fastpathTV.DecMapInt16IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34604,53 +32079,38 @@ func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canC
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 18)
 		v = make(map[int16]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk int16
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34661,13 +32121,13 @@ func (_ fastpathT) DecMapInt16IntfV(v map[int16]interface{}, checkNil bool, canC
 
 func (f *decFnInfo) fastpathDecMapInt16StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]string)
+		vp := rv2i(rv.Addr()).(*map[int16]string)
 		v, changed := fastpathTV.DecMapInt16StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]string)
+		v := rv2i(rv).(map[int16]string)
 		fastpathTV.DecMapInt16StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34688,43 +32148,33 @@ func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 18)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 18)
 		v = make(map[int16]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34735,13 +32185,13 @@ func (_ fastpathT) DecMapInt16StringV(v map[int16]string, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt16UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]uint)
+		vp := rv2i(rv.Addr()).(*map[int16]uint)
 		v, changed := fastpathTV.DecMapInt16UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]uint)
+		v := rv2i(rv).(map[int16]uint)
 		fastpathTV.DecMapInt16UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34762,43 +32212,33 @@ func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int16]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34809,13 +32249,13 @@ func (_ fastpathT) DecMapInt16UintV(v map[int16]uint, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt16Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]uint8)
+		vp := rv2i(rv.Addr()).(*map[int16]uint8)
 		v, changed := fastpathTV.DecMapInt16Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]uint8)
+		v := rv2i(rv).(map[int16]uint8)
 		fastpathTV.DecMapInt16Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34836,43 +32276,33 @@ func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[int16]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34883,13 +32313,13 @@ func (_ fastpathT) DecMapInt16Uint8V(v map[int16]uint8, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt16Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]uint16)
+		vp := rv2i(rv.Addr()).(*map[int16]uint16)
 		v, changed := fastpathTV.DecMapInt16Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]uint16)
+		v := rv2i(rv).(map[int16]uint16)
 		fastpathTV.DecMapInt16Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34910,43 +32340,33 @@ func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 4)
 		v = make(map[int16]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -34957,13 +32377,13 @@ func (_ fastpathT) DecMapInt16Uint16V(v map[int16]uint16, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt16Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]uint32)
+		vp := rv2i(rv.Addr()).(*map[int16]uint32)
 		v, changed := fastpathTV.DecMapInt16Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]uint32)
+		v := rv2i(rv).(map[int16]uint32)
 		fastpathTV.DecMapInt16Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -34984,43 +32404,33 @@ func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[int16]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35031,13 +32441,13 @@ func (_ fastpathT) DecMapInt16Uint32V(v map[int16]uint32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt16Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]uint64)
+		vp := rv2i(rv.Addr()).(*map[int16]uint64)
 		v, changed := fastpathTV.DecMapInt16Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]uint64)
+		v := rv2i(rv).(map[int16]uint64)
 		fastpathTV.DecMapInt16Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35058,43 +32468,33 @@ func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int16]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35105,13 +32505,13 @@ func (_ fastpathT) DecMapInt16Uint64V(v map[int16]uint64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt16UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]uintptr)
+		vp := rv2i(rv.Addr()).(*map[int16]uintptr)
 		v, changed := fastpathTV.DecMapInt16UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]uintptr)
+		v := rv2i(rv).(map[int16]uintptr)
 		fastpathTV.DecMapInt16UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35132,43 +32532,33 @@ func (_ fastpathT) DecMapInt16UintptrV(v map[int16]uintptr, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int16]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35179,13 +32569,13 @@ func (_ fastpathT) DecMapInt16UintptrV(v map[int16]uintptr, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt16IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]int)
+		vp := rv2i(rv.Addr()).(*map[int16]int)
 		v, changed := fastpathTV.DecMapInt16IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]int)
+		v := rv2i(rv).(map[int16]int)
 		fastpathTV.DecMapInt16IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35206,43 +32596,33 @@ func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int16]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35253,13 +32633,13 @@ func (_ fastpathT) DecMapInt16IntV(v map[int16]int, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapInt16Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]int8)
+		vp := rv2i(rv.Addr()).(*map[int16]int8)
 		v, changed := fastpathTV.DecMapInt16Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]int8)
+		v := rv2i(rv).(map[int16]int8)
 		fastpathTV.DecMapInt16Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35280,43 +32660,33 @@ func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[int16]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35327,13 +32697,13 @@ func (_ fastpathT) DecMapInt16Int8V(v map[int16]int8, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt16Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]int16)
+		vp := rv2i(rv.Addr()).(*map[int16]int16)
 		v, changed := fastpathTV.DecMapInt16Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]int16)
+		v := rv2i(rv).(map[int16]int16)
 		fastpathTV.DecMapInt16Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35354,43 +32724,33 @@ func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 4)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 4)
 		v = make(map[int16]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35401,13 +32761,13 @@ func (_ fastpathT) DecMapInt16Int16V(v map[int16]int16, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt16Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]int32)
+		vp := rv2i(rv.Addr()).(*map[int16]int32)
 		v, changed := fastpathTV.DecMapInt16Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]int32)
+		v := rv2i(rv).(map[int16]int32)
 		fastpathTV.DecMapInt16Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35428,43 +32788,33 @@ func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[int16]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35475,13 +32825,13 @@ func (_ fastpathT) DecMapInt16Int32V(v map[int16]int32, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt16Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]int64)
+		vp := rv2i(rv.Addr()).(*map[int16]int64)
 		v, changed := fastpathTV.DecMapInt16Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]int64)
+		v := rv2i(rv).(map[int16]int64)
 		fastpathTV.DecMapInt16Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35502,43 +32852,33 @@ func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int16]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35549,13 +32889,13 @@ func (_ fastpathT) DecMapInt16Int64V(v map[int16]int64, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt16Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]float32)
+		vp := rv2i(rv.Addr()).(*map[int16]float32)
 		v, changed := fastpathTV.DecMapInt16Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]float32)
+		v := rv2i(rv).(map[int16]float32)
 		fastpathTV.DecMapInt16Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35576,43 +32916,33 @@ func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[int16]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35623,13 +32953,13 @@ func (_ fastpathT) DecMapInt16Float32V(v map[int16]float32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt16Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]float64)
+		vp := rv2i(rv.Addr()).(*map[int16]float64)
 		v, changed := fastpathTV.DecMapInt16Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]float64)
+		v := rv2i(rv).(map[int16]float64)
 		fastpathTV.DecMapInt16Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35650,43 +32980,33 @@ func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int16]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35697,13 +33017,13 @@ func (_ fastpathT) DecMapInt16Float64V(v map[int16]float64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt16BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int16]bool)
+		vp := rv2i(rv.Addr()).(*map[int16]bool)
 		v, changed := fastpathTV.DecMapInt16BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int16]bool)
+		v := rv2i(rv).(map[int16]bool)
 		fastpathTV.DecMapInt16BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35724,43 +33044,33 @@ func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[int16]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int16
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int16(dd.DecodeInt(16))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int16(dd.DecodeInt(16))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35771,13 +33081,13 @@ func (_ fastpathT) DecMapInt16BoolV(v map[int16]bool, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt32IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]interface{})
+		vp := rv2i(rv.Addr()).(*map[int32]interface{})
 		v, changed := fastpathTV.DecMapInt32IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]interface{})
+		v := rv2i(rv).(map[int32]interface{})
 		fastpathTV.DecMapInt32IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35798,53 +33108,38 @@ func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canC
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[int32]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk int32
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35855,13 +33150,13 @@ func (_ fastpathT) DecMapInt32IntfV(v map[int32]interface{}, checkNil bool, canC
 
 func (f *decFnInfo) fastpathDecMapInt32StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]string)
+		vp := rv2i(rv.Addr()).(*map[int32]string)
 		v, changed := fastpathTV.DecMapInt32StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]string)
+		v := rv2i(rv).(map[int32]string)
 		fastpathTV.DecMapInt32StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35882,43 +33177,33 @@ func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 20)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 20)
 		v = make(map[int32]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -35929,13 +33214,13 @@ func (_ fastpathT) DecMapInt32StringV(v map[int32]string, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt32UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]uint)
+		vp := rv2i(rv.Addr()).(*map[int32]uint)
 		v, changed := fastpathTV.DecMapInt32UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]uint)
+		v := rv2i(rv).(map[int32]uint)
 		fastpathTV.DecMapInt32UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -35956,43 +33241,33 @@ func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int32]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36003,13 +33278,13 @@ func (_ fastpathT) DecMapInt32UintV(v map[int32]uint, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt32Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]uint8)
+		vp := rv2i(rv.Addr()).(*map[int32]uint8)
 		v, changed := fastpathTV.DecMapInt32Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]uint8)
+		v := rv2i(rv).(map[int32]uint8)
 		fastpathTV.DecMapInt32Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36030,43 +33305,33 @@ func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[int32]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36077,13 +33342,13 @@ func (_ fastpathT) DecMapInt32Uint8V(v map[int32]uint8, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt32Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]uint16)
+		vp := rv2i(rv.Addr()).(*map[int32]uint16)
 		v, changed := fastpathTV.DecMapInt32Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]uint16)
+		v := rv2i(rv).(map[int32]uint16)
 		fastpathTV.DecMapInt32Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36104,43 +33369,33 @@ func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[int32]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36151,13 +33406,13 @@ func (_ fastpathT) DecMapInt32Uint16V(v map[int32]uint16, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt32Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]uint32)
+		vp := rv2i(rv.Addr()).(*map[int32]uint32)
 		v, changed := fastpathTV.DecMapInt32Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]uint32)
+		v := rv2i(rv).(map[int32]uint32)
 		fastpathTV.DecMapInt32Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36178,43 +33433,33 @@ func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[int32]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36225,13 +33470,13 @@ func (_ fastpathT) DecMapInt32Uint32V(v map[int32]uint32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt32Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]uint64)
+		vp := rv2i(rv.Addr()).(*map[int32]uint64)
 		v, changed := fastpathTV.DecMapInt32Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]uint64)
+		v := rv2i(rv).(map[int32]uint64)
 		fastpathTV.DecMapInt32Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36252,43 +33497,33 @@ func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int32]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36299,13 +33534,13 @@ func (_ fastpathT) DecMapInt32Uint64V(v map[int32]uint64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt32UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]uintptr)
+		vp := rv2i(rv.Addr()).(*map[int32]uintptr)
 		v, changed := fastpathTV.DecMapInt32UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]uintptr)
+		v := rv2i(rv).(map[int32]uintptr)
 		fastpathTV.DecMapInt32UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36326,43 +33561,33 @@ func (_ fastpathT) DecMapInt32UintptrV(v map[int32]uintptr, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int32]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36373,13 +33598,13 @@ func (_ fastpathT) DecMapInt32UintptrV(v map[int32]uintptr, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt32IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]int)
+		vp := rv2i(rv.Addr()).(*map[int32]int)
 		v, changed := fastpathTV.DecMapInt32IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]int)
+		v := rv2i(rv).(map[int32]int)
 		fastpathTV.DecMapInt32IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36400,43 +33625,33 @@ func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int32]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36447,13 +33662,13 @@ func (_ fastpathT) DecMapInt32IntV(v map[int32]int, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapInt32Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]int8)
+		vp := rv2i(rv.Addr()).(*map[int32]int8)
 		v, changed := fastpathTV.DecMapInt32Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]int8)
+		v := rv2i(rv).(map[int32]int8)
 		fastpathTV.DecMapInt32Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36474,43 +33689,33 @@ func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[int32]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36521,13 +33726,13 @@ func (_ fastpathT) DecMapInt32Int8V(v map[int32]int8, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt32Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]int16)
+		vp := rv2i(rv.Addr()).(*map[int32]int16)
 		v, changed := fastpathTV.DecMapInt32Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]int16)
+		v := rv2i(rv).(map[int32]int16)
 		fastpathTV.DecMapInt32Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36548,43 +33753,33 @@ func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 6)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 6)
 		v = make(map[int32]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36595,13 +33790,13 @@ func (_ fastpathT) DecMapInt32Int16V(v map[int32]int16, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt32Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]int32)
+		vp := rv2i(rv.Addr()).(*map[int32]int32)
 		v, changed := fastpathTV.DecMapInt32Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]int32)
+		v := rv2i(rv).(map[int32]int32)
 		fastpathTV.DecMapInt32Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36622,43 +33817,33 @@ func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[int32]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36669,13 +33854,13 @@ func (_ fastpathT) DecMapInt32Int32V(v map[int32]int32, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt32Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]int64)
+		vp := rv2i(rv.Addr()).(*map[int32]int64)
 		v, changed := fastpathTV.DecMapInt32Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]int64)
+		v := rv2i(rv).(map[int32]int64)
 		fastpathTV.DecMapInt32Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36696,43 +33881,33 @@ func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int32]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36743,13 +33918,13 @@ func (_ fastpathT) DecMapInt32Int64V(v map[int32]int64, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt32Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]float32)
+		vp := rv2i(rv.Addr()).(*map[int32]float32)
 		v, changed := fastpathTV.DecMapInt32Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]float32)
+		v := rv2i(rv).(map[int32]float32)
 		fastpathTV.DecMapInt32Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36770,43 +33945,33 @@ func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 8)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 8)
 		v = make(map[int32]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36817,13 +33982,13 @@ func (_ fastpathT) DecMapInt32Float32V(v map[int32]float32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt32Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]float64)
+		vp := rv2i(rv.Addr()).(*map[int32]float64)
 		v, changed := fastpathTV.DecMapInt32Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]float64)
+		v := rv2i(rv).(map[int32]float64)
 		fastpathTV.DecMapInt32Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36844,43 +34009,33 @@ func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int32]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36891,13 +34046,13 @@ func (_ fastpathT) DecMapInt32Float64V(v map[int32]float64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt32BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int32]bool)
+		vp := rv2i(rv.Addr()).(*map[int32]bool)
 		v, changed := fastpathTV.DecMapInt32BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int32]bool)
+		v := rv2i(rv).(map[int32]bool)
 		fastpathTV.DecMapInt32BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36918,43 +34073,33 @@ func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[int32]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int32
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = int32(dd.DecodeInt(32))
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = int32(dd.DecodeInt(32))
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -36965,13 +34110,13 @@ func (_ fastpathT) DecMapInt32BoolV(v map[int32]bool, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt64IntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]interface{})
+		vp := rv2i(rv.Addr()).(*map[int64]interface{})
 		v, changed := fastpathTV.DecMapInt64IntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]interface{})
+		v := rv2i(rv).(map[int64]interface{})
 		fastpathTV.DecMapInt64IntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -36992,53 +34137,38 @@ func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canC
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[int64]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk int64
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37049,13 +34179,13 @@ func (_ fastpathT) DecMapInt64IntfV(v map[int64]interface{}, checkNil bool, canC
 
 func (f *decFnInfo) fastpathDecMapInt64StringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]string)
+		vp := rv2i(rv.Addr()).(*map[int64]string)
 		v, changed := fastpathTV.DecMapInt64StringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]string)
+		v := rv2i(rv).(map[int64]string)
 		fastpathTV.DecMapInt64StringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37076,43 +34206,33 @@ func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 24)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 24)
 		v = make(map[int64]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37123,13 +34243,13 @@ func (_ fastpathT) DecMapInt64StringV(v map[int64]string, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt64UintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]uint)
+		vp := rv2i(rv.Addr()).(*map[int64]uint)
 		v, changed := fastpathTV.DecMapInt64UintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]uint)
+		v := rv2i(rv).(map[int64]uint)
 		fastpathTV.DecMapInt64UintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37150,43 +34270,33 @@ func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int64]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37197,13 +34307,13 @@ func (_ fastpathT) DecMapInt64UintV(v map[int64]uint, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt64Uint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]uint8)
+		vp := rv2i(rv.Addr()).(*map[int64]uint8)
 		v, changed := fastpathTV.DecMapInt64Uint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]uint8)
+		v := rv2i(rv).(map[int64]uint8)
 		fastpathTV.DecMapInt64Uint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37224,43 +34334,33 @@ func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int64]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37271,13 +34371,13 @@ func (_ fastpathT) DecMapInt64Uint8V(v map[int64]uint8, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt64Uint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]uint16)
+		vp := rv2i(rv.Addr()).(*map[int64]uint16)
 		v, changed := fastpathTV.DecMapInt64Uint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]uint16)
+		v := rv2i(rv).(map[int64]uint16)
 		fastpathTV.DecMapInt64Uint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37298,43 +34398,33 @@ func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int64]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37345,13 +34435,13 @@ func (_ fastpathT) DecMapInt64Uint16V(v map[int64]uint16, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt64Uint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]uint32)
+		vp := rv2i(rv.Addr()).(*map[int64]uint32)
 		v, changed := fastpathTV.DecMapInt64Uint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]uint32)
+		v := rv2i(rv).(map[int64]uint32)
 		fastpathTV.DecMapInt64Uint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37372,43 +34462,33 @@ func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int64]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37419,13 +34499,13 @@ func (_ fastpathT) DecMapInt64Uint32V(v map[int64]uint32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt64Uint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]uint64)
+		vp := rv2i(rv.Addr()).(*map[int64]uint64)
 		v, changed := fastpathTV.DecMapInt64Uint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]uint64)
+		v := rv2i(rv).(map[int64]uint64)
 		fastpathTV.DecMapInt64Uint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37446,43 +34526,33 @@ func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int64]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37493,13 +34563,13 @@ func (_ fastpathT) DecMapInt64Uint64V(v map[int64]uint64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapInt64UintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]uintptr)
+		vp := rv2i(rv.Addr()).(*map[int64]uintptr)
 		v, changed := fastpathTV.DecMapInt64UintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]uintptr)
+		v := rv2i(rv).(map[int64]uintptr)
 		fastpathTV.DecMapInt64UintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37520,43 +34590,33 @@ func (_ fastpathT) DecMapInt64UintptrV(v map[int64]uintptr, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int64]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37567,13 +34627,13 @@ func (_ fastpathT) DecMapInt64UintptrV(v map[int64]uintptr, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt64IntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]int)
+		vp := rv2i(rv.Addr()).(*map[int64]int)
 		v, changed := fastpathTV.DecMapInt64IntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]int)
+		v := rv2i(rv).(map[int64]int)
 		fastpathTV.DecMapInt64IntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37594,43 +34654,33 @@ func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int64]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37641,13 +34691,13 @@ func (_ fastpathT) DecMapInt64IntV(v map[int64]int, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapInt64Int8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]int8)
+		vp := rv2i(rv.Addr()).(*map[int64]int8)
 		v, changed := fastpathTV.DecMapInt64Int8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]int8)
+		v := rv2i(rv).(map[int64]int8)
 		fastpathTV.DecMapInt64Int8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37668,43 +34718,33 @@ func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int64]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37715,13 +34755,13 @@ func (_ fastpathT) DecMapInt64Int8V(v map[int64]int8, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapInt64Int16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]int16)
+		vp := rv2i(rv.Addr()).(*map[int64]int16)
 		v, changed := fastpathTV.DecMapInt64Int16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]int16)
+		v := rv2i(rv).(map[int64]int16)
 		fastpathTV.DecMapInt64Int16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37742,43 +34782,33 @@ func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 10)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 10)
 		v = make(map[int64]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37789,13 +34819,13 @@ func (_ fastpathT) DecMapInt64Int16V(v map[int64]int16, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt64Int32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]int32)
+		vp := rv2i(rv.Addr()).(*map[int64]int32)
 		v, changed := fastpathTV.DecMapInt64Int32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]int32)
+		v := rv2i(rv).(map[int64]int32)
 		fastpathTV.DecMapInt64Int32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37816,43 +34846,33 @@ func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int64]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37863,13 +34883,13 @@ func (_ fastpathT) DecMapInt64Int32V(v map[int64]int32, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt64Int64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]int64)
+		vp := rv2i(rv.Addr()).(*map[int64]int64)
 		v, changed := fastpathTV.DecMapInt64Int64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]int64)
+		v := rv2i(rv).(map[int64]int64)
 		fastpathTV.DecMapInt64Int64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37890,43 +34910,33 @@ func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int64]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -37937,13 +34947,13 @@ func (_ fastpathT) DecMapInt64Int64V(v map[int64]int64, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapInt64Float32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]float32)
+		vp := rv2i(rv.Addr()).(*map[int64]float32)
 		v, changed := fastpathTV.DecMapInt64Float32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]float32)
+		v := rv2i(rv).(map[int64]float32)
 		fastpathTV.DecMapInt64Float32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -37964,43 +34974,33 @@ func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 12)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 12)
 		v = make(map[int64]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38011,13 +35011,13 @@ func (_ fastpathT) DecMapInt64Float32V(v map[int64]float32, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt64Float64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]float64)
+		vp := rv2i(rv.Addr()).(*map[int64]float64)
 		v, changed := fastpathTV.DecMapInt64Float64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]float64)
+		v := rv2i(rv).(map[int64]float64)
 		fastpathTV.DecMapInt64Float64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38038,43 +35038,33 @@ func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canCh
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 16)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 16)
 		v = make(map[int64]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38085,13 +35075,13 @@ func (_ fastpathT) DecMapInt64Float64V(v map[int64]float64, checkNil bool, canCh
 
 func (f *decFnInfo) fastpathDecMapInt64BoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[int64]bool)
+		vp := rv2i(rv.Addr()).(*map[int64]bool)
 		v, changed := fastpathTV.DecMapInt64BoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[int64]bool)
+		v := rv2i(rv).(map[int64]bool)
 		fastpathTV.DecMapInt64BoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38112,43 +35102,33 @@ func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[int64]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk int64
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeInt(64)
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeInt(64)
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38159,13 +35139,13 @@ func (_ fastpathT) DecMapInt64BoolV(v map[int64]bool, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapBoolIntfR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]interface{})
+		vp := rv2i(rv.Addr()).(*map[bool]interface{})
 		v, changed := fastpathTV.DecMapBoolIntfV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]interface{})
+		v := rv2i(rv).(map[bool]interface{})
 		fastpathTV.DecMapBoolIntfV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38186,53 +35166,38 @@ func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canCha
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[bool]interface{}, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 	mapGet := !d.h.MapValueReset && !d.h.InterfaceReset
 	var mk bool
 	var mv interface{}
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			if mapGet {
-				mv = v[mk]
-			} else {
-				mv = nil
-			}
-			d.decode(&mv)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		if mapGet {
+			mv = v[mk]
+		} else {
+			mv = nil
+		}
+		d.decode(&mv)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38243,13 +35208,13 @@ func (_ fastpathT) DecMapBoolIntfV(v map[bool]interface{}, checkNil bool, canCha
 
 func (f *decFnInfo) fastpathDecMapBoolStringR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]string)
+		vp := rv2i(rv.Addr()).(*map[bool]string)
 		v, changed := fastpathTV.DecMapBoolStringV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]string)
+		v := rv2i(rv).(map[bool]string)
 		fastpathTV.DecMapBoolStringV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38270,43 +35235,33 @@ func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 17)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 17)
 		v = make(map[bool]string, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv string
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeString()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeString()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38317,13 +35272,13 @@ func (_ fastpathT) DecMapBoolStringV(v map[bool]string, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapBoolUintR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]uint)
+		vp := rv2i(rv.Addr()).(*map[bool]uint)
 		v, changed := fastpathTV.DecMapBoolUintV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]uint)
+		v := rv2i(rv).(map[bool]uint)
 		fastpathTV.DecMapBoolUintV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38344,43 +35299,33 @@ func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[bool]uint, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv uint
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38391,13 +35336,13 @@ func (_ fastpathT) DecMapBoolUintV(v map[bool]uint, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapBoolUint8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]uint8)
+		vp := rv2i(rv.Addr()).(*map[bool]uint8)
 		v, changed := fastpathTV.DecMapBoolUint8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]uint8)
+		v := rv2i(rv).(map[bool]uint8)
 		fastpathTV.DecMapBoolUint8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38418,43 +35363,33 @@ func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[bool]uint8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv uint8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint8(dd.DecodeUint(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint8(dd.DecodeUint(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38465,13 +35400,13 @@ func (_ fastpathT) DecMapBoolUint8V(v map[bool]uint8, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapBoolUint16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]uint16)
+		vp := rv2i(rv.Addr()).(*map[bool]uint16)
 		v, changed := fastpathTV.DecMapBoolUint16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]uint16)
+		v := rv2i(rv).(map[bool]uint16)
 		fastpathTV.DecMapBoolUint16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38492,43 +35427,33 @@ func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[bool]uint16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv uint16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint16(dd.DecodeUint(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint16(dd.DecodeUint(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38539,13 +35464,13 @@ func (_ fastpathT) DecMapBoolUint16V(v map[bool]uint16, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapBoolUint32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]uint32)
+		vp := rv2i(rv.Addr()).(*map[bool]uint32)
 		v, changed := fastpathTV.DecMapBoolUint32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]uint32)
+		v := rv2i(rv).(map[bool]uint32)
 		fastpathTV.DecMapBoolUint32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38566,43 +35491,33 @@ func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[bool]uint32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv uint32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uint32(dd.DecodeUint(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uint32(dd.DecodeUint(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38613,13 +35528,13 @@ func (_ fastpathT) DecMapBoolUint32V(v map[bool]uint32, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapBoolUint64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]uint64)
+		vp := rv2i(rv.Addr()).(*map[bool]uint64)
 		v, changed := fastpathTV.DecMapBoolUint64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]uint64)
+		v := rv2i(rv).(map[bool]uint64)
 		fastpathTV.DecMapBoolUint64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38640,43 +35555,33 @@ func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[bool]uint64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv uint64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeUint(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeUint(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38687,13 +35592,13 @@ func (_ fastpathT) DecMapBoolUint64V(v map[bool]uint64, checkNil bool, canChange
 
 func (f *decFnInfo) fastpathDecMapBoolUintptrR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]uintptr)
+		vp := rv2i(rv.Addr()).(*map[bool]uintptr)
 		v, changed := fastpathTV.DecMapBoolUintptrV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]uintptr)
+		v := rv2i(rv).(map[bool]uintptr)
 		fastpathTV.DecMapBoolUintptrV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38714,43 +35619,33 @@ func (_ fastpathT) DecMapBoolUintptrV(v map[bool]uintptr, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[bool]uintptr, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv uintptr
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = uintptr(dd.DecodeUint(uintBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = uintptr(dd.DecodeUint(uintBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38761,13 +35656,13 @@ func (_ fastpathT) DecMapBoolUintptrV(v map[bool]uintptr, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapBoolIntR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]int)
+		vp := rv2i(rv.Addr()).(*map[bool]int)
 		v, changed := fastpathTV.DecMapBoolIntV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]int)
+		v := rv2i(rv).(map[bool]int)
 		fastpathTV.DecMapBoolIntV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38788,43 +35683,33 @@ func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[bool]int, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv int
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int(dd.DecodeInt(intBitsize))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int(dd.DecodeInt(intBitsize))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38835,13 +35720,13 @@ func (_ fastpathT) DecMapBoolIntV(v map[bool]int, checkNil bool, canChange bool,
 
 func (f *decFnInfo) fastpathDecMapBoolInt8R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]int8)
+		vp := rv2i(rv.Addr()).(*map[bool]int8)
 		v, changed := fastpathTV.DecMapBoolInt8V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]int8)
+		v := rv2i(rv).(map[bool]int8)
 		fastpathTV.DecMapBoolInt8V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38862,43 +35747,33 @@ func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[bool]int8, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv int8
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int8(dd.DecodeInt(8))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int8(dd.DecodeInt(8))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38909,13 +35784,13 @@ func (_ fastpathT) DecMapBoolInt8V(v map[bool]int8, checkNil bool, canChange boo
 
 func (f *decFnInfo) fastpathDecMapBoolInt16R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]int16)
+		vp := rv2i(rv.Addr()).(*map[bool]int16)
 		v, changed := fastpathTV.DecMapBoolInt16V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]int16)
+		v := rv2i(rv).(map[bool]int16)
 		fastpathTV.DecMapBoolInt16V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -38936,43 +35811,33 @@ func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 3)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 3)
 		v = make(map[bool]int16, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv int16
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int16(dd.DecodeInt(16))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int16(dd.DecodeInt(16))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -38983,13 +35848,13 @@ func (_ fastpathT) DecMapBoolInt16V(v map[bool]int16, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapBoolInt32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]int32)
+		vp := rv2i(rv.Addr()).(*map[bool]int32)
 		v, changed := fastpathTV.DecMapBoolInt32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]int32)
+		v := rv2i(rv).(map[bool]int32)
 		fastpathTV.DecMapBoolInt32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -39010,43 +35875,33 @@ func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[bool]int32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv int32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = int32(dd.DecodeInt(32))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = int32(dd.DecodeInt(32))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -39057,13 +35912,13 @@ func (_ fastpathT) DecMapBoolInt32V(v map[bool]int32, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapBoolInt64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]int64)
+		vp := rv2i(rv.Addr()).(*map[bool]int64)
 		v, changed := fastpathTV.DecMapBoolInt64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]int64)
+		v := rv2i(rv).(map[bool]int64)
 		fastpathTV.DecMapBoolInt64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -39084,43 +35939,33 @@ func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange b
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[bool]int64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv int64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeInt(64)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeInt(64)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -39131,13 +35976,13 @@ func (_ fastpathT) DecMapBoolInt64V(v map[bool]int64, checkNil bool, canChange b
 
 func (f *decFnInfo) fastpathDecMapBoolFloat32R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]float32)
+		vp := rv2i(rv.Addr()).(*map[bool]float32)
 		v, changed := fastpathTV.DecMapBoolFloat32V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]float32)
+		v := rv2i(rv).(map[bool]float32)
 		fastpathTV.DecMapBoolFloat32V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -39158,43 +36003,33 @@ func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 5)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 5)
 		v = make(map[bool]float32, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv float32
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = float32(dd.DecodeFloat(true))
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = float32(dd.DecodeFloat(true))
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -39205,13 +36040,13 @@ func (_ fastpathT) DecMapBoolFloat32V(v map[bool]float32, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapBoolFloat64R(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]float64)
+		vp := rv2i(rv.Addr()).(*map[bool]float64)
 		v, changed := fastpathTV.DecMapBoolFloat64V(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]float64)
+		v := rv2i(rv).(map[bool]float64)
 		fastpathTV.DecMapBoolFloat64V(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -39232,43 +36067,33 @@ func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChan
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 9)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 9)
 		v = make(map[bool]float64, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv float64
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeFloat(false)
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeFloat(false)
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {
@@ -39279,13 +36104,13 @@ func (_ fastpathT) DecMapBoolFloat64V(v map[bool]float64, checkNil bool, canChan
 
 func (f *decFnInfo) fastpathDecMapBoolBoolR(rv reflect.Value) {
 	if rv.CanAddr() {
-		vp := rv.Addr().Interface().(*map[bool]bool)
+		vp := rv2i(rv.Addr()).(*map[bool]bool)
 		v, changed := fastpathTV.DecMapBoolBoolV(*vp, fastpathCheckNilFalse, true, f.d)
 		if changed {
 			*vp = v
 		}
 	} else {
-		v := rv.Interface().(map[bool]bool)
+		v := rv2i(rv).(map[bool]bool)
 		fastpathTV.DecMapBoolBoolV(v, fastpathCheckNilFalse, false, f.d)
 	}
 }
@@ -39306,43 +36131,33 @@ func (_ fastpathT) DecMapBoolBoolV(v map[bool]bool, checkNil bool, canChange boo
 		}
 		return nil, changed
 	}
-
 	containerLen := dd.ReadMapStart()
 	if canChange && v == nil {
-		xlen, _ := decInferLen(containerLen, d.h.MaxInitLen, 2)
+		xlen := decInferLen(containerLen, d.h.MaxInitLen, 2)
 		v = make(map[bool]bool, xlen)
 		changed = true
+	}
+	if containerLen == 0 {
+		if cr != nil {
+			cr.sendContainerState(containerMapEnd)
+		}
+		return v, changed
 	}
 
 	var mk bool
 	var mv bool
-	if containerLen > 0 {
-		for j := 0; j < containerLen; j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+	hasLen := containerLen > 0
+	for j := 0; (hasLen && j < containerLen) || !(hasLen || dd.CheckBreak()); j++ {
+		if cr != nil {
+			cr.sendContainerState(containerMapKey)
 		}
-	} else if containerLen < 0 {
-		for j := 0; !dd.CheckBreak(); j++ {
-			if cr != nil {
-				cr.sendContainerState(containerMapKey)
-			}
-			mk = dd.DecodeBool()
-			if cr != nil {
-				cr.sendContainerState(containerMapValue)
-			}
-			mv = dd.DecodeBool()
-			if v != nil {
-				v[mk] = mv
-			}
+		mk = dd.DecodeBool()
+		if cr != nil {
+			cr.sendContainerState(containerMapValue)
+		}
+		mv = dd.DecodeBool()
+		if v != nil {
+			v[mk] = mv
 		}
 	}
 	if cr != nil {

--- a/cmd/vendor/github.com/ugorji/go/codec/gen.generated.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/gen.generated.go
@@ -10,7 +10,7 @@ const genDecMapTmpl = `
 {{var "l"}} := r.ReadMapStart()
 {{var "bh"}} := z.DecBasicHandle()
 if {{var "v"}} == nil {
-	{{var "rl"}}, _ := z.DecInferLen({{var "l"}}, {{var "bh"}}.MaxInitLen, {{ .Size }})
+	{{var "rl"}} := z.DecInferLen({{var "l"}}, {{var "bh"}}.MaxInitLen, {{ .Size }})
 	{{var "v"}} = make(map[{{ .KTyp }}]{{ .Typ }}, {{var "rl"}})
 	*{{ .Varname }} = {{var "v"}}
 }
@@ -22,34 +22,15 @@ if {{var "bh"}}.MapValueReset {
 	{{else if decElemKindIntf}}if !{{var "bh"}}.InterfaceReset { {{var "mg"}} = true }
 	{{else if not decElemKindImmutable}}{{var "mg"}} = true
 	{{end}} }
-if {{var "l"}} > 0  {
-for {{var "j"}} := 0; {{var "j"}} < {{var "l"}}; {{var "j"}}++ {
+if {{var "l"}} != 0 {
+{{var "hl"}} := {{var "l"}} > 0 
+	for {{var "j"}} := 0; ({{var "hl"}} && {{var "j"}} < {{var "l"}}) || !({{var "hl"}} || r.CheckBreak()); {{var "j"}}++ {
 	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
 	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
 {{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
 		{{var "mk"}} = string({{var "bv"}})
 	}{{ end }}{{if decElemKindPtr}}
 	{{var "ms"}} = true{{end}}
-	if {{var "mg"}} {
-		{{if decElemKindPtr}}{{var "mv"}}, {{var "mok"}} = {{var "v"}}[{{var "mk"}}] 
-		if {{var "mok"}} {
-			{{var "ms"}} = false
-		} {{else}}{{var "mv"}} = {{var "v"}}[{{var "mk"}}] {{end}}
-	} {{if not decElemKindImmutable}}else { {{var "mv"}} = {{decElemZero}} }{{end}}
-	z.DecSendContainerState(codecSelfer_containerMapValue{{ .Sfx }})
-	{{ $x := printf "%vmv%v" .TempVar .Rand }}{{ decLineVar $x }}
-	if {{if decElemKindPtr}} {{var "ms"}} && {{end}} {{var "v"}} != nil {
-		{{var "v"}}[{{var "mk"}}] = {{var "mv"}}
-	}
-}
-} else if {{var "l"}} < 0  {
-for {{var "j"}} := 0; !r.CheckBreak(); {{var "j"}}++ {
-	z.DecSendContainerState(codecSelfer_containerMapKey{{ .Sfx }})
-	{{ $x := printf "%vmk%v" .TempVar .Rand }}{{ decLineVarK $x }}
-{{ if eq .KTyp "interface{}" }}{{/* // special case if a byte array. */}}if {{var "bv"}}, {{var "bok"}} := {{var "mk"}}.([]byte); {{var "bok"}} {
-		{{var "mk"}} = string({{var "bv"}})
-	}{{ end }}{{if decElemKindPtr}}
-	{{var "ms"}} = true {{ end }}
 	if {{var "mg"}} {
 		{{if decElemKindPtr}}{{var "mv"}}, {{var "mok"}} = {{var "v"}}[{{var "mk"}}] 
 		if {{var "mok"}} {
@@ -82,94 +63,60 @@ if {{var "l"}} == 0 {
 		{{var "v"}} = make({{ .CTyp }}, 0)
 		{{var "c"}} = true
 	} {{end}}
-} else if {{var "l"}} > 0 {
-	{{if isChan }}if {{var "v"}} == nil {
-		{{var "rl"}}, _ = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
-		{{var "v"}} = make({{ .CTyp }}, {{var "rl"}})
-		{{var "c"}} = true
-	}
-	for {{var "r"}} := 0; {{var "r"}} < {{var "l"}}; {{var "r"}}++ {
-		{{var "h"}}.ElemContainerState({{var "r"}})
-		var {{var "t"}} {{ .Typ }}
-		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
-		{{var "v"}} <- {{var "t"}}
-	}
-	{{ else }}	var {{var "rr"}}, {{var "rl"}} int {{/* // num2read, length of slice/array/chan */}}
-	var {{var "rt"}} bool {{/* truncated */}}
-	_, _ = {{var "rl"}}, {{var "rt"}}
-	{{var "rr"}} = {{var "l"}} // len({{var "v"}})
+} else {
+	{{var "hl"}} := {{var "l"}} > 0
+	var {{var "rl"}} int 
+	{{if isSlice }} if {{var "hl"}} {
 	if {{var "l"}} > cap({{var "v"}}) {
-		{{if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "l"}})
-		{{ else }}{{if not .Immutable }}
-		{{var "rg"}} := len({{var "v"}}) > 0
-		{{var "v2"}} := {{var "v"}} {{end}}
-		{{var "rl"}}, {{var "rt"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
-		if {{var "rt"}} {
-			if {{var "rl"}} <= cap({{var "v"}}) {
-				{{var "v"}} = {{var "v"}}[:{{var "rl"}}]
-			} else {
-				{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
-			}
+		{{var "rl"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+		if {{var "rl"}} <= cap({{var "v"}}) {
+			{{var "v"}} = {{var "v"}}[:{{var "rl"}}]
 		} else {
 			{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
 		}
 		{{var "c"}} = true
-		{{var "rr"}} = len({{var "v"}}) {{if not .Immutable }}
-			if {{var "rg"}} { copy({{var "v"}}, {{var "v2"}}) } {{end}} {{end}}{{/* end not Immutable, isArray */}}
-	} {{if isSlice }} else if {{var "l"}} != len({{var "v"}}) {
+	} else if {{var "l"}} != len({{var "v"}}) {
 		{{var "v"}} = {{var "v"}}[:{{var "l"}}]
 		{{var "c"}} = true
-	} {{end}}	{{/* end isSlice:47 */}} 
+	}
+	} {{end}}
 	{{var "j"}} := 0
-	for ; {{var "j"}} < {{var "rr"}} ; {{var "j"}}++ {
-		{{var "h"}}.ElemContainerState({{var "j"}})
-		{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
-	}
-	{{if isArray }}for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
-		{{var "h"}}.ElemContainerState({{var "j"}})
-		z.DecSwallow()
-	}
-	{{ else }}if {{var "rt"}} {
-		for ; {{var "j"}} < {{var "l"}} ; {{var "j"}}++ {
-			{{var "v"}} = append({{var "v"}}, {{ zero}})
-			{{var "h"}}.ElemContainerState({{var "j"}})
-			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
+	for ; ({{var "hl"}} && {{var "j"}} < {{var "l"}}) || !({{var "hl"}} || r.CheckBreak()); {{var "j"}}++ {
+		if {{var "j"}} == 0 && len({{var "v"}}) == 0 {
+			if {{var "hl"}} {
+				{{var "rl"}} = z.DecInferLen({{var "l"}}, z.DecBasicHandle().MaxInitLen, {{ .Size }})
+			} else {
+				{{var "rl"}} = 8
+			}
+			{{var "v"}} = make([]{{ .Typ }}, {{var "rl"}})
+			{{var "c"}} = true 
 		}
-	} {{end}} {{/* end isArray:56 */}}
-	{{end}} {{/* end isChan:16 */}}
-} else { {{/* len < 0 */}}
-	{{var "j"}} := 0
-	for ; !r.CheckBreak(); {{var "j"}}++ {
-		{{if isChan }}
-		{{var "h"}}.ElemContainerState({{var "j"}})
-		var {{var "t"}} {{ .Typ }}
-		{{ $x := printf "%st%s" .TempVar .Rand }}{{ decLineVar $x }}
-		{{var "v"}} <- {{var "t"}} 
-		{{ else }}
+		// if indefinite, etc, then expand the slice if necessary
+		var {{var "db"}} bool
 		if {{var "j"}} >= len({{var "v"}}) {
-			{{if isArray }}z.DecArrayCannotExpand(len({{var "v"}}), {{var "j"}}+1)
-			{{ else }}{{var "v"}} = append({{var "v"}}, {{zero}})// var {{var "z"}} {{ .Typ }}
-			{{var "c"}} = true {{end}}
+			{{if isSlice }} {{var "v"}} = append({{var "v"}}, {{ zero }}); {{var "c"}} = true
+			{{end}} {{if isArray}} z.DecArrayCannotExpand(len(v), {{var "j"}}+1); {{var "db"}} = true
+			{{end}}
 		}
 		{{var "h"}}.ElemContainerState({{var "j"}})
-		if {{var "j"}} < len({{var "v"}}) {
-			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
-		} else {
+		if {{var "db"}} {
 			z.DecSwallow()
+		} else {
+			{{ $x := printf "%[1]vv%[2]v[%[1]vj%[2]v]" .TempVar .Rand }}{{ decLineVar $x }}
 		}
-		{{end}}
 	}
-	{{if isSlice }}if {{var "j"}} < len({{var "v"}}) {
+	{{if isSlice}} if {{var "j"}} < len({{var "v"}}) {
 		{{var "v"}} = {{var "v"}}[:{{var "j"}}]
 		{{var "c"}} = true
 	} else if {{var "j"}} == 0 && {{var "v"}} == nil {
-		{{var "v"}} = []{{ .Typ }}{}
+		{{var "v"}} = make([]{{ .Typ }}, 0)
 		{{var "c"}} = true
-	}{{end}}
+	} {{end}}
 }
 {{var "h"}}.End()
 {{if not isArray }}if {{var "c"}} { 
 	*{{ .Varname }} = {{var "v"}}
 }{{end}}
+
 `
 

--- a/cmd/vendor/github.com/ugorji/go/codec/gen.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/gen.go
@@ -1,3 +1,5 @@
+// +build codecgen.exec
+
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
 
@@ -80,6 +82,10 @@ import (
 // Note:
 //   It was a conscious decision to have gen.go always explicitly call EncodeNil or TryDecodeAsNil.
 //   This way, there isn't a function call overhead just to see that we should not enter a block of code.
+//
+// Note:
+//   codecgen-generated code depends on the variables defined by fast-path.generated.go.
+//   consequently, you cannot run with tags "codecgen notfastpath".
 
 // GenVersion is the current version of codecgen.
 //
@@ -94,7 +100,8 @@ import (
 //     changes in signature of some unpublished helper methods and codecgen cmdline arguments.
 // v4: Removed separator support from (en|de)cDriver, and refactored codec(gen)
 // v5: changes to support faster json decoding. Let encoder/decoder maintain state of collections.
-const GenVersion = 5
+// v6: removed unsafe from gen, and now uses codecgen.exec tag
+const genVersion = 6
 
 const (
 	genCodecPkg        = "codec1978"
@@ -126,7 +133,6 @@ var (
 	genExpectArrayOrMapErr = errors.New("unexpected type. Expecting array/map/slice")
 	genBase64enc           = base64.NewEncoding("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789__")
 	genQNameRegex          = regexp.MustCompile(`[A-Za-z_.]+`)
-	genCheckVendor         bool
 )
 
 // genRunner holds some state used during a Gen run.
@@ -147,8 +153,7 @@ type genRunner struct {
 	is map[reflect.Type]struct{} // types seen during import search
 	bp string                    // base PkgPath, for which we are generating for
 
-	cpfx   string // codec package prefix
-	unsafe bool   // is unsafe to be used in generated code?
+	cpfx string // codec package prefix
 
 	tm map[reflect.Type]struct{} // types for which enc/dec must be generated
 	ts []reflect.Type            // types for which enc/dec must be generated
@@ -163,8 +168,8 @@ type genRunner struct {
 // Gen will write a complete go file containing Selfer implementations for each
 // type passed. All the types must be in the same package.
 //
-// Library users: *DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.*
-func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, ti *TypeInfos, typ ...reflect.Type) {
+// Library users: DO NOT USE IT DIRECTLY. IT WILL CHANGE CONTINOUSLY WITHOUT NOTICE.
+func Gen(w io.Writer, buildTags, pkgName, uid string, ti *TypeInfos, typ ...reflect.Type) {
 	// All types passed to this method do not have a codec.Selfer method implemented directly.
 	// codecgen already checks the AST and skips any types that define the codec.Selfer methods.
 	// Consequently, there's no need to check and trim them if they implement codec.Selfer
@@ -173,19 +178,18 @@ func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, ti *TypeIn
 		return
 	}
 	x := genRunner{
-		unsafe: useUnsafe,
-		w:      w,
-		t:      typ,
-		te:     make(map[uintptr]bool),
-		td:     make(map[uintptr]bool),
-		im:     make(map[string]reflect.Type),
-		imn:    make(map[string]string),
-		is:     make(map[reflect.Type]struct{}),
-		tm:     make(map[reflect.Type]struct{}),
-		ts:     []reflect.Type{},
-		bp:     genImportPath(typ[0]),
-		xs:     uid,
-		ti:     ti,
+		w:   w,
+		t:   typ,
+		te:  make(map[uintptr]bool),
+		td:  make(map[uintptr]bool),
+		im:  make(map[string]reflect.Type),
+		imn: make(map[string]string),
+		is:  make(map[reflect.Type]struct{}),
+		tm:  make(map[reflect.Type]struct{}),
+		ts:  []reflect.Type{},
+		bp:  genImportPath(typ[0]),
+		xs:  uid,
+		ti:  ti,
 	}
 	if x.ti == nil {
 		x.ti = defTypeInfos
@@ -234,11 +238,8 @@ func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, ti *TypeIn
 		x.linef("%s \"%s\"", x.imn[k], k)
 	}
 	// add required packages
-	for _, k := range [...]string{"reflect", "unsafe", "runtime", "fmt", "errors"} {
+	for _, k := range [...]string{"reflect", "runtime", "fmt", "errors"} {
 		if _, ok := x.im[k]; !ok {
-			if k == "unsafe" && !x.unsafe {
-				continue
-			}
 			x.line("\"" + k + "\"")
 		}
 	}
@@ -265,20 +266,16 @@ func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, ti *TypeIn
 	x.line(")")
 	x.line("")
 
-	if x.unsafe {
-		x.line("type codecSelferUnsafeString" + x.xs + " struct { Data uintptr; Len int}")
-		x.line("")
-	}
 	x.hn = "codecSelfer" + x.xs
 	x.line("type " + x.hn + " struct{}")
 	x.line("")
 
 	x.varsfxreset()
 	x.line("func init() {")
-	x.linef("if %sGenVersion != %v {", x.cpfx, GenVersion)
+	x.linef("if %sGenVersion != %v {", x.cpfx, genVersion)
 	x.line("_, file, _, _ := runtime.Caller(0)")
 	x.line(`err := fmt.Errorf("codecgen version mismatch: current: %v, need %v. Re-generate file: %v", `)
-	x.linef(`%v, %sGenVersion, file)`, GenVersion, x.cpfx)
+	x.linef(`%v, %sGenVersion, file)`, genVersion, x.cpfx)
 	x.line("panic(err)")
 	x.linef("}")
 	x.line("if false { // reference the types, but skip this branch at build/run time")
@@ -287,10 +284,6 @@ func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, ti *TypeIn
 	for _, k := range imKeys {
 		t := x.im[k]
 		x.linef("var v%v %s.%s", n, x.imn[k], t.Name())
-		n++
-	}
-	if x.unsafe {
-		x.linef("var v%v unsafe.Pointer", n)
 		n++
 	}
 	if n > 0 {
@@ -315,7 +308,7 @@ func Gen(w io.Writer, buildTags, pkgName, uid string, useUnsafe bool, ti *TypeIn
 	}
 
 	for _, t := range x.ts {
-		rtid := reflect.ValueOf(t).Pointer()
+		rtid := rt2id(t)
 		// generate enc functions for all these slice/map types.
 		x.varsfxreset()
 		x.linef("func (x %s) enc%s(v %s%s, e *%sEncoder) {", x.hn, x.genMethodNameT(t), x.arr2str(t, "*"), x.genTypeName(t), x.cpfx)
@@ -545,21 +538,21 @@ func (x *genRunner) selfer(encode bool) {
 		x.out(fnSigPfx)
 		x.line(") codecDecodeSelfFromMap(l int, d *" + x.cpfx + "Decoder) {")
 		x.genRequiredMethodVars(false)
-		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, genStructMapStyleConsolidated)
+		x.decStructMap(genTopLevelVarName, "l", rt2id(t0), t0, genStructMapStyleConsolidated)
 		x.line("}")
 		x.line("")
 	} else {
 		x.out(fnSigPfx)
 		x.line(") codecDecodeSelfFromMapLenPrefix(l int, d *" + x.cpfx + "Decoder) {")
 		x.genRequiredMethodVars(false)
-		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, genStructMapStyleLenPrefix)
+		x.decStructMap(genTopLevelVarName, "l", rt2id(t0), t0, genStructMapStyleLenPrefix)
 		x.line("}")
 		x.line("")
 
 		x.out(fnSigPfx)
 		x.line(") codecDecodeSelfFromMapCheckBreak(l int, d *" + x.cpfx + "Decoder) {")
 		x.genRequiredMethodVars(false)
-		x.decStructMap(genTopLevelVarName, "l", reflect.ValueOf(t0).Pointer(), t0, genStructMapStyleCheckBreak)
+		x.decStructMap(genTopLevelVarName, "l", rt2id(t0), t0, genStructMapStyleCheckBreak)
 		x.line("}")
 		x.line("")
 	}
@@ -568,7 +561,7 @@ func (x *genRunner) selfer(encode bool) {
 	x.out(fnSigPfx)
 	x.line(") codecDecodeSelfFromArray(l int, d *" + x.cpfx + "Decoder) {")
 	x.genRequiredMethodVars(false)
-	x.decStructArray(genTopLevelVarName, "l", "return", reflect.ValueOf(t0).Pointer(), t0)
+	x.decStructArray(genTopLevelVarName, "l", "return", rt2id(t0), t0)
 	x.line("}")
 	x.line("")
 
@@ -645,7 +638,7 @@ func (x *genRunner) encVar(varname string, t reflect.Type) {
 // enc will encode a variable (varname) of type t,
 // except t is of kind reflect.Struct or reflect.Array, wherein varname is of type ptrTo(T) (to prevent copying)
 func (x *genRunner) enc(varname string, t reflect.Type) {
-	rtid := reflect.ValueOf(t).Pointer()
+	rtid := rt2id(t)
 	// We call CodecEncodeSelf if one of the following are honored:
 	//   - the type already implements Selfer, call that
 	//   - the type has a Selfer implementation just created, use that
@@ -1098,7 +1091,7 @@ func (x *genRunner) dec(varname string, t reflect.Type) {
 	// assumptions:
 	//   - the varname is to a pointer already. No need to take address of it
 	//   - t is always a baseType T (not a *T, etc).
-	rtid := reflect.ValueOf(t).Pointer()
+	rtid := rt2id(t)
 	tptr := reflect.PtrTo(t)
 	if x.checkForSelfer(t, varname) {
 		if t.Implements(selferTyp) || tptr.Implements(selferTyp) {
@@ -1231,7 +1224,7 @@ func (x *genRunner) dec(varname string, t reflect.Type) {
 		// - if elements are primitives or Selfers, call dedicated function on each member.
 		// - else call Encoder.encode(XXX) on it.
 		if rtid == uint8SliceTypId {
-			x.line("*" + varname + " = r.DecodeBytes(*(*[]byte)(" + varname + "), false, false)")
+			x.line("*" + varname + " = r.DecodeBytes(*(*[]byte)(" + varname + "), false)")
 		} else if fastpathAV.index(rtid) != -1 {
 			g := x.newGenV(t)
 			x.line("z.F." + g.MethodNamePfx("Dec", false) + "X(" + varname + ", false, d)")
@@ -1318,11 +1311,11 @@ func (x *genRunner) decTryAssignPrimitive(varname string, t reflect.Type) (tryAs
 
 func (x *genRunner) decListFallback(varname string, rtid uintptr, t reflect.Type) {
 	if t.AssignableTo(uint8SliceTyp) {
-		x.line("*" + varname + " = r.DecodeBytes(*((*[]byte)(" + varname + ")), false, false)")
+		x.line("*" + varname + " = r.DecodeBytes(*((*[]byte)(" + varname + ")), false)")
 		return
 	}
 	if t.Kind() == reflect.Array && t.Elem().Kind() == reflect.Uint8 {
-		x.linef("r.DecodeBytes( ((*[%s]byte)(%s))[:], false, true)", t.Len(), varname)
+		x.linef("r.DecodeBytes( ((*[%s]byte)(%s))[:], true)", t.Len(), varname)
 		return
 	}
 	type tstruc struct {
@@ -1469,17 +1462,6 @@ func (x *genRunner) decStructMap(varname, lenvarname string, rtid uintptr, t ref
 	i := x.varsfx()
 	kName := tpfx + "s" + i
 
-	// We thought to use ReadStringAsBytes, as go compiler might optimize the copy out.
-	// However, using that was more expensive, as it seems that the switch expression
-	// is evaluated each time.
-	//
-	// We could depend on decodeString using a temporary/shared buffer internally.
-	// However, this model of creating a byte array, and using explicitly is faster,
-	// and allows optional use of unsafe []byte->string conversion without alloc.
-
-	// Also, ensure that the slice array doesn't escape.
-	// That will help escape analysis prevent allocation when it gets better.
-
 	// x.line("var " + kName + "Arr = [32]byte{} // default string to decode into")
 	// x.line("var " + kName + "Slc = " + kName + "Arr[:] // default slice to decode into")
 	// use the scratch buffer to avoid allocation (most field names are < 32).
@@ -1499,15 +1481,9 @@ func (x *genRunner) decStructMap(varname, lenvarname string, rtid uintptr, t ref
 		x.line("} else { if r.CheckBreak() { break }; }")
 	}
 	x.linef("z.DecSendContainerState(codecSelfer_containerMapKey%s)", x.xs)
-	x.line(kName + "Slc = r.DecodeBytes(" + kName + "Slc, true, true)")
+	x.line(kName + "Slc = r.DecodeStringAsBytes()")
 	// let string be scoped to this loop alone, so it doesn't escape.
-	if x.unsafe {
-		x.line(kName + "SlcHdr := codecSelferUnsafeString" + x.xs + "{uintptr(unsafe.Pointer(&" +
-			kName + "Slc[0])), len(" + kName + "Slc)}")
-		x.line(kName + " := *(*string)(unsafe.Pointer(&" + kName + "SlcHdr))")
-	} else {
-		x.line(kName + " := string(" + kName + "Slc)")
-	}
+	x.line(kName + " := string(" + kName + "Slc)")
 	x.linef("z.DecSendContainerState(codecSelfer_containerMapValue%s)", x.xs)
 	x.decStructMapSwitch(kName, varname, rtid, t)
 
@@ -1653,15 +1629,8 @@ func (x *genV) MethodNamePfx(prefix string, prim bool) string {
 func genImportPath(t reflect.Type) (s string) {
 	s = t.PkgPath()
 	if genCheckVendor {
-		// HACK: Misbehaviour occurs in go 1.5. May have to re-visit this later.
-		// if s contains /vendor/ OR startsWith vendor/, then return everything after it.
-		const vendorStart = "vendor/"
-		const vendorInline = "/vendor/"
-		if i := strings.LastIndex(s, vendorInline); i >= 0 {
-			s = s[i+len(vendorInline):]
-		} else if strings.HasPrefix(s, vendorStart) {
-			s = s[len(vendorStart):]
-		}
+		// HACK: always handle vendoring. It should be typically on in go 1.6, 1.7
+		s = stripVendor(s)
 	}
 	return
 }
@@ -1783,8 +1752,8 @@ func genIsImmutable(t reflect.Type) (v bool) {
 }
 
 type genInternal struct {
-	Values []genV
-	Unsafe bool
+	Version int
+	Values  []genV
 }
 
 func (x genInternal) FastpathLen() (l int) {
@@ -1884,8 +1853,21 @@ func genInternalSortType(s string, elem bool) string {
 	panic("sorttype: unexpected type: " + s)
 }
 
+func stripVendor(s string) string {
+	// HACK: Misbehaviour occurs in go 1.5. May have to re-visit this later.
+	// if s contains /vendor/ OR startsWith vendor/, then return everything after it.
+	const vendorStart = "vendor/"
+	const vendorInline = "/vendor/"
+	if i := strings.LastIndex(s, vendorInline); i >= 0 {
+		s = s[i+len(vendorInline):]
+	} else if strings.HasPrefix(s, vendorStart) {
+		s = s[len(vendorStart):]
+	}
+	return s
+}
+
 // var genInternalMu sync.Mutex
-var genInternalV genInternal
+var genInternalV = genInternal{Version: genVersion}
 var genInternalTmplFuncs template.FuncMap
 var genInternalOnce sync.Once
 
@@ -1948,7 +1930,7 @@ func genInternalInit() {
 		"float64":     8,
 		"bool":        1,
 	}
-	var gt genInternal
+	var gt = genInternal{Version: genVersion}
 
 	// For each slice or map type, there must be a (symmetrical) Encode and Decode fast-path function
 	for _, s := range types {
@@ -1980,11 +1962,10 @@ func genInternalInit() {
 // It is run by the program author alone.
 // Unfortunately, it has to be exported so that it can be called from a command line tool.
 // *** DO NOT USE ***
-func genInternalGoFile(r io.Reader, w io.Writer, safe bool) (err error) {
+func genInternalGoFile(r io.Reader, w io.Writer) (err error) {
 	genInternalOnce.Do(genInternalInit)
 
 	gt := genInternalV
-	gt.Unsafe = !safe
 
 	t := template.New("").Funcs(genInternalTmplFuncs)
 

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_arrayof_gte_go15.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_arrayof_gte_go15.go
@@ -9,8 +9,6 @@ import "reflect"
 
 const reflectArrayOfSupported = true
 
-func reflectArrayOf(rvn reflect.Value) (rvn2 reflect.Value) {
-	rvn2 = reflect.New(reflect.ArrayOf(rvn.Len(), intfTyp)).Elem()
-	reflect.Copy(rvn2, rvn)
-	return
+func reflectArrayOf(count int, elem reflect.Type) reflect.Type {
+	return reflect.ArrayOf(count, elem)
 }

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_arrayof_lt_go15.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_arrayof_lt_go15.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build !go1.5
+
+package codec
+
+import "reflect"
+
+const reflectArrayOfSupported = false
+
+func reflectArrayOf(count int, elem reflect.Type) reflect.Type {
+	panic("codec: reflect.ArrayOf unsupported in this go version")
+}

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_makemap_gte_go19.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_makemap_gte_go19.go
@@ -1,14 +1,15 @@
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
 
-// +build !go1.5
+// +build go1.9
 
 package codec
 
 import "reflect"
 
-const reflectArrayOfSupported = false
-
-func reflectArrayOf(rvn reflect.Value) (rvn2 reflect.Value) {
-	panic("reflect.ArrayOf unsupported")
+func makeMapReflect(t reflect.Type, size int) reflect.Value {
+	if size < 0 {
+		return reflect.MakeMapWithSize(t, 4)
+	}
+	return reflect.MakeMapWithSize(t, size)
 }

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_makemap_lt_go19.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_makemap_lt_go19.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build !go1.9
+
+package codec
+
+import "reflect"
+
+func makeMapReflect(t reflect.Type, size int) reflect.Value {
+	return reflect.MakeMap(t)
+}

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_unsupported_lt_go14.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_unsupported_lt_go14.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build !go1.4
+
+package codec
+
+// This codec package will only work for go1.4 and above.
+// This is for the following reasons:
+//   - go 1.4 was released in 2014
+//   - go runtime is written fully in go
+//   - interface only holds pointers
+//   - reflect.Value is stabilized as 3 words
+
+func init() {
+	panic("codec: go 1.3 and below are not supported")
+}

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_vendor_eq_go15.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_vendor_eq_go15.go
@@ -1,12 +1,10 @@
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
 
-// +build go1.6
+// +build go1.5,!go1.6
 
 package codec
 
 import "os"
 
-func init() {
-	genCheckVendor = os.Getenv("GO15VENDOREXPERIMENT") != "0"
-}
+var genCheckVendor = os.Getenv("GO15VENDOREXPERIMENT") == "1"

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_vendor_eq_go16.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_vendor_eq_go16.go
@@ -1,10 +1,10 @@
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
 
-// +build go1.7
+// +build go1.6,!go1.7
 
 package codec
 
-func init() {
-	genCheckVendor = true
-}
+import "os"
+
+var genCheckVendor = os.Getenv("GO15VENDOREXPERIMENT") != "0"

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_vendor_gte_go17.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_vendor_gte_go17.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+// +build go1.7
+
+package codec
+
+const genCheckVendor = true

--- a/cmd/vendor/github.com/ugorji/go/codec/goversion_vendor_lt_go15.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/goversion_vendor_lt_go15.go
@@ -1,12 +1,8 @@
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
 
-// +build go1.5,!go1.6
+// +build !go1.5
 
 package codec
 
-import "os"
-
-func init() {
-	genCheckVendor = os.Getenv("GO15VENDOREXPERIMENT") == "1"
-}
+var genCheckVendor = false

--- a/cmd/vendor/github.com/ugorji/go/codec/helper_internal.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/helper_internal.go
@@ -219,24 +219,3 @@ func growCap(oldCap, unit, num int) (newCap int) {
 	}
 	return
 }
-
-func expandSliceValue(s reflect.Value, num int) reflect.Value {
-	if num <= 0 {
-		return s
-	}
-	l0 := s.Len()
-	l1 := l0 + num // new slice length
-	if l1 < l0 {
-		panic("ExpandSlice: slice overflow")
-	}
-	c0 := s.Cap()
-	if l1 <= c0 {
-		return s.Slice(0, l1)
-	}
-	st := s.Type()
-	c1 := growCap(c0, int(st.Elem().Size()), num)
-	s2 := reflect.MakeSlice(st, l1, c1)
-	// println("expandslicevalue: cap-old: ", c0, ", cap-new: ", c1, ", len-new: ", l1)
-	reflect.Copy(s2, s)
-	return s2
-}

--- a/cmd/vendor/github.com/ugorji/go/codec/helper_not_unsafe.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/helper_not_unsafe.go
@@ -1,13 +1,21 @@
-// +build !unsafe
+// +build !go1.7 safe appengine
 
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
 
 package codec
 
+import (
+	"reflect"
+	"sync/atomic"
+)
+
 // stringView returns a view of the []byte as a string.
 // In unsafe mode, it doesn't incur allocation and copying caused by conversion.
 // In regular safe mode, it is an allocation and copy.
+//
+// Usage: Always maintain a reference to v while result of this call is in use,
+//        and call keepAlive4BytesView(v) at point where done with view.
 func stringView(v []byte) string {
 	return string(v)
 }
@@ -15,6 +23,121 @@ func stringView(v []byte) string {
 // bytesView returns a view of the string as a []byte.
 // In unsafe mode, it doesn't incur allocation and copying caused by conversion.
 // In regular safe mode, it is an allocation and copy.
+//
+// Usage: Always maintain a reference to v while result of this call is in use,
+//        and call keepAlive4BytesView(v) at point where done with view.
 func bytesView(v string) []byte {
 	return []byte(v)
 }
+
+// // keepAlive4BytesView maintains a reference to the input parameter for bytesView.
+// //
+// // Usage: call this at point where done with the bytes view.
+// func keepAlive4BytesView(v string) {}
+
+// // keepAlive4BytesView maintains a reference to the input parameter for stringView.
+// //
+// // Usage: call this at point where done with the string view.
+// func keepAlive4StringView(v []byte) {}
+
+func rv2i(rv reflect.Value) interface{} {
+	return rv.Interface()
+}
+
+func rt2id(rt reflect.Type) uintptr {
+	return reflect.ValueOf(rt).Pointer()
+}
+
+// --------------------------
+type ptrToRvMap struct{}
+
+func (_ *ptrToRvMap) init() {}
+func (_ *ptrToRvMap) get(i interface{}) reflect.Value {
+	return reflect.ValueOf(i).Elem()
+}
+
+// --------------------------
+type atomicTypeInfoSlice struct {
+	v atomic.Value
+}
+
+func (x *atomicTypeInfoSlice) load() *[]rtid2ti {
+	i := x.v.Load()
+	if i == nil {
+		return nil
+	}
+	return i.(*[]rtid2ti)
+}
+
+func (x *atomicTypeInfoSlice) store(p *[]rtid2ti) {
+	x.v.Store(p)
+}
+
+// --------------------------
+func (f *decFnInfo) raw(rv reflect.Value) {
+	rv.SetBytes(f.d.raw())
+}
+
+func (f *decFnInfo) kString(rv reflect.Value) {
+	rv.SetString(f.d.d.DecodeString())
+}
+
+func (f *decFnInfo) kBool(rv reflect.Value) {
+	rv.SetBool(f.d.d.DecodeBool())
+}
+
+func (f *decFnInfo) kFloat32(rv reflect.Value) {
+	rv.SetFloat(f.d.d.DecodeFloat(true))
+}
+
+func (f *decFnInfo) kFloat64(rv reflect.Value) {
+	rv.SetFloat(f.d.d.DecodeFloat(false))
+}
+
+func (f *decFnInfo) kInt(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(intBitsize))
+}
+
+func (f *decFnInfo) kInt8(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(8))
+}
+
+func (f *decFnInfo) kInt16(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(16))
+}
+
+func (f *decFnInfo) kInt32(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(32))
+}
+
+func (f *decFnInfo) kInt64(rv reflect.Value) {
+	rv.SetInt(f.d.d.DecodeInt(64))
+}
+
+func (f *decFnInfo) kUint(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(uintBitsize))
+}
+
+func (f *decFnInfo) kUintptr(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(uintBitsize))
+}
+
+func (f *decFnInfo) kUint8(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(8))
+}
+
+func (f *decFnInfo) kUint16(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(16))
+}
+
+func (f *decFnInfo) kUint32(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(32))
+}
+
+func (f *decFnInfo) kUint64(rv reflect.Value) {
+	rv.SetUint(f.d.d.DecodeUint(64))
+}
+
+// func i2rv(i interface{}) reflect.Value {
+// 	return reflect.ValueOf(i)
+// }

--- a/cmd/vendor/github.com/ugorji/go/codec/helper_unsafe.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/helper_unsafe.go
@@ -1,4 +1,6 @@
-// +build unsafe
+// +build !safe
+// +build !appengine
+// +build go1.7
 
 // Copyright (c) 2012-2015 Ugorji Nwoke. All rights reserved.
 // Use of this source code is governed by a MIT license found in the LICENSE file.
@@ -6,10 +8,15 @@
 package codec
 
 import (
+	"reflect"
+	"sync/atomic"
 	"unsafe"
 )
 
 // This file has unsafe variants of some helper methods.
+// NOTE: See helper_not_unsafe.go for the usage information.
+
+// var zeroRTv [4]uintptr
 
 type unsafeString struct {
 	Data uintptr
@@ -22,9 +29,17 @@ type unsafeSlice struct {
 	Cap  int
 }
 
-// stringView returns a view of the []byte as a string.
-// In unsafe mode, it doesn't incur allocation and copying caused by conversion.
-// In regular safe mode, it is an allocation and copy.
+type unsafeIntf struct {
+	typ  unsafe.Pointer
+	word unsafe.Pointer
+}
+
+type unsafeReflectValue struct {
+	typ  unsafe.Pointer
+	ptr  unsafe.Pointer
+	flag uintptr
+}
+
 func stringView(v []byte) string {
 	if len(v) == 0 {
 		return ""
@@ -35,9 +50,6 @@ func stringView(v []byte) string {
 	return *(*string)(unsafe.Pointer(&sx))
 }
 
-// bytesView returns a view of the string as a []byte.
-// In unsafe mode, it doesn't incur allocation and copying caused by conversion.
-// In regular safe mode, it is an allocation and copy.
 func bytesView(v string) []byte {
 	if len(v) == 0 {
 		return zeroByteSlice
@@ -47,3 +59,404 @@ func bytesView(v string) []byte {
 	bx := unsafeSlice{sx.Data, sx.Len, sx.Len}
 	return *(*[]byte)(unsafe.Pointer(&bx))
 }
+
+// func keepAlive4BytesView(v string) {
+// 	runtime.KeepAlive(v)
+// }
+
+// func keepAlive4StringView(v []byte) {
+// 	runtime.KeepAlive(v)
+// }
+
+const _unsafe_rv2i_is_safe = false
+
+// TODO: consider a more generally-known optimization for reflect.Value ==> Interface
+//
+// Currently, we use this fragile method that taps into implememtation details from
+// the source go stdlib reflect/value.go,
+// and trims the implementation.
+func rv2i(rv reflect.Value) interface{} {
+	if _unsafe_rv2i_is_safe {
+		return rv.Interface()
+	}
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	// references that are single-words (map, ptr) may be double-referenced as flagIndir
+	kk := urv.flag & (1<<5 - 1)
+	if (kk == uintptr(reflect.Map) || kk == uintptr(reflect.Ptr)) && urv.flag&(1<<7) != 0 {
+		return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: *(*unsafe.Pointer)(urv.ptr), typ: urv.typ}))
+	}
+	return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: urv.ptr, typ: urv.typ}))
+}
+
+func rt2id(rt reflect.Type) uintptr {
+	return uintptr(((*unsafeIntf)(unsafe.Pointer(&rt))).word)
+}
+
+// func rv0t(rt reflect.Type) reflect.Value {
+// 	ut := (*unsafeIntf)(unsafe.Pointer(&rt))
+// 	// we need to determine whether ifaceIndir, and then whether to just pass 0 as the ptr
+// 	uv := unsafeReflectValue{ut.word, &zeroRTv, flag(rt.Kind())}
+// 	return *(*reflect.Value)(unsafe.Pointer(&uv})
+// }
+
+type ptrToRVKV struct {
+	k uintptr
+	v reflect.Value
+}
+
+type ptrToRvMap struct {
+	// m map[uintptr]reflect.Value
+	a [4]ptrToRVKV
+	v []ptrToRVKV
+}
+
+func (p *ptrToRvMap) init() {
+	// fmt.Printf(">>>> new ptr to rv map\n")
+	// p.m = make(map[uintptr]reflect.Value, 32)
+	p.v = p.a[:0]
+}
+
+func (p *ptrToRvMap) get(intf interface{}) (rv reflect.Value) {
+	word := uintptr(((*unsafeIntf)(unsafe.Pointer(&intf))).word)
+	// binary search. adapted from sort/search.go.
+	h, i, j := 0, 0, len(p.v)
+	for i < j {
+		h = i + (j-i)/2
+		if p.v[h].k < word {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	if i < len(p.v) && p.v[i].k == word {
+		return p.v[i].v
+	}
+
+	// insert into position i
+	// fmt.Printf(">>>> resetting rv for word: %x, interface: %v\n", word, intf)
+	rv = reflect.ValueOf(intf).Elem()
+	p.v = append(p.v, ptrToRVKV{})
+	copy(p.v[i+1:len(p.v)], p.v[i:len(p.v)-1])
+	p.v[i].k, p.v[i].v = word, rv
+	return
+}
+
+// --------------------------
+type atomicTypeInfoSlice struct {
+	v unsafe.Pointer
+}
+
+func (x *atomicTypeInfoSlice) load() *[]rtid2ti {
+	return (*[]rtid2ti)(atomic.LoadPointer(&x.v))
+}
+
+func (x *atomicTypeInfoSlice) store(p *[]rtid2ti) {
+	atomic.StorePointer(&x.v, unsafe.Pointer(p))
+}
+
+// --------------------------
+func (f *decFnInfo) raw(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*[]byte)(urv.ptr) = f.d.raw()
+}
+
+func (f *decFnInfo) kString(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*string)(urv.ptr) = f.d.d.DecodeString()
+}
+
+func (f *decFnInfo) kBool(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*bool)(urv.ptr) = f.d.d.DecodeBool()
+}
+
+func (f *decFnInfo) kFloat32(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*float32)(urv.ptr) = float32(f.d.d.DecodeFloat(true))
+}
+
+func (f *decFnInfo) kFloat64(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*float64)(urv.ptr) = f.d.d.DecodeFloat(false)
+}
+
+func (f *decFnInfo) kInt(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*int)(urv.ptr) = int(f.d.d.DecodeInt(intBitsize))
+}
+
+func (f *decFnInfo) kInt8(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*int8)(urv.ptr) = int8(f.d.d.DecodeInt(8))
+}
+
+func (f *decFnInfo) kInt16(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*int16)(urv.ptr) = int16(f.d.d.DecodeInt(16))
+}
+
+func (f *decFnInfo) kInt32(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*int32)(urv.ptr) = int32(f.d.d.DecodeInt(32))
+}
+
+func (f *decFnInfo) kInt64(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*int64)(urv.ptr) = f.d.d.DecodeInt(64)
+}
+
+func (f *decFnInfo) kUint(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*uint)(urv.ptr) = uint(f.d.d.DecodeUint(uintBitsize))
+}
+
+func (f *decFnInfo) kUintptr(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*uintptr)(urv.ptr) = uintptr(f.d.d.DecodeUint(uintBitsize))
+}
+
+func (f *decFnInfo) kUint8(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*uint8)(urv.ptr) = uint8(f.d.d.DecodeUint(8))
+}
+
+func (f *decFnInfo) kUint16(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*uint16)(urv.ptr) = uint16(f.d.d.DecodeUint(16))
+}
+
+func (f *decFnInfo) kUint32(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*uint32)(urv.ptr) = uint32(f.d.d.DecodeUint(32))
+}
+func (f *decFnInfo) kUint64(rv reflect.Value) {
+	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+	*(*uint64)(urv.ptr) = f.d.d.DecodeUint(64)
+}
+
+// func (p *ptrToRvMap) get(i interface{}) (rv reflect.Value) {
+// 	word := uintptr(((*unsafeIntf)(unsafe.Pointer(&i))).word)
+// 	rv, exists := p.m[word]
+// 	if !exists {
+// 		fmt.Printf(">>>> resetting rv for word: %x, interface: %v\n", word, i)
+// 		rv = reflect.ValueOf(i).Elem()
+// 		p.m[word] = rv
+// 	}
+// 	return
+// }
+
+// func rt2id(rt reflect.Type) uintptr {
+// 	return uintptr(((*unsafeIntf)(unsafe.Pointer(&rt))).word)
+// 	// var i interface{} = rt
+// 	// // ui := (*unsafeIntf)(unsafe.Pointer(&i))
+// 	// return ((*unsafeIntf)(unsafe.Pointer(&i))).word
+// }
+
+// func rv2i(rv reflect.Value) interface{} {
+// 	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+// 	// non-reference type: already indir
+// 	// reference type: depend on flagIndir property ('cos maybe was double-referenced)
+// 	// const (unsafeRvFlagKindMask    = 1<<5 - 1 , unsafeRvFlagIndir       = 1 << 7 )
+// 	// rvk := reflect.Kind(urv.flag & (1<<5 - 1))
+// 	// if (rvk == reflect.Chan ||
+// 	// 	rvk == reflect.Func ||
+// 	// 	rvk == reflect.Interface ||
+// 	// 	rvk == reflect.Map ||
+// 	// 	rvk == reflect.Ptr ||
+// 	// 	rvk == reflect.UnsafePointer) && urv.flag&(1<<8) != 0 {
+// 	// 	fmt.Printf(">>>>> ---- double indirect reference: %v, %v\n", rvk, rv.Type())
+// 	// 	return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: *(*unsafe.Pointer)(urv.ptr), typ: urv.typ}))
+// 	// }
+// 	if urv.flag&(1<<5-1) == uintptr(reflect.Map) && urv.flag&(1<<7) != 0 {
+// 		// fmt.Printf(">>>>> ---- double indirect reference: %v, %v\n", rvk, rv.Type())
+// 		return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: *(*unsafe.Pointer)(urv.ptr), typ: urv.typ}))
+// 	}
+// 	// fmt.Printf(">>>>> ++++ direct reference: %v, %v\n", rvk, rv.Type())
+// 	return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: urv.ptr, typ: urv.typ}))
+// }
+
+// const (
+// 	unsafeRvFlagKindMask    = 1<<5 - 1
+// 	unsafeRvKindDirectIface = 1 << 5
+// 	unsafeRvFlagIndir       = 1 << 7
+// 	unsafeRvFlagAddr        = 1 << 8
+// 	unsafeRvFlagMethod      = 1 << 9
+
+// 	_USE_RV_INTERFACE bool = false
+// 	_UNSAFE_RV_DEBUG       = true
+// )
+
+// type unsafeRtype struct {
+// 	_    [2]uintptr
+// 	_    uint32
+// 	_    uint8
+// 	_    uint8
+// 	_    uint8
+// 	kind uint8
+// 	_    [2]uintptr
+// 	_    int32
+// }
+
+// func _rv2i(rv reflect.Value) interface{} {
+// 	// Note: From use,
+// 	//   - it's never an interface
+// 	//   - the only calls here are for ifaceIndir types.
+// 	//     (though that conditional is wrong)
+// 	//     To know for sure, we need the value of t.kind (which is not exposed).
+// 	//
+// 	// Need to validate the path: type is indirect ==> only value is indirect ==> default (value is direct)
+// 	//    - Type indirect, Value indirect: ==> numbers, boolean, slice, struct, array, string
+// 	//    - Type Direct,   Value indirect: ==> map???
+// 	//    - Type Direct,   Value direct:   ==> pointers, unsafe.Pointer, func, chan, map
+// 	//
+// 	// TRANSLATES TO:
+// 	//    if typeIndirect { } else if valueIndirect { } else { }
+// 	//
+// 	// Since we don't deal with funcs, then "flagNethod" is unset, and can be ignored.
+
+// 	if _USE_RV_INTERFACE {
+// 		return rv.Interface()
+// 	}
+// 	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+
+// 	// if urv.flag&unsafeRvFlagMethod != 0 || urv.flag&unsafeRvFlagKindMask == uintptr(reflect.Interface) {
+// 	// 	println("***** IS flag method or interface: delegating to rv.Interface()")
+// 	// 	return rv.Interface()
+// 	// }
+
+// 	// if urv.flag&unsafeRvFlagKindMask == uintptr(reflect.Interface) {
+// 	// 	println("***** IS Interface: delegate to rv.Interface")
+// 	// 	return rv.Interface()
+// 	// }
+// 	// if urv.flag&unsafeRvFlagKindMask&unsafeRvKindDirectIface == 0 {
+// 	// 	if urv.flag&unsafeRvFlagAddr == 0 {
+// 	// 		println("***** IS ifaceIndir typ")
+// 	// 		// ui := unsafeIntf{word: urv.ptr, typ: urv.typ}
+// 	// 		// return *(*interface{})(unsafe.Pointer(&ui))
+// 	// 		// return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: urv.ptr, typ: urv.typ}))
+// 	// 	}
+// 	// } else if urv.flag&unsafeRvFlagIndir != 0 {
+// 	// 	println("***** IS flagindir")
+// 	// 	// return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: *(*unsafe.Pointer)(urv.ptr), typ: urv.typ}))
+// 	// } else {
+// 	// 	println("***** NOT flagindir")
+// 	// 	return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: urv.ptr, typ: urv.typ}))
+// 	// }
+// 	// println("***** default: delegate to rv.Interface")
+
+// 	urt := (*unsafeRtype)(unsafe.Pointer(urv.typ))
+// 	if _UNSAFE_RV_DEBUG {
+// 		fmt.Printf(">>>> start: %v: ", rv.Type())
+// 		fmt.Printf("%v - %v\n", *urv, *urt)
+// 	}
+// 	if urt.kind&unsafeRvKindDirectIface == 0 {
+// 		if _UNSAFE_RV_DEBUG {
+// 			fmt.Printf("**** +ifaceIndir type: %v\n", rv.Type())
+// 		}
+// 		// println("***** IS ifaceIndir typ")
+// 		// if true || urv.flag&unsafeRvFlagAddr == 0 {
+// 		// 	// println("    ***** IS NOT addr")
+// 		return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: urv.ptr, typ: urv.typ}))
+// 		// }
+// 	} else if urv.flag&unsafeRvFlagIndir != 0 {
+// 		if _UNSAFE_RV_DEBUG {
+// 			fmt.Printf("**** +flagIndir type: %v\n", rv.Type())
+// 		}
+// 		// println("***** IS flagindir")
+// 		return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: *(*unsafe.Pointer)(urv.ptr), typ: urv.typ}))
+// 	} else {
+// 		if _UNSAFE_RV_DEBUG {
+// 			fmt.Printf("**** -flagIndir type: %v\n", rv.Type())
+// 		}
+// 		// println("***** NOT flagindir")
+// 		return *(*interface{})(unsafe.Pointer(&unsafeIntf{word: urv.ptr, typ: urv.typ}))
+// 	}
+// 	// println("***** default: delegating to rv.Interface()")
+// 	// return rv.Interface()
+// }
+
+// var staticM0 = make(map[string]uint64)
+// var staticI0 = (int32)(-5)
+
+// func staticRv2iTest() {
+// 	i0 := (int32)(-5)
+// 	m0 := make(map[string]uint16)
+// 	m0["1"] = 1
+// 	for _, i := range []interface{}{
+// 		(int)(7),
+// 		(uint)(8),
+// 		(int16)(-9),
+// 		(uint16)(19),
+// 		(uintptr)(77),
+// 		(bool)(true),
+// 		float32(-32.7),
+// 		float64(64.9),
+// 		complex(float32(19), 5),
+// 		complex(float64(-32), 7),
+// 		[4]uint64{1, 2, 3, 4},
+// 		(chan<- int)(nil), // chan,
+// 		rv2i,              // func
+// 		io.Writer(ioutil.Discard),
+// 		make(map[string]uint),
+// 		(map[string]uint)(nil),
+// 		staticM0,
+// 		m0,
+// 		&m0,
+// 		i0,
+// 		&i0,
+// 		&staticI0,
+// 		&staticM0,
+// 		[]uint32{6, 7, 8},
+// 		"abc",
+// 		Raw{},
+// 		RawExt{},
+// 		&Raw{},
+// 		&RawExt{},
+// 		unsafe.Pointer(&i0),
+// 	} {
+// 		i2 := rv2i(reflect.ValueOf(i))
+// 		eq := reflect.DeepEqual(i, i2)
+// 		fmt.Printf(">>>> %v == %v? %v\n", i, i2, eq)
+// 	}
+// 	// os.Exit(0)
+// }
+
+// func init() {
+// 	staticRv2iTest()
+// }
+
+// func rv2i(rv reflect.Value) interface{} {
+// 	if _USE_RV_INTERFACE || rv.Kind() == reflect.Interface || rv.CanAddr() {
+// 		return rv.Interface()
+// 	}
+// 	// var i interface{}
+// 	// ui := (*unsafeIntf)(unsafe.Pointer(&i))
+// 	var ui unsafeIntf
+// 	urv := (*unsafeReflectValue)(unsafe.Pointer(&rv))
+// 	// fmt.Printf("urv: flag: %b, typ: %b, ptr: %b\n", urv.flag, uintptr(urv.typ), uintptr(urv.ptr))
+// 	if (urv.flag&unsafeRvFlagKindMask)&unsafeRvKindDirectIface == 0 {
+// 		if urv.flag&unsafeRvFlagAddr != 0 {
+// 			println("***** indirect and addressable! Needs typed move - delegate to rv.Interface()")
+// 			return rv.Interface()
+// 		}
+// 		println("****** indirect type/kind")
+// 		ui.word = urv.ptr
+// 	} else if urv.flag&unsafeRvFlagIndir != 0 {
+// 		println("****** unsafe rv flag indir")
+// 		ui.word = *(*unsafe.Pointer)(urv.ptr)
+// 	} else {
+// 		println("****** default: assign prt to word directly")
+// 		ui.word = urv.ptr
+// 	}
+// 	// ui.word = urv.ptr
+// 	ui.typ = urv.typ
+// 	// fmt.Printf("(pointers) ui.typ: %p, word: %p\n", ui.typ, ui.word)
+// 	// fmt.Printf("(binary)   ui.typ: %b, word: %b\n", uintptr(ui.typ), uintptr(ui.word))
+// 	return *(*interface{})(unsafe.Pointer(&ui))
+// 	// return i
+// }
+
+// func i2rv(i interface{}) reflect.Value {
+// 	// u := *(*unsafeIntf)(unsafe.Pointer(&i))
+// 	return reflect.ValueOf(i)
+// }

--- a/cmd/vendor/github.com/ugorji/go/codec/json.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/json.go
@@ -34,7 +34,6 @@ package codec
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"reflect"
 	"strconv"
 	"unicode/utf16"
@@ -59,6 +58,11 @@ var (
 
 	// jsonTabs and jsonSpaces are used as caches for indents
 	jsonTabs, jsonSpaces string
+
+	jsonCharHtmlSafeSet   [utf8.RuneSelf]bool
+	jsonCharSafeSet       [utf8.RuneSelf]bool
+	jsonCharWhitespaceSet [256]bool
+	jsonNumSet            [256]bool
 )
 
 const (
@@ -78,19 +82,6 @@ const (
 	// P.S. Do not expect a significant decoding boost from this.
 	jsonValidateSymbols = true
 
-	// if jsonTruncateMantissa, truncate mantissa if trailing 0's.
-	// This is important because it could allow some floats to be decoded without
-	// deferring to strconv.ParseFloat.
-	jsonTruncateMantissa = true
-
-	// if mantissa >= jsonNumUintCutoff before multiplying by 10, this is an overflow
-	jsonNumUintCutoff = (1<<64-1)/uint64(10) + 1 // cutoff64(base)
-
-	// if mantissa >= jsonNumUintMaxVal, this is an overflow
-	jsonNumUintMaxVal = 1<<uint64(64) - 1
-
-	// jsonNumDigitsUint64Largest = 19
-
 	jsonSpacesOrTabsLen = 128
 )
 
@@ -105,6 +96,31 @@ func init() {
 		bs[i] = '\t'
 	}
 	jsonTabs = string(bs[:])
+
+	// populate the safe values as true: note: ASCII control characters are (0-31)
+	// jsonCharSafeSet:     all true except (0-31) " \
+	// jsonCharHtmlSafeSet: all true except (0-31) " \ < > &
+	for i := 32; i < utf8.RuneSelf; i++ {
+		switch i {
+		case '"', '\\':
+			jsonCharSafeSet[i] = false
+			jsonCharHtmlSafeSet[i] = false
+		case '<', '>', '&':
+			jsonCharHtmlSafeSet[i] = false
+			jsonCharSafeSet[i] = true
+		default:
+			jsonCharSafeSet[i] = true
+			jsonCharHtmlSafeSet[i] = true
+		}
+	}
+	for i := 0; i < 256; i++ {
+		switch i {
+		case ' ', '\t', '\r', '\n':
+			jsonCharWhitespaceSet[i] = true
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'e', 'E', '.', '+', '-':
+			jsonNumSet[i] = true
+		}
+	}
 }
 
 type jsonEncDriver struct {
@@ -214,6 +230,7 @@ func (e *jsonEncDriver) encodeFloat(f float64, numbits int) {
 }
 
 func (e *jsonEncDriver) EncodeInt(v int64) {
+	// if e.h.IntegerAsString == 'A' || e.h.IntegerAsString == 'L' && (v > 1<<53 || v < -(1<<53)) {
 	if x := e.h.IntegerAsString; x == 'A' || x == 'L' && (v > 1<<53 || v < -(1<<53)) {
 		e.w.writen1('"')
 		e.w.writeb(strconv.AppendInt(e.b[:0], v, 10))
@@ -224,6 +241,7 @@ func (e *jsonEncDriver) EncodeInt(v int64) {
 }
 
 func (e *jsonEncDriver) EncodeUint(v uint64) {
+	// if e.h.IntegerAsString == 'A' || e.h.IntegerAsString == 'L' && v > 1<<53 {
 	if x := e.h.IntegerAsString; x == 'A' || x == 'L' && v > 1<<53 {
 		e.w.writen1('"')
 		e.w.writeb(strconv.AppendUint(e.b[:0], v, 10))
@@ -310,8 +328,11 @@ func (e *jsonEncDriver) quoteStr(s string) {
 	w.writen1('"')
 	start := 0
 	for i := 0; i < len(s); {
+		// encode all bytes < 0x20 (except \r, \n).
+		// also encode < > & to prevent security holes when served to some browsers.
 		if b := s[i]; b < utf8.RuneSelf {
-			if 0x20 <= b && b != '\\' && b != '"' && b != '<' && b != '>' && b != '&' {
+			// if 0x20 <= b && b != '\\' && b != '"' && b != '<' && b != '>' && b != '&' {
+			if jsonCharHtmlSafeSet[b] || (e.h.HTMLCharsAsIs && jsonCharSafeSet[b]) {
 				i++
 				continue
 			}
@@ -332,8 +353,6 @@ func (e *jsonEncDriver) quoteStr(s string) {
 			case '\t':
 				w.writen2('\\', 't')
 			default:
-				// encode all bytes < 0x20 (except \r, \n).
-				// also encode < > & to prevent security holes when served to some browsers.
 				w.writestr(`\u00`)
 				w.writen2(hex[b>>4], hex[b&0xF])
 			}
@@ -352,7 +371,7 @@ func (e *jsonEncDriver) quoteStr(s string) {
 			continue
 		}
 		// U+2028 is LINE SEPARATOR. U+2029 is PARAGRAPH SEPARATOR.
-		// Both technically valid JSON, but bomb on JSONP, so fix here.
+		// Both technically valid JSON, but bomb on JSONP, so fix here unconditionally.
 		if c == '\u2028' || c == '\u2029' {
 			if start < i {
 				w.writestr(s[start:i])
@@ -369,88 +388,6 @@ func (e *jsonEncDriver) quoteStr(s string) {
 		w.writestr(s[start:])
 	}
 	w.writen1('"')
-}
-
-//--------------------------------
-
-type jsonNum struct {
-	// bytes            []byte // may have [+-.eE0-9]
-	mantissa         uint64 // where mantissa ends, and maybe dot begins.
-	exponent         int16  // exponent value.
-	manOverflow      bool
-	neg              bool // started with -. No initial sign in the bytes above.
-	dot              bool // has dot
-	explicitExponent bool // explicit exponent
-}
-
-func (x *jsonNum) reset() {
-	x.manOverflow = false
-	x.neg = false
-	x.dot = false
-	x.explicitExponent = false
-	x.mantissa = 0
-	x.exponent = 0
-}
-
-// uintExp is called only if exponent > 0.
-func (x *jsonNum) uintExp() (n uint64, overflow bool) {
-	n = x.mantissa
-	e := x.exponent
-	if e >= int16(len(jsonUint64Pow10)) {
-		overflow = true
-		return
-	}
-	n *= jsonUint64Pow10[e]
-	if n < x.mantissa || n > jsonNumUintMaxVal {
-		overflow = true
-		return
-	}
-	return
-	// for i := int16(0); i < e; i++ {
-	// 	if n >= jsonNumUintCutoff {
-	// 		overflow = true
-	// 		return
-	// 	}
-	// 	n *= 10
-	// }
-	// return
-}
-
-// these constants are only used withn floatVal.
-// They are brought out, so that floatVal can be inlined.
-const (
-	jsonUint64MantissaBits = 52
-	jsonMaxExponent        = int16(len(jsonFloat64Pow10)) - 1
-)
-
-func (x *jsonNum) floatVal() (f float64, parseUsingStrConv bool) {
-	// We do not want to lose precision.
-	// Consequently, we will delegate to strconv.ParseFloat if any of the following happen:
-	//    - There are more digits than in math.MaxUint64: 18446744073709551615 (20 digits)
-	//      We expect up to 99.... (19 digits)
-	//    - The mantissa cannot fit into a 52 bits of uint64
-	//    - The exponent is beyond our scope ie beyong 22.
-	parseUsingStrConv = x.manOverflow ||
-		x.exponent > jsonMaxExponent ||
-		(x.exponent < 0 && -(x.exponent) > jsonMaxExponent) ||
-		x.mantissa>>jsonUint64MantissaBits != 0
-
-	if parseUsingStrConv {
-		return
-	}
-
-	// all good. so handle parse here.
-	f = float64(x.mantissa)
-	// fmt.Printf(".Float: uint64 value: %v, float: %v\n", m, f)
-	if x.neg {
-		f = -f
-	}
-	if x.exponent > 0 {
-		f *= jsonFloat64Pow10[x.exponent]
-	} else if x.exponent < 0 {
-		f /= jsonFloat64Pow10[-x.exponent]
-	}
-	return
 }
 
 type jsonDecDriver struct {
@@ -470,25 +407,13 @@ type jsonDecDriver struct {
 
 	se setExtWrapper
 
-	n jsonNum
+	// n jsonNum
 }
 
 func jsonIsWS(b byte) bool {
-	return b == ' ' || b == '\t' || b == '\r' || b == '\n'
+	// return b == ' ' || b == '\t' || b == '\r' || b == '\n'
+	return jsonCharWhitespaceSet[b]
 }
-
-// // This will skip whitespace characters and return the next byte to read.
-// // The next byte determines what the value will be one of.
-// func (d *jsonDecDriver) skipWhitespace() {
-// 	// fast-path: do not enter loop. Just check first (in case no whitespace).
-// 	b := d.r.readn1()
-// 	if jsonIsWS(b) {
-// 		r := d.r
-// 		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-// 		}
-// 	}
-// 	d.tok = b
-// }
 
 func (d *jsonDecDriver) uncacheRead() {
 	if d.tok != 0 {
@@ -499,11 +424,7 @@ func (d *jsonDecDriver) uncacheRead() {
 
 func (d *jsonDecDriver) sendContainerState(c containerState) {
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
 	var xc uint8 // char expected
 	if c == containerMapKey {
@@ -532,37 +453,23 @@ func (d *jsonDecDriver) sendContainerState(c containerState) {
 
 func (d *jsonDecDriver) CheckBreak() bool {
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
-	if d.tok == '}' || d.tok == ']' {
-		// d.tok = 0 // only checking, not consuming
-		return true
-	}
-	return false
+	return d.tok == '}' || d.tok == ']'
 }
 
 func (d *jsonDecDriver) readStrIdx(fromIdx, toIdx uint8) {
 	bs := d.r.readx(int(toIdx - fromIdx))
 	d.tok = 0
-	if jsonValidateSymbols {
-		if !bytes.Equal(bs, jsonLiterals[fromIdx:toIdx]) {
-			d.d.errorf("json: expecting %s: got %s", jsonLiterals[fromIdx:toIdx], bs)
-			return
-		}
+	if jsonValidateSymbols && !bytes.Equal(bs, jsonLiterals[fromIdx:toIdx]) {
+		d.d.errorf("json: expecting %s: got %s", jsonLiterals[fromIdx:toIdx], bs)
+		return
 	}
 }
 
 func (d *jsonDecDriver) TryDecodeAsNil() bool {
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
 	if d.tok == 'n' {
 		d.readStrIdx(10, 13) // ull
@@ -573,11 +480,7 @@ func (d *jsonDecDriver) TryDecodeAsNil() bool {
 
 func (d *jsonDecDriver) DecodeBool() bool {
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
 	if d.tok == 'f' {
 		d.readStrIdx(5, 9) // alse
@@ -593,11 +496,7 @@ func (d *jsonDecDriver) DecodeBool() bool {
 
 func (d *jsonDecDriver) ReadMapStart() int {
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
 	if d.tok != '{' {
 		d.d.errorf("json: expect char '%c' but got char '%c'", '{', d.tok)
@@ -609,11 +508,7 @@ func (d *jsonDecDriver) ReadMapStart() int {
 
 func (d *jsonDecDriver) ReadArrayStart() int {
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
 	if d.tok != '[' {
 		d.d.errorf("json: expect char '%c' but got char '%c'", '[', d.tok)
@@ -626,11 +521,7 @@ func (d *jsonDecDriver) ReadArrayStart() int {
 func (d *jsonDecDriver) ContainerType() (vt valueType) {
 	// check container type by checking the first char
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
 	if b := d.tok; b == '{' {
 		return valueTypeMap
@@ -646,260 +537,57 @@ func (d *jsonDecDriver) ContainerType() (vt valueType) {
 	// return false // "unreachable"
 }
 
-func (d *jsonDecDriver) decNum(storeBytes bool) {
-	// If it is has a . or an e|E, decode as a float; else decode as an int.
+func (d *jsonDecDriver) decNumBytes() (bs []byte) {
+	// stores num bytes in d.bs
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
-	b := d.tok
-	var str bool
-	if b == '"' {
-		str = true
-		b = d.r.readn1()
-	}
-	if !(b == '+' || b == '-' || b == '.' || (b >= '0' && b <= '9')) {
-		d.d.errorf("json: decNum: got first char '%c'", b)
-		return
+	if d.tok == '"' {
+		bs = d.r.readUntil(d.b2[:0], '"')
+		bs = bs[:len(bs)-1]
+	} else {
+		d.r.unreadn1()
+		bs = d.r.readTo(d.bs[:0], &jsonNumSet)
+		// bs = d.r.readbUntilAny(d.bs[:0], " \t\n:,{}[]")
 	}
 	d.tok = 0
+	// fmt.Printf(">>>> decNumBytes: returning: '%s'\n", bs)
+	return bs
+}
 
-	const cutoff = (1<<64-1)/uint64(10) + 1 // cutoff64(base)
-	const jsonNumUintMaxVal = 1<<uint64(64) - 1
-
-	n := &d.n
-	r := d.r
-	n.reset()
-	d.bs = d.bs[:0]
-
-	if str && storeBytes {
-		d.bs = append(d.bs, '"')
+func (d *jsonDecDriver) DecodeUint(bitsize uint8) (u uint64) {
+	bs := d.decNumBytes()
+	u, err := strconv.ParseUint(stringView(bs), 10, int(bitsize))
+	if err != nil {
+		d.d.errorf("json: decode uint from %s: %v", bs, err)
+		return
 	}
-
-	// The format of a number is as below:
-	// parsing:     sign? digit* dot? digit* e?  sign? digit*
-	// states:  0   1*    2      3*   4      5*  6     7
-	// We honor this state so we can break correctly.
-	var state uint8 = 0
-	var eNeg bool
-	var e int16
-	var eof bool
-LOOP:
-	for !eof {
-		// fmt.Printf("LOOP: b: %q\n", b)
-		switch b {
-		case '+':
-			switch state {
-			case 0:
-				state = 2
-				// do not add sign to the slice ...
-				b, eof = r.readn1eof()
-				continue
-			case 6: // typ = jsonNumFloat
-				state = 7
-			default:
-				break LOOP
-			}
-		case '-':
-			switch state {
-			case 0:
-				state = 2
-				n.neg = true
-				// do not add sign to the slice ...
-				b, eof = r.readn1eof()
-				continue
-			case 6: // typ = jsonNumFloat
-				eNeg = true
-				state = 7
-			default:
-				break LOOP
-			}
-		case '.':
-			switch state {
-			case 0, 2: // typ = jsonNumFloat
-				state = 4
-				n.dot = true
-			default:
-				break LOOP
-			}
-		case 'e', 'E':
-			switch state {
-			case 0, 2, 4: // typ = jsonNumFloat
-				state = 6
-				// n.mantissaEndIndex = int16(len(n.bytes))
-				n.explicitExponent = true
-			default:
-				break LOOP
-			}
-		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-			switch state {
-			case 0:
-				state = 2
-				fallthrough
-			case 2:
-				fallthrough
-			case 4:
-				if n.dot {
-					n.exponent--
-				}
-				if n.mantissa >= jsonNumUintCutoff {
-					n.manOverflow = true
-					break
-				}
-				v := uint64(b - '0')
-				n.mantissa *= 10
-				if v != 0 {
-					n1 := n.mantissa + v
-					if n1 < n.mantissa || n1 > jsonNumUintMaxVal {
-						n.manOverflow = true // n+v overflows
-						break
-					}
-					n.mantissa = n1
-				}
-			case 6:
-				state = 7
-				fallthrough
-			case 7:
-				if !(b == '0' && e == 0) {
-					e = e*10 + int16(b-'0')
-				}
-			default:
-				break LOOP
-			}
-		case '"':
-			if str {
-				if storeBytes {
-					d.bs = append(d.bs, '"')
-				}
-				b, eof = r.readn1eof()
-			}
-			break LOOP
-		default:
-			break LOOP
-		}
-		if storeBytes {
-			d.bs = append(d.bs, b)
-		}
-		b, eof = r.readn1eof()
-	}
-
-	if jsonTruncateMantissa && n.mantissa != 0 {
-		for n.mantissa%10 == 0 {
-			n.mantissa /= 10
-			n.exponent++
-		}
-	}
-
-	if e != 0 {
-		if eNeg {
-			n.exponent -= e
-		} else {
-			n.exponent += e
-		}
-	}
-
-	// d.n = n
-
-	if !eof {
-		if jsonUnreadAfterDecNum {
-			r.unreadn1()
-		} else {
-			if !jsonIsWS(b) {
-				d.tok = b
-			}
-		}
-	}
-	// fmt.Printf("1: n: bytes: %s, neg: %v, dot: %v, exponent: %v, mantissaEndIndex: %v\n",
-	// 	n.bytes, n.neg, n.dot, n.exponent, n.mantissaEndIndex)
 	return
 }
 
 func (d *jsonDecDriver) DecodeInt(bitsize uint8) (i int64) {
-	d.decNum(false)
-	n := &d.n
-	if n.manOverflow {
-		d.d.errorf("json: overflow integer after: %v", n.mantissa)
+	bs := d.decNumBytes()
+	// if bytes.ContainsAny(bs, ".eE") {
+	// 	d.d.errorf("json: decoding int, but found one or more of the chars: .eE: %s", bs)
+	// 	return
+	// }
+	i, err := strconv.ParseInt(stringView(bs), 10, int(bitsize))
+	if err != nil {
+		d.d.errorf("json: decode int from %s: %v", bs, err)
 		return
 	}
-	var u uint64
-	if n.exponent == 0 {
-		u = n.mantissa
-	} else if n.exponent < 0 {
-		d.d.errorf("json: fractional integer")
-		return
-	} else if n.exponent > 0 {
-		var overflow bool
-		if u, overflow = n.uintExp(); overflow {
-			d.d.errorf("json: overflow integer")
-			return
-		}
-	}
-	i = int64(u)
-	if n.neg {
-		i = -i
-	}
-	if chkOvf.Int(i, bitsize) {
-		d.d.errorf("json: overflow %v bits: %s", bitsize, d.bs)
-		return
-	}
-	// fmt.Printf("DecodeInt: %v\n", i)
-	return
-}
-
-// floatVal MUST only be called after a decNum, as d.bs now contains the bytes of the number
-func (d *jsonDecDriver) floatVal() (f float64) {
-	f, useStrConv := d.n.floatVal()
-	if useStrConv {
-		var err error
-		if f, err = strconv.ParseFloat(stringView(d.bs), 64); err != nil {
-			panic(fmt.Errorf("parse float: %s, %v", d.bs, err))
-		}
-		if d.n.neg {
-			f = -f
-		}
-	}
-	return
-}
-
-func (d *jsonDecDriver) DecodeUint(bitsize uint8) (u uint64) {
-	d.decNum(false)
-	n := &d.n
-	if n.neg {
-		d.d.errorf("json: unsigned integer cannot be negative")
-		return
-	}
-	if n.manOverflow {
-		d.d.errorf("json: overflow integer after: %v", n.mantissa)
-		return
-	}
-	if n.exponent == 0 {
-		u = n.mantissa
-	} else if n.exponent < 0 {
-		d.d.errorf("json: fractional integer")
-		return
-	} else if n.exponent > 0 {
-		var overflow bool
-		if u, overflow = n.uintExp(); overflow {
-			d.d.errorf("json: overflow integer")
-			return
-		}
-	}
-	if chkOvf.Uint(u, bitsize) {
-		d.d.errorf("json: overflow %v bits: %s", bitsize, d.bs)
-		return
-	}
-	// fmt.Printf("DecodeUint: %v\n", u)
 	return
 }
 
 func (d *jsonDecDriver) DecodeFloat(chkOverflow32 bool) (f float64) {
-	d.decNum(true)
-	f = d.floatVal()
-	if chkOverflow32 && chkOvf.Float32(f) {
-		d.d.errorf("json: overflow float32: %v, %s", f, d.bs)
+	bs := d.decNumBytes()
+	bitsize := 64
+	if chkOverflow32 {
+		bitsize = 32
+	}
+	f, err := strconv.ParseFloat(stringView(bs), bitsize)
+	if err != nil {
+		d.d.errorf("json: decode float from %s: %v", bs, err)
 		return
 	}
 	return
@@ -918,19 +606,14 @@ func (d *jsonDecDriver) DecodeExt(rv interface{}, xtag uint64, ext Ext) (realxta
 	return
 }
 
-func (d *jsonDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
+func (d *jsonDecDriver) DecodeBytes(bs []byte, zerocopy bool) (bsOut []byte) {
 	// if decoding into raw bytes, and the RawBytesExt is configured, use it to decode.
-	if !isstring && d.se.i != nil {
+	if d.se.i != nil {
 		bsOut = bs
 		d.DecodeExt(&bsOut, 0, &d.se)
 		return
 	}
 	d.appendStringAsBytes()
-	// if isstring, then just return the bytes, even if it is using the scratch buffer.
-	// the bytes will be converted to a string as needed.
-	if isstring {
-		return d.bs
-	}
 	// if appendStringAsBytes returned a zero-len slice, then treat as nil.
 	// This should only happen for null, and "".
 	if len(d.bs) == 0 {
@@ -956,86 +639,110 @@ func (d *jsonDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut [
 	return
 }
 
+const jsonAlwaysReturnInternString = false
+
 func (d *jsonDecDriver) DecodeString() (s string) {
 	d.appendStringAsBytes()
 	// if x := d.s.sc; x != nil && x.so && x.st == '}' { // map key
-	if d.c == containerMapKey {
+	if jsonAlwaysReturnInternString || d.c == containerMapKey {
 		return d.d.string(d.bs)
 	}
 	return string(d.bs)
 }
 
+func (d *jsonDecDriver) DecodeStringAsBytes() (s []byte) {
+	d.appendStringAsBytes()
+	return d.bs
+}
+
 func (d *jsonDecDriver) appendStringAsBytes() {
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
-	}
-
-	// handle null as a string
-	if d.tok == 'n' {
-		d.readStrIdx(10, 13) // ull
-		d.bs = d.bs[:0]
-		return
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
 
 	if d.tok != '"' {
-		d.d.errorf("json: expect char '%c' but got char '%c'", '"', d.tok)
+		// d.d.errorf("json: expect char '%c' but got char '%c'", '"', d.tok)
+		// handle non-string scalar: null, true, false or a number
+		switch d.tok {
+		case 'n':
+			d.readStrIdx(10, 13) // ull
+			d.bs = d.bs[:0]
+		case 'f':
+			d.readStrIdx(5, 9) // alse
+			d.bs = d.bs[:5]
+			copy(d.bs, "false")
+		case 't':
+			d.readStrIdx(1, 4) // rue
+			d.bs = d.bs[:4]
+			copy(d.bs, "true")
+		default:
+			// try to parse a valid number
+			bs := d.decNumBytes()
+			d.bs = d.bs[:len(bs)]
+			copy(d.bs, bs)
+		}
+		return
 	}
-	d.tok = 0
 
-	v := d.bs[:0]
-	var c uint8
+	d.tok = 0
 	r := d.r
-	for {
-		c = r.readn1()
-		if c == '"' {
+	var cs []byte
+	v := d.bs[:0]
+	// var c uint8
+	for i := 0; ; i++ {
+		if i == len(cs) {
+			cs = r.readUntil(d.b2[:0], '"')
+			i = 0
+		}
+		if cs[i] == '"' {
 			break
-		} else if c == '\\' {
-			c = r.readn1()
-			switch c {
-			case '"', '\\', '/', '\'':
-				v = append(v, c)
-			case 'b':
-				v = append(v, '\b')
-			case 'f':
-				v = append(v, '\f')
-			case 'n':
-				v = append(v, '\n')
-			case 'r':
-				v = append(v, '\r')
-			case 't':
-				v = append(v, '\t')
-			case 'u':
-				rr := d.jsonU4(false)
-				// fmt.Printf("$$$$$$$$$: is surrogate: %v\n", utf16.IsSurrogate(rr))
-				if utf16.IsSurrogate(rr) {
-					rr = utf16.DecodeRune(rr, d.jsonU4(true))
+		}
+		if cs[i] != '\\' {
+			v = append(v, cs[i])
+			continue
+		}
+		// cs[i] == '\\'
+		i++
+		switch cs[i] {
+		case '"', '\\', '/', '\'':
+			v = append(v, cs[i])
+		case 'b':
+			v = append(v, '\b')
+		case 'f':
+			v = append(v, '\f')
+		case 'n':
+			v = append(v, '\n')
+		case 'r':
+			v = append(v, '\r')
+		case 't':
+			v = append(v, '\t')
+		case 'u':
+			rr := d.jsonU4Arr([4]byte{cs[i+1], cs[i+2], cs[i+3], cs[i+4]})
+			i += 4
+			// fmt.Printf("$$$$$$$$$: is surrogate: %v\n", utf16.IsSurrogate(rr))
+			if utf16.IsSurrogate(rr) {
+				// fmt.Printf(">>>> checking utf16 surrogate\n")
+				if !(cs[i+1] == '\\' && cs[i+2] == 'u') {
+					d.d.errorf(`json: unquoteStr: invalid unicode sequence. Expecting \u`)
+					return
 				}
-				w2 := utf8.EncodeRune(d.bstr[:], rr)
-				v = append(v, d.bstr[:w2]...)
-			default:
-				d.d.errorf("json: unsupported escaped value: %c", c)
+				i += 2
+				rr = utf16.DecodeRune(rr, d.jsonU4Arr([4]byte{cs[i+1], cs[i+2], cs[i+3], cs[i+4]}))
+				i += 4
 			}
-		} else {
-			v = append(v, c)
+			w2 := utf8.EncodeRune(d.bstr[:], rr)
+			v = append(v, d.bstr[:w2]...)
+		default:
+			d.d.errorf("json: unsupported escaped value: %c", cs[i])
 		}
 	}
 	d.bs = v
 }
 
-func (d *jsonDecDriver) jsonU4(checkSlashU bool) rune {
-	r := d.r
-	if checkSlashU && !(r.readn1() == '\\' && r.readn1() == 'u') {
-		d.d.errorf(`json: unquoteStr: invalid unicode sequence. Expecting \u`)
-		return 0
-	}
+func (d *jsonDecDriver) jsonU4Arr(bs [4]byte) (r rune) {
 	// u, _ := strconv.ParseUint(string(d.bstr[:4]), 16, 64)
 	var u uint32
-	for i := 0; i < 4; i++ {
-		v := r.readn1()
+	for _, v := range bs {
 		if '0' <= v && v <= '9' {
 			v = v - '0'
 		} else if 'a' <= v && v <= 'z' {
@@ -1048,6 +755,7 @@ func (d *jsonDecDriver) jsonU4(checkSlashU bool) rune {
 		}
 		u = u*16 + uint32(v)
 	}
+	// fmt.Printf(">>>>>>>> jsonU4Arr: %v, %s\n", rune(u), string(rune(u)))
 	return rune(u)
 }
 
@@ -1056,11 +764,7 @@ func (d *jsonDecDriver) DecodeNaked() {
 	// var decodeFurther bool
 
 	if d.tok == 0 {
-		var b byte
-		r := d.r
-		for b = r.readn1(); jsonIsWS(b); b = r.readn1() {
-		}
-		d.tok = b
+		d.tok = d.r.skip(&jsonCharWhitespaceSet)
 	}
 	switch d.tok {
 	case 'n':
@@ -1086,41 +790,35 @@ func (d *jsonDecDriver) DecodeNaked() {
 		z.v = valueTypeString
 		z.s = d.DecodeString()
 	default: // number
-		d.decNum(true)
-		n := &d.n
-		// if the string had a any of [.eE], then decode as float.
-		switch {
-		case n.explicitExponent, n.dot, n.exponent < 0, n.manOverflow:
+		bs := d.decNumBytes()
+		var err error
+		if len(bs) == 0 {
+			d.d.errorf("json: decode number from empty string")
+			return
+		} else if d.h.PreferFloat ||
+			bytes.IndexByte(bs, '.') != -1 ||
+			bytes.IndexByte(bs, 'e') != -1 ||
+			bytes.IndexByte(bs, 'E') != -1 {
+			// } else if d.h.PreferFloat || bytes.ContainsAny(bs, ".eE") {
 			z.v = valueTypeFloat
-			z.f = d.floatVal()
-		case n.exponent == 0:
-			u := n.mantissa
-			switch {
-			case n.neg:
-				z.v = valueTypeInt
-				z.i = -int64(u)
-			case d.h.SignedInteger:
-				z.v = valueTypeInt
-				z.i = int64(u)
-			default:
-				z.v = valueTypeUint
-				z.u = u
+			z.f, err = strconv.ParseFloat(stringView(bs), 64)
+		} else if d.h.SignedInteger || bs[0] == '-' {
+			z.v = valueTypeInt
+			z.i, err = strconv.ParseInt(stringView(bs), 10, 64)
+		} else {
+			z.v = valueTypeUint
+			z.u, err = strconv.ParseUint(stringView(bs), 10, 64)
+		}
+		if err != nil {
+			if z.v == valueTypeInt || z.v == valueTypeUint {
+				if v, ok := err.(*strconv.NumError); ok && (v.Err == strconv.ErrRange || v.Err == strconv.ErrSyntax) {
+					z.v = valueTypeFloat
+					z.f, err = strconv.ParseFloat(stringView(bs), 64)
+				}
 			}
-		default:
-			u, overflow := n.uintExp()
-			switch {
-			case overflow:
-				z.v = valueTypeFloat
-				z.f = d.floatVal()
-			case n.neg:
-				z.v = valueTypeInt
-				z.i = -int64(u)
-			case d.h.SignedInteger:
-				z.v = valueTypeInt
-				z.i = int64(u)
-			default:
-				z.v = valueTypeUint
-				z.u = u
+			if err != nil {
+				d.d.errorf("json: decode number from %s: %v", bs, err)
+				return
 			}
 		}
 		// fmt.Printf("DecodeNaked: Number: %T, %v\n", v, v)
@@ -1130,6 +828,14 @@ func (d *jsonDecDriver) DecodeNaked() {
 	// }
 	return
 }
+
+// func jsonAcceptNonWS(b byte) bool {
+// 	return !jsonCharWhitespaceSet[b]
+// }
+
+// func jsonAcceptDQuote(b byte) bool {
+// 	return b == '"'
+// }
 
 //----------------------
 
@@ -1152,6 +858,7 @@ func (d *jsonDecDriver) DecodeNaked() {
 type JsonHandle struct {
 	textEncodingType
 	BasicHandle
+
 	// RawBytesExt, if configured, is used to encode and decode raw bytes in a custom way.
 	// If not configured, raw bytes are encoded to/from base64 text.
 	RawBytesExt InterfaceExt
@@ -1173,6 +880,17 @@ type JsonHandle struct {
 	//             containing the exact integer representation as a decimal.
 	//   - else    encode all integers as a json number (default)
 	IntegerAsString uint8
+
+	// HTMLCharsAsIs controls how to encode some special characters to html: < > &
+	//
+	// By default, we encode them as \uXXX
+	// to prevent security holes when served from some browsers.
+	HTMLCharsAsIs bool
+
+	// PreferFloat says that we will default to decoding a number as a float.
+	// If not set, we will examine the characters of the number and decode as an
+	// integer type if it doesn't have any of the characters [.eE].
+	PreferFloat bool
 }
 
 func (h *JsonHandle) SetInterfaceExt(rt reflect.Type, tag uint64, ext InterfaceExt) (err error) {
@@ -1221,7 +939,7 @@ func (d *jsonDecDriver) reset() {
 		d.bs = d.bs[:0]
 	}
 	d.c, d.tok = 0, 0
-	d.n.reset()
+	// d.n.reset()
 }
 
 var jsonEncodeTerminate = []byte{' '}

--- a/cmd/vendor/github.com/ugorji/go/codec/msgpack.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/msgpack.go
@@ -349,11 +349,11 @@ func (d *msgpackDecDriver) DecodeNaked() {
 				n.s = d.DecodeString()
 			} else {
 				n.v = valueTypeBytes
-				n.l = d.DecodeBytes(nil, false, false)
+				n.l = d.DecodeBytes(nil, false)
 			}
 		case bd == mpBin8, bd == mpBin16, bd == mpBin32:
 			n.v = valueTypeBytes
-			n.l = d.DecodeBytes(nil, false, false)
+			n.l = d.DecodeBytes(nil, false)
 		case bd == mpArray16, bd == mpArray32, bd >= mpFixArrayMin && bd <= mpFixArrayMax:
 			n.v = valueTypeArray
 			decodeFurther = true
@@ -525,12 +525,11 @@ func (d *msgpackDecDriver) DecodeBool() (b bool) {
 	return
 }
 
-func (d *msgpackDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOut []byte) {
+func (d *msgpackDecDriver) DecodeBytes(bs []byte, zerocopy bool) (bsOut []byte) {
 	if !d.bdRead {
 		d.readNextBd()
 	}
 	var clen int
-	// ignore isstring. Expect that the bytes may be found from msgpackContainerStr or msgpackContainerBin
 	if bd := d.bd; bd == mpBin8 || bd == mpBin16 || bd == mpBin32 {
 		clen = d.readContainerLen(msgpackContainerBin)
 	} else {
@@ -549,11 +548,15 @@ func (d *msgpackDecDriver) DecodeBytes(bs []byte, isstring, zerocopy bool) (bsOu
 			bs = d.b[:]
 		}
 	}
-	return decByteSlice(d.r, clen, bs)
+	return decByteSlice(d.r, clen, d.d.h.MaxInitLen, bs)
 }
 
 func (d *msgpackDecDriver) DecodeString() (s string) {
-	return string(d.DecodeBytes(d.b[:], true, true))
+	return string(d.DecodeBytes(d.b[:], true))
+}
+
+func (d *msgpackDecDriver) DecodeStringAsBytes() (s []byte) {
+	return d.DecodeBytes(d.b[:], true)
 }
 
 func (d *msgpackDecDriver) readNextBd() {
@@ -569,6 +572,9 @@ func (d *msgpackDecDriver) uncacheRead() {
 }
 
 func (d *msgpackDecDriver) ContainerType() (vt valueType) {
+	if !d.bdRead {
+		d.readNextBd()
+	}
 	bd := d.bd
 	if bd == mpNil {
 		return valueTypeNil
@@ -621,10 +627,16 @@ func (d *msgpackDecDriver) readContainerLen(ct msgpackContainerType) (clen int) 
 }
 
 func (d *msgpackDecDriver) ReadMapStart() int {
+	if !d.bdRead {
+		d.readNextBd()
+	}
 	return d.readContainerLen(msgpackContainerMap)
 }
 
 func (d *msgpackDecDriver) ReadArrayStart() int {
+	if !d.bdRead {
+		d.readNextBd()
+	}
 	return d.readContainerLen(msgpackContainerList)
 }
 
@@ -678,10 +690,10 @@ func (d *msgpackDecDriver) decodeExtV(verifyTag bool, tag byte) (xtag byte, xbs 
 	}
 	xbd := d.bd
 	if xbd == mpBin8 || xbd == mpBin16 || xbd == mpBin32 {
-		xbs = d.DecodeBytes(nil, false, true)
+		xbs = d.DecodeBytes(nil, true)
 	} else if xbd == mpStr8 || xbd == mpStr16 || xbd == mpStr32 ||
 		(xbd >= mpFixStrMin && xbd <= mpFixStrMax) {
-		xbs = d.DecodeBytes(nil, true, true)
+		xbs = d.DecodeStringAsBytes()
 	} else {
 		clen := d.readExtLen()
 		xtag = d.r.readn1()
@@ -727,7 +739,7 @@ func (h *MsgpackHandle) newEncDriver(e *Encoder) encDriver {
 }
 
 func (h *MsgpackHandle) newDecDriver(d *Decoder) decDriver {
-	return &msgpackDecDriver{d: d, r: d.r, h: h, br: d.bytes}
+	return &msgpackDecDriver{d: d, h: h, r: d.r, br: d.bytes}
 }
 
 func (e *msgpackEncDriver) reset() {
@@ -735,7 +747,7 @@ func (e *msgpackEncDriver) reset() {
 }
 
 func (d *msgpackDecDriver) reset() {
-	d.r = d.d.r
+	d.r, d.br = d.d.r, d.d.bytes
 	d.bd, d.bdRead = 0, false
 }
 

--- a/cmd/vendor/github.com/ugorji/go/codec/noop.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/noop.go
@@ -105,10 +105,9 @@ func (h *noopDrv) DecodeUint(bitsize uint8) (ui uint64)       { return uint64(h.
 func (h *noopDrv) DecodeFloat(chkOverflow32 bool) (f float64) { return float64(h.m(95)) }
 func (h *noopDrv) DecodeBool() (b bool)                       { return h.m(2) == 0 }
 func (h *noopDrv) DecodeString() (s string)                   { return h.S[h.m(8)] }
+func (h *noopDrv) DecodeStringAsBytes() []byte                { return h.DecodeBytes(nil, true) }
 
-// func (h *noopDrv) DecodeStringAsBytes(bs []byte) []byte       { return h.DecodeBytes(bs) }
-
-func (h *noopDrv) DecodeBytes(bs []byte, isstring, zerocopy bool) []byte { return h.B[h.m(len(h.B))] }
+func (h *noopDrv) DecodeBytes(bs []byte, zerocopy bool) []byte { return h.B[h.m(len(h.B))] }
 
 func (h *noopDrv) ReadEnd() { h.end() }
 

--- a/cmd/vendor/github.com/ugorji/go/codec/prebuild.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/prebuild.go
@@ -1,3 +1,0 @@
-package codec
-
-//go:generate bash prebuild.sh

--- a/cmd/vendor/github.com/ugorji/go/codec/time.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/time.go
@@ -5,23 +5,10 @@ package codec
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 )
 
-var (
-	timeDigits   = [...]byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
-	timeExtEncFn = func(rv reflect.Value) (bs []byte, err error) {
-		defer panicToErr(&err)
-		bs = timeExt{}.WriteExt(rv.Interface())
-		return
-	}
-	timeExtDecFn = func(rv reflect.Value, bs []byte) (err error) {
-		defer panicToErr(&err)
-		timeExt{}.ReadExt(rv.Interface(), bs)
-		return
-	}
-)
+var timeDigits = [...]byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
 
 type timeExt struct{}
 

--- a/cmd/vendor/github.com/ugorji/go/codec/xml.go
+++ b/cmd/vendor/github.com/ugorji/go/codec/xml.go
@@ -1,0 +1,426 @@
+// +build ignore
+
+package codec
+
+import "reflect"
+
+/*
+
+A strict Non-validating namespace-aware XML 1.0 parser and (en|de)coder.
+
+We are attempting this due to perceived issues with encoding/xml:
+  - Complicated. It tried to do too much, and is not as simple to use as json.
+  - Due to over-engineering, reflection is over-used AND performance suffers:
+    java is 6X faster:http://fabsk.eu/blog/category/informatique/dev/golang/
+    even PYTHON performs better: http://outgoing.typepad.com/outgoing/2014/07/exploring-golang.html
+
+codec framework will offer the following benefits
+  - VASTLY improved performance (when using reflection-mode or codecgen)
+  - simplicity and consistency: with the rest of the supported formats
+  - all other benefits of codec framework (streaming, codegeneration, etc)
+
+codec is not a drop-in replacement for encoding/xml.
+It is a replacement, based on the simplicity and performance of codec.
+Look at it like JAXB for Go.
+
+Challenges:
+
+  - Need to output XML preamble, with all namespaces at the right location in the output.
+  - Each "end" block is dynamic, so we need to maintain a context-aware stack
+  - How to decide when to use an attribute VS an element
+  - How to handle chardata, attr, comment EXPLICITLY.
+  - Should it output fragments?
+    e.g. encoding a bool should just output true OR false, which is not well-formed XML.
+
+Extend the struct tag. See representative example:
+  type X struct {
+    ID uint8 codec:"xid|http://ugorji.net/x-namespace id,omitempty,toarray,attr,cdata"
+  }
+
+Based on this, we encode
+  - fields as elements, BUT encode as attributes if struct tag contains ",attr".
+  - text as entity-escaped text, BUT encode as CDATA if struct tag contains ",cdata".
+
+In this mode, we only encode as attribute if ",attr" is found, and only encode as CDATA
+if ",cdata" is found in the struct tag.
+
+To handle namespaces:
+  - XMLHandle is denoted as being namespace-aware.
+    Consequently, we WILL use the ns:name pair to encode and decode if defined, else use the plain name.
+  - *Encoder and *Decoder know whether the Handle "prefers" namespaces.
+  - add *Encoder.getEncName(*structFieldInfo).
+    No one calls *structFieldInfo.indexForEncName directly anymore
+  - add *Decoder.getStructFieldInfo(encName string) // encName here is either like abc, or h1:nsabc
+    No one accesses .encName anymore except in
+  - let encode.go and decode.go use these (for consistency)
+  - only problem exists for gen.go, where we create a big switch on encName.
+    Now, we also have to add a switch on strings.endsWith(kName, encNsName)
+    - gen.go will need to have many more methods, and then double-on the 2 switch loops like:
+      switch k {
+        case "abc" : x.abc()
+        case "def" : x.def()
+        default {
+          switch {
+            case !nsAware: panic(...)
+            case strings.endsWith("nsabc"): x.abc()
+            default: panic(...)
+          }
+        }
+     }
+
+The structure below accomodates this:
+
+  type typeInfo struct {
+    sfi []*structFieldInfo // sorted by encName
+    sfins // sorted by namespace
+    sfia  // sorted, to have those with attributes at the top. Needed to write XML appropriately.
+    sfip  // unsorted
+  }
+  type structFieldInfo struct {
+    encName
+    nsEncName
+    ns string
+    attr bool
+    cdata bool
+  }
+
+indexForEncName is now an internal helper function that takes a sorted array
+(one of ti.sfins or ti.sfi). It is only used by *Encoder.getStructFieldInfo(...)
+
+There will be a separate parser from the builder.
+The parser will have a method: next() xmlToken method.
+
+xmlToken has fields:
+  - type uint8: 0 | ElementStart | ElementEnd | AttrKey | AttrVal | Text
+  - value string
+  - ns string
+
+SEE: http://www.xml.com/pub/a/98/10/guide0.html?page=3#ENTDECL
+
+The following are skipped when parsing:
+  - External Entities (from external file)
+  - Notation Declaration e.g. <!NOTATION GIF87A SYSTEM "GIF">
+  - Entity Declarations & References
+  - XML Declaration (assume UTF-8)
+  - XML Directive i.e. <! ... >
+  - Other Declarations: Notation, etc.
+  - Comment
+  - Processing Instruction
+  - schema / DTD for validation:
+    We are not a VALIDATING parser. Validation is done elsewhere.
+    However, some parts of the DTD internal subset are used (SEE BELOW).
+    For Attribute List Declarations e.g.
+    <!ATTLIST foo:oldjoke name ID #REQUIRED label CDATA #IMPLIED status ( funny | notfunny ) 'funny' >
+    We considered using the ATTLIST to get "default" value, but not to validate the contents. (VETOED)
+
+The following XML features are supported
+  - Namespace
+  - Element
+  - Attribute
+  - cdata
+  - Unicode escape
+
+The following DTD (when as an internal sub-set) features are supported:
+  - Internal Entities e.g.
+    <!ELEMENT burns "ugorji is cool" > AND entities for the set: [<>&"']
+  - Parameter entities e.g.
+    <!ENTITY % personcontent "ugorji is cool"> <!ELEMENT burns (%personcontent;)*>
+
+At decode time, a structure containing the following is kept
+  - namespace mapping
+  - default attribute values
+  - all internal entities (<>&"' and others written in the document)
+
+When decode starts, it parses XML namespace declarations and creates a map in the
+xmlDecDriver. While parsing, that map continously gets updated.
+The only problem happens when a namespace declaration happens on the node that it defines.
+e.g. <hn:name xmlns:hn="http://www.ugorji.net" >
+To handle this, each Element must be fully parsed at a time,
+even if it amounts to multiple tokens which are returned one at a time on request.
+
+xmlns is a special attribute name.
+  - It is used to define namespaces, including the default
+  - It is never returned as an AttrKey or AttrVal.
+  *We may decide later to allow user to use it e.g. you want to parse the xmlns mappings into a field.*
+
+Number, bool, null, mapKey, etc can all be decoded from any xmlToken.
+This accomodates map[int]string for example.
+
+It should be possible to create a schema from the types,
+or vice versa (generate types from schema with appropriate tags).
+This is however out-of-scope from this parsing project.
+
+We should write all namespace information at the first point that it is referenced in the tree,
+and use the mapping for all child nodes and attributes. This means that state is maintained
+at a point in the tree. This also means that calls to Decode or MustDecode will reset some state.
+
+When decoding, it is important to keep track of entity references and default attribute values.
+It seems these can only be stored in the DTD components. We should honor them when decoding.
+
+Configuration for XMLHandle will look like this:
+
+  XMLHandle
+    DefaultNS string
+    // Encoding:
+    NS map[string]string // ns URI to key, used for encoding
+    // Decoding: in case ENTITY declared in external schema or dtd, store info needed here
+    Entities map[string]string // map of entity rep to character
+
+
+During encode, if a namespace mapping is not defined for a namespace found on a struct,
+then we create a mapping for it using nsN (where N is 1..1000000, and doesn't conflict
+with any other namespace mapping).
+
+Note that different fields in a struct can have different namespaces.
+However, all fields will default to the namespace on the _struct field (if defined).
+
+An XML document is a name, a map of attributes and a list of children.
+Consequently, we cannot "DecodeNaked" into a map[string]interface{} (for example).
+We have to "DecodeNaked" into something that resembles XML data.
+
+To support DecodeNaked (decode into nil interface{}) we have to define some "supporting" types:
+    type Name struct { // Prefered. Less allocations due to conversions.
+      Local string
+      Space string
+    }
+    type Element struct {
+      Name Name
+      Attrs map[Name]string
+      Children []interface{} // each child is either *Element or string
+    }
+Only two "supporting" types are exposed for XML: Name and Element.
+
+We considered 'type Name string' where Name is like "Space Local" (space-separated).
+We decided against it, because each creation of a name would lead to
+double allocation (first convert []byte to string, then concatenate them into a string).
+The benefit is that it is faster to read Attrs from a map. But given that Element is a value
+object, we want to eschew methods and have public exposed variables.
+
+We also considered the following, where xml types were not value objects, and we used
+intelligent accessor methods to extract information and for performance.
+*** WE DECIDED AGAINST THIS. ***
+    type Attr struct {
+      Name Name
+      Value string
+    }
+    // Element is a ValueObject: There are no accessor methods.
+    // Make element self-contained.
+    type Element struct {
+      Name Name
+      attrsMap map[string]string // where key is "Space Local"
+      attrs []Attr
+      childrenT []string
+      childrenE []Element
+      childrenI []int // each child is a index into T or E.
+    }
+    func (x *Element) child(i) interface{} // returns string or *Element
+
+Per XML spec and our default handling, white space is insignificant between elements,
+specifically between parent-child or siblings. White space occuring alone between start
+and end element IS significant. However, if xml:space='preserve', then we 'preserve'
+all whitespace. This is more critical when doing a DecodeNaked, but MAY not be as critical
+when decoding into a typed value.
+
+**Note: there is no xml: namespace. The xml: attributes were defined before namespaces.**
+**So treat them as just "directives" that should be interpreted to mean something**.
+
+On encoding, we don't add any prettifying markup (indenting, etc).
+
+A document or element can only be encoded/decoded from/to a struct. In this mode:
+  - struct name maps to element name (or tag-info from _struct field)
+  - fields are mapped to child elements or attributes
+
+A map is either encoded as attributes on current element, or as a set of child elements.
+Maps are encoded as attributes iff their keys and values are primitives (number, bool, string).
+
+A list is encoded as a set of child elements.
+
+Primitives (number, bool, string) are encoded as an element, attribute or text
+depending on the context.
+
+Extensions must encode themselves as a text string.
+
+Encoding is tough, specifically when encoding mappings, because we need to encode
+as either attribute or element. To do this, we need to default to encoding as attributes,
+and then let Encoder inform the Handle when to start encoding as nodes.
+i.e. Encoder does something like:
+
+    h.EncodeMapStart()
+    h.Encode(), h.Encode(), ...
+    h.EncodeMapNotAttrSignal() // this is not a bool, because it's a signal
+    h.Encode(), h.Encode(), ...
+    h.EncodeEnd()
+
+Only XMLHandle understands this, and will set itself to start encoding as elements.
+
+This support extends to maps. For example, if a struct field is a map, and it has
+the struct tag signifying it should be attr, then all its fields are encoded as attributes.
+e.g.
+
+    type X struct {
+       M map[string]int `codec:"m,attr"` // encode as attributes
+    }
+
+Question:
+  - if encoding a map, what if map keys have spaces in them???
+    Then they cannot be attributes or child elements. Error.
+
+Misc:
+
+  - For attribute values, normalize by trimming beginning and ending white space,
+    and converting every white space sequence to a single space.
+  - ATTLIST restrictions are enforced.
+    e.g. default value of xml:space, skipping xml:XYZ style attributes, etc.
+  - Consider supporting NON-STRICT mode (e.g. to handle HTML parsing).
+    Some elements e.g. br, hr, etc need not close and should be auto-closed
+    ... (see http://www.w3.org/TR/html4/loose.dtd)
+    An expansive set of entities are pre-defined.
+  - Have easy way to create a HTML parser:
+    add a HTML() method to XMLHandle, that will set Strict=false, specify AutoClose,
+    and add HTML Entities to the list.
+  - Support validating element/attribute XMLName before writing it.
+    Keep this behind a flag, which is set to false by default (for performance).
+    type XMLHandle struct {
+      CheckName bool
+    }
+
+ROADMAP (1 weeks):
+  - build encoder (1 day)
+  - build decoder (based off xmlParser) (1 day)
+  - implement xmlParser (2 days).
+    Look at encoding/xml for inspiration.
+  - integrate and TEST (1 days)
+  - write article and post it (1 day)
+
+
+*/
+
+// ----------- PARSER  -------------------
+
+type xmlTokenType uint8
+
+const (
+	_ xmlTokenType = iota << 1
+	xmlTokenElemStart
+	xmlTokenElemEnd
+	xmlTokenAttrKey
+	xmlTokenAttrVal
+	xmlTokenText
+)
+
+type xmlToken struct {
+	Type      xmlTokenType
+	Value     string
+	Namespace string // blank for AttrVal and Text
+}
+
+type xmlParser struct {
+	r    decReader
+	toks []xmlToken // list of tokens.
+	ptr  int        // ptr into the toks slice
+	done bool       // nothing else to parse. r now returns EOF.
+}
+
+func (x *xmlParser) next() (t *xmlToken) {
+	// once x.done, or x.ptr == len(x.toks) == 0, then return nil (to signify finish)
+	if !x.done && len(x.toks) == 0 {
+		x.nextTag()
+	}
+	// parses one element at a time (into possible many tokens)
+	if x.ptr < len(x.toks) {
+		t = &(x.toks[x.ptr])
+		x.ptr++
+		if x.ptr == len(x.toks) {
+			x.ptr = 0
+			x.toks = x.toks[:0]
+		}
+	}
+	return
+}
+
+// nextTag will parses the next element and fill up toks.
+// It set done flag if/once EOF is reached.
+func (x *xmlParser) nextTag() {
+	// TODO: implement.
+}
+
+// ----------- ENCODER -------------------
+
+type xmlEncDriver struct {
+	e  *Encoder
+	w  encWriter
+	h  *XMLHandle
+	b  [64]byte // scratch
+	bs []byte   // scratch
+	// s  jsonStack
+	noBuiltInTypes
+}
+
+// ----------- DECODER -------------------
+
+type xmlDecDriver struct {
+	d    *Decoder
+	h    *XMLHandle
+	r    decReader // *bytesDecReader decReader
+	ct   valueType // container type. one of unset, array or map.
+	bstr [8]byte   // scratch used for string \UXXX parsing
+	b    [64]byte  // scratch
+
+	// wsSkipped bool // whitespace skipped
+
+	// s jsonStack
+
+	noBuiltInTypes
+}
+
+// DecodeNaked will decode into an XMLNode
+
+// XMLName is a value object representing a namespace-aware NAME
+type XMLName struct {
+	Local string
+	Space string
+}
+
+// XMLNode represents a "union" of the different types of XML Nodes.
+// Only one of fields (Text or *Element) is set.
+type XMLNode struct {
+	Element *Element
+	Text    string
+}
+
+// XMLElement is a value object representing an fully-parsed XML element.
+type XMLElement struct {
+	Name  Name
+	Attrs map[XMLName]string
+	// Children is a list of child nodes, each being a *XMLElement or string
+	Children []XMLNode
+}
+
+// ----------- HANDLE  -------------------
+
+type XMLHandle struct {
+	BasicHandle
+	textEncodingType
+
+	DefaultNS string
+	NS        map[string]string // ns URI to key, for encoding
+	Entities  map[string]string // entity representation to string, for encoding.
+}
+
+func (h *XMLHandle) newEncDriver(e *Encoder) encDriver {
+	return &xmlEncDriver{e: e, w: e.w, h: h}
+}
+
+func (h *XMLHandle) newDecDriver(d *Decoder) decDriver {
+	// d := xmlDecDriver{r: r.(*bytesDecReader), h: h}
+	hd := xmlDecDriver{d: d, r: d.r, h: h}
+	hd.n.bytes = d.b[:]
+	return &hd
+}
+
+func (h *XMLHandle) SetInterfaceExt(rt reflect.Type, tag uint64, ext InterfaceExt) (err error) {
+	return h.SetExt(rt, tag, &setExtWrapper{i: ext})
+}
+
+var _ decDriver = (*xmlDecDriver)(nil)
+var _ encDriver = (*xmlEncDriver)(nil)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f12c87d509e99534547e948533b8e8a88043c2261c0be08f155a26cd920b5fd4
-updated: 2017-09-11T14:52:48.727295105-07:00
+hash: 49950d40cee960e66f818746fca6ccaa849c62851d81d0960f6089c3677eec65
+updated: 2017-09-19T14:50:30.702073385+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -102,7 +102,7 @@ imports:
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  version: 54210f4e076c57f351166f0ed60e67d3fca57a36
   subpackages:
   - codec
 - name: github.com/urfave/cli

--- a/glide.yaml
+++ b/glide.yaml
@@ -68,7 +68,7 @@ import:
 - package: github.com/spf13/pflag
   version: v1.0.0
 - package: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  version: 54210f4e076c57f351166f0ed60e67d3fca57a36
   subpackages:
   - codec
 - package: github.com/urfave/cli


### PR DESCRIPTION
Major updates to ugorji/go changed the signature of some
methods, resulting in the build failing for etcd/client.

We regenerate the sources using codecgen to reflect on the
new changes.

Fixes #8573

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>
