### PR TITLE
semaphore.sh, go: add semaphore to release-3.1 branch, upgrade release-3.1 to go 1.8.5

### DIFF
--- a/.semaphore.sh
+++ b/.semaphore.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+TEST_SUFFIX=$(date +%s | base64 | head -c 15)
+
+TEST_OPTS="RELEASE_TEST=y INTEGRATION=y PASSES='build unit release integration_e2e functional'"
+if [ "$TEST_ARCH" == "386" ]; then
+	TEST_OPTS="GOARCH=386 PASSES='build unit integration_e2e'"
+fi
+
+docker run \
+	--rm \
+	--volume=`pwd`:/go/src/github.com/coreos/etcd \
+	gcr.io/etcd-development/etcd-test:go1.8.5 \
+	/bin/bash -c "${TEST_OPTS} ./test 2>&1 | tee test-${TEST_SUFFIX}.log"
+
+! grep FAIL -A10 -B50 test-${TEST_SUFFIX}.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go_import_path: github.com/coreos/etcd
 sudo: false
 
 go:
-  - 1.8.3
+  - 1.8.5
 
 notifications:
   on_success: never

--- a/client/integration/client_test.go
+++ b/client/integration/client_test.go
@@ -34,7 +34,7 @@ import (
 func TestV2NoRetryEOF(t *testing.T) {
 	defer testutil.AfterTest(t)
 	// generate an EOF response; specify address so appears first in sorted ep list
-	lEOF := integration.NewListenerWithAddr(t, fmt.Sprintf("eof:123.%d.sock", os.Getpid()))
+	lEOF := integration.NewListenerWithAddr(t, fmt.Sprintf("127.0.0.1:%05d", os.Getpid()))
 	defer lEOF.Close()
 	tries := uint32(0)
 	go func() {
@@ -65,8 +65,7 @@ func TestV2NoRetryEOF(t *testing.T) {
 // TestV2NoRetryNoLeader tests destructive api calls won't retry if given an error code.
 func TestV2NoRetryNoLeader(t *testing.T) {
 	defer testutil.AfterTest(t)
-
-	lHttp := integration.NewListenerWithAddr(t, fmt.Sprintf("errHttp:123.%d.sock", os.Getpid()))
+	lHttp := integration.NewListenerWithAddr(t, fmt.Sprintf("127.0.0.1:%05d", os.Getpid()))
 	eh := &errHandler{errCode: http.StatusServiceUnavailable}
 	srv := httptest.NewUnstartedServer(eh)
 	defer lHttp.Close()


### PR DESCRIPTION
Pending approval of https://github.com/coreos/etcd/pull/8805. This adds semaphore to 3.1 branch, like https://github.com/coreos/etcd/commit/2f74456443f97d34ee5a23591fdd4a4ab9405aea did for the 3.2 branch.

This also upgrades the 3.1 branch from go 1.8.3 to 1.8.5, primarly because we already have `gcr.io/etcd-development/etcd-test:go1.8.5` in the registry and don't see any point adding `1.8.3` when we can more easily upgrade go by a couple patch versions.