### PR TITLE
build: fix "internal/version" LD flags

### DIFF
--- a/build
+++ b/build
@@ -10,7 +10,7 @@ if [ ! -z "$FAILPOINTS" ]; then
 fi
 
 # Set GO_LDFLAGS="-s" for building without symbols for debugging.
-GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/version.GitSHA=${GIT_SHA}"
+GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/internal/version.GitSHA=${GIT_SHA}"
 
 # enable/disable failpoints
 toggle_failpoints() {


### PR DESCRIPTION
Package `version` has been moved to `internal/version`.