### PR TITLE
auth: use binary search for checking root permission

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -943,12 +943,9 @@ func NewAuthStore(be backend.Backend, tp TokenProvider) *authStore {
 }
 
 func hasRootRole(u *authpb.User) bool {
-	for _, r := range u.Roles {
-		if r == rootRole {
-			return true
-		}
-	}
-	return false
+	// u.Roles is sorted in UserGrantRole(), so we can use binary search.
+	idx := sort.SearchStrings(u.Roles, rootRole)
+	return idx != len(u.Roles) && u.Roles[idx] == rootRole
 }
 
 func (as *authStore) commitRevision(tx backend.BatchTx) {


### PR DESCRIPTION
authpb.User.Roles is sorted so we don't need a linear search for
checking the user has a root role or not.
