### PR TITLE
rafthttp: make "ActiveSince" non-blocking on write lock

### DIFF
--- a/rafthttp/transport.go
+++ b/rafthttp/transport.go
@@ -338,8 +338,8 @@ func (t *Transport) UpdatePeer(id types.ID, us []string) {
 }
 
 func (t *Transport) ActiveSince(id types.ID) time.Time {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	if p, ok := t.peers[id]; ok {
 		return p.activeSince()
 	}


### PR DESCRIPTION
"ActiveSince" is read-only, and should be able to call
concurrently, as long as there is no routine holding
write lock (send, send snapshot).

e.g. "ActiveSince" is used around etcd server
"processInternalRaftRequestOnce", should be non-blocking
