### PR TITLE
clientv3: fix indentation in doc.go

### DIFF
--- a/clientv3/doc.go
+++ b/clientv3/doc.go
@@ -59,9 +59,9 @@
 //
 // etcd client returns 3 types of errors:
 //
-//	1. context error: canceled or deadline exceeded.
+//  1. context error: canceled or deadline exceeded.
 //  2. gRPC status error: e.g. when clock drifts in server-side before client's context deadline exceeded.
-//	3. gRPC error: see https://github.com/coreos/etcd/blob/master/etcdserver/api/v3rpc/rpctypes/error.go
+//  3. gRPC error: see https://github.com/coreos/etcd/blob/master/etcdserver/api/v3rpc/rpctypes/error.go
 //
 // Here is the example code to handle client errors:
 //


### PR DESCRIPTION
Looks off in https://godoc.org/github.com/coreos/etcd/clientv3.
