### PR TITLE
etcd.conf.yml.example: peer-client-cert-auth flag

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -123,7 +123,7 @@ peer-transport-security:
   key-file:
 
   # Enable peer client cert authentication.
-  client-cert-auth: false
+  peer-client-cert-auth: false
 
   # Path to the peer server TLS trusted CA key file.
   trusted-ca-file:


### PR DESCRIPTION
Previous config was incorrect for peer client cert auth
  Enable peer client cert authentication.
  client-cert-auth: false

corrected to 
peer-client-cert-auth