### PR TITLE
Update Running etcd section for pre-built install of etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,22 @@ For those wanting to try the very latest version, [build the latest version of e
 
 ### Running etcd
 
-First start a single-member cluster of etcd:
+First start a single-member cluster of etcd.
+
+If etcd is installed using the [pre-built release binaries][github-release], run it from the installation location as below:
+
+```sh
+/tmp/etcd-download-test/etcd
+```
+The etcd command can be simply run as such if it is moved to the system path as below:
+
+```sh
+mv /tmp/etcd-download-test/etcd /usr/locale/bin/
+
+etcd
+```
+
+If etcd is [build from the master branch][dl-build], run it as below:
 
 ```sh
 ./bin/etcd


### PR DESCRIPTION
The current Running etcd section only shows how to run etcd for installation
with master branch. If user has installed a pre-built release following the
instructions on the release page, the ./bin/etcd won't work to bring up the
etcd. The Getting etcd section covers both, pre-built and master branch,
with recommendation of pre-built usage so the Running etcd section is updated
accordingly.

fix #9003

# Contributing guidelines

Please read our [contribution workflow][contributing] before submitting a pull request.

[contributing]: https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow
