### PR TITLE
*: enable initial corrupt check in tests

### DIFF
--- a/e2e/ctl_v3_test.go
+++ b/e2e/ctl_v3_test.go
@@ -82,6 +82,7 @@ func (cx *ctlCtx) applyOpts(opts []ctlOption) {
 	for _, opt := range opts {
 		opt(cx)
 	}
+	cx.initialCorruptCheck = true
 }
 
 func withCfg(cfg etcdProcessClusterConfig) ctlOption {

--- a/tools/functional-tester/etcd-tester/member.go
+++ b/tools/functional-tester/etcd-tester/member.go
@@ -47,6 +47,7 @@ func (m *member) Flags() []string {
 		"--listen-peer-urls", m.PeerURL,
 		"--initial-advertise-peer-urls", m.PeerURL,
 		"--initial-cluster-state", "new",
+		"--experimental-initial-corrupt-check",
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/8909.