### PR TITLE
*: add "--cluster" flag to defrag, highlight defrag endpoints

### DIFF
--- a/Documentation/op-guide/maintenance.md
+++ b/Documentation/op-guide/maintenance.md
@@ -47,7 +47,18 @@ $ etcdctl defrag
 Finished defragmenting etcd member[127.0.0.1:2379]
 ```
 
-Note that defragmentation to a live member blocks the system from reading and writing data while rebuilding its states.
+**Note that defragmentation to a live member blocks the system from reading and writing data while rebuilding its states**.
+
+**Note that defragmentation request does not get replicated over cluster. That is, the request is only applied to the local node. Specify all members in `--endpoints` flag or `--cluster` flag to automatically find all cluster members.**
+
+Run defragment operations for all endpoints in the cluster associated with the default endpoint:
+
+```bash
+$ etcdctl defrag --cluster
+Finished defragmenting etcd member[http://127.0.0.1:2379]
+Finished defragmenting etcd member[http://127.0.0.1:22379]
+Finished defragmenting etcd member[http://127.0.0.1:32379]
+```
 
 To defragment an etcd data directory directly, while etcd is not running, use the command:
 

--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -878,6 +878,10 @@ If NOSPACE alarm is present:
 
 DEFRAG defragments the backend database file for a set of given endpoints while etcd is running, or directly defragments an etcd data directory while etcd is not running. When an etcd member reclaims storage space from deleted and compacted keys, the space is kept in a free list and the database file remains the same size. By defragmenting the database, the etcd member releases this free space back to the file system.
 
+**Note that defragmentation to a live member blocks the system from reading and writing data while rebuilding its states.**
+
+**Note that defragmentation request does not get replicated over cluster. That is, the request is only applied to the local node. Specify all members in `--endpoints` flag or `--cluster` flag to automatically find all cluster members.**
+
 #### Options
 
 - data-dir -- Optional. If present, defragments a data directory not in use by etcd.

--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -876,10 +876,7 @@ If NOSPACE alarm is present:
 
 ### DEFRAG [options]
 
-DEFRAG defragments the backend database file for a set of given endpoints while etcd is running, or directly defragments an
-etcd data directory while etcd is not running. When an etcd member reclaims storage space from deleted and compacted keys, the
-space is kept in a free list and the database file remains the same size. By defragmenting the database, the etcd member
-releases this free space back to the file system.
+DEFRAG defragments the backend database file for a set of given endpoints while etcd is running, or directly defragments an etcd data directory while etcd is not running. When an etcd member reclaims storage space from deleted and compacted keys, the space is kept in a free list and the database file remains the same size. By defragmenting the database, the etcd member releases this free space back to the file system.
 
 #### Options
 
@@ -895,6 +892,15 @@ For each endpoints, prints a message indicating whether the endpoint was success
 ./etcdctl --endpoints=localhost:2379,badendpoint:2379 defrag
 # Finished defragmenting etcd member[localhost:2379]
 # Failed to defragment etcd member[badendpoint:2379] (grpc: timed out trying to connect)
+```
+
+Run defragment operations for all endpoints in the cluster associated with the default endpoint:
+
+```bash
+./etcdctl defrag --cluster
+Finished defragmenting etcd member[http://127.0.0.1:2379]
+Finished defragmenting etcd member[http://127.0.0.1:22379]
+Finished defragmenting etcd member[http://127.0.0.1:32379]
 ```
 
 To defragment a data directory directly, use the `--data-dir` flag:

--- a/etcdctl/ctlv3/command/defrag_command.go
+++ b/etcdctl/ctlv3/command/defrag_command.go
@@ -35,6 +35,7 @@ func NewDefragCommand() *cobra.Command {
 		Short: "Defragments the storage of the etcd members with given endpoints",
 		Run:   defragCommandFunc,
 	}
+	cmd.PersistentFlags().BoolVar(&epClusterEndpoints, "cluster", false, "use all endpoints from the cluster member list")
 	cmd.Flags().StringVar(&defragDataDir, "data-dir", "", "Optional. If present, defragments a data directory not in use by etcd.")
 	return cmd
 }
@@ -51,7 +52,7 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 
 	failures := 0
 	c := mustClientFromCmd(cmd)
-	for _, ep := range c.Endpoints() {
+	for _, ep := range endpointsFromCluster(cmd) {
 		ctx, cancel := commandCtx(cmd)
 		_, err := c.Defragment(ctx, ep)
 		cancel()


### PR DESCRIPTION
Had a customer hit database size limit issue, but the doc was not clear about `--endpoints` flag in `defrag` command.