### PR TITLE
httpproxy: cancel requests when client closes a connection

### DIFF
--- a/proxy/httpproxy/reverse.go
+++ b/proxy/httpproxy/reverse.go
@@ -119,6 +119,7 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 			case <-closeCh:
 				atomic.StoreInt32(&requestClosed, 1)
 				plog.Printf("client %v closed request prematurely", clientreq.RemoteAddr)
+				cancel()
 			case <-completeCh:
 			}
 		}()


### PR DESCRIPTION
This change fixes https://github.com/coreos/etcd/issues/9335. I've:

- run the repro scenario described in that issue and confirmed that filehandles aren't leaked
- added a temporary log to confirm that `io.Copy` does now exit (so we don't leak a goroutine)
- checked that it is safe to call `cancel()` repeatedly (https://golang.org/pkg/context/#CancelFunc - "After the first call, subsequent calls to a CancelFunc do nothing.")