### PR TITLE
travis: use generic for testing with container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: go
+language: generic
 go_import_path: github.com/coreos/etcd
 
 sudo: required
@@ -6,7 +6,6 @@ sudo: required
 services: docker
 
 go:
-- 1.9.1
 - tip
 
 notifications:
@@ -30,8 +29,6 @@ matrix:
   - go: tip
     env: TARGET=amd64-go-tip
   exclude:
-  - go: 1.9.1
-    env: TARGET=amd64-go-tip
   - go: tip
     env: TARGET=amd64
   - go: tip


### PR DESCRIPTION
To bypass Go runtime install in Travis, when it just uses container images.