### PR TITLE
clientv3: disable server logging for client testing

### DIFF
--- a/clientv3/ordering/logger_test.go
+++ b/clientv3/ordering/logger_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The etcd Authors
+// Copyright 2017 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package integration
+package ordering
 
 import "github.com/coreos/pkg/capnslog"
 


### PR DESCRIPTION
The server side logging is verbose when failures are injected. Also it does not make sense to enable server logging when we test clients. For debugging purpose, logging should be enabled on demand.
