### PR TITLE
test: bump up clientv3/integration test time out

### DIFF
--- a/test
+++ b/test
@@ -102,7 +102,7 @@ function integration_pass {
 
 function integration_extra {
 	go test -timeout 1m -v ${RACE} -cpu 1,2,4 "$@" "${REPO_PATH}/client/integration"
-	go test -timeout 15m -v ${RACE} -cpu 1,2,4 "$@" "${REPO_PATH}/clientv3/integration"
+	go test -timeout 20m -v ${RACE} -cpu 1,2,4 "$@" "${REPO_PATH}/clientv3/integration"
 	go test -timeout 1m -v -cpu 1,2,4 "$@" "${REPO_PATH}/contrib/raftexample"
 	go test -timeout 5m -v ${RACE} -tags v2v3 "$@" "${REPO_PATH}/store"
 	go test -timeout 1m -v ${RACE} -cpu 1,2,4 -run=Example "$@" "${TEST[@]}"


### PR DESCRIPTION
Recently we've added many more tests.
Until we parallelize tests, just increase the timeout.

https://semaphoreci.com/coreos/etcd/branches/master/builds/2696

ref. https://github.com/coreos/etcd/issues/8862