### PR TITLE
docs: fix invalid reference in Raft README

### DIFF
--- a/raft/README.md
+++ b/raft/README.md
@@ -140,7 +140,7 @@ The total state machine handling loop will look something like this:
     case <-s.Ticker:
       n.Tick()
     case rd := <-s.Node.Ready():
-      saveToStorage(rd.State, rd.Entries, rd.Snapshot)
+      saveToStorage(rd.HardState, rd.Entries, rd.Snapshot)
       send(rd.Messages)
       if !raft.IsEmptySnap(rd.Snapshot) {
         processSnapshot(rd.Snapshot)


### PR DESCRIPTION
Code snippet in Raft README refers to non-existent field `State`. Fixed the reference by setting it to `HardState`.