### PR TITLE
pkg/fileutil: fix preallocate under OS X kernel

### DIFF
--- a/pkg/fileutil/preallocate_darwin.go
+++ b/pkg/fileutil/preallocate_darwin.go
@@ -30,6 +30,8 @@ func preallocExtend(f *os.File, sizeInBytes int64) error {
 }
 
 func preallocFixed(f *os.File, sizeInBytes int64) error {
+	// allocate all requested space or no space at all
+	// TODO: allocate contiguous space on disk with F_ALLOCATECONTIG flag
 	fstore := &syscall.Fstore_t{
 		Flags:   syscall.F_ALLOCATEALL,
 		Posmode: syscall.F_PEOFPOSMODE,
@@ -38,6 +40,26 @@ func preallocFixed(f *os.File, sizeInBytes int64) error {
 	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), uintptr(syscall.F_PREALLOCATE), uintptr(p))
 	if errno == 0 || errno == syscall.ENOTSUP {
 		return nil
+	}
+
+	// wrong argument to fallocate syscall
+	if errno == syscall.EINVAL {
+		// filesystem "st_blocks" are allocated in the units of
+		// "Allocation Block Size" (run "diskutil info /" command)
+		var stat syscall.Stat_t
+		syscall.Fstat(int(f.Fd()), &stat)
+
+		// syscall.Statfs_t.Bsize is "optimal transfer block size"
+		// and contains matching 4096 value when latest OS X kernel
+		// supports 4,096 KB filesystem block size
+		var statfs syscall.Statfs_t
+		syscall.Fstatfs(int(f.Fd()), &statfs)
+		blockSize := int64(statfs.Bsize)
+
+		if stat.Blocks*blockSize >= sizeInBytes {
+			// enough blocks are already allocated
+			return nil
+		}
 	}
 	return errno
 }


### PR DESCRIPTION
ftruncate changes st_blocks, and following fallocate
syscalls would return EINVAL when allocated block size
is already greater than requested block size
(e.g. st_blocks==8, requested blocks are 2).

ref. https://github.com/apple/darwin-xnu/blob/master/bsd/kern/kern_descrip.c#L1241

Cross checked the behavior in C++:

```cpp
#include <fstream>
#include <iostream>
#include <fcntl.h>
#include <sys/stat.h>
#include <unistd.h>
using namespace std;

void fallocate(int fd, off_t len) {
  // preallocate contiguous chunks on disk
  fstore_t store={F_ALLOCATECONTIG,F_PEOFPOSMODE,0,len};
  int ret=fcntl(fd,F_PREALLOCATE,&store);
  if(ret<0) {
    // non-contiguous allocation
    store.fst_flags=F_ALLOCATEALL;
    if(fcntl(fd,F_PREALLOCATE,&store)<0) perror("fcntl error");
  }
}

void print_stats(int fd) {
  struct stat stat;
  if(fstat(fd,&stat)<0) perror("stat");
  cout << "st_size: " << stat.st_size << endl;
  cout << "st_blocks: " << stat.st_blocks << endl;
  cout << "allocated size: " << stat.st_blocks*512 << endl;
  cout << "st_blksize: " << stat.st_blksize << endl << endl;
}

#define BUF_SZ 1024
static char buf[BUF_SZ];

int main(int argc, char* argv[]) {
  int fd=open(argv[1],O_RDWR|O_CREAT|O_EXCL,0666);

  // already exists
  if (fd==-1) fd=open(argv[1],O_RDWR,0666);

  if (fd==-1) {
    fprintf(stderr, "bad fd=%d on %s\n", fd, argv[1]);
    return 1;
  }

  memset(buf,0xff,sizeof(buf));

  write(fd,buf,sizeof(buf));
  fsync(fd);
  print_stats(fd);

  if(ftruncate(fd,512)<0) perror("ftruncate");

  print_stats(fd);

  fallocate(fd,1024);
  print_stats(fd);

  if(close(fd)<0) perror("close");
}
```

```
st_size: 1024
st_blocks: 8
allocated size: 4096
st_blksize: 4194304

st_size: 512
st_blocks: 8
allocated size: 4096
st_blksize: 4194304

fcntl error: Invalid argument
st_size: 512
st_blocks: 8
allocated size: 4096
st_blksize: 4194304
```

Fix https://github.com/coreos/etcd/issues/8872.