### PR TITLE
*: WIP add testmode

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -157,6 +157,12 @@ type Config struct {
 	ListenMetricsUrls     []url.URL
 	ListenMetricsUrlsJSON string `json:"listen-metrics-urls"`
 
+	// test-mode
+
+	TestMode        bool          `json:"test-mode"`
+	TestDNS         string        `json:"test-dns"`
+	TestMaxDuration time.Duration `json:"test-max-duration"`
+
 	// ForceNewCluster starts a new cluster even if previously started; unsafe.
 	ForceNewCluster bool `json:"force-new-cluster"`
 
@@ -297,6 +303,22 @@ func (cfg *Config) SetupLogging() {
 	default:
 		plog.Panicf(`unknown log-output %q (only supports %q, "stdout", "stderr")`, cfg.LogOutput, DefaultLogOutput)
 	}
+}
+
+func (cfg *Config) SetupTestDNS() error {
+	d := cfg.TestDNS
+	if d != "" {
+		host, _, err := net.SplitHostPort(d)
+		if err != nil {
+			return err
+		}
+		if host != "localhost" {
+			if net.ParseIP(host) == nil {
+				return fmt.Errorf("expected ip:port for test-dns (%s)", d)
+			}
+		}
+	}
+	return nil
 }
 
 func ConfigFromFile(path string) (*Config, error) {
@@ -499,9 +521,13 @@ func (cfg *Config) GetDNSClusterNames() ([]string, error) {
 	if cfg.DNSClusterServiceName != "" {
 		serviceNameSuffix = "-" + cfg.DNSClusterServiceName
 	}
+	err := cfg.SetupTestDNS()
+	if err != nil {
+		plog.Errorf("couldn't setup testDNS for SRV discovery (%v)", err)
+	}
 	// Use both etcd-server-ssl and etcd-server for discovery. Combine the results if both are available.
-	clusterStrs, cerr = srv.GetCluster("https", "etcd-server-ssl"+serviceNameSuffix, cfg.Name, cfg.DNSCluster, cfg.APUrls)
-	defaultHTTPClusterStrs, httpCerr := srv.GetCluster("http", "etcd-server"+serviceNameSuffix, cfg.Name, cfg.DNSCluster, cfg.APUrls)
+	clusterStrs, cerr = srv.GetCluster("https", "etcd-server-ssl"+serviceNameSuffix, cfg.Name, cfg.DNSCluster, cfg.APUrls, cfg.TestDNS)
+	defaultHTTPClusterStrs, httpCerr := srv.GetCluster("http", "etcd-server"+serviceNameSuffix, cfg.Name, cfg.DNSCluster, cfg.APUrls, cfg.TestDNS)
 	if cerr != nil {
 		clusterStrs = make([]string, 0)
 	}

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -181,6 +181,9 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		InitialCorruptCheck:     cfg.ExperimentalInitialCorruptCheck,
 		CorruptCheckTime:        cfg.ExperimentalCorruptCheckTime,
 		Debug:                   cfg.Debug,
+		TestMode:                cfg.TestMode,
+		TestDNS:                 cfg.TestDNS,
+		TestMaxDuration:         cfg.TestMaxDuration,
 	}
 
 	if e.Server, err = etcdserver.NewServer(srvcfg); err != nil {

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -217,6 +217,11 @@ func newConfig() *config {
 	fs.BoolVar(&cfg.ec.ExperimentalInitialCorruptCheck, "experimental-initial-corrupt-check", cfg.ec.ExperimentalInitialCorruptCheck, "Enable to check data corruption before serving any client/peer traffic.")
 	fs.DurationVar(&cfg.ec.ExperimentalCorruptCheckTime, "experimental-corrupt-check-time", cfg.ec.ExperimentalCorruptCheckTime, "Duration of time between cluster corruption check passes.")
 
+	// testmode
+	fs.BoolVar(&cfg.ec.TestMode, "test-mode", false, "Enable etcd test-mode.")
+	fs.StringVar(&cfg.ec.TestDNS, "test-dns", cfg.ec.TestDNS, "Define custom ip:port for DNS resolution.")
+	fs.DurationVar(&cfg.ec.TestMaxDuration, "test-max-duration", cfg.ec.TestMaxDuration, "Duration of time to run test-mode.")
+
 	// ignored
 	for _, f := range cfg.ignored {
 		fs.Var(&flags.IgnoredFlag{Name: f}, f, "")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -157,6 +157,15 @@ security flags:
 	--peer-crl-file ''
 		path to the peer certificate revocation list file.
 
+test-mode flags:
+
+	--test-mode 'false'
+		enable test mode, if flags using the test- prefix are defined test-mode must be true.
+	--test-max-duration ''
+		the time duration that the etcd will run in test-mode before it shutsdown. test-mode default is 24h.
+	--test-dns ''
+		dns host:port to use during test-mode.
+
 logging flags
 
 	--debug 'false'

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -72,6 +72,10 @@ type ServerConfig struct {
 	CorruptCheckTime    time.Duration
 
 	Debug bool
+
+	TestMode        bool
+	TestDNS         string
+	TestMaxDuration time.Duration
 }
 
 // VerifyBootstrap sanity-checks the initial config for bootstrap case
@@ -197,6 +201,15 @@ func (c *ServerConfig) peerDialTimeout() time.Duration {
 	// 1s for queue wait and election timeout
 	return time.Second + time.Duration(c.ElectionTicks*int(c.TickMs))*time.Millisecond
 }
+func (c *ServerConfig) CheckTestMode() error {
+	if c.TestDNS != "" && !c.TestMode {
+		return fmt.Errorf("test-dns also requires test-mode")
+	}
+	if c.TestMaxDuration != 0 && !c.TestMode {
+		return fmt.Errorf("test-max-duration also requires test-mode")
+	}
+	return nil
+}
 
 func (c *ServerConfig) PrintWithInitial() { c.print(true) }
 
@@ -204,6 +217,9 @@ func (c *ServerConfig) Print() { c.print(false) }
 
 func (c *ServerConfig) print(initial bool) {
 	plog.Infof("name = %s", c.Name)
+	if c.TestMode {
+		plog.Infof("running in test-mode")
+	}
 	if c.ForceNewCluster {
 		plog.Infof("force new cluster")
 	}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -86,6 +86,9 @@ const (
 	// maxPendingRevokes is the maximum number of outstanding expired lease revocations.
 	maxPendingRevokes = 16
 
+	// defaultTestMaxDuration is the default max duration etcd with run during test-mode
+	defaultTestMaxDuration = 24 * time.Hour
+
 	recommendedMaxRequestBytes = 10 * 1024 * 1024
 )
 
@@ -291,6 +294,9 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		}
 	}()
 
+	if err = cfg.CheckTestMode(); err != nil {
+		return nil, err
+	}
 	prt, err := rafthttp.NewRoundTripper(cfg.PeerTLSInfo, cfg.peerDialTimeout())
 	if err != nil {
 		return nil, err
@@ -533,6 +539,7 @@ func (s *EtcdServer) Start() {
 	s.goAttach(s.monitorVersions)
 	s.goAttach(s.linearizableReadLoop)
 	s.goAttach(s.monitorKVHash)
+	s.goAttach(s.testModeTimer)
 }
 
 // start prepares and starts server in a new goroutine. It is no longer safe to
@@ -1074,6 +1081,33 @@ func (s *EtcdServer) checkMembershipOperationPermission(ctx context.Context) err
 	}
 
 	return s.AuthStore().IsAdminPermitted(authInfo)
+}
+
+// testModeTimer is enabled by the --test-mode flag and it's purpose is to
+// shutdown the server after a period of time.
+func (s *EtcdServer) testModeTimer() {
+	if !s.Cfg.TestMode {
+		return
+	}
+	d := s.Cfg.TestMaxDuration
+	if d == 0 || d > defaultTestMaxDuration {
+		s.Cfg.TestMaxDuration = defaultTestMaxDuration
+	}
+
+	testModeExpired := make(chan bool)
+	go func() {
+		time.Sleep(s.Cfg.TestMaxDuration)
+		testModeExpired <- true
+	}()
+	for {
+		select {
+		case <-s.stopping:
+			return
+		case <-testModeExpired:
+			plog.Infof("test-mode duration has passed, shutting down")
+			s.HardStop()
+		}
+	}
 }
 
 func (s *EtcdServer) AddMember(ctx context.Context, memb membership.Member) ([]*membership.Member, error) {

--- a/pkg/srv/srv_test.go
+++ b/pkg/srv/srv_test.go
@@ -47,6 +47,7 @@ func TestSRVGetCluster(t *testing.T) {
 		scheme  string
 		records []*net.SRV
 		urls    []string
+		dns     string
 
 		expected string
 	}{
@@ -54,6 +55,7 @@ func TestSRVGetCluster(t *testing.T) {
 			"https",
 			[]*net.SRV{},
 			nil,
+			"",
 
 			"",
 		},
@@ -61,6 +63,7 @@ func TestSRVGetCluster(t *testing.T) {
 			"https",
 			srvAll,
 			nil,
+			"",
 
 			"0=https://1.example.com:2480,1=https://2.example.com:2480,2=https://3.example.com:2480",
 		},
@@ -68,6 +71,7 @@ func TestSRVGetCluster(t *testing.T) {
 			"http",
 			srvAll,
 			nil,
+			"",
 
 			"0=http://1.example.com:2480,1=http://2.example.com:2480,2=http://3.example.com:2480",
 		},
@@ -75,6 +79,7 @@ func TestSRVGetCluster(t *testing.T) {
 			"https",
 			srvAll,
 			[]string{"https://10.0.0.1:2480"},
+			"",
 
 			"dnsClusterTest=https://1.example.com:2480,0=https://2.example.com:2480,1=https://3.example.com:2480",
 		},
@@ -83,6 +88,7 @@ func TestSRVGetCluster(t *testing.T) {
 			"https",
 			srvAll,
 			[]string{"https://10.0.0.1:2480"},
+			"",
 
 			"dnsClusterTest=https://1.example.com:2480,0=https://2.example.com:2480,1=https://3.example.com:2480",
 		},
@@ -91,6 +97,7 @@ func TestSRVGetCluster(t *testing.T) {
 			"http",
 			srvAll,
 			[]string{"https://10.0.0.1:2480"},
+			"",
 
 			"0=http://2.example.com:2480,1=http://3.example.com:2480",
 		},
@@ -112,7 +119,7 @@ func TestSRVGetCluster(t *testing.T) {
 			return "", tt.records, nil
 		}
 		urls := testutil.MustNewURLs(t, tt.urls)
-		str, err := GetCluster(tt.scheme, "etcd-server", name, "example.com", urls)
+		str, err := GetCluster(tt.scheme, "etcd-server", name, "example.com", urls, tt.dns)
 		if err != nil {
 			t.Fatalf("%d: err: %#v", i, err)
 		}


### PR DESCRIPTION
Initial stab add adding test-mode and custom DNS resolver for e2e SRV discovery testing. More cleanup required.

ref: https://github.com/coreos/etcd/issues/9236
