### PR TITLE
mvcc: allow large concurrent reads under light  write workload

### DIFF
--- a/internal/mvcc/backend/backend.go
+++ b/internal/mvcc/backend/backend.go
@@ -271,7 +271,9 @@ func (b *backend) run() {
 			b.batchTx.CommitAndStop()
 			return
 		}
-		b.batchTx.Commit()
+		if b.batchTx.safePending() != 0 {
+			b.batchTx.Commit()
+		}
 		t.Reset(b.batchInterval)
 	}
 }
@@ -302,11 +304,7 @@ func (b *backend) defrag() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// block concurrent read requests while resetting tx
-	b.readTx.mu.Lock()
-	defer b.readTx.mu.Unlock()
-
-	b.batchTx.unsafeCommit(true)
+	b.batchTx.commit(true)
 	b.batchTx.tx = nil
 
 	tmpdb, err := bolt.Open(b.db.Path()+".tmp", 0600, boltOpenOptions)

--- a/internal/mvcc/backend/batch_tx.go
+++ b/internal/mvcc/backend/batch_tx.go
@@ -98,6 +98,7 @@ func unsafeRange(c *bolt.Cursor, key, endKey []byte, limit int64) (keys [][]byte
 		isMatch = func(b []byte) bool { return bytes.Equal(b, key) }
 		limit = 1
 	}
+
 	for ck, cv := c.Seek(key); ck != nil && isMatch(ck); ck, cv = c.Next() {
 		vs = append(vs, cv)
 		keys = append(keys, ck)
@@ -152,6 +153,12 @@ func (t *batchTx) Unlock() {
 		t.commit(false)
 	}
 	t.Mutex.Unlock()
+}
+
+func (t *batchTx) safePending() int {
+	t.Mutex.Lock()
+	defer t.Mutex.Unlock()
+	return t.pending
 }
 
 func (t *batchTx) commit(stop bool) {


### PR DESCRIPTION
I found that etcd is unable to process large (take more than 100ms) read requests concurrently even under light or no write workload. We already put some effort to solve the current read problem by adding a writeback buffer in front of the database transaction. So I want to fix this problem.

The root cause of the problem is that although we use Read Lock to allow current read go-routines, but we have another long running go-routine that tries to flush data back to disk every 100ms which requires Write Lock.

Obviously, the write lock has a higher priority that read lock, and will always kick in to block any later read locks. So with this behavior, we basically put a barrier for every 100ms to block all reads until the write lock is acquired by the long running go-routine and then released. The write lock can only be acquired after all previous read locks are released, which can be seconds if the reads are large. Thus we can block reads for seconds even when there is no write.

However, if there is no pending write, we do not need to get the write lock at all. 

This PR delays the routine to acquire the write lock only when there are pending writes. So under no or light write conditions, large read can be executed concurrently.

/cc @jpbetz @mitake @heyitsanthony 


