### PR TITLE
Makefile: clean up all redundant targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /coverage
+/covdir
 /gopath
 /gopath.proto
 /go-bindata

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -21,7 +21,9 @@ RUN go get -v -u -tags spell github.com/chzchzchz/goword \
   && go get -v -u honnef.co/go/tools/cmd/staticcheck \
   && go get -v -u github.com/wadey/gocovmerge \
   && go get -v -u github.com/gordonklaus/ineffassign \
-  && ./scripts/install-marker.sh amd64
+  && ./scripts/install-marker.sh amd64 \
+  && curl -s https://codecov.io/bash >/codecov \
+  && chmod 700 /codecov
 
 # e.g.
 # docker build --tag etcd-test --file ./Dockerfile-test .

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,9 @@
 # run from repository root
 
-TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)
-
-.PHONY: build
-build:
-	GO_BUILD_FLAGS="-v" ./build
-	./bin/etcd --version
-	ETCDCTL_API=3 ./bin/etcdctl version
-
-.PHONY: test
-test:
-	$(info log-file: test-$(TEST_SUFFIX).log)
-	PASSES='fmt bom dep compile build unit' ./test 2>&1 | tee test-$(TEST_SUFFIX).log
-	! grep FAIL -A10 -B50 test-$(TEST_SUFFIX).log
-
-test-fmt:
-	$(info log-file: test-fmt-$(TEST_SUFFIX).log)
-	PASSES='fmt' ./test 2>&1 | tee test-fmt-$(TEST_SUFFIX).log
-	! grep FAIL -A10 -B50 test-fmt-$(TEST_SUFFIX).log
-
-test-all:
-	$(info log-file: test-all-$(TEST_SUFFIX).log)
-	RELEASE_TEST=y INTEGRATION=y PASSES='build unit release integration_e2e functional' ./test 2>&1 | tee test-all-$(TEST_SUFFIX).log
-	! grep FAIL -A10 -B50 test-all-$(TEST_SUFFIX).log
-
-test-proxy:
-	$(info log-file: test-proxy-$(TEST_SUFFIX).log)
-	PASSES='build grpcproxy' ./test 2>&1 | tee test-proxy-$(TEST_SUFFIX).log
-	! grep FAIL -A10 -B50 test-proxy-$(TEST_SUFFIX).log
-
-test-coverage:
-	$(info log-file: test-coverage-$(TEST_SUFFIX).log)
-	COVERDIR=covdir PASSES='build build_cov cov' ./test 2>&1 | tee test-coverage-$(TEST_SUFFIX).log
-	$(shell curl -s https://codecov.io/bash >codecov)
-	chmod 700 ./codecov
-	./codecov -h
-	./codecov -t 6040de41-c073-4d6f-bbf8-d89256ef31e1
-
 # clean up failed tests, logs, dependencies
 clean:
 	rm -f ./codecov
+	rm -rf ./covdir
 	rm -f ./*.log
 	rm -f ./bin/Dockerfile-release
 	rm -rf ./bin/*.etcd
@@ -49,86 +13,93 @@ clean:
 	rm -f ./clientv3/integration/127.0.0.1:* ./clientv3/integration/localhost:*
 	rm -f ./clientv3/ordering/127.0.0.1:* ./clientv3/ordering/localhost:*
 
+TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)
+
+.PHONY: build
+build:
+	GO_BUILD_FLAGS="-v" ./build
+	./bin/etcd --version
+	ETCDCTL_API=3 ./bin/etcdctl version
+
 # sync with Dockerfile-test, e2e/docker-dns/Dockerfile, e2e/docker-dns-srv/Dockerfile
 _GO_VERSION = go1.9.1
 ifdef GO_VERSION
 	_GO_VERSION = $(GO_VERSION)
 endif
 
-# build base container image for testing on Linux
-docker-test-build:
+# Example:
+#   make build-docker-test
+#   gcloud docker -- login -u _json_key -p "$(cat /etc/gcp-key-etcd.json)" https://gcr.io
+#   make push-docker-test
+
+build-docker-test:
 	docker build --tag gcr.io/etcd-development/etcd-test:$(_GO_VERSION) --file ./Dockerfile-test .
 
-# e.g.
-# gcloud docker -- login -u _json_key -p "$(cat /etc/gcp-key-etcd.json)" https://gcr.io
-docker-test-push:
+push-docker-test:
 	gcloud docker -- push gcr.io/etcd-development/etcd-test:$(_GO_VERSION)
 
-docker-test-pull:
+pull-docker-test:
 	docker pull gcr.io/etcd-development/etcd-test:$(_GO_VERSION)
 
 # compile etcd and etcdctl with Linux
-docker-test-compile:
+compile-with-docker-test:
 	docker run \
 	  --rm \
 	  --volume=`pwd`/:/etcd \
 	  gcr.io/etcd-development/etcd-test:$(_GO_VERSION) \
 	  /bin/bash -c "cd /etcd && GO_BUILD_FLAGS=-v ./build && ./bin/etcd --version"
 
-# run tests inside container
+# Local machine:
+#   TEST_OPTS="PASSES='fmt'" make test
+#   TEST_OPTS="PASSES='fmt bom dep compile build unit'" make test
+#   TEST_OPTS="RELEASE_TEST=y INTEGRATION=y PASSES='build unit release integration_e2e functional'" make test
+#   TEST_OPTS="PASSES='build grpcproxy'" make test
+#
+# Example (test with docker):
+#   make pull-docker-test
+#   TEST_OPTS="VERBOSE=1 PASSES='unit'" make docker-test
+#   TEST_OPTS="VERBOSE=2 PASSES='unit'" make docker-test
+#
+# Travis CI (test with docker):
+#   TEST_OPTS="PASSES='fmt bom dep compile build unit'" make docker-test
+#
+# Semaphore CI (test with docker):
+#   TEST_OPTS="RELEASE_TEST=y INTEGRATION=y PASSES='build unit release integration_e2e functional'" make docker-test
+#   TEST_OPTS="GOARCH=386 PASSES='build unit integration_e2e'" make docker-test
+#
+# grpc-proxy tests (test with docker):
+#   TEST_OPTS="PASSES='build grpcproxy'" make docker-test
+
+_TEST_OPTS = "PASSES='unit'"
+ifdef TEST_OPTS
+	_TEST_OPTS = $(TEST_OPTS)
+endif
+
+.PHONY: test
+test:
+	$(info TEST_OPTS: $(_TEST_OPTS))
+	$(info log-file: test-$(TEST_SUFFIX).log)
+	$(_TEST_OPTS) ./test 2>&1 | tee test-$(TEST_SUFFIX).log
+	! grep FAIL -A10 -B50 test-$(TEST_SUFFIX).log
+
 docker-test:
-	$(info log-file: docker-test-$(TEST_SUFFIX).log)
+	$(info TEST_OPTS: $(_TEST_OPTS))
+	$(info log-file: test-$(TEST_SUFFIX).log)
 	docker run \
 	  --rm \
 	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
 	  gcr.io/etcd-development/etcd-test:$(_GO_VERSION) \
-	  /bin/bash -c "PASSES='fmt bom dep compile build unit' ./test 2>&1 | tee docker-test-$(TEST_SUFFIX).log"
-	! grep FAIL -A10 -B50 docker-test-$(TEST_SUFFIX).log
+	  /bin/bash -c "$(_TEST_OPTS) ./test 2>&1 | tee test-$(TEST_SUFFIX).log"
+	! grep FAIL -A10 -B50 test-$(TEST_SUFFIX).log
 
-docker-test-386:
-	$(info log-file: docker-test-386-$(TEST_SUFFIX).log)
+docker-test-coverage:
+	$(info log-file: docker-test-coverage-$(TEST_SUFFIX).log)
 	docker run \
 	  --rm \
 	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
 	  gcr.io/etcd-development/etcd-test:$(_GO_VERSION) \
-	  /bin/bash -c "GOARCH=386 PASSES='build unit integration_e2e' ./test 2>&1 | tee docker-test-386-$(TEST_SUFFIX).log"
-	! grep FAIL -A10 -B50 docker-test-386-$(TEST_SUFFIX).log
-
-docker-test-fmt:
-	$(info log-file: docker-test-fmt-$(TEST_SUFFIX).log)
-	docker run \
-	  --rm \
-	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
-	  gcr.io/etcd-development/etcd-test:$(_GO_VERSION) \
-	  /bin/bash -c "PASSES='fmt' ./test 2>&1 | tee docker-test-fmt-$(TEST_SUFFIX).log"
-	! grep FAIL -A10 -B50 docker-test-fmt-$(TEST_SUFFIX).log
-
-docker-test-all:
-	$(info log-file: docker-test-all-$(TEST_SUFFIX).log)
-	docker run \
-	  --rm \
-	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
-	  gcr.io/etcd-development/etcd-test:$(_GO_VERSION) \
-	  /bin/bash -c "RELEASE_TEST=y INTEGRATION=y PASSES='build unit release integration_e2e functional' ./test 2>&1 | tee docker-test-all-$(TEST_SUFFIX).log"
-	! grep FAIL -A10 -B50 docker-test-all-$(TEST_SUFFIX).log
-
-docker-test-all-386:
-	$(info log-file: docker-test-all-386-$(TEST_SUFFIX).log)
-	docker run \
-	  --rm \
-	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
-	  gcr.io/etcd-development/etcd-test:$(_GO_VERSION) \
-	  /bin/bash -c "GOARCH=386 PASSES='build unit release integration_e2e functional' ./test 2>&1 | tee docker-test-all-386-$(TEST_SUFFIX).log"
-	! grep FAIL -A10 -B50 docker-test-all-386-$(TEST_SUFFIX).log
-
-docker-test-proxy:
-	$(info log-file: docker-test-proxy-$(TEST_SUFFIX).log)
-	docker run \
-	  --rm \
-	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
-	  gcr.io/etcd-development/etcd-test:$(_GO_VERSION) \
-	  /bin/bash -c "PASSES='build grpcproxy' ./test 2>&1 | tee docker-test-proxy-$(TEST_SUFFIX).log"
-	! grep FAIL -A10 -B50 docker-test-proxy-$(TEST_SUFFIX).log
+	  /bin/bash -c "COVERDIR=covdir PASSES='build build_cov cov' ./test 2>&1 | tee docker-test-coverage-$(TEST_SUFFIX).log && /codecov -t 6040de41-c073-4d6f-bbf8-d89256ef31e1"
+	! grep FAIL -A10 -B50 docker-test-coverage-$(TEST_SUFFIX).log
 
 # build release container image with Linux
 _ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
@@ -136,7 +107,7 @@ ifdef ETCD_VERSION
 	_ETCD_VERSION = $(ETCD_VERSION)
 endif
 
-docker-release-master-build: docker-test-compile
+build-docker-release-master: compile-with-docker-test
 	cp ./Dockerfile-release ./bin/Dockerfile-release
 	docker build \
 	  --tag gcr.io/etcd-development/etcd:$(_ETCD_VERSION) \
@@ -149,11 +120,18 @@ docker-release-master-build: docker-test-compile
 	  gcr.io/etcd-development/etcd:$(_ETCD_VERSION) \
 	  /bin/sh -c "/usr/local/bin/etcd --version && ETCDCTL_API=3 /usr/local/bin/etcdctl version"
 
-docker-release-master-push:
+push-docker-release-master:
 	gcloud docker -- push gcr.io/etcd-development/etcd:$(_ETCD_VERSION)
 
+# Example:
+#   make build-docker-dns-test
+#   gcloud docker -- login -u _json_key -p "$(cat /etc/gcp-key-etcd.json)" https://gcr.io
+#   make push-docker-dns-test
+#   make pull-docker-dns-test
+#   make docker-dns-test-run
+
 # build base container image for DNS testing
-docker-dns-test-build:
+build-docker-dns-test:
 	docker build \
 	  --tag gcr.io/etcd-development/etcd-dns-test:$(_GO_VERSION) \
 	  --file ./e2e/docker-dns/Dockerfile \
@@ -165,10 +143,10 @@ docker-dns-test-build:
 	  gcr.io/etcd-development/etcd-dns-test:$(_GO_VERSION) \
 	  /bin/bash -c "/etc/init.d/bind9 start && cat /dev/null >/etc/hosts && dig etcd.local"
 
-docker-dns-test-push:
+push-docker-dns-test:
 	gcloud docker -- push gcr.io/etcd-development/etcd-dns-test:$(_GO_VERSION)
 
-docker-dns-test-pull:
+pull-docker-dns-test:
 	docker pull gcr.io/etcd-development/etcd-dns-test:$(_GO_VERSION)
 
 # run DNS tests inside container
@@ -182,8 +160,15 @@ docker-dns-test-run:
 	  gcr.io/etcd-development/etcd-dns-test:$(_GO_VERSION) \
 	  /bin/bash -c "cd /etcd && /run.sh && rm -rf m*.etcd"
 
+# Example:
+#   make build-docker-dns-srv-test
+#   gcloud docker -- login -u _json_key -p "$(cat /etc/gcp-key-etcd.json)" https://gcr.io
+#   make push-docker-dns-srv-test
+#   make pull-docker-dns-srv-test
+#   make docker-dns-srv-test-run
+
 # build base container image for DNS/SRV testing
-docker-dns-srv-test-build:
+build-docker-dns-srv-test:
 	docker build \
 	  --tag gcr.io/etcd-development/etcd-dns-srv-test:$(_GO_VERSION) \
 	  --file ./e2e/docker-dns-srv/Dockerfile \
@@ -195,10 +180,10 @@ docker-dns-srv-test-build:
 	  gcr.io/etcd-development/etcd-dns-srv-test:$(_GO_VERSION) \
 	  /bin/bash -c "/etc/init.d/bind9 start && cat /dev/null >/etc/hosts && dig +noall +answer SRV _etcd-client-ssl._tcp.etcd.local && dig +noall +answer SRV _etcd-server-ssl._tcp.etcd.local && dig +noall +answer m1.etcd.local m2.etcd.local m3.etcd.local"
 
-docker-dns-srv-test-push:
+push-docker-dns-srv-test:
 	gcloud docker -- push gcr.io/etcd-development/etcd-dns-srv-test:$(_GO_VERSION)
 
-docker-dns-srv-test-pull:
+pull-docker-dns-srv-test:
 	docker pull gcr.io/etcd-development/etcd-dns-srv-test:$(_GO_VERSION)
 
 # run DNS/SRV tests inside container

--- a/test
+++ b/test
@@ -82,8 +82,16 @@ fi
 
 function unit_pass {
 	echo "Running unit tests..."
+	GO_TEST_FLAG=""
+	if [ "${VERBOSE}" == "1" ]; then
+		GO_TEST_FLAG="-v"
+	fi
+	if [ "${VERBOSE}" == "2" ]; then
+		GO_TEST_FLAG="-v"
+		export CLIENT_DEBUG=1
+	fi
 	# only -run=Test so examples can run in integration tests
-	go test -timeout 3m "${COVER}" ${RACE} -cpu 1,2,4 -run=Test "$@" "${TEST[@]}"
+	go test ${GO_TEST_FLAG} -timeout 3m "${COVER}" ${RACE} -cpu 1,2,4 -run=Test "$@" "${TEST[@]}"
 }
 
 function integration_pass {


### PR DESCRIPTION
Instead just specify `TEST_OPTS` env

> TEST_OPTS="RELEASE_TEST=y INTEGRATION=y PASSES='build unit release integration_e2e functional'" make docker-test

Removed all redundant targets (e.g. `docker-test-all`, `docker-test-proxy`, `docker-test-386`, etc.)