### PR TITLE
clientv3/integration: add waitPinReady

### DIFF
--- a/clientv3/integration/black_hole_test.go
+++ b/clientv3/integration/black_hole_test.go
@@ -47,13 +47,8 @@ func TestBlackholePutWithoutKeealiveEnabled(t *testing.T) {
 	}
 	defer cli.Close()
 
-	// wait for eps[0] to be pinned
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	_, err = cli.Get(ctx, "foo")
-	cancel()
-	if err != nil {
-		t.Fatal(err)
-	}
+	// wait for ep[0] to be pinned
+	waitPinReady(t, cli)
 
 	cli.SetEndpoints(clus.Members[0].GRPCAddr(), clus.Members[1].GRPCAddr())
 	clus.Members[0].Blackhole()

--- a/clientv3/integration/network_partition_test.go
+++ b/clientv3/integration/network_partition_test.go
@@ -70,6 +70,9 @@ func testBalancerUnderNetworkPartition(t *testing.T, op func(*clientv3.Client, c
 	}
 	defer cli.Close()
 
+	// wait for ep[0] to be pinned
+	waitPinReady(t, cli)
+
 	// add other endpoints for later endpoint switch
 	cli.SetEndpoints(clus.Members[0].GRPCAddr(), clus.Members[1].GRPCAddr(), clus.Members[2].GRPCAddr())
 	clus.Members[0].InjectPartition(t, clus.Members[1:]...)

--- a/clientv3/integration/server_shutdown_test.go
+++ b/clientv3/integration/server_shutdown_test.go
@@ -48,12 +48,7 @@ func TestBalancerUnderServerShutdownWatch(t *testing.T) {
 	defer watchCli.Close()
 
 	// wait for eps[lead] to be pinned
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	_, err = watchCli.Get(ctx, "foo")
-	cancel()
-	if err != nil {
-		t.Fatal(err)
-	}
+	waitPinReady(t, watchCli)
 
 	// add all eps to list, so that when the original pined one fails
 	// the client can switch to other available eps

--- a/clientv3/integration/util.go
+++ b/clientv3/integration/util.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+// waitPinReady waits until connection is up (new pinned address).
+func waitPinReady(t *testing.T, cli *clientv3.Client) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	_, err := cli.Get(ctx, "foo")
+	cancel()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
RPC should be sent to trigger 'readyWait' on new pin address.
Otherwise, endpoints other than ep[0] may be pinned.
