### PR TITLE
clientv3: reset unhealthy on updateAddrs

### DIFF
--- a/clientv3/health_balancer.go
+++ b/clientv3/health_balancer.go
@@ -120,6 +120,7 @@ func (hb *healthBalancer) updateAddrs(eps ...string) {
 	addrs, host2ep := eps2addrs(eps), getHost2ep(eps)
 	hb.mu.Lock()
 	hb.addrs, hb.eps, hb.host2ep = addrs, eps, host2ep
+	hb.unhealthy = make(map[string]time.Time)
 	hb.mu.Unlock()
 	hb.balancer.updateAddrs(eps...)
 }


### PR DESCRIPTION
Otherwise, 'mayPin' incorrectly decides if an address
should be pinned or not. Balancer is clearly broken because of this.

This should help address https://github.com/coreos/etcd/issues/8624.
With this patch, the failure doesn't happen in my VM anymore.

Will keep an eye on it, if it still fails.