### PR TITLE
*: regenerate proto

### DIFF
--- a/Documentation/dev-guide/api_reference_v3.md
+++ b/Documentation/dev-guide/api_reference_v3.md
@@ -785,12 +785,13 @@ Empty field.
 | ----- | ----------- | ---- |
 | header |  | ResponseHeader |
 | version | version is the cluster protocol version used by the responding member. | string |
-| dbSize | dbSize is the size of the backend database, in bytes, of the responding member. | int64 |
+| dbSize | dbSize is the size of the backend database physically allocated, in bytes, of the responding member. | int64 |
 | leader | leader is the member ID which the responding member believes is the current leader. | uint64 |
 | raftIndex | raftIndex is the current raft index of the responding member. | uint64 |
 | raftTerm | raftTerm is the current raft term of the responding member. | uint64 |
 | raftAppliedIndex | raftAppliedIndex is the current raft applied index of the responding member. | uint64 |
 | errors | errors contains alarm/health information and status. | (slice of) string |
+| dbSizeInUse | dbSizeInUse is the size of the backend database logically in use, in bytes, of the responding member. | int64 |
 
 
 


### PR DESCRIPTION
genproto populated a change from https://github.com/coreos/etcd/commit/6b775cd786d897f6cc8d0e552456558399135459 breaking it out here in seperate commit.

@yudai
