### PR TITLE
etcdctl: close snapshot backend to close open file on member/snap/db

### DIFF
--- a/etcdctl/ctlv3/command/snapshot_command.go
+++ b/etcdctl/ctlv3/command/snapshot_command.go
@@ -392,6 +392,7 @@ func makeDB(snapdir, dbfile string, commit int) {
 	txn.End()
 	s.Commit()
 	s.Close()
+	be.Close()
 }
 
 type dbstatus struct {


### PR DESCRIPTION
Without calling `Close()`, the backend keeps the `db` file open.

