### PR TITLE
clientv3/leasing: fix racey waitSession

### DIFF
--- a/clientv3/leasing/kv.go
+++ b/clientv3/leasing/kv.go
@@ -445,8 +445,11 @@ func (lkv *leasingKV) revokeLeaseKvs(ctx context.Context, kvs []*mvccpb.KeyValue
 }
 
 func (lkv *leasingKV) waitSession(ctx context.Context) error {
+	lkv.leases.mu.RLock()
+	sessionc := lkv.sessionc
+	lkv.leases.mu.RUnlock()
 	select {
-	case <-lkv.sessionc:
+	case <-sessionc:
 		return nil
 	case <-lkv.ctx.Done():
 		return lkv.ctx.Err()


### PR DESCRIPTION
Fix

```
=== RUN   TestLeasingSessionExpireCancel
==================
WARNING: DATA RACE
Read at 0x00c42022e780 by goroutine 48:
  github.com/coreos/etcd/clientv3/leasing.(*leasingKV).waitSession()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/leasing/kv.go:449 +0x5a
  github.com/coreos/etcd/clientv3/leasing.(*leasingKV).put()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/leasing/kv.go:232 +0x6d
  github.com/coreos/etcd/clientv3/leasing.(*leasingKV).Do()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/leasing/kv.go:103 +0x53f
  github.com/coreos/etcd/clientv3/integration.TestLeasingSessionExpireCancel.func5()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/integration/leasing_test.go:1944 +0x119
  github.com/coreos/etcd/clientv3/integration.TestLeasingSessionExpireCancel.func9()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/integration/leasing_test.go:1979 +0xb7

Previous write at 0x00c42022e780 by goroutine 168:
  github.com/coreos/etcd/clientv3/leasing.(*leasingKV).monitorSession()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/leasing/kv.go:136 +0x307
  github.com/coreos/etcd/clientv3/leasing.NewKV.func1()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/leasing/kv.go:71 +0x68

Goroutine 48 (running) created at:
  github.com/coreos/etcd/clientv3/integration.TestLeasingSessionExpireCancel()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/integration/leasing_test.go:1979 +0x8ee
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

Goroutine 168 (running) created at:
  github.com/coreos/etcd/clientv3/leasing.NewKV()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/leasing/kv.go:69 +0x386
  github.com/coreos/etcd/clientv3/integration.TestLeasingSessionExpireCancel()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/integration/leasing_test.go:1962 +0x49f
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c
==================
--- FAIL: TestLeasingSessionExpireCancel (75.58s)
	testing.go:699: race detected during execution of test
```

https://semaphoreci.com/coreos/etcd/branches/master/builds/2721