### PR TITLE
travis: specify Go minor versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go_import_path: github.com/coreos/etcd
 sudo: false
 
 go:
-  - 1.9.x
+  - 1.9.1
   - tip
 
 notifications:


### PR DESCRIPTION
1.9.x doesn't work with travis Go 'gimme'.
https://travis-ci.org/coreos/etcd/jobs/283789582#L616-L629
