### PR TITLE
*: translate linearizable read context errors

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -507,10 +507,16 @@ func toErr(ctx context.Context, err error) error {
 	code := ev.Code()
 	switch code {
 	case codes.DeadlineExceeded:
-		fallthrough
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		} else if strings.Contains(err.Error(), "context deadline exceeded") {
+			err = context.DeadlineExceeded
+		}
 	case codes.Canceled:
 		if ctx.Err() != nil {
 			err = ctx.Err()
+		} else if strings.Contains(err.Error(), "context canceled") {
+			err = context.Canceled
 		}
 	case codes.Unavailable:
 	case codes.FailedPrecondition:

--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -21,7 +21,7 @@ import (
 	"github.com/coreos/etcd/etcdserver/membership"
 	"github.com/coreos/etcd/lease"
 	"github.com/coreos/etcd/mvcc"
-	"google.golang.org/grpc/codes"
+
 	"google.golang.org/grpc/status"
 )
 
@@ -70,7 +70,7 @@ var toGRPCErrorMap = map[error]error{
 func togRPCError(err error) error {
 	grpcErr, ok := toGRPCErrorMap[err]
 	if !ok {
-		return status.Error(codes.Unknown, err.Error())
+		return status.Error(rpctypes.ConvertCode(err), err.Error())
 	}
 	return grpcErr
 }


### PR DESCRIPTION
context.DeadlineExceeded error from etcdserver/(s *EtcdServer).Range
linearizableReadNotify is returned to gRPC processUnaryRPC's Range
handler, where its code is Unknown.

Fix togRPCError to translate context errors.