### PR TITLE
clientv3/doc: update dial-timeout error handling with new gRPC

### DIFF
--- a/clientv3/doc.go
+++ b/clientv3/doc.go
@@ -21,6 +21,13 @@
 //		Endpoints:   []string{"http://254.0.0.1:12345"},
 //		DialTimeout: 2 * time.Second
 //	})
+//
+//	// etcd clientv3 >= v3.2.10, grpc/grpc-go >= v1.7.3
+//	if err == context.DeadlineExceeded {
+//		// handle errors
+//	}
+//
+//	// etcd clientv3 <= v3.2.9, grpc/grpc-go <= v1.2.1
 //	if err == grpc.ErrClientConnTimeout {
 //		// handle errors
 //	}


### PR DESCRIPTION
See https://github.com/coreos/etcd/blob/master/Documentation/upgrades/upgrade_3_2.md#client-upgrade-checklists-3210.

It was documented based on old etcd versions. Making godoc sync with latest release.