### PR TITLE
metrics: Add server_version metric

### DIFF
--- a/e2e/metrics_test.go
+++ b/e2e/metrics_test.go
@@ -15,7 +15,10 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/coreos/etcd/version"
 )
 
 func TestV3MetricsSecure(t *testing.T) {
@@ -37,6 +40,9 @@ func metricsTest(cx ctlCtx) {
 		cx.t.Fatal(err)
 	}
 	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: `etcd_debugging_mvcc_keys_total 1`, metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
+		cx.t.Fatalf("failed get with curl (%v)", err)
+	}
+	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version), metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
 		cx.t.Fatalf("failed get with curl (%v)", err)
 	}
 	if err := cURLGet(cx.epc, cURLReq{endpoint: "/health", expected: `{"health":true}`, metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {

--- a/etcdserver/metrics.go
+++ b/etcdserver/metrics.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/pkg/runtime"
+	"github.com/coreos/etcd/version"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -64,6 +65,13 @@ var (
 		Name:      "lease_expired_total",
 		Help:      "The total number of expired leases.",
 	})
+	currentVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "version",
+		Help:      "Which version is running. 1 for 'server_version' label with current version.",
+	},
+		[]string{"server_version"})
 )
 
 func init() {
@@ -74,6 +82,11 @@ func init() {
 	prometheus.MustRegister(proposalsPending)
 	prometheus.MustRegister(proposalsFailed)
 	prometheus.MustRegister(leaseExpired)
+	prometheus.MustRegister(currentVersion)
+
+	currentVersion.With(prometheus.Labels{
+		"server_version": version.Version,
+	}).Set(1)
 }
 
 func monitorFileDescriptor(done <-chan struct{}) {


### PR DESCRIPTION
Fixes #8948 

Example output:

```
curl -s http://localhost:2379/metrics  | grep etcd_server_version
# HELP etcd_server_version Which version is running. 1 for 'server_version' label with current version.
# TYPE etcd_server_version gauge
etcd_server_version{server_version="3.2.0+git"} 1
```
When the metric aggregated from multiple etcd nodes, can be used to monitor the # of nodes running each etcd version.