### PR TITLE
integration: use variadic parameters for *Partition

### DIFF
--- a/clientv3/integration/dial_test.go
+++ b/clientv3/integration/dial_test.go
@@ -139,7 +139,7 @@ func TestSwitchSetEndpoints(t *testing.T) {
 	eps := []string{clus.Members[1].GRPCAddr(), clus.Members[2].GRPCAddr()}
 
 	cli := clus.Client(0)
-	clus.Members[0].InjectPartition(t, clus.Members[1:])
+	clus.Members[0].InjectPartition(t, clus.Members[1:]...)
 
 	cli.SetEndpoints(eps...)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -939,7 +939,7 @@ func TestKVSwitchUnavailable(t *testing.T) {
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3, SkipCreatingClient: true})
 	defer clus.Terminate(t)
 
-	clus.Members[0].InjectPartition(t, clus.Members[1:])
+	clus.Members[0].InjectPartition(t, clus.Members[1:]...)
 	// try to connect with dead node in the endpoint list
 	cfg := clientv3.Config{
 		Endpoints: []string{

--- a/clientv3/integration/network_partition_test.go
+++ b/clientv3/integration/network_partition_test.go
@@ -72,7 +72,7 @@ func testNetworkPartitionBalancer(t *testing.T, op func(*clientv3.Client, contex
 
 	// add other endpoints for later endpoint switch
 	cli.SetEndpoints(clus.Members[0].GRPCAddr(), clus.Members[1].GRPCAddr(), clus.Members[2].GRPCAddr())
-	clus.Members[0].InjectPartition(t, clus.Members[1:])
+	clus.Members[0].InjectPartition(t, clus.Members[1:]...)
 
 	for i := 0; i < 2; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/clientv3/ordering/util_test.go
+++ b/clientv3/ordering/util_test.go
@@ -52,7 +52,7 @@ func TestEndpointSwitchResolvesViolation(t *testing.T) {
 	// create partition between third members and the first two members
 	// in order to guarantee that the third member's revision of "foo"
 	// falls behind as updates to "foo" are issued to the first two members.
-	clus.Members[2].InjectPartition(t, clus.Members[:2])
+	clus.Members[2].InjectPartition(t, clus.Members[:2]...)
 	time.Sleep(1 * time.Second) // give enough time for the operation
 
 	// update to "foo" will not be replicated to the third member due to the partition

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -925,7 +925,7 @@ func (m *member) Metric(metricName string) (string, error) {
 }
 
 // InjectPartition drops connections from m to others, vice versa.
-func (m *member) InjectPartition(t *testing.T, others []*member) {
+func (m *member) InjectPartition(t *testing.T, others ...*member) {
 	for _, other := range others {
 		m.s.CutPeer(other.s.ID())
 		other.s.CutPeer(m.s.ID())
@@ -933,7 +933,7 @@ func (m *member) InjectPartition(t *testing.T, others []*member) {
 }
 
 // RecoverPartition recovers connections from m to others, vice versa.
-func (m *member) RecoverPartition(t *testing.T, others []*member) {
+func (m *member) RecoverPartition(t *testing.T, others ...*member) {
 	for _, other := range others {
 		m.s.MendPeer(other.s.ID())
 		other.s.MendPeer(m.s.ID())

--- a/integration/network_partition_test.go
+++ b/integration/network_partition_test.go
@@ -149,12 +149,12 @@ func getMembersByIndexSlice(clus *cluster, idxs []int) []*member {
 
 func injectPartition(t *testing.T, src, others []*member) {
 	for _, m := range src {
-		m.InjectPartition(t, others)
+		m.InjectPartition(t, others...)
 	}
 }
 
 func recoverPartition(t *testing.T, src, others []*member) {
 	for _, m := range src {
-		m.RecoverPartition(t, others)
+		m.RecoverPartition(t, others...)
 	}
 }


### PR DESCRIPTION
'member' type is not exported.
In network partition tests, we want do

```
InjectPartition(t, clus.Members[lead], clus.Members[lead+1])
```
