### PR TITLE
e2e: log an error of TempDir() during the preparation of cluster crea…

### DIFF
--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -197,7 +197,7 @@ func (cfg *etcdProcessClusterConfig) etcdServerProcessConfigs() []*etcdServerPro
 			var derr error
 			dataDirPath, derr = ioutil.TempDir("", name+".etcd")
 			if derr != nil {
-				panic("could not get tempdir for datadir")
+				panic(fmt.Sprintf("could not get tempdir for datadir: %s", derr))
 			}
 		}
 		initialCluster[i] = fmt.Sprintf("%s=%s", name, purl.String())


### PR DESCRIPTION
…tion

I actually see the error in CI failure: https://jenkins-etcd-public.prod.coreos.systems/job/etcd-coverage/2365/console but the error code couldn't be checked because e2e didn't log it. This commit lets e2e log the error.