### PR TITLE
auth: Fix simpleToken to respect disabled state for assign

### DIFF
--- a/auth/simple_token.go
+++ b/auth/simple_token.go
@@ -118,6 +118,9 @@ func (t *tokenSimple) genTokenPrefix() (string, error) {
 func (t *tokenSimple) assignSimpleTokenToUser(username, token string) {
 	t.simpleTokensMu.Lock()
 	defer t.simpleTokensMu.Unlock()
+	if t.simpleTokenKeeper == nil {
+		return
+	}
 
 	_, ok := t.simpleTokens[token]
 	if ok {

--- a/auth/simple_token_test.go
+++ b/auth/simple_token_test.go
@@ -1,0 +1,67 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSimpleTokenDisabled ensures that TokenProviderSimple behaves correctly when
+// disabled.
+func TestSimpleTokenDisabled(t *testing.T) {
+	initialState := newTokenProviderSimple(dummyIndexWaiter)
+
+	explicitlyDisabled := newTokenProviderSimple(dummyIndexWaiter)
+	explicitlyDisabled.enable()
+	explicitlyDisabled.disable()
+
+	for _, tp := range []*tokenSimple{initialState, explicitlyDisabled} {
+		ctx := context.WithValue(context.WithValue(context.TODO(), "index", uint64(1)), "simpleToken", "dummy")
+		token, err := tp.assign(ctx, "user1", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		authInfo, ok := tp.info(ctx, token, 0)
+		if ok {
+			t.Errorf("expected (true, \"user1\") got (%t, %s)", ok, authInfo.Username)
+		}
+
+		tp.invalidateUser("user1") // should be no-op
+	}
+}
+
+// TestSimpleTokenAssign ensures that TokenProviderSimple can correctly assign a
+// token, look it up with info, and invalidate it by user.
+func TestSimpleTokenAssign(t *testing.T) {
+	tp := newTokenProviderSimple(dummyIndexWaiter)
+	tp.enable()
+	ctx := context.WithValue(context.WithValue(context.TODO(), "index", uint64(1)), "simpleToken", "dummy")
+	token, err := tp.assign(ctx, "user1", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authInfo, ok := tp.info(ctx, token, 0)
+	if !ok || authInfo.Username != "user1" {
+		t.Errorf("expected (true, \"token2\") got (%t, %s)", ok, authInfo.Username)
+	}
+
+	tp.invalidateUser("user1")
+
+	_, ok = tp.info(context.TODO(), token, 0)
+	if ok {
+		t.Errorf("expected ok == false after user is invalidated")
+	}
+}


### PR DESCRIPTION
`TokenProvider`s can be `enabled` and `disabled`. The `tokenSimple` implementation is disabled when the `simpleTokenKeeper` field is set to`nil`. 

`func (t *tokenSimple) assignSimpleTokenToUser(...)`, however, is missing a `t.simpleTokenKeeper != nil` check like those found in `(t *tokenSimple) invalidateUser(...)` and `(t *tokenSimple) info(...)`, and if it is called when tokenSimple is disabled, a nil pointer derference panic will occur. This appears to be the cause of https://github.com/coreos/etcd/issues/8608:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x90197c]

goroutine 133 [running]:
github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/auth.(*simpleTokenTTLKeeper).addSimpleToken(0x0, 0xc4239045c0, 0x16)
	/root/etcd/gopath/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/auth/simple_token.go:59 +0x3c
github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/auth.(*tokenSimple).assignSimpleTokenToUser(0xc4203f64e0, 0xc421688178, 0x4, 0xc4239045c0, 0x16)
	/root/etcd/gopath/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/auth/simple_token.go:128 +0x12d
github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/auth.(*tokenSimple).assign(0xc4203f64e0, 0x14db740, 0xc4238feae0, 0xc421688178, 0x4, 0xbb, 0x7ffd9f077a28, 0x0, 0x0, 0xc42002e700)
	/root/etcd/gopath/src/github.com/coreos/etcd/cmd/vendor/github.com/coreos/etcd/auth/simple_token.go:191 +0x1e7
...
```

Adding the check appears safe and is consistent with the intended behavior of the `disabled` state.