### PR TITLE
etcd-tester: fix "writeTxn" key selection

### DIFF
--- a/tools/functional-tester/etcd-tester/key_stresser.go
+++ b/tools/functional-tester/etcd-tester/key_stresser.go
@@ -225,7 +225,7 @@ func writeTxn(kvc pb.KVClient, keys []string, txnOps int) stressFunc {
 	return func(ctx context.Context) (error, int64) {
 		ks := make(map[string]struct{}, txnOps)
 		for len(ks) != txnOps {
-			ks[keys[rand.Intn(64)]] = struct{}{}
+			ks[keys[rand.Intn(len(keys))]] = struct{}{}
 		}
 		selected := make([]string, 0, txnOps)
 		for k := range ks {


### PR DESCRIPTION
Found when debugging https://github.com/coreos/etcd/issues/9130.
