### PR TITLE
tools/etcd-dump-*: add TODOs, --decode flag

### DIFF
--- a/tools/etcd-dump-db/main.go
+++ b/tools/etcd-dump-db/main.go
@@ -35,7 +35,7 @@ var (
 		Run:   listBucketCommandFunc,
 	}
 	iterateBucketCommand = &cobra.Command{
-		Use:   "iterate-bucket [data dir or db file path]",
+		Use:   "iterate-bucket [data dir or db file path] [bucket name]",
 		Short: "iterate-bucket lists key-value pairs in reverse order.",
 		Run:   iterateBucketCommandFunc,
 	}
@@ -46,14 +46,12 @@ var (
 	}
 )
 
-var (
-	iterateBucketName  string
-	iterateBucketLimit uint64
-)
+var iterateBucketLimit uint64
+var iterateBucketDecode bool
 
 func init() {
-	iterateBucketCommand.PersistentFlags().StringVar(&iterateBucketName, "bucket", "", "bucket name to iterate")
 	iterateBucketCommand.PersistentFlags().Uint64Var(&iterateBucketLimit, "limit", 0, "max number of key-value pairs to iterate (0< to iterate all)")
+	iterateBucketCommand.PersistentFlags().BoolVar(&iterateBucketDecode, "decode", false, "true to decode Protocol Buffer encoded data")
 
 	rootCommand.AddCommand(listBucketCommand)
 	rootCommand.AddCommand(iterateBucketCommand)
@@ -89,8 +87,8 @@ func listBucketCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func iterateBucketCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) < 1 {
-		log.Fatalf("Must provide at least 1 argument (got %v)", args)
+	if len(args) != 2 {
+		log.Fatalf("Must provide 2 arguments (got %v)", args)
 	}
 	dp := args[0]
 	if !strings.HasSuffix(dp, "db") {
@@ -99,12 +97,8 @@ func iterateBucketCommandFunc(cmd *cobra.Command, args []string) {
 	if !existFileOrDir(dp) {
 		log.Fatalf("%q does not exist", dp)
 	}
-
-	if iterateBucketName == "" {
-		log.Fatal("got empty bucket name")
-	}
-
-	err := iterateBucket(dp, iterateBucketName, iterateBucketLimit)
+	bucket := args[1]
+	err := iterateBucket(dp, bucket, iterateBucketLimit, iterateBucketDecode)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Helpful when debugging issues like https://github.com/coreos/etcd/pull/9031. And take data directory as an argument rather than flag (less typing).

Also add TODO for https://github.com/coreos/etcd/issues/7620.

```
etcd-dump-db iterate-bucket ./agent-1/etcd.data/ lease --decode
lease ID=5f3b606ba41b115a, TTL=120s
lease ID=5f3b606ba41b1158, TTL=120s
lease ID=5f3b606ba41b1156, TTL=120s
lease ID=5f3b606ba41b1154, TTL=120s
lease ID=5f3b606ba41b1152, TTL=120s

etcd-dump-db iterate-bucket ./agent-1/etcd.data/ key --decode
rev={main:6984 sub:0}, value=[key "foo000000000003ccd8" | val "aaa" | created 6984 | mod 6984 | ver 1]
rev={main:6983 sub:0}, value=[key "foo00000000000004f3" | val "aaa" | created 6983 | mod 6983 | ver 1]
rev={main:6982 sub:0}, value=[key "foo000000000002eaee" | val "aaa" | created 6982 | mod 6982 | ver 1]
```

/cc @jpbetz 
