### PR TITLE
CHANELOG/hack: add Election HTTP API fix

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -10,6 +10,9 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.2.16...v3.2.17) and
 
 ### Fixed(v3)
 
+- Fix [server panic on invalid Election Proclaim/Resign HTTP(S) requests](https://github.com/coreos/etcd/pull/9379).
+  - Previously, wrong-formatted HTTP requests to Election API could trigger panic in etcd server.
+  - e.g. `curl -L http://localhost:2379/v3/election/proclaim -X POST -d '{"value":""}'`, `curl -L http://localhost:2379/v3/election/resign -X POST -d '{"value":""}'`.
 - Enable etcd server [`raft.Config.CheckQuorum` when starting with `ForceNewCluster`](https://github.com/coreos/etcd/pull/9347).
 
 ### Security

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -10,6 +10,9 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.3.1...v3.3.2) and [
 
 ### Fixed(v3)
 
+- Fix [server panic on invalid Election Proclaim/Resign HTTP(S) requests](https://github.com/coreos/etcd/pull/9379).
+  - Previously, wrong-formatted HTTP requests to Election API could trigger panic in etcd server.
+  - e.g. `curl -L http://localhost:2379/v3/election/proclaim -X POST -d '{"value":""}'`, `curl -L http://localhost:2379/v3/election/resign -X POST -d '{"value":""}'`.
 - Fix [revision-based compaction retention parsing](https://github.com/coreos/etcd/pull/9339).
   - Previously, `--auto-compaction-mode revision --auto-compaction-retention 1` was [translated to revision retention 3600000000000](https://github.com/coreos/etcd/issues/9337).
   - Now, `--auto-compaction-mode revision --auto-compaction-retention 1` is correctly parsed as revision retention 1.

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -108,6 +108,9 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.3.0...v3.4.0) and [
   - That is, "unsynced" watcher is the slow watcher that was requested on old revision.
   - "unsynced" watcher restore operation was not correctly populating its underlying watcher group.
   - Which possibly causes missing events from "unsynced" watchers.
+- Fix [server panic on invalid Election Proclaim/Resign HTTP(S) requests](https://github.com/coreos/etcd/pull/9379).
+  - Previously, wrong-formatted HTTP requests to Election API could trigger panic in etcd server.
+  - e.g. `curl -L http://localhost:2379/v3/election/proclaim -X POST -d '{"value":""}'`, `curl -L http://localhost:2379/v3/election/resign -X POST -d '{"value":""}'`.
 - Fix [revision-based compaction retention parsing](https://github.com/coreos/etcd/pull/9339).
   - Previously, `--auto-compaction-mode revision --auto-compaction-retention 1` was [translated to revision retention 3600000000000](https://github.com/coreos/etcd/issues/9337).
   - Now, `--auto-compaction-mode revision --auto-compaction-retention 1` is correctly parsed as revision retention 1.

--- a/hack/scripts-dev/docker-dns/insecure/run.sh
+++ b/hack/scripts-dev/docker-dns/insecure/run.sh
@@ -57,4 +57,33 @@ printf "\n\nFetching 'curl http://m1.etcd.local:2379/metrics'...\n"
 curl \
   -L http://m1.etcd.local:2379/metrics | grep Put | tail -3
 
+name1=$(base64 <<< "/election-prefix")
+val1=$(base64 <<< "v1")
+data1="{\"name\":\"${name1}\", \"value\":\"${val1}\"}"
+
+printf "\n\nCampaign: ${data1}\n"
+result1=$(curl -L http://m1.etcd.local:2379/v3/election/campaign -X POST -d "${data1}")
+echo ${result1}
+
+# should not panic servers
+val2=$(base64 <<< "v2")
+data2="{\"value\": \"${val2}\"}"
+printf "\n\nProclaim (wrong-format): ${data2}\n"
+curl \
+  -L http://m1.etcd.local:2379/v3/election/proclaim \
+  -X POST \
+  -d "${data2}"
+
+printf "\n\nProclaim (wrong-format)...\n"
+curl \
+  -L http://m1.etcd.local:2379/v3/election/proclaim \
+  -X POST \
+  -d '}'
+
+printf "\n\nProclaim (wrong-format)...\n"
+curl \
+  -L http://m1.etcd.local:2379/v3/election/proclaim \
+  -X POST \
+  -d '{"value": "Zm9v"}'
+
 printf "\n\nDone!!!\n\n"


### PR DESCRIPTION
Separate commits from https://github.com/coreos/etcd/pull/9379 to make backport easier.