### PR TITLE
Documentation/op-guide: Fix missing docker volume commands and specify the initial DATA_DIR

### DIFF
--- a/Documentation/op-guide/container.md
+++ b/Documentation/op-guide/container.md
@@ -76,6 +76,13 @@ Use the host IP address when configuring etcd:
 export NODE1=192.168.1.21
 ```
 
+Configure a Docker volume to store etcd data:
+
+```
+docker volume create --name etcd-data
+export DATA_DIR="etcd-data"
+```
+
 Run the latest version of etcd:
 
 ```


### PR DESCRIPTION
The documentation examples for running a single etcd node fail due to a number of issues, one being DATA_DIR is not set but is used in the example.

The `Run the latest version of etcd` example does not work out of the box.