### PR TITLE
Documentation/op-guide: fix typo, s/member_round_trip_time/peer_round_trip_time/

### DIFF
--- a/Documentation/op-guide/etcd3_alert.rules
+++ b/Documentation/op-guide/etcd3_alert.rules
@@ -154,7 +154,7 @@ ANNOTATIONS {
 
 # alert if 99th percentile of round trips take 150ms
 ALERT EtcdMemberCommunicationSlow
-IF histogram_quantile(0.99, rate(etcd_network_member_round_trip_time_seconds_bucket[5m])) > 0.15
+IF histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m])) > 0.15
 FOR 10m
 LABELS {
   severity = "warning"

--- a/Documentation/op-guide/etcd3_alert.rules.yml
+++ b/Documentation/op-guide/etcd3_alert.rules.yml
@@ -106,7 +106,7 @@ groups:
         its file descriptors soon'
       summary: file descriptors soon exhausted
   - alert: EtcdMemberCommunicationSlow
-    expr: histogram_quantile(0.99, rate(etcd_network_member_round_trip_time_seconds_bucket[5m]))
+    expr: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
       > 0.15
     for: 10m
     labels:


### PR DESCRIPTION
/cc @brancz 

The example alerts make reference to `etcd_network_member_round_trip_time_seconds_bucket`, but the codebase only contains `etcd_network_peer_round_trip_time_seconds_bucket` (in rafthttp/metrics.go).  Is this a mistake?