### PR TITLE
*: fix govet warnings

### DIFF
--- a/tools/etcd-test-proxy/main.go
+++ b/tools/etcd-test-proxy/main.go
@@ -62,8 +62,7 @@ $ ./bin/etcd-test-proxy --help
 $ ./bin/etcd-test-proxy --from localhost:23790 --to localhost:2379 --http-port 2378 --verbose
 
 $ ETCDCTL_API=3 ./bin/etcdctl --endpoints localhost:2379 put foo bar
-$ ETCDCTL_API=3 ./bin/etcdctl --endpoints localhost:23790 put foo bar
-`)
+$ ETCDCTL_API=3 ./bin/etcdctl --endpoints localhost:23790 put foo bar`)
 		flag.PrintDefaults()
 	}
 


### PR DESCRIPTION
Fix govet warnings with Go tip

```
tools/etcd-test-proxy/main.go:47: Fprintln arg list ends with redundant
newline
```

https://travis-ci.org/coreos/etcd/jobs/339098329#L746