### PR TITLE
WIP Allow large range to run concurrently with writes

### DIFF
--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -243,7 +243,13 @@ func (a *applierV3backend) Range(txn mvcc.TxnRead, r *pb.RangeRequest) (*pb.Rang
 	resp.Header = &pb.ResponseHeader{}
 
 	if txn == nil {
-		txn = a.s.kv.Read()
+		// Correct me!
+		// We should issue a normal read with limit=1000
+		// If there are more keys to get, we should:
+		// 1. wait the pending transcation to commit by calling force commit
+		// 2. get a stale concurrent read transcation along with the revision
+		// inside the first revision to get more keys.
+		txn = a.s.kv.StaleConcurrentRead()
 		defer txn.End()
 	}
 

--- a/internal/mvcc/backend/stale_concurrent_read_tx.go
+++ b/internal/mvcc/backend/stale_concurrent_read_tx.go
@@ -1,0 +1,44 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	bolt "github.com/coreos/bbolt"
+)
+
+type staleConcurrentReadTx struct {
+	tx *bolt.Tx
+}
+
+func (rt *staleConcurrentReadTx) Lock() {}
+func (rt *staleConcurrentReadTx) Unlock() {
+	err := rt.tx.Rollback()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (rt *staleConcurrentReadTx) UnsafeRange(bucketName, key, endKey []byte, limit int64) ([][]byte, [][]byte) {
+	bucket := rt.tx.Bucket(bucketName)
+	if bucket == nil {
+		plog.Fatalf("bucket %s does not exist", bucketName)
+	}
+	return unsafeRange(bucket.Cursor(), key, endKey, limit)
+}
+
+func (rt *staleConcurrentReadTx) UnsafeForEach(bucketName []byte, visitor func(k, v []byte) error) error {
+	return unsafeForEach(rt.tx, bucketName, visitor)
+
+}

--- a/internal/mvcc/kv.go
+++ b/internal/mvcc/kv.go
@@ -104,6 +104,8 @@ type KV interface {
 	// Read creates a read transaction.
 	Read() TxnRead
 
+	StaleConcurrentRead() TxnRead
+
 	// Write creates a write transaction.
 	Write() TxnWrite
 

--- a/internal/mvcc/kvstore_txn.go
+++ b/internal/mvcc/kvstore_txn.go
@@ -38,6 +38,19 @@ func (s *store) Read() TxnRead {
 	return newMetricsTxnRead(&storeTxnRead{s, tx, firstRev, rev})
 }
 
+func (s *store) StaleConcurrentRead() TxnRead {
+	s.mu.RLock()
+	tx := s.b.StaleConcurrentReadTx()
+	tx.Lock()
+	s.revMu.RLock()
+	defer s.revMu.RUnlock()
+	// Correct me!
+	// Replace `s.currentRev - 10000` with revision in the backend.
+	// Also StaleConcurrentRead should only allow read with given revision.
+	// Probably we should have a different interface for it?!
+	return newMetricsTxnRead(&storeTxnRead{s, tx, s.compactMainRev, s.currentRev - 10000})
+}
+
 func (tr *storeTxnRead) FirstRev() int64 { return tr.firstRev }
 func (tr *storeTxnRead) Rev() int64      { return tr.rev }
 


### PR DESCRIPTION
The main idea is to get a dedicated boltdb transaction for range request instead of using the readtx which blocks batchtx for writes.

This PR includes a draft work, which makes all requests behavior as what large request should...

But the result is promising! With a large range over 1mm keys that taking 3s to finish, the write latency remains stable! Before this patches, the slowest put takes 3s.

```
Summary:
  Total:	49.1813 secs.
  Slowest:	0.7156 secs.
  Fastest:	0.0004 secs.
  Average:	0.0048 secs.
  Stddev:	0.0075 secs.
  Requests/sec:	203.3294
```

/cc @heyitsanthony @mitake What do you think about this?