### PR TITLE
Dockerfile: Improve file permissions for docker build images using bind9

### DIFF
--- a/e2e/docker-dns-srv/Dockerfile
+++ b/e2e/docker-dns-srv/Dockerfile
@@ -2,16 +2,17 @@ FROM golang:1.9.1-stretch
 LABEL Description="Image for etcd DNS SRV testing"
 
 RUN apt update -y \
-  && apt install -y \
+  && apt install -y -q \
   bind9 \
   dnsutils
 
-RUN mkdir /var/bind
-RUN chown bind /var/bind
+RUN mkdir -p /var/bind /etc/bind
+RUN chown root:bind /var/bind /etc/bind
 ADD Procfile /Procfile
 ADD run.sh /run.sh
 
 ADD named.conf etcd.zone rdns.zone /etc/bind/
+RUN chown root:bind /etc/bind/named.conf /etc/bind/etcd.zone /etc/bind/rdns.zone
 ADD resolv.conf /etc/resolv.conf
 
 RUN go get github.com/mattn/goreman

--- a/e2e/docker-dns/Dockerfile
+++ b/e2e/docker-dns/Dockerfile
@@ -2,16 +2,17 @@ FROM golang:1.9.1-stretch
 LABEL Description="Image for etcd DNS testing"
 
 RUN apt update -y \
-  && apt install -y \
+  && apt install -y -q \
   bind9 \
   dnsutils
 
-RUN mkdir /var/bind
-RUN chown bind /var/bind
+RUN mkdir -p /var/bind /etc/bind
+RUN chown root:bind /var/bind /etc/bind
 ADD Procfile.tls /Procfile.tls
 ADD run.sh /run.sh
 
 ADD named.conf etcd.zone rdns.zone /etc/bind/
+RUN chown root:bind /etc/bind/named.conf /etc/bind/etcd.zone /etc/bind/rdns.zone
 ADD resolv.conf /etc/resolv.conf
 
 RUN go get github.com/mattn/goreman


### PR DESCRIPTION
This was noticed when attempting to replicate #8608 using the very convenient `make docker-dns-srv-test-build` command added in #8628.

On some system configurations bind9 failed to start in the container with 'permission denied' errors when accessing the config files added by the `Dockerfile`.  In my case the system configuration was Ubuntu trusty 14.04 and docker 1.12.6.

I'm not entirely clear on why this succeeds on other system configurations, but since `/etc/init.d/bind9` runs the daemon as the 'bind' user, setting the config file permissions appropriately seems like the way to go.