### PR TITLE
Documentation: change "key file" to "cert file"

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -248,7 +248,7 @@ The security flags help to [build a secure etcd cluster][security].
 + env variable: ETCD_CLIENT_CRL_FILE
 
 ### --trusted-ca-file
-+ Path to the client server TLS trusted CA key file.
++ Path to the client server TLS trusted CA cert file.
 + default: ""
 + env variable: ETCD_TRUSTED_CA_FILE
 

--- a/Documentation/v2/configuration.md
+++ b/Documentation/v2/configuration.md
@@ -205,7 +205,7 @@ The security flags help to [build a secure etcd cluster][security].
 + env variable: ETCD_CLIENT_CERT_AUTH
 
 ### --trusted-ca-file
-+ Path to the client server TLS trusted CA key file.
++ Path to the client server TLS trusted CA cert file.
 + default: none
 + env variable: ETCD_TRUSTED_CA_FILE
 

--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -106,7 +106,7 @@ client-transport-security:
   # Enable client cert authentication.
   client-cert-auth: false
 
-  # Path to the client server TLS trusted CA key file.
+  # Path to the client server TLS trusted CA cert file.
   trusted-ca-file:
 
   # Client TLS using generated certificates
@@ -125,7 +125,7 @@ peer-transport-security:
   # Enable peer client cert authentication.
   peer-client-cert-auth: false
 
-  # Path to the peer server TLS trusted CA key file.
+  # Path to the peer server TLS trusted CA cert file.
   trusted-ca-file:
 
   # Peer TLS using generated certificates.

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -178,7 +178,7 @@ func newConfig() *config {
 	fs.StringVar(&cfg.ec.ClientTLSInfo.KeyFile, "key-file", "", "Path to the client server TLS key file.")
 	fs.BoolVar(&cfg.ec.ClientTLSInfo.ClientCertAuth, "client-cert-auth", false, "Enable client cert authentication.")
 	fs.StringVar(&cfg.ec.ClientTLSInfo.CRLFile, "client-crl-file", "", "Path to the client certificate revocation list file.")
-	fs.StringVar(&cfg.ec.ClientTLSInfo.TrustedCAFile, "trusted-ca-file", "", "Path to the client server TLS trusted CA key file.")
+	fs.StringVar(&cfg.ec.ClientTLSInfo.TrustedCAFile, "trusted-ca-file", "", "Path to the client server TLS trusted CA cert file.")
 	fs.BoolVar(&cfg.ec.ClientAutoTLS, "auto-tls", false, "Client TLS using generated certificates")
 	fs.StringVar(&cfg.ec.PeerTLSInfo.CAFile, "peer-ca-file", "", "DEPRECATED: Path to the peer server TLS CA file.")
 	fs.StringVar(&cfg.ec.PeerTLSInfo.CertFile, "peer-cert-file", "", "Path to the peer server TLS cert file.")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -139,7 +139,7 @@ security flags:
 	--client-crl-file ''
 		path to the client certificate revocation list file.
 	--trusted-ca-file ''
-		path to the client server TLS trusted CA key file.
+		path to the client server TLS trusted CA cert file.
 	--auto-tls 'false'
 		client TLS using generated certificates.
 	--peer-ca-file '' [DEPRECATED]


### PR DESCRIPTION
when i try to configure an etcd cluster with https,the word "key file" mislead me.what we need provide should be a CA cert file,not the CA private key.so the word "cert" will be better than the word "key".
