### PR TITLE
embed: use loopback addresses instead of localhost for default URLs

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -52,8 +52,8 @@ const (
 	DefaultGRPCKeepAliveInterval = 2 * time.Hour
 	DefaultGRPCKeepAliveTimeout  = 20 * time.Second
 
-	DefaultListenPeerURLs   = "http://localhost:2380"
-	DefaultListenClientURLs = "http://localhost:2379"
+	DefaultListenPeerURLs   = "http://127.0.0.1:2380"
+	DefaultListenClientURLs = "http://127.0.0.1:2379"
 
 	DefaultLogOutput = "default"
 
@@ -75,8 +75,8 @@ var (
 		"Choose one of \"initial-cluster\", \"discovery\" or \"discovery-srv\"")
 	ErrUnsetAdvertiseClientURLsFlag = fmt.Errorf("--advertise-client-urls is required when --listen-client-urls is set explicitly")
 
-	DefaultInitialAdvertisePeerURLs = "http://localhost:2380"
-	DefaultAdvertiseClientURLs      = "http://localhost:2379"
+	DefaultInitialAdvertisePeerURLs = "http://127.0.0.1:2380"
+	DefaultAdvertiseClientURLs      = "http://127.0.0.1:2379"
 
 	defaultHostname   string
 	defaultHostStatus error
@@ -544,8 +544,8 @@ func (cfg *Config) PeerSelfCert() (err error) {
 }
 
 // UpdateDefaultClusterFromName updates cluster advertise URLs with, if available, default host,
-// if advertise URLs are default values(localhost:2379,2380) AND if listen URL is 0.0.0.0.
-// e.g. advertise peer URL localhost:2380 or listen peer URL 0.0.0.0:2380
+// if advertise URLs are default values(127.0.0.1:2379,2380) AND if listen URL is 0.0.0.0.
+// e.g. advertise peer URL 127.0.0.1:2380 or listen peer URL 0.0.0.0:2380
 // then the advertise peer host would be updated with machine's default host,
 // while keeping the listen URL's port.
 // User can work around this by explicitly setting URL with 127.0.0.1.

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -54,9 +54,9 @@ member flags:
 		time (in milliseconds) of a heartbeat interval.
 	--election-timeout '1000'
 		time (in milliseconds) for an election to timeout. See tuning documentation for details.
-	--listen-peer-urls 'http://localhost:2380'
+	--listen-peer-urls 'http://127.0.0.1:2380'
 		list of URLs to listen on for peer traffic.
-	--listen-client-urls 'http://localhost:2379'
+	--listen-client-urls 'http://127.0.0.1:2379'
 		list of URLs to listen on for client traffic.
 	--max-snapshots '` + strconv.Itoa(embed.DefaultMaxSnapshots) + `'
 		maximum number of snapshot files to retain (0 is unlimited).
@@ -79,16 +79,16 @@ member flags:
 
 clustering flags:
 
-	--initial-advertise-peer-urls 'http://localhost:2380'
+	--initial-advertise-peer-urls 'http://127.0.0.1:2380'
 		list of this member's peer URLs to advertise to the rest of the cluster.
-	--initial-cluster 'default=http://localhost:2380'
+	--initial-cluster 'default=http://127.0.0.1:2380'
 		initial cluster configuration for bootstrapping.
 	--initial-cluster-state 'new'
 		initial cluster state ('new' or 'existing').
 	--initial-cluster-token 'etcd-cluster'
 		initial cluster token for the etcd cluster during bootstrap.
 		Specifying this can protect you from unintended cross-cluster interaction when running multiple clusters.
-	--advertise-client-urls 'http://localhost:2379'
+	--advertise-client-urls 'http://127.0.0.1:2379'
 		list of this member's client URLs to advertise to the public.
 		The client URLs advertised should be accessible to machines that talk to etcd cluster. etcd client libraries parse these URLs to connect to the cluster.
 	--discovery ''


### PR DESCRIPTION
this change allows the default configuration URLs to be used in
environments where 'localhost' resolves to an IP address of some other
machine

Fixes #9070



This improves etcd's default behavior in environments without glibc-based DNS resolution like alpine or busybox.