### PR TITLE
compactor: fix error message of Revision compactor

### DIFF
--- a/compactor/revision.go
+++ b/compactor/revision.go
@@ -82,7 +82,7 @@ func (t *Revision) Run() {
 				previous = rev
 				plog.Noticef("Finished auto-compaction at revision %d", rev)
 			} else {
-				plog.Noticef("Failed auto-compaction at revision %d (%v)", err, rev)
+				plog.Noticef("Failed auto-compaction at revision %d (%v)", rev, err)
 				plog.Noticef("Retry after %v", checkCompactionInterval)
 			}
 		}


### PR DESCRIPTION
Hello,

This is just a quick fix for an error message formatting. The Periodic compactor does not have the same issue. 

---
Reorder the parameters so that Noticef can output the error properly.