### PR TITLE
*: allow dbSizeInUse not to equal to dbSize when growing

### DIFF
--- a/Documentation/op-guide/maintenance.md
+++ b/Documentation/op-guide/maintenance.md
@@ -104,7 +104,7 @@ $ ETCDCTL_API=3 etcdctl put newkey 123
 OK
 ```
 
-The metric `etcd_debugging_mvcc_db_total_size_in_use_in_bytes` indicates the actual database usage after a history compaction, while `etcd_debugging_mvcc_db_total_size_in_bytes` shows the database size including free space waiting for defragmentation. The latter increases only when the former equals to it, meaning when both of these metrics are close to the quota, a history compaction is required to avoid triggering the space quota.
+The metric `etcd_debugging_mvcc_db_total_size_in_use_in_bytes` indicates the actual database usage after a history compaction, while `etcd_debugging_mvcc_db_total_size_in_bytes` shows the database size including free space waiting for defragmentation. The latter increases only when the former is close to it, meaning when both of these metrics are close to the quota, a history compaction is required to avoid triggering the space quota.
 
 ## Snapshot backup
 

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -53,6 +53,7 @@ func TestMetricDbSizeDefrag(t *testing.T) {
 	numPuts := 25 // large enough to write more than 1 page
 	putreq := &pb.PutRequest{Key: []byte("k"), Value: make([]byte, 4096)}
 	for i := 0; i < numPuts; i++ {
+		time.Sleep(10 * time.Millisecond) // to execute multiple backend txn
 		if _, err := kvc.Put(context.TODO(), putreq); err != nil {
 			t.Fatal(err)
 		}
@@ -61,6 +62,7 @@ func TestMetricDbSizeDefrag(t *testing.T) {
 	// wait for backend txn sync
 	time.Sleep(500 * time.Millisecond)
 
+	expected := numPuts * len(putreq.Value)
 	beforeDefrag, err := clus.Members[0].Metric("etcd_debugging_mvcc_db_total_size_in_bytes")
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +71,7 @@ func TestMetricDbSizeDefrag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expected := numPuts * len(putreq.Value); bv < expected {
+	if bv < expected {
 		t.Fatalf("expected db size greater than %d, got %d", expected, bv)
 	}
 	beforeDefragInUse, err := clus.Members[0].Metric("etcd_debugging_mvcc_db_total_size_in_use_in_bytes")
@@ -80,8 +82,8 @@ func TestMetricDbSizeDefrag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if biu != bv {
-		t.Fatalf("when db size is growing, db size (%d) and db size in use (%d) is expected to be equal", bv, biu)
+	if biu < expected {
+		t.Fatalf("expected db size in use is greater than %d, got %d", expected, biu)
 	}
 
 	// clear out historical keys, in use bytes should free pages


### PR DESCRIPTION
Due to boltdb behavior, dbSizeInUse can be unequal to dbSize even when
dbSize is growing in some conditions. The possible gap between the sizes
is up to a couple of pages.

Closes #9302
