### PR TITLE
Log: add information statement

### DIFF
--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -247,7 +247,7 @@ func (cfg *config) parse(arguments []string) error {
 
 	var err error
 	if cfg.configFile != "" {
-		plog.Infof("Loading server configuration from %q", cfg.configFile)
+		plog.Infof("Loading server configuration from %q. Other configuration command line flags and environment variables will be ignored if provided.", cfg.configFile)
 		err = cfg.configFromFile(cfg.configFile)
 	} else {
 		err = cfg.configFromCmdLine()


### PR DESCRIPTION
Adding information that when config file is used other command line flags
and env variables will be ignored. This changes are a follow up of a
disucssion under PR https://github.com/coreos/etcd/pull/9066

# Contributing guidelines

Please read our [contribution workflow][contributing] before submitting a pull request.

[contributing]: https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow
