### PR TITLE
clientv3/integration: rename to 'mustWaitPinReady'

### DIFF
--- a/clientv3/integration/black_hole_test.go
+++ b/clientv3/integration/black_hole_test.go
@@ -48,7 +48,7 @@ func TestBlackholePutWithoutKeealiveEnabled(t *testing.T) {
 	defer cli.Close()
 
 	// wait for ep[0] to be pinned
-	waitPinReady(t, cli)
+	mustWaitPinReady(t, cli)
 
 	cli.SetEndpoints(clus.Members[0].GRPCAddr(), clus.Members[1].GRPCAddr())
 	clus.Members[0].Blackhole()

--- a/clientv3/integration/network_partition_test.go
+++ b/clientv3/integration/network_partition_test.go
@@ -82,7 +82,7 @@ func testBalancerUnderNetworkPartition(t *testing.T, op func(*clientv3.Client, c
 	defer cli.Close()
 
 	// wait for ep[0] to be pinned
-	waitPinReady(t, cli)
+	mustWaitPinReady(t, cli)
 
 	// add other endpoints for later endpoint switch
 	cli.SetEndpoints(clus.Members[0].GRPCAddr(), clus.Members[1].GRPCAddr(), clus.Members[2].GRPCAddr())
@@ -144,7 +144,7 @@ func testBalancerUnderNetworkPartitionWatch(t *testing.T, isolateLeader bool) {
 	defer watchCli.Close()
 
 	// wait for eps[target] to be pinned
-	waitPinReady(t, watchCli)
+	mustWaitPinReady(t, watchCli)
 
 	// add all eps to list, so that when the original pined one fails
 	// the client can switch to other available eps

--- a/clientv3/integration/server_shutdown_test.go
+++ b/clientv3/integration/server_shutdown_test.go
@@ -48,7 +48,7 @@ func TestBalancerUnderServerShutdownWatch(t *testing.T) {
 	defer watchCli.Close()
 
 	// wait for eps[lead] to be pinned
-	waitPinReady(t, watchCli)
+	mustWaitPinReady(t, watchCli)
 
 	// add all eps to list, so that when the original pined one fails
 	// the client can switch to other available eps
@@ -158,7 +158,7 @@ func testBalancerUnderServerShutdownMutable(t *testing.T, op func(*clientv3.Clie
 	defer cli.Close()
 
 	// wait for eps[0] to be pinned
-	waitPinReady(t, cli)
+	mustWaitPinReady(t, cli)
 
 	// add all eps to list, so that when the original pined one fails
 	// the client can switch to other available eps
@@ -216,7 +216,7 @@ func testBalancerUnderServerShutdownImmutable(t *testing.T, op func(*clientv3.Cl
 	defer cli.Close()
 
 	// wait for eps[0] to be pinned
-	waitPinReady(t, cli)
+	mustWaitPinReady(t, cli)
 
 	// add all eps to list, so that when the original pined one fails
 	// the client can switch to other available eps

--- a/clientv3/integration/util.go
+++ b/clientv3/integration/util.go
@@ -22,8 +22,9 @@ import (
 	"github.com/coreos/etcd/clientv3"
 )
 
-// waitPinReady waits until connection is up (new pinned address).
-func waitPinReady(t *testing.T, cli *clientv3.Client) {
+// mustWaitPinReady waits up to 3-second until connection is up (pin endpoint).
+// Fatal on time-out.
+func mustWaitPinReady(t *testing.T, cli *clientv3.Client) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	_, err := cli.Get(ctx, "foo")
 	cancel()


### PR DESCRIPTION
https://github.com/coreos/etcd/pull/8779#discussion_r147487474