### PR TITLE
etcdctl: fix snapshot status accidentally modified the db file

### DIFF
--- a/etcdctl/ctlv3/command/snapshot_command.go
+++ b/etcdctl/ctlv3/command/snapshot_command.go
@@ -409,7 +409,7 @@ func dbStatus(p string) dbstatus {
 
 	ds := dbstatus{}
 
-	db, err := bolt.Open(p, 0400, nil)
+	db, err := bolt.Open(p, 0400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}


### PR DESCRIPTION
etcdctl: snapshot status open bbolt with ReadOnly as true

this can avoid writing the freelist to the db file
