### PR TITLE
raft: s/leaner/learner/g

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -116,8 +116,9 @@ type Config struct {
 	// used for testing right now.
 	peers []uint64
 
-	// learners contains the IDs of all leaner nodes (including self if the local node is a leaner) in the raft cluster.
-	// learners only receives entries from the leader node. It does not vote or promote itself.
+	// learners contains the IDs of all learner nodes (including self if the
+	// local node is a learner) in the raft cluster. learners only receives
+	// entries from the leader node. It does not vote or promote itself.
 	learners []uint64
 
 	// ElectionTick is the number of Node.Tick invocations that must pass between
@@ -1277,7 +1278,7 @@ func (r *raft) addNodeOrLearnerNode(id uint64, isLearner bool) {
 	} else {
 		if isLearner && !pr.IsLearner {
 			// can only change Learner to Voter
-			r.logger.Infof("%x ignored addLeaner: do not support changing %x from raft peer to learner.", r.id, id)
+			r.logger.Infof("%x ignored addLearner: do not support changing %x from raft peer to learner.", r.id, id)
 			return
 		}
 

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -368,7 +368,7 @@ func TestLearnerElectionTimeout(t *testing.T) {
 	}
 }
 
-// TestLearnerPromotion verifies that the leaner should not election until
+// TestLearnerPromotion verifies that the learner should not election until
 // it is promoted to a normal peer.
 func TestLearnerPromotion(t *testing.T) {
 	n1 := newTestLearnerRaft(1, []uint64{1}, []uint64{2}, 10, 1, NewMemoryStorage())


### PR DESCRIPTION
"Learner" was spelled incorrectly in a few places.