### PR TITLE
release-3.2: Revert "embed: fix HTTPs + DNS SRV discovery"

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -331,9 +331,7 @@ func (cfg *Config) PeerURLsMapAndToken(which string) (urlsmap types.URLsMap, tok
 		}
 		clusterStr := strings.Join(clusterStrs, ",")
 		if strings.Contains(clusterStr, "https://") && cfg.PeerTLSInfo.CAFile == "" {
-			// SRV targets have subdomains under the given DNSCluster, so wildcard matching
-			// is needed.
-			cfg.PeerTLSInfo.ServerName = "*." + cfg.DNSCluster
+			cfg.PeerTLSInfo.ServerName = cfg.DNSCluster
 		}
 		urlsmap, err = types.NewURLsMap(clusterStr)
 		// only etcd member must belong to the discovered cluster.


### PR DESCRIPTION
This reverts commit f79d5aaca475f6d36985856f2fba5b2ed3df7249.

Backporting https://github.com/coreos/etcd/pull/8884 to release-3.2.