### PR TITLE
etcdctl/v3: add keep alive time/timeout

### DIFF
--- a/etcdctl/ctlv3/command/ep_command.go
+++ b/etcdctl/ctlv3/command/ep_command.go
@@ -82,10 +82,12 @@ func epHealthCommandFunc(cmd *cobra.Command, args []string) {
 
 	sec := secureCfgFromCmd(cmd)
 	dt := dialTimeoutFromCmd(cmd)
+	ka := keepAliveTimeFromCmd(cmd)
+	kat := keepAliveTimeoutFromCmd(cmd)
 	auth := authCfgFromCmd(cmd)
 	cfgs := []*v3.Config{}
 	for _, ep := range endpointsFromCluster(cmd) {
-		cfg, err := newClientCfg([]string{ep}, dt, sec, auth)
+		cfg, err := newClientCfg([]string{ep}, dt, ka, kat, sec, auth)
 		if err != nil {
 			ExitWithError(ExitBadArgs, err)
 		}

--- a/etcdctl/ctlv3/command/make_mirror_command.go
+++ b/etcdctl/ctlv3/command/make_mirror_command.go
@@ -66,6 +66,8 @@ func makeMirrorCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	dialTimeout := dialTimeoutFromCmd(cmd)
+	keepAliveTime := keepAliveTimeFromCmd(cmd)
+	keepAliveTimeout := keepAliveTimeoutFromCmd(cmd)
 	sec := &secureCfg{
 		cert:              mmcert,
 		key:               mmkey,
@@ -73,7 +75,7 @@ func makeMirrorCommandFunc(cmd *cobra.Command, args []string) {
 		insecureTransport: mminsecureTr,
 	}
 
-	dc := mustClient([]string{args[0]}, dialTimeout, sec, nil)
+	dc := mustClient([]string{args[0]}, dialTimeout, keepAliveTime, keepAliveTimeout, sec, nil)
 	c := mustClientFromCmd(cmd)
 
 	err := makeMirror(context.TODO(), c, dc)

--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -26,8 +26,10 @@ const (
 	cliName        = "etcdctl"
 	cliDescription = "A simple command line client for etcd3."
 
-	defaultDialTimeout    = 2 * time.Second
-	defaultCommandTimeOut = 5 * time.Second
+	defaultDialTimeout      = 2 * time.Second
+	defaultCommandTimeOut   = 5 * time.Second
+	defaultKeepAliveTime    = 2 * time.Second
+	defaultKeepAliveTimeOut = 6 * time.Second
 )
 
 var (
@@ -51,6 +53,8 @@ func init() {
 
 	rootCmd.PersistentFlags().DurationVar(&globalFlags.DialTimeout, "dial-timeout", defaultDialTimeout, "dial timeout for client connections")
 	rootCmd.PersistentFlags().DurationVar(&globalFlags.CommandTimeOut, "command-timeout", defaultCommandTimeOut, "timeout for short running command (excluding dial timeout)")
+	rootCmd.PersistentFlags().DurationVar(&globalFlags.KeepAliveTime, "keepalive-time", defaultKeepAliveTime, "keepalive time for client connections")
+	rootCmd.PersistentFlags().DurationVar(&globalFlags.KeepAliveTimeout, "keepalive-timeout", defaultKeepAliveTimeOut, "keepalive timeout for client connections")
 
 	// TODO: secure by default when etcd enables secure gRPC by default.
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.Insecure, "insecure-transport", true, "disable transport security for client connections")


### PR DESCRIPTION
etcdctl: add keep alive time/timeout in etcdctl

client can switch from fault node to normal when keep alive is timeout

Fixes #7941
