### PR TITLE
etcdctl,clientv3: add debugging logs

### DIFF
--- a/clientv3/balancer.go
+++ b/clientv3/balancer.go
@@ -309,6 +309,9 @@ func (b *simpleBalancer) up(addr grpc.Address) (func(error), bool) {
 	close(b.upc)
 	b.downc = make(chan struct{})
 	b.pinAddr = addr.Addr
+	if logger.V(4) {
+		logger.Infof("clientv3: balancer pins endpoint to %s", addr.Addr)
+	}
 	// notify client that a connection is up
 	b.readyOnce.Do(func() { close(b.readyc) })
 	return func(err error) {
@@ -317,6 +320,9 @@ func (b *simpleBalancer) up(addr grpc.Address) (func(error), bool) {
 		close(b.downc)
 		b.pinAddr = ""
 		b.mu.Unlock()
+		if logger.V(4) {
+			logger.Infof("clientv3: unpin %s (%v)", addr.Addr, err)
+		}
 	}, true
 }
 

--- a/clientv3/health_balancer.go
+++ b/clientv3/health_balancer.go
@@ -186,6 +186,9 @@ func (hb *healthBalancer) mayPin(addr grpc.Address) bool {
 	hb.mu.Lock()
 	hb.unhealthy[addr.Addr] = time.Now()
 	hb.mu.Unlock()
+	if logger.V(4) {
+		logger.Infof("clientv3: %s becomes unhealthy", addr.Addr)
+	}
 	return false
 }
 


### PR DESCRIPTION
For https://github.com/coreos/etcd/issues/8591.
Sets logger level 2 as debugging level in clientv3.

Example output:

```
ETCDCTL_API=3 ./bin/etcdctl put foo bar --debug
ETCDCTL_CACERT=
ETCDCTL_CERT=
ETCDCTL_COMMAND_TIMEOUT=5s
ETCDCTL_DEBUG=true
ETCDCTL_DIAL_TIMEOUT=2s
ETCDCTL_DISCOVERY_SRV=
ETCDCTL_ENDPOINTS=[127.0.0.1:2379]
ETCDCTL_HEX=false
ETCDCTL_INSECURE_DISCOVERY=true
ETCDCTL_INSECURE_SKIP_TLS_VERIFY=false
ETCDCTL_INSECURE_TRANSPORT=true
ETCDCTL_KEY=
ETCDCTL_USER=
ETCDCTL_WRITE_OUT=simple
OK
```
