### PR TITLE
etcdctl/ctlv3: clarify "lease timetolive" output on expired lease 

### DIFF
--- a/e2e/ctl_v3_lease_test.go
+++ b/e2e/ctl_v3_lease_test.go
@@ -94,12 +94,8 @@ func leaseTestTimeToLiveExpire(cx ctlCtx, ttl int) error {
 	// eliminate false positive
 	time.Sleep(time.Duration(ttl+1) * time.Second)
 	cmdArgs := append(cx.PrefixArgs(), "lease", "timetolive", leaseID)
-	proc, err := spawnCmd(cmdArgs)
-	if err != nil {
-		return err
-	}
-	_, err = proc.Expect("TTL(0s), remaining(-1s)") // expect expired lease
-	if err != nil {
+	exp := fmt.Sprintf("lease %s already expired", leaseID)
+	if err = spawnWithExpect(cmdArgs, exp); err != nil {
 		return err
 	}
 	if err := ctlV3Get(cx, []string{"key"}); err != nil {

--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -468,6 +468,9 @@ Prints lease information.
 
 ./etcdctl lease timetolive 2d8257079fa1bc0c --write-out=json --keys
 # {"cluster_id":17186838941855831277,"member_id":4845372305070271874,"revision":3,"raft_term":2,"id":3279279168933706764,"ttl":459,"granted-ttl":500,"keys":["Zm9vMQ==","Zm9vMg=="]}
+
+./etcdctl lease timetolive 2d8257079fa1bc0c
+# lease 2d8257079fa1bc0c already expired
 ```
 
 ### LEASE LIST

--- a/etcdctl/ctlv3/command/printer_simple.go
+++ b/etcdctl/ctlv3/command/printer_simple.go
@@ -93,6 +93,11 @@ func (p *simplePrinter) KeepAlive(resp v3.LeaseKeepAliveResponse) {
 }
 
 func (s *simplePrinter) TimeToLive(resp v3.LeaseTimeToLiveResponse, keys bool) {
+	if resp.GrantedTTL == 0 && resp.TTL == -1 {
+		fmt.Printf("lease %016x already expired\n", resp.ID)
+		return
+	}
+
 	txt := fmt.Sprintf("lease %016x granted with TTL(%ds), remaining(%ds)", resp.ID, resp.GrantedTTL, resp.TTL)
 	if keys {
 		ks := make([]string, len(resp.Keys))


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/9028.

@hexfusion Could you review? Had to finish this early, to ship this in today's rc release.