### PR TITLE
Documentation/op-guide: refine the number of failed followers

### DIFF
--- a/Documentation/op-guide/failures.md
+++ b/Documentation/op-guide/failures.md
@@ -6,7 +6,7 @@ In this section, we catalog kinds of failures and discuss how etcd is designed t
 
 ## Minor followers failure
 
-When fewer than half of the followers fail, the etcd cluster can still accept requests and make progress without any major disruption. For example, two follower failures will not affect a five member etcd cluster’s operation. However, clients will lose connectivity to the failed members. Client libraries should hide these interruptions from users for read requests by automatically reconnecting to other members. Operators should expect the system load on the other members to increase due to the reconnections.
+When fewer than (or equal to, if the cluster has odd members) half of the followers fail, the etcd cluster can still accept requests and make progress without any major disruption. For example, two follower failures will not affect a five member etcd cluster’s operation. However, clients will lose connectivity to the failed members. Client libraries should hide these interruptions from users for read requests by automatically reconnecting to other members. Operators should expect the system load on the other members to increase due to the reconnections.
 
 ## Leader failure
 


### PR DESCRIPTION
The number of followers in an N-node cluster is N-1, thus exactly a half of followers are okay to fail.

Actually in the following example, two followers' failure is acceptable in a five member etcd cluster, which has only four followers (the last one is the leader.)