### PR TITLE
clientv3/integration: block grpc.Dial until connection up in client closing tests

### DIFF
--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -658,7 +658,7 @@ func TestWatchEventType(t *testing.T) {
 func TestWatchErrConnClosed(t *testing.T) {
 	defer testutil.AfterTest(t)
 
-	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1, ClientDialWithBlock: true})
 	defer clus.Terminate(t)
 
 	cli := clus.Client(0)
@@ -687,7 +687,7 @@ func TestWatchErrConnClosed(t *testing.T) {
 func TestWatchAfterClose(t *testing.T) {
 	defer testutil.AfterTest(t)
 
-	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1, ClientDialWithBlock: true})
 	defer clus.Terminate(t)
 
 	cli := clus.Client(0)


### PR DESCRIPTION
Test `grpc.ErrClientConnClosing`, so it must ensure that connection is up
before closing it. Otherwise, it can time out when we introduce back-off
to client retrial logic.

Separate out from https://github.com/coreos/etcd/pull/8710.
c.f. https://github.com/coreos/etcd/issues/8691.

```
Integration tests have dial timeout 5-sec, and it's possible that
balancer retry logic waits 5-sec and test times out because gRPC calls
grpc.downErr function after connection wait starts in retrial part.
Just increasing time-out should be ok. In most cases, grpc.downErr gets
called before starting the wait.

e.g.

=== RUN   TestWatchErrConnClosed
INFO: 2017/10/18 23:55:39 clientv3/balancer: pin "localhost:91847156765553894590"
INFO: 2017/10/18 23:55:39 clientv3/retry: wait 5s for healthy endpoint
INFO: 2017/10/18 23:55:39 clientv3/balancer: unpin "localhost:91847156765553894590" ("grpc: the client connection is closing")
INFO: 2017/10/18 23:55:39 clientv3/health-balancer: "localhost:91847156765553894590" becomes unhealthy ("grpc: the client connection is closing")
--- FAIL: TestWatchErrConnClosed (3.07s)
        watch_test.go:682: wc.Watch took too long
```