### PR TITLE
clientv3: add quote that Go v1.9 is required

### DIFF
--- a/clientv3/README.md
+++ b/clientv3/README.md
@@ -10,6 +10,8 @@
 go get github.com/coreos/etcd/clientv3
 ```
 
+> Requires Go v1.9
+
 ## Get started
 
 Create client using `clientv3.New`:

--- a/clientv3/README.md
+++ b/clientv3/README.md
@@ -10,7 +10,7 @@
 go get github.com/coreos/etcd/clientv3
 ```
 
-> Requires Go v1.9
+> **Requires Go v1.9+**
 
 ## Get started
 


### PR DESCRIPTION
Updated clientv3 with quote that Go v1.9 is required

#8548