### PR TITLE
*: fix test docker images, switch travis to docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
-dist: trusty
 language: go
 go_import_path: github.com/coreos/etcd
-sudo: false
+
+sudo: required
+
+services: docker
 
 go:
-  - 1.9.1
-  - tip
+- 1.9.1
+- tip
 
 notifications:
   on_success: never
@@ -13,19 +15,25 @@ notifications:
 
 env:
   matrix:
-   - TARGET=amd64
-   - TARGET=darwin-amd64
-   - TARGET=windows-amd64
-   - TARGET=arm64
-   - TARGET=arm
-   - TARGET=386
-   - TARGET=ppc64le
+  - TARGET=amd64
+  - TARGET=amd64-go-tip
+  - TARGET=darwin-amd64
+  - TARGET=windows-amd64
+  - TARGET=arm64
+  - TARGET=arm
+  - TARGET=386
+  - TARGET=ppc64le
 
 matrix:
   fast_finish: true
   allow_failures:
-    - go: tip
+  - go: tip
+    env: TARGET=amd64-go-tip
   exclude:
+  - go: 1.9.1
+    env: TARGET=amd64-go-tip
+  - go: tip
+    env: TARGET=amd64
   - go: tip
     env: TARGET=darwin-amd64
   - go: tip
@@ -39,48 +47,42 @@ matrix:
   - go: tip
     env: TARGET=ppc64le
 
-addons:
-  apt:
-    sources:
-    - debian-sid
-    packages:
-    - libaspell-dev
-    - libhunspell-dev
-    - hunspell-en-us
-    - aspell-en
-    - shellcheck
-
 before_install:
- - go get -v -u -tags spell github.com/chzchzchz/goword
- - go get -v -u github.com/coreos/license-bill-of-materials
- - go get -v -u honnef.co/go/tools/cmd/gosimple
- - go get -v -u honnef.co/go/tools/cmd/unused
- - go get -v -u honnef.co/go/tools/cmd/staticcheck
- - go get -v -u github.com/gordonklaus/ineffassign
- - ./scripts/install-marker.sh amd64
- - export GOROOT=$(go env GOROOT)
+- docker pull gcr.io/etcd-development/etcd-test:go1.9.1
 
-# disable godep restore override
 install:
- - pushd cmd/etcd && go get -t -v ./... && popd
+- pushd cmd/etcd && go get -t -v ./... && popd
 
 script:
  - >
     case "${TARGET}" in
       amd64)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go1.9.1 \
+          /bin/bash -c "GOARCH=amd64 ./test"
+        ;;
+      amd64-go-tip)
         GOARCH=amd64 ./test
         ;;
       darwin-amd64)
-        GO_BUILD_FLAGS="-a -v"  GOPATH="" GOOS=darwin GOARCH=amd64 ./build
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go1.9.1 \
+          /bin/bash -c "GO_BUILD_FLAGS='-a -v' GOOS=darwin GOARCH=amd64 ./build"
         ;;
       windows-amd64)
-        GO_BUILD_FLAGS="-a -v"  GOPATH="" GOOS=windows GOARCH=amd64 ./build
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go1.9.1 \
+          /bin/bash -c "GO_BUILD_FLAGS='-a -v' GOOS=windows GOARCH=amd64 ./build"
         ;;
       386)
-        GOARCH=386 PASSES="build unit" ./test
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go1.9.1 \
+          /bin/bash -c "GOARCH=386 PASSES='build unit' ./test"
         ;;
       *)
         # test building out of gopath
-        GO_BUILD_FLAGS="-a -v" GOPATH="" GOARCH="${TARGET}" ./build
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go1.9.1 \
+          /bin/bash -c "GO_BUILD_FLAGS='-a -v' GOARCH='${TARGET}' ./build"
         ;;
     esac

--- a/.words
+++ b/.words
@@ -1,8 +1,11 @@
 ErrCodeEnhanceYourCalm
+ErrTimeout
 GoAway
 RPC
 RPCs
+TODO
 backoff
