### PR TITLE
e2e: fix remote error string in TestEtcdPeerCNAuth

### DIFF
--- a/e2e/etcd_config_test.go
+++ b/e2e/etcd_config_test.go
@@ -183,7 +183,7 @@ func TestEtcdPeerCNAuth(t *testing.T) {
 		if i <= 1 {
 			expect = etcdServerReadyLines
 		} else {
-			expect = []string{"(remote error: tls: bad certificate)"}
+			expect = []string{"remote error: tls: bad certificate"}
 		}
 		if err := waitReadyExpectProc(p, expect); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Now error is `embed: rejected connection from "127.0.0.1:58527" (error "remote error: tls: bad certificate", ServerName "")`.
Change from https://github.com/coreos/etcd/pull/8952.
