### PR TITLE
api/v3rpc: log grpc stream send/recv errors in server-side

### DIFF
--- a/etcdserver/api/v3rpc/lease.go
+++ b/etcdserver/api/v3rpc/lease.go
@@ -107,6 +107,7 @@ func (ls *LeaseServer) leaseKeepAlive(stream pb.Lease_LeaseKeepAliveServer) erro
 			return nil
 		}
 		if err != nil {
+			plog.Warningf("failed to receive lease keepalive request from gRPC stream (%q)", err.Error())
 			return err
 		}
 
@@ -132,6 +133,7 @@ func (ls *LeaseServer) leaseKeepAlive(stream pb.Lease_LeaseKeepAliveServer) erro
 		resp.TTL = ttl
 		err = stream.Send(resp)
 		if err != nil {
+			plog.Warningf("failed to send lease keepalive response to gRPC stream (%q)", err.Error())
 			return err
 		}
 	}

--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -140,6 +140,7 @@ func (ws *watchServer) Watch(stream pb.Watch_WatchServer) (err error) {
 	// deadlock when calling sws.close().
 	go func() {
 		if rerr := sws.recvLoop(); rerr != nil {
+			plog.Warningf("failed to receive watch request from gRPC stream (%q)", rerr.Error())
 			errc <- rerr
 		}
 	}()
@@ -338,6 +339,7 @@ func (sws *serverWatchStream) sendLoop() {
 
 			mvcc.ReportEventReceived(len(evs))
 			if err := sws.gRPCStream.Send(wr); err != nil {
+				plog.Warningf("failed to send watch response to gRPC stream (%q)", err.Error())
 				return
 			}
 
@@ -354,6 +356,7 @@ func (sws *serverWatchStream) sendLoop() {
 			}
 
 			if err := sws.gRPCStream.Send(c); err != nil {
+				plog.Warningf("failed to send watch control response to gRPC stream (%q)", err.Error())
 				return
 			}
 
@@ -369,6 +372,7 @@ func (sws *serverWatchStream) sendLoop() {
 				for _, v := range pending[wid] {
 					mvcc.ReportEventReceived(len(v.Events))
 					if err := sws.gRPCStream.Send(v); err != nil {
+						plog.Warningf("failed to send pending watch response to gRPC stream (%q)", err.Error())
 						return
 					}
 				}


### PR DESCRIPTION
Helpful for debugging https://github.com/coreos/etcd/issues/8904.

c.f. https://github.com/grpc/grpc-go/pull/1687