### PR TITLE
embed: define "embed.CompactorMode*"

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -71,6 +71,8 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.2.0...v3.3.0-rc.0) 
   - Useful for [bypassing critical APIs when monitoring etcd](https://github.com/coreos/etcd/issues/8060).
 - Add [`--auto-compaction-mode`](https://github.com/coreos/etcd/pull/8123) flag to [support revision-based compaction](https://github.com/coreos/etcd/issues/8098).
 - Change `--auto-compaction-retention` flag to [accept string values](https://github.com/coreos/etcd/pull/8563) with [finer granularity](https://github.com/coreos/etcd/issues/8503).
+  - e.g. `--auto-compaction-mode=periodic --auto-compaction-retention=30m` automatically `Compact` on latest revision every 30-minute.
+  - e.g. `--auto-compaction-mode=revision --auto-compaction-retention=1000` automatically `Compact` on `"latest revision" - 1000` every 5-minute (when latest revision is 30000, compact on revision 29000).
 - Add [`--grpc-keepalive-min-time`, `--grpc-keepalive-interval`, `--grpc-keepalive-timeout`](https://github.com/coreos/etcd/pull/8535) flags to configure server-side keepalive policies.
 - Serve [`/health` endpoint as unhealthy](https://github.com/coreos/etcd/pull/8272) when [alarm (e.g. `NOSPACE`) is raised or there's no leader](https://github.com/coreos/etcd/issues/8207).
   - Define [`etcdhttp.Health`](https://godoc.org/github.com/coreos/etcd/etcdserver/api/etcdhttp#Health) struct with JSON encoder.

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -23,9 +23,12 @@
   - Remove recursive symlinks in `cmd` directory.
   - Now `go get/install/build` on `etcd` packages (e.g. `clientv3`, `tools/benchmark`) enforce builds with etcd `vendor` directory.
 - Reorganize [internal packages](https://github.com/coreos/etcd/issues/9220).
+  - `internal/*` packages [cannot be(are not meant to be) imported by external projects](https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit).
   - Move `"github.com/coreos/etcd/alarm"` to [`"github.com/coreos/etcd/internal/alarm"`](https://github.com/coreos/etcd/pull/9234).
   - Move `"github.com/coreos/etcd/auth"` to [`"github.com/coreos/etcd/internal/auth"`](https://github.com/coreos/etcd/pull/9243).
   - Move `"github.com/coreos/etcd/compactor"` to [`"github.com/coreos/etcd/internal/compactor"`](https://github.com/coreos/etcd/pull/9234).
+    - [`embed.CompactorModePeriodic`](https://github.com/coreos/etcd/pull/9247) to replace `compactor.ModePeriodic`.
+    - [`embed.CompactorModeRevision`](https://github.com/coreos/etcd/pull/9247) to replace `compactor.ModeRevision`.
   - Move `"github.com/coreos/etcd/discovery"` to [`"github.com/coreos/etcd/internal/discovery"`](https://github.com/coreos/etcd/pull/9233).
   - Move `"github.com/coreos/etcd/lease"` to [`"github.com/coreos/etcd/internal/lease"`](https://github.com/coreos/etcd/pull/9238).
   - Move `"github.com/coreos/etcd/mvcc"` to [`"github.com/coreos/etcd/internal/mvcc"`](https://github.com/coreos/etcd/pull/9238).

--- a/embed/config.go
+++ b/embed/config.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/etcdserver"
+	"github.com/coreos/etcd/internal/compactor"
 	"github.com/coreos/etcd/pkg/cors"
 	"github.com/coreos/etcd/pkg/netutil"
 	"github.com/coreos/etcd/pkg/srv"
@@ -80,6 +81,23 @@ var (
 
 	defaultHostname   string
 	defaultHostStatus error
+)
+
+var (
+	// CompactorModePeriodic is periodic compaction mode
+	// for "Config.AutoCompactionMode" field.
+	// If "AutoCompactionMode" is CompactorModePeriodic and
+	// "AutoCompactionRetention" is "1h", it automatically compacts
+	// compacts storage every hour.
+	CompactorModePeriodic = compactor.ModePeriodic
+
+	// CompactorModeRevision is revision-based compaction mode
+	// for "Config.AutoCompactionMode" field.
+	// If "AutoCompactionMode" is CompactorModeRevision and
+	// "AutoCompactionRetention" is "1000", it compacts log on
+	// revision 5000 when the current revision is 6000.
+	// This runs every 5-minute if enough of logs have proceeded.
+	CompactorModeRevision = compactor.ModeRevision
 )
 
 func init() {


### PR DESCRIPTION
[Go internal packages](https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit) cannot be imported by external projects. So, define compactor mode variable in embed packages. It broke https://travis-ci.org/coreos/etcdlabs/jobs/334931774#L467.