### PR TITLE
mvcc: remove unnecessary metrics update code

### DIFF
--- a/internal/mvcc/backend/backend.go
+++ b/internal/mvcc/backend/backend.go
@@ -288,15 +288,7 @@ func (b *backend) Commits() int64 {
 }
 
 func (b *backend) Defrag() error {
-	err := b.defrag()
-	if err != nil {
-		return err
-	}
-
-	// commit to update metadata like db.size
-	b.batchTx.Commit()
-
-	return nil
+	return b.defrag()
 }
 
 func (b *backend) defrag() error {

--- a/internal/mvcc/backend/batch_tx.go
+++ b/internal/mvcc/backend/batch_tx.go
@@ -158,17 +158,6 @@ func (t *batchTx) commit(stop bool) {
 	// commit the last tx
 	if t.tx != nil {
 		if t.pending == 0 && !stop {
-			t.backend.mu.RLock()
-			defer t.backend.mu.RUnlock()
-
-			// t.tx.DB()==nil if 'CommitAndStop' calls 'batchTx.commit(true)',
-			// which initializes *bolt.Tx.db and *bolt.Tx.meta as nil; panics t.tx.Size().
-			// Server must make sure 'batchTx.commit(false)' does not follow
-			// 'batchTx.commit(true)' (e.g. stopping backend, and inflight Hash call).
-			size := t.tx.Size()
-			db := t.tx.DB()
-			atomic.StoreInt64(&t.backend.size, size)
-			atomic.StoreInt64(&t.backend.sizeInUse, size-(int64(db.Stats().FreePageN)*int64(db.Info().PageSize)))
 			return
 		}
 


### PR DESCRIPTION
/cc @yudai 

After your PR, we now update metrics in defrag func. So no need to call commit to update metrics.
