### PR TITLE
clientv3/balancer: propagate network-partition error to gRPC

### DIFF
--- a/clientv3/health_balancer.go
+++ b/clientv3/health_balancer.go
@@ -185,6 +185,7 @@ func (hb *healthBalancer) endpointError(addr string, err error) {
 	if logger.V(4) {
 		logger.Infof("clientv3/health-balancer: marking %s as unhealthy (%v)", addr, err)
 	}
+	hb.balancer.endpointError(addr, err)
 }
 
 func (hb *healthBalancer) mayPin(addr grpc.Address) bool {

--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -473,8 +473,8 @@ func TestKVNewAfterClose(t *testing.T) {
 
 	donec := make(chan struct{})
 	go func() {
-		if _, err := cli.Get(context.TODO(), "foo"); err != context.Canceled {
-			t.Fatalf("expected %v, got %v", context.Canceled, err)
+		if _, err := cli.Get(context.TODO(), "foo"); err != context.Canceled && err != grpc.ErrClientConnClosing {
+			t.Fatalf("expected %v or %v, got %v", context.Canceled, grpc.ErrClientConnClosing, err)
 		}
 		close(donec)
 	}()


### PR DESCRIPTION
So that time-outs on network partition can trigger
connection resets to gRPC via Notify channel.
Here we are expecting time-out errors, not gRPC
transport-layer errors, so need manual unpin
to trigger connection resets.