### PR TITLE
snapshot: fix "TestSnapshotV3RestoreMultiMemberAdd"

### DIFF
--- a/pkg/testutil/var.go
+++ b/pkg/testutil/var.go
@@ -17,5 +17,6 @@ package testutil
 import "time"
 
 var (
+	ApplyTimeout   = time.Second
 	RequestTimeout = 3 * time.Second
 )


### PR DESCRIPTION
Membership reconfiguration may not be applied
when the new member joins. Also pass all endpoints
to check restore data in case of leader election or
network faults.

Fix https://github.com/coreos/etcd/issues/9219 and https://semaphoreci.com/coreos/etcd/branches/master/builds/2878.

> --- FAIL: TestSnapshotV3RestoreMultiMemberAdd (14.75s)
	member_test.go:78: error validating peerURLs {ClusterID:2dcab7bbeafb497c Members:[&{ID:42fbaab60780e599 RaftAttributes:{PeerURLs:[unix://localhost:18469]} Attributes:{Name:0 ClientURLs:[unix://localhost:42777]}} &{ID:fd5b89a5f93ca727 RaftAttributes:{PeerURLs:[unix://localhost:29664]} Attributes:{Name:1 ClientURLs:[unix://localhost:35826]}} &{ID:336967b030dec3fa RaftAttributes:{PeerURLs:[unix://localhost:10625]} Attributes:{Name:2 ClientURLs:[unix://localhost:33018]}}] RemovedMemberIDs:[]}: member count is unequal