### PR TITLE
Documentation/op-guide: add Grafana dashboard link

### DIFF
--- a/Documentation/op-guide/monitoring.md
+++ b/Documentation/op-guide/monitoring.md
@@ -117,6 +117,8 @@ Access: proxy
 
 Then import the default [etcd dashboard template][template] and customize. For instance, if Prometheus data source name is `my-etcd`, the `datasource` field values in JSON also need to be `my-etcd`.
 
+See the [demo][demo].
+
 Sample dashboard:
 
 ![](./etcd-sample-grafana.png)
@@ -125,3 +127,4 @@ Sample dashboard:
 [prometheus]: https://prometheus.io/
 [grafana]: http://grafana.org/
 [template]: ./grafana.json
+[demo]: http://dash.etcd.io/dashboard/db/test-etcd-kubernetes


### PR DESCRIPTION
Add back dashboard link removed from https://github.com/coreos/etcd/commit/607d0762eb670c444ef873e7debcb69b167a76c8#diff-0f3cf03299e1ba976aa2c96fa242e51c.
The one with kubemark.