### PR TITLE
raft: clarify candidate message handling, test candidate to follower transition with message from leader

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1128,13 +1128,13 @@ func stepCandidate(r *raft, m pb.Message) error {
 		r.logger.Infof("%x no leader at term %d; dropping proposal", r.id, r.Term)
 		return ErrProposalDropped
 	case pb.MsgApp:
-		r.becomeFollower(r.Term, m.From)
+		r.becomeFollower(m.Term, m.From) // always m.Term == r.Term
 		r.handleAppendEntries(m)
 	case pb.MsgHeartbeat:
-		r.becomeFollower(r.Term, m.From)
+		r.becomeFollower(m.Term, m.From) // always m.Term == r.Term
 		r.handleHeartbeat(m)
 	case pb.MsgSnap:
-		r.becomeFollower(m.Term, m.From)
+		r.becomeFollower(m.Term, m.From) // always m.Term == r.Term
 		r.handleSnapshot(m)
 	case myVoteRespType:
 		gr := r.poll(m.From, m.Type, !m.Reject)

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1148,6 +1148,8 @@ func stepCandidate(r *raft, m pb.Message) error {
 				r.bcastAppend()
 			}
 		case len(r.votes) - gr:
+			// pb.MsgPreVoteResp contains future term of pre-candidate
+			// m.Term > r.Term; reuse r.Term
 			r.becomeFollower(r.Term, None)
 		}
 	case pb.MsgTimeoutNow:

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -220,7 +220,7 @@ func TestLeaderElectionInOneRoundRPC(t *testing.T) {
 
 		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 		for id, vote := range tt.votes {
-			r.Step(pb.Message{From: id, To: 1, Type: pb.MsgVoteResp, Reject: !vote})
+			r.Step(pb.Message{From: id, To: 1, Term: r.Term, Type: pb.MsgVoteResp, Reject: !vote})
 		}
 
 		if r.state != tt.state {


### PR DESCRIPTION
`raft.Step` already ensures that when `m.Term > r.Term`, candidate reverts back to follower with its term being reset with `m.Term`, thus it's always true that `m.Term == r.Term` in `stepCandidate`. This just makes `r.becomeFollower` calls consistent. Also add tests around this behavior.

Also document why `stepCandidate` should reuse candidate's own term, not `m.Term`. This is because pre-vote is requested with future term.

