### PR TITLE
*: grpclog.SetLoggerV2 on clientv3.SetLogger, disable gRPC client logs

### DIFF
--- a/clientv3/integration/logger_test.go
+++ b/clientv3/integration/logger_test.go
@@ -17,11 +17,13 @@ package integration
 import (
 	"io/ioutil"
 
+	"github.com/coreos/etcd/clientv3"
+
 	"github.com/coreos/pkg/capnslog"
 	"google.golang.org/grpc/grpclog"
 )
 
 func init() {
 	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	clientv3.SetLogger(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 }

--- a/clientv3/logger.go
+++ b/clientv3/logger.go
@@ -61,6 +61,7 @@ func GetLogger() Logger {
 func (s *settableLogger) set(l Logger) {
 	s.mu.Lock()
 	logger.l = l
+	grpclog.SetLoggerV2(&logger)
 	s.mu.Unlock()
 }
 

--- a/clientv3/ordering/logger_test.go
+++ b/clientv3/ordering/logger_test.go
@@ -17,11 +17,13 @@ package ordering
 import (
 	"io/ioutil"
 
+	"github.com/coreos/etcd/clientv3"
+
 	"github.com/coreos/pkg/capnslog"
 	"google.golang.org/grpc/grpclog"
 )
 
 func init() {
 	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	clientv3.SetLogger(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 }

--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -114,6 +114,8 @@ func clientConfigFromCmd(cmd *cobra.Command) *clientConfig {
 		fs.VisitAll(func(f *pflag.Flag) {
 			fmt.Fprintf(os.Stderr, "%s=%v\n", flags.FlagToEnv("ETCDCTL", f.Name), f.Value)
 		})
+	} else {
+		clientv3.SetLogger(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 	}
 
 	cfg := &clientConfig{}

--- a/integration/logger_test.go
+++ b/integration/logger_test.go
@@ -17,6 +17,8 @@ package integration
 import (
 	"io/ioutil"
 
+	"github.com/coreos/etcd/clientv3"
+
 	"github.com/coreos/pkg/capnslog"
 	"google.golang.org/grpc/grpclog"
 )
@@ -25,5 +27,5 @@ const defaultLogLevel = capnslog.CRITICAL
 
 func init() {
 	capnslog.SetGlobalLogLevel(defaultLogLevel)
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	clientv3.SetLogger(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 }

--- a/store/store_v2v3_test.go
+++ b/store/store_v2v3_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/etcdserver/api/v2v3"
 	"github.com/coreos/etcd/integration"
 	"github.com/coreos/etcd/store"
@@ -30,7 +31,7 @@ import (
 
 func init() {
 	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	clientv3.SetLogger(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 }
 
 type v2v3TestStore struct {


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/8856.