### PR TITLE
*: add "--unsupported-arch" flag to remove confusing error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.2.0...v3.3.0-rc.0) 
   - Useful for [bypassing critical APIs when monitoring etcd](https://github.com/coreos/etcd/issues/8060).
 - Add [`--auto-compaction-mode`](https://github.com/coreos/etcd/pull/8123) flag to [support revision-based compaction](https://github.com/coreos/etcd/issues/8098).
 - Change `--auto-compaction-retention` flag to [accept string values](https://github.com/coreos/etcd/pull/8563) with [finer granularity](https://github.com/coreos/etcd/issues/8503).
+- Add [`--unsupported-arch`](https://github.com/coreos/etcd/pull/9088) flag to remove [confusing environment variable warnings](https://github.com/coreos/etcd/issues/9077).
 - Add [`--grpc-keepalive-min-time`, `--grpc-keepalive-interval`, `--grpc-keepalive-timeout`](https://github.com/coreos/etcd/pull/8535) flags to configure server-side keepalive policies.
 - Serve [`/health` endpoint as unhealthy](https://github.com/coreos/etcd/pull/8272) when [alarm is raised](https://github.com/coreos/etcd/issues/8207).
 - Provide [error information in `/health`](https://github.com/coreos/etcd/pull/8312).

--- a/Documentation/op-guide/supported-platform.md
+++ b/Documentation/op-guide/supported-platform.md
@@ -6,7 +6,7 @@ The following table lists etcd support status for common architectures and opera
 
 | Architecture | Operating System | Status       | Maintainers                 |
 | ------------ | ---------------- | ------------ | --------------------------- |
-| amd64        | Darwin           | Experimental | etcd maintainers            | 
+| amd64        | Darwin           | Experimental | etcd maintainers            |
 | amd64        | Linux            | Stable       | etcd maintainers            |
 | amd64        | Windows          | Experimental |                             |
 | arm64        | Linux            | Experimental | @glevand                    |
@@ -32,7 +32,7 @@ For etcd to officially support a new platform as stable, a few requirements are 
 
 etcd has known issues on 32-bit systems due to a bug in the Go runtime. See the [Go issue][go-issue] and [atomic package][go-atomic] for more information.
 
-To avoid inadvertently running a possibly unstable etcd server, `etcd` on unstable or unsupported architectures will print a warning message and immediately exit if the environment variable `ETCD_UNSUPPORTED_ARCH` is not set to the target architecture.
+To avoid inadvertently running a possibly unstable etcd server, `etcd` on unstable or unsupported architectures will print a warning message and immediately exit if flag `--unsupported-arch` or environment variable `ETCD_UNSUPPORTED_ARCH` is not set to the target architecture.
 
 Currently amd64 and ppc64le architectures are officially supported by `etcd`.
 

--- a/embed/main_test.go
+++ b/embed/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The etcd Authors
+// Copyright 2018 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,26 +15,13 @@
 package embed
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
-
-	"github.com/coreos/etcd/auth"
 )
 
-// TestStartEtcdWrongToken ensures that StartEtcd with wrong configs returns with error.
-func TestStartEtcdWrongToken(t *testing.T) {
-	tdir, err := ioutil.TempDir(os.TempDir(), "token-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tdir)
-	cfg := NewConfig()
-	cfg.Dir = tdir
-	cfg.AuthToken = "wrong-token"
-	cfg.UnsupportedArch = runtime.GOARCH // for 32-bit CIs
-	if _, err = StartEtcd(cfg); err != auth.ErrInvalidAuthOpts {
-		t.Fatalf("expected %v, got %v", auth.ErrInvalidAuthOpts, err)
-	}
+func TestMain(m *testing.M) {
+	os.Setenv("ETCD_UNSUPPORTED_ARCH", runtime.GOARCH)
+	v := m.Run()
+	os.Exit(v)
 }

--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -142,3 +142,5 @@ log-output: default
 
 # Force to create a new one member cluster.
 force-new-cluster: false
+
+unsupported-arch:

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -197,6 +197,9 @@ func newConfig() *config {
 	// unsafe
 	fs.BoolVar(&cfg.ec.ForceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster.")
 
+	// unsupported architecture
+	fs.StringVar(&cfg.ec.UnsupportedArch, "unsupported-arch", "", "Specify the name of architecture name to override unsupported architecture warning (immediately exit if not set).")
+
 	// version
 	fs.BoolVar(&cfg.printVersion, "version", false, "Print the version and exit.")
 

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -386,16 +386,3 @@ func identifyDataDirOrDie(dir string) dirType {
 	}
 	return dirEmpty
 }
-
-func checkSupportArch() {
-	// TODO qualify arm64
-	if runtime.GOARCH == "amd64" || runtime.GOARCH == "ppc64le" {
-		return
-	}
-	if env, ok := os.LookupEnv("ETCD_UNSUPPORTED_ARCH"); ok && env == runtime.GOARCH {
-		plog.Warningf("running etcd on unsupported architecture %q since ETCD_UNSUPPORTED_ARCH is set", env)
-		return
-	}
-	plog.Errorf("etcd on unsupported platform without ETCD_UNSUPPORTED_ARCH=%s set.", runtime.GOARCH)
-	os.Exit(1)
-}

--- a/etcdmain/main.go
+++ b/etcdmain/main.go
@@ -24,8 +24,6 @@ import (
 )
 
 func Main() {
-	checkSupportArch()
-
 	if len(os.Args) > 1 {
 		cmd := os.Args[1]
 		if covArgs := os.Getenv("ETCDCOV_ARGS"); len(covArgs) > 0 {

--- a/etcdmain/main_test.go
+++ b/etcdmain/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The etcd Authors
+// Copyright 2018 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,29 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package embed
+package etcdmain
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
-
-	"github.com/coreos/etcd/auth"
 )
 
-// TestStartEtcdWrongToken ensures that StartEtcd with wrong configs returns with error.
-func TestStartEtcdWrongToken(t *testing.T) {
-	tdir, err := ioutil.TempDir(os.TempDir(), "token-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tdir)
-	cfg := NewConfig()
-	cfg.Dir = tdir
-	cfg.AuthToken = "wrong-token"
-	cfg.UnsupportedArch = runtime.GOARCH // for 32-bit CIs
-	if _, err = StartEtcd(cfg); err != auth.ErrInvalidAuthOpts {
-		t.Fatalf("expected %v, got %v", auth.ErrInvalidAuthOpts, err)
-	}
+func TestMain(m *testing.M) {
+	os.Setenv("ETCD_UNSUPPORTED_ARCH", runtime.GOARCH)
+	v := m.Run()
+	os.Exit(v)
 }

--- a/integration/embed_test.go
+++ b/integration/embed_test.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -72,6 +73,7 @@ func TestEmbedEtcd(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	for i, tt := range tests {
+		tests[i].cfg.UnsupportedArch = runtime.GOARCH
 		tests[i].cfg.Dir = dir
 		e, err := embed.StartEtcd(&tests[i].cfg)
 		if e != nil {
@@ -112,6 +114,7 @@ func TestEmbedEtcdGracefulStopInsecure(t *testing.T) { testEmbedEtcdGracefulStop
 // cutting existing transports.
 func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 	cfg := embed.NewConfig()
+	cfg.UnsupportedArch = runtime.GOARCH
 	if secure {
 		cfg.ClientTLSInfo = testTLSInfo
 		cfg.PeerTLSInfo = testTLSInfo
@@ -175,6 +178,7 @@ func newEmbedURLs(secure bool, n int) (urls []url.URL) {
 }
 
 func setupEmbedCfg(cfg *embed.Config, curls []url.URL, purls []url.URL) {
+	cfg.UnsupportedArch = runtime.GOARCH
 	cfg.ClusterState = "new"
 	cfg.LCUrls, cfg.ACUrls = curls, curls
 	cfg.LPUrls, cfg.APUrls = purls, purls

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -6,12 +6,14 @@ package integration
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/coreos/etcd/pkg/testutil"
 )
 
 func TestMain(m *testing.M) {
+	os.Setenv("ETCD_UNSUPPORTED_ARCH", runtime.GOARCH)
 	v := m.Run()
 	if v == 0 && testutil.CheckLeakedGoroutine() {
 		os.Exit(1)


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/9077.

The confusing warning disappears with this.