### PR TITLE
clientv3/integration: match more errors in put retries

### DIFF
--- a/clientv3/integration/server_shutdown_test.go
+++ b/clientv3/integration/server_shutdown_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/coreos/etcd/integration"
 	"github.com/coreos/etcd/pkg/testutil"
 )
@@ -99,7 +100,7 @@ func TestBalancerUnderServerShutdownWatch(t *testing.T) {
 		if err == nil {
 			break
 		}
-		if err == context.DeadlineExceeded {
+		if err == context.DeadlineExceeded || err == rpctypes.ErrTimeout || err == rpctypes.ErrTimeoutDueToLeaderFail {
 			continue
 		}
 		t.Fatal(err)


### PR DESCRIPTION
Fix

```
=== RUN   TestBalancerUnderServerShutdownWatch
WARNING: 2017/10/31 20:06:47 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: Error while dialing dial unix localhost:21207094780: connect: no such file or directory"; Reconnecting to {localhost:21207094780 <nil>}
WARNING: 2017/10/31 20:06:47 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: Error while dialing dial unix localhost:21207094780: connect: no such file or directory"; Reconnecting to {localhost:21207094780 <nil>}
INFO: 2017/10/31 20:06:47 get error from resetTransport context canceled, transportMonitor returning
WARNING: 2017/10/31 20:06:47 grpc: addrConn.transportMonitor exits due to: context canceled
WARNING: 2017/10/31 20:06:47 grpc: addrConn.transportMonitor exits due to: context canceled
WARNING: 2017/10/31 20:06:49 Error creating connection to {localhost:4854536610 <nil>}. Err: grpc: the client connection is closing
WARNING: 2017/10/31 20:06:49 Error creating connection to {localhost:4854536610 <nil>}. Err: grpc: the client connection is closing
--- FAIL: TestBalancerUnderServerShutdownWatch (2.07s)
	server_shutdown_test.go:105: etcdserver: request timed out, possibly due to previous leader failure
	server_shutdown_test.go:76: expected one event, got {Header:{ClusterId:0 MemberId:0 Revision:0 RaftTerm:0} Events:[] CompactRevision:0 Canceled:false Created:false closeErr:<nil> cancelReason:}
```

https://semaphoreci.com/coreos/etcd/branches/pull-request-8795/builds/8