### PR TITLE
*: fix govet -shadow warnings

### DIFF
--- a/etcdctl/ctlv2/command/backup_command.go
+++ b/etcdctl/ctlv2/command/backup_command.go
@@ -189,11 +189,11 @@ func saveDB(destDB, srcDB string, idx uint64, v3 bool) {
 		var src *bolt.DB
 		ch := make(chan *bolt.DB, 1)
 		go func() {
-			src, err := bolt.Open(srcDB, 0444, &bolt.Options{ReadOnly: true})
+			db, err := bolt.Open(srcDB, 0444, &bolt.Options{ReadOnly: true})
 			if err != nil {
 				log.Fatal(err)
 			}
-			ch <- src
+			ch <- db
 		}()
 		select {
 		case src = <-ch:

--- a/tools/functional-tester/etcd-runner/command/global.go
+++ b/tools/functional-tester/etcd-runner/command/global.go
@@ -106,9 +106,9 @@ func doRounds(rcs []roundClient, rounds int, requests int) {
 }
 
 func endpointsFromFlag(cmd *cobra.Command) []string {
-	endpoints, err := cmd.Flags().GetStringSlice("endpoints")
+	eps, err := cmd.Flags().GetStringSlice("endpoints")
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}
-	return endpoints
+	return eps
 }


### PR DESCRIPTION
```
govet -all -shadow checking failed:
etcdctl/ctlv2/command/backup_command.go:192: declaration of "src" shadows declaration at etcdctl/ctlv2/command/backup_command.go:189
etcdctl/ctlv2/command/backup_command.go:192: declaration of "src" shadows declaration at etcdctl/ctlv2/command/backup_command.go:189
etcdctl/ctlv2/command/backup_command.go:192: declaration of "src" shadows declaration at etcdctl/ctlv2/command/backup_command.go:189
tools/functional-tester/etcd-runner/command/global.go:109: declaration of "endpoints" shadows declaration at tools/functional-tester/etcd-runner/command/global.go:33
tools/functional-tester/etcd-runner/command/global.go:109: declaration of "endpoints" shadows declaration at tools/functional-tester/etcd-runner/command/global.go:33
```