### PR TITLE
Fix go fmt for gotip

### DIFF
--- a/etcdmain/config_test.go
+++ b/etcdmain/config_test.go
@@ -148,9 +148,8 @@ func TestConfigFileClusteringFlags(t *testing.T) {
 		DNSCluster     string `json:"discovery-srv"`
 		Durl           string `json:"discovery"`
 	}{
-		{
 		// Use default name and generate a default initial-cluster
-		},
+		{},
 		{
 			Name: "non-default",
 		},


### PR DESCRIPTION
This will fix following error for gotip:

```
Starting 'fmt' pass at Fri Nov 17 20:40:20 UTC 2017
Checking gofmt...
gofmt checking failed:
etcdmain/config_test.go
diff -u etcdmain/config_test.go.orig etcdmain/config_test.go
--- etcdmain/config_test.go.orig	2017-11-17 20:40:20.691852875 +0000
+++ etcdmain/config_test.go	2017-11-17 20:40:20.691852875 +0000
@@ -149,7 +149,7 @@
 		Durl           string `json:"discovery"`
 	}{
 		{
-		// Use default name and generate a default initial-cluster
+			// Use default name and generate a default initial-cluster
 		},
 		{
 			Name: "non-default",
```

Fixes: https://github.com/coreos/etcd/issues/8900