### PR TITLE
vendor: update 'golang.org/x/crypto'

### DIFF
--- a/cmd/vendor/golang.org/x/crypto/bcrypt/bcrypt.go
+++ b/cmd/vendor/golang.org/x/crypto/bcrypt/bcrypt.go
@@ -12,9 +12,10 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/blowfish"
 	"io"
 	"strconv"
+
+	"golang.org/x/crypto/blowfish"
 )
 
 const (
@@ -205,7 +206,6 @@ func bcrypt(password []byte, cost int, salt []byte) ([]byte, error) {
 }
 
 func expensiveBlowfishSetup(key []byte, cost uint32, salt []byte) (*blowfish.Cipher, error) {
-
 	csalt, err := base64Decode(salt)
 	if err != nil {
 		return nil, err
@@ -213,7 +213,8 @@ func expensiveBlowfishSetup(key []byte, cost uint32, salt []byte) (*blowfish.Cip
 
 	// Bug compatibility with C bcrypt implementations. They use the trailing
 	// NULL in the key string during expansion.
-	ckey := append(key, 0)
+	// We copy the key to prevent changing the underlying array.
+	ckey := append(key[:len(key):len(key)], 0)
 
 	c, err := blowfish.NewSaltedCipher(ckey, csalt)
 	if err != nil {

--- a/cmd/vendor/golang.org/x/crypto/blowfish/cipher.go
+++ b/cmd/vendor/golang.org/x/crypto/blowfish/cipher.go
@@ -6,7 +6,7 @@
 package blowfish // import "golang.org/x/crypto/blowfish"
 
 // The code is a port of Bruce Schneier's C implementation.
-// See http://www.schneier.com/blowfish.html.
+// See https://www.schneier.com/blowfish.html.
 
 import "strconv"
 
@@ -39,7 +39,7 @@ func NewCipher(key []byte) (*Cipher, error) {
 
 // NewSaltedCipher creates a returns a Cipher that folds a salt into its key
 // schedule. For most purposes, NewCipher, instead of NewSaltedCipher, is
-// sufficient and desirable. For bcrypt compatiblity, the key can be over 56
+// sufficient and desirable. For bcrypt compatibility, the key can be over 56
 // bytes.
 func NewSaltedCipher(key, salt []byte) (*Cipher, error) {
 	if len(salt) == 0 {

--- a/cmd/vendor/golang.org/x/crypto/blowfish/const.go
+++ b/cmd/vendor/golang.org/x/crypto/blowfish/const.go
@@ -4,7 +4,7 @@
 
 // The startup permutation array and substitution boxes.
 // They are the hexadecimal digits of PI; see:
-// http://www.schneier.com/code/constants.txt.
+// https://www.schneier.com/code/constants.txt.
 
 package blowfish
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c9112594e510eb16840a825117ac0945777d4ac56ce4dcde5fa76cd7a1c130d5
-updated: 2017-09-28T13:34:20.16956-07:00
+hash: e18fa8fb6e4dc1d7eb3cd538c90b0927f26e1ab0b04cbdd209d2d5c3233b7c5b
+updated: 2017-10-05T07:34:38.051011-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -113,7 +113,7 @@ imports:
 - name: github.com/xiang90/probing
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
 - name: golang.org/x/crypto
-  version: 1351f936d976c60a0a48d728281922cf63eafb8d
+  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
   subpackages:
   - bcrypt
   - blowfish

--- a/glide.yaml
+++ b/glide.yaml
@@ -78,7 +78,7 @@ import:
 - package: github.com/grpc-ecosystem/go-grpc-prometheus
   version: v1.1
 - package: golang.org/x/crypto
-  version: 1351f936d976c60a0a48d728281922cf63eafb8d
+  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
   subpackages:
   - bcrypt
   - blowfish


### PR DESCRIPTION
To include https://github.com/golang/crypto/commit/6c586e17d90a7d08bbbc4069984180dce3b04117.
