### PR TITLE
grpc_naming.md: improve docs invoke grpc naming by balance

### DIFF
--- a/Documentation/dev-guide/grpc_naming.md
+++ b/Documentation/dev-guide/grpc_naming.md
@@ -19,7 +19,7 @@ import (
 cli, cerr := clientv3.NewFromURL("http://localhost:2379")
 r := &etcdnaming.GRPCResolver{Client: cli}
 b := grpc.RoundRobin(r)
-conn, gerr := grpc.Dial("my-service", grpc.WithBalancer(b))
+conn, gerr := grpc.Dial("my-service", grpc.WithBalancer(b), grpc.WithBlock(), ...)
 ```
 
 ## Managing service endpoints


### PR DESCRIPTION
there is a error in invoke service by balance like grpc_naming.md
sometimes occurs:  
```
rpc error: code = Unavailable desc = there is no address available
```
#8701
