### PR TITLE
clientv3/balancer: handle network partition in health check

### DIFF
--- a/.words
+++ b/.words
@@ -1,5 +1,8 @@
+ErrCodeEnhanceYourCalm
+GoAway
 RPC
 RPCs
+backoff
 blackholed
 cancelable
 cancelation
@@ -10,6 +13,7 @@ etcd
 gRPC
 goroutine
 goroutines
+healthcheck
 iff
 inflight
 keepalive

--- a/clientv3/balancer.go
+++ b/clientv3/balancer.go
@@ -44,6 +44,8 @@ type balancer interface {
 	endpoints() []string
 	// pinned returns the current pinned endpoint.
 	pinned() string
+	// endpointError handles error from server-side.
+	endpointError(addr string, err error)
 
 	// up is Up but includes whether the balancer will use the connection.
 	up(addr grpc.Address) (func(error), bool)
@@ -149,6 +151,8 @@ func (b *simpleBalancer) pinned() string {
 	defer b.mu.RUnlock()
 	return b.pinAddr
 }
+
+func (b *simpleBalancer) endpointError(addr string, err error) { return }
 
 func getHost2ep(eps []string) map[string]string {
 	hm := make(map[string]string, len(eps))

--- a/clientv3/health_balancer.go
+++ b/clientv3/health_balancer.go
@@ -177,6 +177,15 @@ func (hb *healthBalancer) liveAddrs() []grpc.Address {
 	return addrs
 }
 
+func (hb *healthBalancer) endpointError(addr string, err error) {
+	hb.mu.Lock()
+	hb.unhealthy[addr] = time.Now()
+	hb.mu.Unlock()
+	if logger.V(4) {
+		logger.Infof("clientv3/health-balancer: marking %s as unhealthy (%v)", addr, err)
+	}
+}
+
 func (hb *healthBalancer) mayPin(addr grpc.Address) bool {
 	hb.mu.RLock()
 	skip := len(hb.addrs) == 1 || len(hb.unhealthy) == 0

--- a/clientv3/health_balancer.go
+++ b/clientv3/health_balancer.go
@@ -188,7 +188,7 @@ func (hb *healthBalancer) endpointError(addr string, err error) {
 
 func (hb *healthBalancer) mayPin(addr grpc.Address) bool {
 	hb.mu.RLock()
-	skip := len(hb.addrs) == 1 || len(hb.unhealthy) == 0
+	skip := len(hb.addrs) == 1 || len(hb.unhealthy) == 0 || len(hb.addrs) == len(hb.unhealthy)
 	failedTime, bad := hb.unhealthy[addr.Addr]
 	dur := hb.healthCheckTimeout
 	hb.mu.RUnlock()

--- a/clientv3/integration/network_partition_test.go
+++ b/clientv3/integration/network_partition_test.go
@@ -1,0 +1,97 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !cluster_proxy
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/integration"
+	"github.com/coreos/etcd/pkg/testutil"
+)
+
+// TestNetworkPartitionBalancerPut tests when one member becomes isolated,
+// first Put request fails, and following retry succeeds with client balancer
+// switching to others.
+func TestNetworkPartitionBalancerPut(t *testing.T) {
+	testNetworkPartitionBalancer(t, func(cli *clientv3.Client, ctx context.Context) error {
+		_, err := cli.Put(ctx, "a", "b")
+		return err
+	})
+}
+
+// TestNetworkPartitionBalancerGet tests when one member becomes isolated,
+// first Get request fails, and following retry succeeds with client balancer
+// switching to others.
+func TestNetworkPartitionBalancerGet(t *testing.T) {
+	testNetworkPartitionBalancer(t, func(cli *clientv3.Client, ctx context.Context) error {
+		_, err := cli.Get(ctx, "a")
+		return err
+	})
+}
+
+func testNetworkPartitionBalancer(t *testing.T, op func(*clientv3.Client, context.Context) error) {
+	defer testutil.AfterTest(t)
+
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{
+		Size:                 3,
+		GRPCKeepAliveMinTime: time.Millisecond, // avoid too_many_pings
+	})
+	defer clus.Terminate(t)
+
+	// expect pin ep[0]
+	ccfg := clientv3.Config{
+		Endpoints:            []string{clus.Members[0].GRPCAddr()},
+		DialTimeout:          3 * time.Second,
+		DialKeepAliveTime:    2 * time.Second,
+		DialKeepAliveTimeout: 2 * time.Second,
+	}
+	cli, err := clientv3.New(ccfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	// add other endpoints for later endpoint switch
+	cli.SetEndpoints(clus.Members[0].GRPCAddr(), clus.Members[1].GRPCAddr(), clus.Members[1].GRPCAddr())
+
+	time.Sleep(3 * time.Second)
+	clus.Members[0].InjectPartition(t, clus.Members[1:])
+	defer clus.Members[0].RecoverPartition(t, clus.Members[1:])
+
+	for i := 0; i < 2; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		err = op(cli, ctx)
+		cancel()
+		if err == nil {
+			break
+		}
+		if err != context.DeadlineExceeded {
+			t.Fatalf("#%d: expected %v, got %v", i, context.DeadlineExceeded, err)
+		}
+		// give enough time for endpoint switch
+		// TODO: remove random sleep by syncing directly with balancer
+		if i == 0 {
+			time.Sleep(5 * time.Second)
+		}
+	}
+	if err != nil {
+		t.Fatalf("balancer did not switch in time (%v)", err)
+	}
+}

--- a/clientv3/retry.go
+++ b/clientv3/retry.go
@@ -66,6 +66,8 @@ func (c *Client) newRetryWrapper(isStop retryStopErrFunc) retryRpcFunc {
 			if logger.V(4) {
 				logger.Infof("clientv3/retry: error %v on pinned endpoint %s", err, pinned)
 			}
+			// mark this before endpoint switch is triggered
+			c.balancer.endpointError(pinned, err)
 			notify := c.balancer.ConnectNotify()
 			if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
 				c.balancer.next()


### PR DESCRIPTION
Only health-check when timeout elapses since last failure.
Otherwise network-partitioned member with active health-check
server would not be gray-listed, making health-balancer stuck
with isolated endpoint. Also clarifies some log messages.

Mark partitioned member as unhealthy in retry code paths.

Previous behavior is when server returns errors, retry
wrapper does not do anything, while passively expecting
balancer to gray-list the isolated endpoint. This is
problematic when multiple endpoints are passed, and
network partition happens.

This patch adds `endpointError` method to `balancer` interface
to actively(possibly even before health-check API gets called)
handle RPC errors and gray-list endpoints for the time being,
thus speeding up the endpoint switch.

This is safe in a single-endpoint case, because balancer will
retry no matter what in such case.

Added integration tests fail without this patch.
Also manually tested to confirm this fixes https://github.com/coreos/etcd/issues/8660.


<details>
  <summary>Logs</summary>
<pre>
<code>
GET

2017-10-09 13:55:28.265074433 +0000 UTC m=+148.050834478 sleeping...
2017-10-09 13:55:33.265267969 +0000 UTC m=+153.051028081 starts get...
INFO: 2017/10/09 13:55:38 clientv3/retry: error rpc error: code = DeadlineExceeded desc = context deadline exceeded on pinned endpoint 10.138.0.21:2379
INFO: 2017/10/09 13:55:38 clientv3/health-balancer: marking 10.138.0.21:2379 as unhealthy (rpc error: code = DeadlineExceeded desc = context deadline exceeded)
2017-10-09 13:55:38.26572891 +0000 UTC m=+158.051488955 failed context deadline exceeded

2017-10-09 13:55:38.265765899 +0000 UTC m=+158.051525944 sleeping...
INFO: 2017/10/09 13:55:39 clientv3/balancer: unpin 10.138.0.21:2379 (grpc: the connection is drained)
INFO: 2017/10/09 13:55:39 clientv3/health-balancer: 10.138.0.21:2379 becomes unhealthy (grpc: the connection is drained)
INFO: 2017/10/09 13:55:39 clientv3/balancer: pin 10.138.0.22:2379
INFO: 2017/10/09 13:55:39 clientv3/balancer: 10.138.0.23:2379 is up but not pinned (already pinned 10.138.0.22:2379)
INFO: 2017/10/09 13:55:42 clientv3/health-balancer: removes 10.138.0.21:2379 from unhealthy after 3s
2017-10-09 13:55:43.265951664 +0000 UTC m=+163.051711812 starts get...
2017-10-09 13:55:43.269703717 +0000 UTC m=+163.055463762 success!


PUT

INFO: 2017/10/09 13:58:00 clientv3/balancer: pin 10.138.0.22:2379
INFO: 2017/10/09 13:58:00 clientv3/balancer: 10.138.0.23:2379 is up but not pinned (already pinned 10.138.0.22:2379)
INFO: 2017/10/09 13:58:00 clientv3/balancer: 10.138.0.21:2379 is up but not pinned (already pinned 10.138.0.22:2379)

2017-10-09 13:58:03.830506173 +0000 UTC m=+3.002894666 sleeping
2017-10-09 13:58:08.83076711 +0000 UTC m=+8.003155592 starts put...
2017-10-09 13:58:08.83494924 +0000 UTC m=+8.007337654 success!

2017-10-09 13:58:18.842551525 +0000 UTC m=+18.014939934 sleeping
2017-10-09 13:58:23.842763057 +0000 UTC m=+23.015151547 starts put...
INFO: 2017/10/09 13:58:28 clientv3/retry: error rpc error: code = DeadlineExceeded desc = context deadline exceeded on pinned endpoint 10.138.0.22:2379
INFO: 2017/10/09 13:58:28 clientv3/health-balancer: marking 10.138.0.22:2379 as unhealthy (rpc error: code = DeadlineExceeded desc = context deadline exceeded)
2017-10-09 13:58:28.843253482 +0000 UTC m=+28.015641904 failed: context deadline exceeded

2017-10-09 13:58:28.84326634 +0000 UTC m=+28.015654761 sleeping
INFO: 2017/10/09 13:58:30 clientv3/balancer: unpin 10.138.0.22:2379 (grpc: the connection is drained)
INFO: 2017/10/09 13:58:30 clientv3/health-balancer: 10.138.0.22:2379 becomes unhealthy (grpc: the connection is drained)
INFO: 2017/10/09 13:58:30 clientv3/balancer: pin 10.138.0.21:2379
WARNING: 2017/10/09 13:58:30 Failed to dial 10.138.0.23:2379: grpc: the connection is closing; please retry.
WARNING: 2017/10/09 13:58:30 Failed to dial 10.138.0.23:2379: grpc: the connection is closing; please retry.
INFO: 2017/10/09 13:58:33 clientv3/health-balancer: removes 10.138.0.22:2379 from unhealthy after 3s
2017-10-09 13:58:33.843439088 +0000 UTC m=+33.015827591 starts put...
2017-10-09 13:58:33.846525885 +0000 UTC m=+33.018914309 success!
</code>
</pre>
</details>