### PR TITLE
Documentation/integrations.md: Add aioetcd3 to Python language bindings

### DIFF
--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -47,6 +47,7 @@
 - [lisael/aioetcd](https://github.com/lisael/aioetcd) - (Python 3.4+) Asyncio coroutines client (Supports v2)
 - [txaio-etcd](https://github.com/crossbario/txaio-etcd) - Asynchronous etcd v3-only client library for Twisted (today) and asyncio (future)
 - [dims/etcd3-gateway](https://github.com/dims/etcd3-gateway) - etcd v3 API library using the HTTP grpc gateway
+- [aioetcd3](https://github.com/gaopeiliang/aioetcd3) - (Python 3.6+) etcd v3 API for asyncio
 
 **Node libraries**
 


### PR DESCRIPTION
aioetcd3 is a Python binding for etcdv3 API for asyncio.
[https://github.com/gaopeiliang/aioetcd3](https://github.com/gaopeiliang/aioetcd3)