### PR TITLE
test: always fetch latest tags for release upgrade tests

### DIFF
--- a/test
+++ b/test
@@ -235,7 +235,7 @@ function grpcproxy_pass {
 function release_pass {
 	rm -f ./bin/etcd-last-release
 	# to grab latest patch release; bump this up for every minor release
-	UPGRADE_VER=$(git tag -l --sort=-version:refname "v3.2.*" | head -1)
+	UPGRADE_VER=$(git describe --match "v3.2.*")
 	if [ -n "$MANUAL_VER" ]; then
 		# in case, we need to test against different version
 		UPGRADE_VER=$MANUAL_VER


### PR DESCRIPTION
Semaphore CI was using old tags (v3.2.2) while we expect it
to use v3.2.9.