+blackhole
 blackholed
 cancelable
 cancelation

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,18 +1,48 @@
-FROM golang:1.9.1-stretch
+FROM ubuntu:16.10
 
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get -y update \
+  && apt-get -y install \
+  build-essential \
+  gcc \
+  apt-utils \
+  pkg-config \
+  software-properties-common \
+  apt-transport-https \
+  libssl-dev \
+  sudo \
+  bash \
+  curl \
+  wget \
+  tar \
+  git \
   netcat \
   libaspell-dev \
   libhunspell-dev \
   hunspell-en-us \
   aspell-en \
-  shellcheck
+  shellcheck \
+  && apt-get -y update \
+  && apt-get -y upgrade \
+  && apt-get -y autoremove \
+  && apt-get -y autoclean
+
+ENV GOROOT /usr/local/go
+ENV GOPATH /go
+ENV PATH ${GOPATH}/bin:${GOROOT}/bin:${PATH}
+ENV GO_VERSION 1.9.1
+ENV GO_DOWNLOAD_URL https://storage.googleapis.com/golang
+RUN rm -rf ${GOROOT} \
+  && curl -s ${GO_DOWNLOAD_URL}/go${GO_VERSION}.linux-amd64.tar.gz | tar -v -C /usr/local/ -xz \
+  && mkdir -p ${GOPATH}/src ${GOPATH}/bin \
+  && go version
 
 RUN mkdir -p ${GOPATH}/src/github.com/coreos/etcd
 WORKDIR ${GOPATH}/src/github.com/coreos/etcd
 
-ADD ./scripts/install-marker.sh ./scripts/install-marker.sh
+ADD ./scripts/install-marker.sh /tmp/install-marker.sh
 
 RUN go get -v -u -tags spell github.com/chzchzchz/goword \
   && go get -v -u github.com/coreos/license-bill-of-materials \
@@ -21,12 +51,7 @@ RUN go get -v -u -tags spell github.com/chzchzchz/goword \
   && go get -v -u honnef.co/go/tools/cmd/staticcheck \
   && go get -v -u github.com/wadey/gocovmerge \
   && go get -v -u github.com/gordonklaus/ineffassign \
-  && ./scripts/install-marker.sh amd64 \
+  && /tmp/install-marker.sh amd64 \
+  && rm -f /tmp/install-marker.sh \
   && curl -s https://codecov.io/bash >/codecov \
   && chmod 700 /codecov
-
-# e.g.
-# docker build --tag etcd-test --file ./Dockerfile-test .
-# docker run --volume=`pwd`:/go/src/github.com/coreos/etcd etcd-test \
-#  /bin/sh -c "INTEGRATION=y PASSES='build integration_e2e' ./test"
-

--- a/clientv3/integration/network_partition_test.go
+++ b/clientv3/integration/network_partition_test.go
@@ -80,8 +80,8 @@ func testNetworkPartitionBalancer(t *testing.T, op func(*clientv3.Client, contex
 		if err == nil {
 			break
 		}
-		// todo: separate put and get test for error checking.
-		// we do not really expect errTimeout on get.
+		// TODO: separate put and get test for error checking.
+		// we do not really expect ErrTimeout on get.
 		if err != context.DeadlineExceeded && err != rpctypes.ErrTimeout {
 			t.Errorf("#%d: expected %v or %v, got %v", i, context.DeadlineExceeded, rpctypes.ErrTimeout, err)
 		}

--- a/clientv3/integration/watch_keepalive_test.go
+++ b/clientv3/integration/watch_keepalive_test.go
@@ -46,7 +46,7 @@ func TestWatchKeepAlive(t *testing.T) {
 		DialKeepAliveTimeout: 500 * time.Millisecond,
 	}
 
-	// gRPC internal implmentation related.
+	// gRPC internal implementation related.
 	pingInterval := ccfg.DialKeepAliveTime + ccfg.DialKeepAliveTimeout
 	timeout := pingInterval + 2*time.Second // 2s for slow machine to process watch and reset connections
 


### PR DESCRIPTION
Debian base image from golang-stretch was breaking
shellcheck tests.

`shellcheck` test is now fixed

```bash
docker run \
	  --rm \
	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
	  gcr.io/etcd-development/etcd-test:go1.9.1 \
	  /bin/bash -c "PASSES='fmt' ./test"
```

(I pushed the docker image to our registry)

We need to use docker as well in Travis, to fix the CI failures.