### PR TITLE
semaphore, test: grep "test timed out" first, specify leaky goroutine string 

### DIFF
--- a/.semaphore.sh
+++ b/.semaphore.sh
@@ -13,4 +13,4 @@ docker run \
 	gcr.io/etcd-development/etcd-test:go1.9.2 \
 	/bin/bash -c "${TEST_OPTS} ./test 2>&1 | tee test-${TEST_SUFFIX}.log"
 
-! egrep "(--- FAIL:|leak|panic: test timed out)" -A10 -B50 test-${TEST_SUFFIX}.log
+! egrep "(--- FAIL:|panic: test timed out|appears to have leaked|Too many goroutines)" -B50 -A10 test-${TEST_SUFFIX}.log

--- a/hack/scripts-dev/Makefile
+++ b/hack/scripts-dev/Makefile
@@ -12,6 +12,7 @@ build:
 
 clean:
 	rm -f ./codecov
+	rm -rf ./agent-*
 	rm -rf ./covdir
 	rm -f ./*.log
 	rm -f ./bin/Dockerfile-release
@@ -94,7 +95,7 @@ test:
 	$(info TEST_OPTS: $(_TEST_OPTS))
 	$(info log-file: test-$(TEST_SUFFIX).log)
 	$(_TEST_OPTS) ./test 2>&1 | tee test-$(TEST_SUFFIX).log
-	! egrep "(--- FAIL:|leak|panic: test timed out)" -A10 -B50 test-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|panic: test timed out|appears to have leaked|Too many goroutines)" -B50 -A10 test-$(TEST_SUFFIX).log
 
 docker-test:
 	$(info GO_VERSION: $(_GO_VERSION))
@@ -105,7 +106,7 @@ docker-test:
 	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(_GO_VERSION) \
 	  /bin/bash -c "$(_TEST_OPTS) ./test 2>&1 | tee test-$(TEST_SUFFIX).log"
-	! egrep "(--- FAIL:|leak|panic: test timed out)" -A10 -B50 test-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|panic: test timed out|appears to have leaked|Too many goroutines)" -B50 -A10 test-$(TEST_SUFFIX).log
 
 docker-test-coverage:
 	$(info GO_VERSION: $(_GO_VERSION))
@@ -115,7 +116,7 @@ docker-test-coverage:
 	  --volume=`pwd`:/go/src/github.com/coreos/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(_GO_VERSION) \
 	  /bin/bash -c "COVERDIR=covdir PASSES='build build_cov cov' ./test 2>&1 | tee docker-test-coverage-$(TEST_SUFFIX).log && /codecov -t 6040de41-c073-4d6f-bbf8-d89256ef31e1"
-	! egrep "(--- FAIL:|leak|panic: test timed out)" -A10 -B50 docker-test-coverage-$(TEST_SUFFIX).log
+	! egrep "(--- FAIL:|panic: test timed out|appears to have leaked|Too many goroutines)" -B50 -A10 docker-test-coverage-$(TEST_SUFFIX).log
 
 # build release container image with Linux
 _ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")


### PR DESCRIPTION
Specify more leaky goroutine errors (e.g. `Too many goroutines`).

Separating out https://github.com/coreos/etcd/pull/8954.

/cc @fanminshi 