### PR TITLE
Documentation: Add release manager table

### DIFF
--- a/Documentation/branch_management.md
+++ b/Documentation/branch_management.md
@@ -15,12 +15,12 @@ The `master` branch is our development branch. All new features land here first.
 
 To try new and experimental features, pull `master` and play with it. Note that `master` may not be stable because new features may introduce bugs.
 
-Before the release of the next stable version, feature PRs will be frozen. We will focus on the testing, bug-fix and documentation for one to two weeks.
+Before the release of the next stable version, feature PRs will be frozen. A [release manager](./dev-internal/release.md#release-management) will be assigned to major/minor version and will lead the etcd community in test, bug-fix and documentation of the release for one to two weeks.
 
 ### Stable branches
 
 All branches with prefix `release-` are considered _stable_ branches.
 
-After every minor release (http://semver.org/), we will have a new stable branch for that release. We will keep fixing the backwards-compatible bugs for the latest two stable releases. A _patch_ release to each supported release branch, incorporating any bug fixes, will be once every two weeks, given any patches.
+After every minor release (http://semver.org/), we will have a new stable branch for that release, managed by a [patch release manager](./dev-internal/release.md#release-management). We will keep fixing the backwards-compatible bugs for the latest two stable releases. A _patch_ release to each supported release branch, incorporating any bug fixes, will be once every two weeks, given any patches.
 
 [master]: https://github.com/coreos/etcd/tree/master

--- a/Documentation/dev-internal/release.md
+++ b/Documentation/dev-internal/release.md
@@ -4,6 +4,17 @@ The guide talks about how to release a new version of etcd.
 
 The procedure includes some manual steps for sanity checking, but it can probably be further scripted. Please keep this document up-to-date if making changes to the release process.
 
+## Release management
+
+etcd community members are assigned to manage the release each etcd major/minor version as well as manage patches
+and to each stable release branch. The managers are responsible for communicating the timelines and status of each
+release and for ensuring the stability of the release branch.
+
+| Releases | Manager |
+| -------- | ------- |
+| 3.1 patch (post 3.1.0) | Joe Betz [@jpbetz](https://github.com/jpbetz) |
+| 3.2 patch (post 3.2.0) | Gyuho Lee [@gyuho](https://github.com/gyuho) |
+
 ## Prepare release
 
 Set desired version as environment variable for following steps. Here is an example to release 2.3.0:


### PR DESCRIPTION
Add a release manager listing similar to the [kubernetes one](https://github.com/kubernetes/community/wiki), but simplified.

The only other page with release management docs is `Documentation/branch_management.md`. Should I add a link to this section from that page?