### PR TITLE
api/v3rpc: do not convert server context error to grpc/*status.statusError

### DIFF
--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -15,12 +15,15 @@
 package v3rpc
 
 import (
+	"context"
+
 	"github.com/coreos/etcd/auth"
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/coreos/etcd/etcdserver/membership"
 	"github.com/coreos/etcd/lease"
 	"github.com/coreos/etcd/mvcc"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -68,6 +71,10 @@ var toGRPCErrorMap = map[error]error{
 }
 
 func togRPCError(err error) error {
+	// let gRPC server convert to codes.Canceled, codes.DeadlineExceeded
+	if err == context.Canceled || err == context.DeadlineExceeded {
+		return err
+	}
 	grpcErr, ok := toGRPCErrorMap[err]
 	if !ok {
 		return status.Error(codes.Unknown, err.Error())

--- a/etcdserver/api/v3rpc/util_test.go
+++ b/etcdserver/api/v3rpc/util_test.go
@@ -1,0 +1,50 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3rpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
+	"github.com/coreos/etcd/mvcc"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGRPCError(t *testing.T) {
+	tt := []struct {
+		err error
+		exp error
+	}{
+		{err: mvcc.ErrCompacted, exp: rpctypes.ErrGRPCCompacted},
+		{err: mvcc.ErrFutureRev, exp: rpctypes.ErrGRPCFutureRev},
+		{err: context.Canceled, exp: context.Canceled},
+		{err: context.DeadlineExceeded, exp: context.DeadlineExceeded},
+		{err: errors.New("foo"), exp: status.Error(codes.Unknown, "foo")},
+	}
+	for i := range tt {
+		if err := togRPCError(tt[i].err); err != tt[i].exp {
+			if _, ok := status.FromError(err); ok {
+				if err.Error() == tt[i].exp.Error() {
+					continue
+				}
+			}
+			t.Errorf("#%d: got %v, expected %v", i, err, tt[i].exp)
+		}
+	}
+}


### PR DESCRIPTION
Fix error handling on `*status.statusError` errors from server side (e.g. linearizableReadNotify).

ref https://github.com/coreos/etcd/pull/8821.
Fix https://github.com/coreos/etcd/issues/8809.