### PR TITLE
Documentation/upgrades: highlight 3.2 breaking change, require gRPC v1.7.4

### DIFF
--- a/Documentation/upgrades/upgrade_3_2.md
+++ b/Documentation/upgrades/upgrade_3_2.md
@@ -6,7 +6,7 @@ In the general case, upgrading from etcd 3.1 to 3.2 can be a zero-downtime, roll
 
 Before [starting an upgrade](#upgrade-procedure), read through the rest of this guide to prepare.
 
-### Server upgrade checklists
+### Server upgrade checklists (breaking change)
 
 3.2 now rejects domains names for `--listen-peer-urls` and `--listen-client-urls` (3.1 only prints out warnings), since domain name is invalid for network interface binding. Make sure that those URLs are properly formated as `scheme://IP:port`.
 
@@ -54,7 +54,7 @@ clientv3yaml.NewConfig
 
 ### Client upgrade checklists (>=3.2.10)
 
-Note that >=3.2.10 requires `grpc/grpc-go` v1.7.3 (<=3.2.9 with v1.2.1), which introduces some breaking changes.
+Note that >=3.2.10 requires `grpc/grpc-go` v1.7.4 (<=3.2.9 with v1.2.1), which introduces some breaking changes.
 
 Previously, `grpc.ErrClientConnTimeout` error is returned on client dial time-outs. >=3.2.10 instead returns `context.DeadlineExceeded` (see [#8504](https://github.com/coreos/etcd/issues/8504)).
 

--- a/Documentation/upgrades/upgrade_3_3.md
+++ b/Documentation/upgrades/upgrade_3_3.md
@@ -145,9 +145,9 @@ import "context"
 cli.Put(context.Background(), "f", "v")
 ```
 
-#### Upgrade grpc/grpc-go to `v1.7.x`
+#### Upgrade grpc/grpc-go to `v1.7.4`
 
-3.3 now requires [grpc/grpc-go](https://github.com/grpc/grpc-go/releases) `v1.7.x`.
+3.3 now requires [grpc/grpc-go](https://github.com/grpc/grpc-go/releases) `v1.7.4`.
 
 ##### Deprecate `grpclog.Logger`
 


### PR DESCRIPTION
There's already a section called "Server upgrade checklists" below.
Instead, highlight the listen URLs change as a breaking change in
server. Also update 3.2 and 3.3 gRPC requirements as v1.7.4.
