### PR TITLE
clientv3/ordering: add missing 'errOrderViolation' error check

### DIFF
--- a/clientv3/ordering/kv_test.go
+++ b/clientv3/ordering/kv_test.go
@@ -149,8 +149,8 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 	cli.SetEndpoints(clus.Members[2].GRPCAddr())
 
 	_, err = orderingKv.Get(ctx, "foo", clientv3.WithSerializable())
-	if err != nil {
-		t.Fatal(err)
+	if err != errOrderViolation {
+		t.Fatalf("expected %v, got %v", errOrderViolation, err)
 	}
 	orderingTxn = orderingKv.Txn(ctx)
 	_, err = orderingTxn.If(


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/8641.

`ordering` package is working as expected, we just didn't check the errors in tests.