### PR TITLE
*: upgrade to Go 1.10

### DIFF
--- a/.semaphore.sh
+++ b/.semaphore.sh
@@ -10,7 +10,7 @@ fi
 docker run \
 	--rm \
 	--volume=`pwd`:/go/src/github.com/coreos/etcd \
-	gcr.io/etcd-development/etcd-test:go1.9.4 \
+	gcr.io/etcd-development/etcd-test:go1.10 \
 	/bin/bash -c "${TEST_OPTS} ./test 2>&1 | tee test-${TEST_SUFFIX}.log"
 
 ! egrep "(--- FAIL:|panic: test timed out|appears to have leaked)" -B50 -A10 test-${TEST_SUFFIX}.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 services: docker
 
 go:
-- 1.9.4
+- "1.10"
 - tip
 
 notifications:
@@ -30,7 +30,7 @@ matrix:
   - go: tip
     env: TARGET=amd64-go-tip
   exclude:
-  - go: 1.9.4
+  - go: "1.10"
     env: TARGET=amd64-go-tip
   - go: tip
     env: TARGET=amd64

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -47,6 +47,7 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.3.0...v3.4.0) and [
   - Move `"github.com/coreos/etcd/etcdserver/auth"` to [`"github.com/coreos/etcd/etcdserver/v2auth"`](https://github.com/coreos/etcd/pull/9275).
   - Change v3 `etcdctl snapshot` exit codes with [`snapshot` package](https://github.com/coreos/etcd/pull/9118/commits/df689f4280e1cce4b9d61300be13ca604d41670a).
     - Exit on error with exit code 1 (no more exit code 5 or 6 on `snapshot save/restore` commands).
+- Require Go 1.10+.
 
 ### Added(`etcd`)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ etcd contributors and maintainers have bi-weekly meetings at 11:00 AM (USA Pacif
 
 The easiest way to get etcd is to use one of the pre-built release binaries which are available for OSX, Linux, Windows, [rkt][rkt], and Docker. Instructions for using these binaries are on the [GitHub releases page][github-release].
 
-For those wanting to try the very latest version, [build the latest version of etcd][dl-build] from the `master` branch. This first needs [*Go*](https://golang.org/) installed (version 1.9+ is required). All development occurs on `master`, including new features and bug fixes. Bug fixes are first targeted at `master` and subsequently ported to release branches, as described in the [branch management][branch-management] guide.
+For those wanting to try the very latest version, [build the latest version of etcd][dl-build] from the `master` branch. This first needs [*Go*](https://golang.org/) installed (version 1.10+ is required). All development occurs on `master`, including new features and bug fixes. Bug fixes are first targeted at `master` and subsequently ported to release branches, as described in the [branch management][branch-management] guide.
 
 [rkt]: https://github.com/rkt/rkt/releases/
 [github-release]: https://github.com/coreos/etcd/releases/

--- a/hack/scripts-dev/Makefile
+++ b/hack/scripts-dev/Makefile
@@ -27,7 +27,7 @@ clean:
 
 
 
-GO_VERSION ?= 1.9.4
+GO_VERSION ?= 1.10
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)

--- a/tools/functional-tester/scripts/docker-local-agent.sh
+++ b/tools/functional-tester/scripts/docker-local-agent.sh
@@ -13,7 +13,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-agent.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.9.4
+  GO_VERSION=1.10
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 

--- a/tools/functional-tester/scripts/docker-local-tester.sh
+++ b/tools/functional-tester/scripts/docker-local-tester.sh
@@ -3,8 +3,8 @@
 <<COMMENT
 # to run with different Go version
 # requires prebuilt Docker image
-#   GO_VERSION=1.9.4 make build-docker-functional-tester -f ./hack/scripts-dev/Makefile
-GO_VERSION=1.9.4 ./scripts/docker-local-tester.sh
+#   GO_VERSION=1.10 make build-docker-functional-tester -f ./hack/scripts-dev/Makefile
+GO_VERSION=1.10 ./scripts/docker-local-tester.sh
 
 # to run only 1 tester round
 LIMIT=1 ./scripts/docker-local-tester.sh
@@ -27,7 +27,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-tester.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.9.4
+  GO_VERSION=1.10
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 


### PR DESCRIPTION
Pushed Go 1.10 test image to https://console.cloud.google.com/gcr/images/etcd-development/GLOBAL/etcd-test.
