### PR TITLE
clientv3/integration: increase balancer switch timeout for TestKVGetResetLoneEndpoint

### DIFF
--- a/.words
+++ b/.words
@@ -27,6 +27,7 @@ localhost
 mutex
 prefetching
 protobuf
+repin
 serializable
 teardown
 too_many_pings

--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -881,7 +881,11 @@ func TestKVGetResetLoneEndpoint(t *testing.T) {
 	// have Get try to reconnect
 	donec := make(chan struct{})
 	go func() {
-		ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+		// 3-second is the minimum interval between endpoint being marked
+		// as unhealthy and being removed from unhealthy, so possibly
+		// takes >5-second to unpin and repin an endpoint
+		// TODO: decrease timeout when balancer switch rewrite
+		ctx, cancel := context.WithTimeout(context.TODO(), 7*time.Second)
 		if _, err := cli.Get(ctx, "abc", clientv3.WithSerializable()); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Since 3-second is the minimum time to keep an endpoint in unhealthy,
it is possible that endpoint switch happens right after context timeout.

Fix https://github.com/coreos/etcd/issues/8757.