### PR TITLE
etcdctl/ctlv3: inherit/update flags only once in 'check' command

### DIFF
--- a/etcdctl/ctlv3/command/check.go
+++ b/etcdctl/ctlv3/command/check.go
@@ -112,9 +112,10 @@ func newCheckPerfCommand(cmd *cobra.Command, args []string) {
 	requests := make(chan v3.Op, cfg.clients)
 	limit := rate.NewLimiter(rate.Limit(cfg.limit), 1)
 
-	var clients []*v3.Client
+	cc := clientConfigFromCmd(cmd)
+	clients := make([]*v3.Client, cfg.clients)
 	for i := 0; i < cfg.clients; i++ {
-		clients = append(clients, mustClientFromCmd(cmd))
+		clients[i] = cc.mustClient()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.duration)*time.Second)

--- a/etcdctl/ctlv3/command/make_mirror_command.go
+++ b/etcdctl/ctlv3/command/make_mirror_command.go
@@ -75,7 +75,15 @@ func makeMirrorCommandFunc(cmd *cobra.Command, args []string) {
 		insecureTransport: mminsecureTr,
 	}
 
-	dc := mustClient([]string{args[0]}, dialTimeout, keepAliveTime, keepAliveTimeout, sec, nil)
+	cc := &clientConfig{
+		endpoints:        []string{args[0]},
+		dialTimeout:      dialTimeout,
+		keepAliveTime:    keepAliveTime,
+		keepAliveTimeout: keepAliveTimeout,
+		scfg:             sec,
+		acfg:             nil,
+	}
+	dc := cc.mustClient()
 	c := mustClientFromCmd(cmd)
 
 	err := makeMirror(context.TODO(), c, dc)


### PR DESCRIPTION
When creating multiple clients, 'mustClientFromCmd' overwrites
inherited flags with environment variables, so later clients
were printing warnings on duplicate key updates.

Fix https://github.com/coreos/etcd/issues/8664.

Nothing was breaking. This just removes the warnings.