### PR TITLE
fix bug in auto-compact

### DIFF
--- a/compactor/periodic.go
+++ b/compactor/periodic.go
@@ -86,8 +86,11 @@ func (t *Periodic) Run() {
 			}
 			plog.Noticef("Starting auto-compaction at revision %d (retention: %v)", rev, t.period)
 			_, err := t.c.Compact(t.ctx, &pb.CompactionRequest{Revision: rev})
+
 			if err == nil || err == mvcc.ErrCompacted {
 				t.revs = remaining
+				// update the last compaction time
+				last = clock.Now()
 				plog.Noticef("Finished auto-compaction at revision %d", rev)
 			} else {
 				plog.Noticef("Failed auto-compaction at revision %d (%v)", rev, err)


### PR DESCRIPTION
we need to update the `last` variable to record the last compaction time in the for loop. If not we will do compaction in  checkCompactInterval instead of t.period . Not quite sure about whether unit test failed to test it out.