### PR TITLE
*: fix gosimple warnings on sort.StringSlice

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -458,7 +458,7 @@ func (as *authStore) UserGrantRole(r *pb.AuthUserGrantRoleRequest) (*pb.AuthUser
 	}
 
 	user.Roles = append(user.Roles, r.Role)
-	sort.Sort(sort.StringSlice(user.Roles))
+	sort.Strings(user.Roles)
 
 	putUser(tx, user)
 

--- a/lease/lessor_test.go
+++ b/lease/lessor_test.go
@@ -183,7 +183,7 @@ func TestLessorRevoke(t *testing.T) {
 	}
 
 	wdeleted := []string{"bar_", "foo_"}
-	sort.Sort(sort.StringSlice(fd.deleted))
+	sort.Strings(fd.deleted)
 	if !reflect.DeepEqual(fd.deleted, wdeleted) {
 		t.Errorf("deleted= %v, want %v", fd.deleted, wdeleted)
 	}


### PR DESCRIPTION
I just rebuilt our base test-image with latest `gosimple`, and found this via https://travis-ci.org/coreos/etcd/jobs/311545346#L843-L844.