### PR TITLE
Documentation/dev-guide: update TimeToLive documentation.

### DIFF
--- a/Documentation/dev-guide/api_reference_v3.md
+++ b/Documentation/dev-guide/api_reference_v3.md
@@ -480,7 +480,7 @@ Empty field.
 
 | Field | Description | Type |
 | ----- | ----------- | ---- |
-| TTL | TTL is the advisory time-to-live in seconds. | int64 |
+| TTL | TTL is the advisory time-to-live in seconds. Expired lease will return -1. | int64 |
 | ID | ID is the requested ID for the lease. If ID is set to 0, the lessor chooses an ID. | int64 |
 
 

--- a/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
+++ b/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
@@ -1639,7 +1639,7 @@
           "format": "int64"
         },
         "TTL": {
-          "description": "TTL is the advisory time-to-live in seconds.",
+          "description": "TTL is the advisory time-to-live in seconds. Expired lease will return -1.",
           "type": "string",
           "format": "int64"
         }

--- a/etcdserver/etcdserverpb/rpc.pb.go
+++ b/etcdserver/etcdserverpb/rpc.pb.go
@@ -1767,7 +1767,7 @@ func (m *WatchResponse) GetEvents() []*mvccpb.Event {
 }
 
 type LeaseGrantRequest struct {
-	// TTL is the advisory time-to-live in seconds.
+	// TTL is the advisory time-to-live in seconds. Expired lease will return -1.
 	TTL int64 `protobuf:"varint,1,opt,name=TTL,proto3" json:"TTL,omitempty"`
 	// ID is the requested ID for the lease. If ID is set to 0, the lessor chooses an ID.
 	ID int64 `protobuf:"varint,2,opt,name=ID,proto3" json:"ID,omitempty"`

--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -707,7 +707,7 @@ message WatchResponse {
 }
 
 message LeaseGrantRequest {
-  // TTL is the advisory time-to-live in seconds.
+  // TTL is the advisory time-to-live in seconds. Expired lease will return -1.
   int64 TTL = 1;
   // ID is the requested ID for the lease. If ID is set to 0, the lessor chooses an ID.
   int64 ID = 2;


### PR DESCRIPTION
Update documentation of expected expired lease output using scripts/genproto.sh.
