### PR TITLE
pkg/flags: fatal on conflicting environment variable

### DIFF
--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -119,9 +119,7 @@ func verifyEnv(prefix string, usedEnvKey, alreadySet map[string]bool) {
 			continue
 		}
 		if alreadySet[kv[0]] {
-			// TODO: exit with error in v3.4
-			plog.Warningf("recognized environment variable %s, but unused: shadowed by corresponding flag", kv[0])
-			continue
+			plog.Fatalf("conflicting environment variable %q is shadowed by corresponding command-line flag (either unset environment variable or disable flag)", kv[0])
 		}
 		if strings.HasPrefix(env, prefix+"_") {
 			plog.Warningf("unrecognized environment variable %s", env)

--- a/pkg/flags/flag_test.go
+++ b/pkg/flags/flag_test.go
@@ -34,17 +34,11 @@ func TestSetFlagsFromEnv(t *testing.T) {
 	if err := fs.Set("b", "bar"); err != nil {
 		t.Fatal(err)
 	}
-	// command-line flags take precedence over env vars
-	os.Setenv("ETCD_C", "woof")
-	if err := fs.Set("c", "quack"); err != nil {
-		t.Fatal(err)
-	}
 
 	// first verify that flags are as expected before reading the env
 	for f, want := range map[string]string{
 		"a": "",
 		"b": "bar",
-		"c": "quack",
 	} {
 		if got := fs.Lookup(f).Value.String(); got != want {
 			t.Fatalf("flag %q=%q, want %q", f, got, want)
@@ -59,7 +53,6 @@ func TestSetFlagsFromEnv(t *testing.T) {
 	for f, want := range map[string]string{
 		"a": "foo",
 		"b": "bar",
-		"c": "quack",
 	} {
 		if got := fs.Lookup(f).Value.String(); got != want {
 			t.Errorf("flag %q=%q, want %q", f, got, want)


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/8380.

```
export ETCD_NAME=aaaaa
./bin/etcd --name bbb
2018-03-02 10:27:49.770161 C | pkg/flags: conflicting environment variable "ETCD_NAME" is shadowed by corresponding command-line flag (either unset environment variable or disable flag)

export ETCDCTL_ENDPOINTS=aaaaa.com
ETCDCTL_API=3 ./bin/etcdctl endpoint health --endpoints=bbb.com
2018-03-02 10:28:09.438985 C | pkg/flags: conflicting environment variable "ETCDCTL_ENDPOINTS" is shadowed by corresponding command-line flag (either unset environment variable or disable flag)
```
