### PR TITLE
*: disable grpc client log in tests by default

### DIFF
--- a/clientv3/integration/logger_test.go
+++ b/clientv3/integration/logger_test.go
@@ -14,8 +14,14 @@
 
 package integration
 
-import "github.com/coreos/pkg/capnslog"
+import (
+	"io/ioutil"
+
+	"github.com/coreos/pkg/capnslog"
+	"google.golang.org/grpc/grpclog"
+)
 
 func init() {
 	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 }

--- a/clientv3/ordering/logger_test.go
+++ b/clientv3/ordering/logger_test.go
@@ -14,8 +14,14 @@
 
 package ordering
 
-import "github.com/coreos/pkg/capnslog"
+import (
+	"io/ioutil"
+
+	"github.com/coreos/pkg/capnslog"
+	"google.golang.org/grpc/grpclog"
+)
 
 func init() {
 	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 }

--- a/integration/logger_test.go
+++ b/integration/logger_test.go
@@ -14,10 +14,16 @@
 
 package integration
 
-import "github.com/coreos/pkg/capnslog"
+import (
+	"io/ioutil"
+
+	"github.com/coreos/pkg/capnslog"
+	"google.golang.org/grpc/grpclog"
+)
 
 const defaultLogLevel = capnslog.CRITICAL
 
 func init() {
 	capnslog.SetGlobalLogLevel(defaultLogLevel)
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 }


### PR DESCRIPTION
Silence logs like

> WARNING: 2017/11/07 15:03:56 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: Error while dialing dial unix localhost:87057270247096176020: connect: no such file or directory"; Reconnecting to {localhost:87057270247096176020 <nil>}