### PR TITLE
*: fail tests with egrep "(--- FAIL:|leak)"

### DIFF
--- a/.semaphore.sh
+++ b/.semaphore.sh
@@ -13,4 +13,4 @@ docker run \
 	gcr.io/etcd-development/etcd-test:go1.9.2 \
 	/bin/bash -c "${TEST_OPTS} ./test 2>&1 | tee test-${TEST_SUFFIX}.log"
 
-! grep FAIL -A10 -B50 test-${TEST_SUFFIX}.log
+! egrep "(--- FAIL:|leak)" -A10 -B50 test-${TEST_SUFFIX}.log

--- a/hack/scripts-dev/Makefile
+++ b/hack/scripts-dev/Makefile
@@ -94,7 +94,7 @@ test:
 	$(info TEST_OPTS: $(_TEST_OPTS))
 	$(info log-file: test-$(TEST_SUFFIX).log)
 	$(_TEST_OPTS) ./test 2>&1 | tee test-$(TEST_SUFFIX).log
-	! grep FAIL -A10 -B50 test-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|leak)" -A10 -B50 test-$(TEST_SUFFIX).log
 
 docker-test:
 	$(info GO_VERSION: $(_GO_VERSION))
@@ -105,7 +105,7 @@ docker-test:
 	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(_GO_VERSION) \
 	  /bin/bash -c "$(_TEST_OPTS) ./test 2>&1 | tee test-$(TEST_SUFFIX).log"
-	! grep FAIL -A10 -B50 test-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|leak)" -A10 -B50 test-$(TEST_SUFFIX).log
 
 docker-test-coverage:
 	$(info GO_VERSION: $(_GO_VERSION))
@@ -115,7 +115,7 @@ docker-test-coverage:
 	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(_GO_VERSION) \
 	  /bin/bash -c "COVERDIR=covdir PASSES='build build_cov cov' ./test 2>&1 | tee docker-test-coverage-$(TEST_SUFFIX).log && /codecov -t 6040de41-c073-4d6f-bbf8-d89256ef31e1"
-	! grep FAIL -A10 -B50 docker-test-coverage-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|leak)" -A10 -B50 docker-test-coverage-$(TEST_SUFFIX).log
 
 # build release container image with Linux
 _ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")

--- a/test
+++ b/test
@@ -141,7 +141,7 @@ function functional_pass {
 	rm -rf ./agent-*
 
 	if [[ "${ETCD_TESTER_EXIT_CODE}" -ne "0" ]]; then
-		echo "FAIL with exit code" ${ETCD_TESTER_EXIT_CODE}
+		echo "--- FAIL: exit code" ${ETCD_TESTER_EXIT_CODE}
 		exit ${ETCD_TESTER_EXIT_CODE}
 	fi
 }
@@ -211,7 +211,7 @@ function cov_pass {
 	# held failures to generate the full coverage file, now fail
 	if [ -n "$failed" ]; then
 		for f in $failed; do
-			echo FAIL "$f"
+			echo "--- FAIL:" "$f"
 		done
 		exit 255
 	fi
@@ -262,7 +262,7 @@ function release_pass {
 	set -e
 	case $result in
 		0)	;;
-		*)	echo "FAIL with" ${result}
+		*)	echo "--- FAIL:" ${result}
 			exit $result
 			;;
 	esac


### PR DESCRIPTION
Need these changes for upcoming gRPC upgrade, since new gRPC client logs have `TRANSIENT_FAILURE`. `egrep` commands are already used by Jenkins CIs.

Cherry-picked from https://github.com/coreos/etcd/pull/8771, since it's been taking awhile to figure out gRPC balancer issues.