### PR TITLE
*: move logging to embed, disable grpc server log by default

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/ghodss/yaml"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
 )
 
 const (
@@ -244,6 +245,8 @@ func (cfg *Config) SetupLogging() {
 	if cfg.Debug {
 		capnslog.SetGlobalLogLevel(capnslog.DEBUG)
 		grpc.EnableTracing = true
+	} else {
+		grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 	}
 	if cfg.LogPkgLevels != "" {
 		repoLog := capnslog.MustRepoLogger("github.com/coreos/etcd")

--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -137,5 +137,8 @@ debug: false
 # Specify a particular log level for each etcd package (eg: 'etcdmain=CRITICAL,etcdserver=DEBUG'.
 log-package-levels:
 
+# Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.
+log-output: default
+
 # Force to create a new one member cluster.
 force-new-cluster: false

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coreos/etcd/pkg/flags"
 	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/version"
+
 	"github.com/ghodss/yaml"
 )
 
@@ -80,7 +81,6 @@ type config struct {
 	configFile   string
 	printVersion bool
 	ignored      []string
-	logOutput    string
 }
 
 // configFlags has the set of flags used for command line parsing a Config
@@ -192,7 +192,7 @@ func newConfig() *config {
 	// logging
 	fs.BoolVar(&cfg.Debug, "debug", false, "Enable debug-level logging for etcd.")
 	fs.StringVar(&cfg.LogPkgLevels, "log-package-levels", "", "Specify a particular log level for each etcd package (eg: 'etcdmain=CRITICAL,etcdserver=DEBUG').")
-	fs.StringVar(&cfg.logOutput, "log-output", "default", "Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.")
+	fs.StringVar(&cfg.LogOutput, "log-output", "default", "Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.")
 
 	// unsafe
 	fs.BoolVar(&cfg.ForceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster.")


### PR DESCRIPTION
Remove grpc logs when `--debug=false`:

```
WARNING: 2017/11/02 11:35:51 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: Error while dialing dial tcp: operation was canceled"; Reconnecting to {localhost:2379 <nil>}
WARNING: 2017/11/02 11:35:51 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: Error while dialing dial tcp: operation was canceled"; Reconnecting to {localhost:2379 <nil>}
INFO: 2017/11/02 11:35:51 get error from resetTransport grpc: the connection is closing, transportMonitor returning
```