### PR TITLE
mvcc/backend: defrag to block concurrent read requests while resetting tx

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -304,7 +304,12 @@ func (b *backend) defrag() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.batchTx.commit(true)
+	// block concurrent read requests while resetting tx
+	b.readTx.mu.Lock()
+	defer b.readTx.mu.Unlock()
+
+	b.batchTx.unsafeCommit(true)
+
 	b.batchTx.tx = nil
 
 	tmpdb, err := bolt.Open(b.db.Path()+".tmp", 0600, boltOpenOptions)


### PR DESCRIPTION
From https://github.com/coreos/etcd/commit/3ebee21407da8913f183a9e1354513ba8759521e.

```bash
$ go test -v -run TestV3MaintenanceDefragmentInflightRange -race
=== RUN   TestV3MaintenanceDefragmentInflightRange
==================
WARNING: DATA RACE
Write at 0x00c42026aba0 by goroutine 121:
  runtime.mapdelete_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:883 +0x0
  ./mvcc/backend.(*txBuffer).reset()
      ./mvcc/backend/tx_buffer.go:31 +0x17f
  ./mvcc/backend.(*readTx).reset()
      ./mvcc/backend/read_tx.go:117 +0x42
  ./mvcc/backend.(*backend).defrag()
      ./mvcc/backend/backend.go:348 +0x95f
  ./mvcc/backend.(*backend).Defrag()
      ./mvcc/backend/backend.go:293 +0x38
  ./etcdserver/api/v3rpc.(*maintenanceServer).Defragment()
      ./etcdserver/api/v3rpc/maintenance.go:72 +0xb1
  ./etcdserver/api/v3rpc.(*authMaintenanceServer).Defragment()
      ./etcdserver/api/v3rpc/maintenance.go:205 +0xe4
  ./etcdserver/etcdserverpb._Maintenance_Defragment_Handler.func1()
      ./etcdserver/etcdserverpb/rpc.pb.go:4166 +0xa1
  ./vendor/github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      ./vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server_metrics.go:112 +0x120
  ./etcdserver/api/v3rpc.newUnaryInterceptor.func1()
      ./etcdserver/api/v3rpc/interceptor.go:57 +0x117
  ./etcdserver/etcdserverpb._Maintenance_Defragment_Handler()
      ./etcdserver/etcdserverpb/rpc.pb.go:4168 +0x1e3
  ./vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      ./vendor/google.golang.org/grpc/server.go:843 +0xf88
  ./vendor/google.golang.org/grpc.(*Server).handleStream()
      ./vendor/google.golang.org/grpc/server.go:1040 +0x1364
  ./vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      ./vendor/google.golang.org/grpc/server.go:589 +0xac

Previous read at 0x00c42026aba0 by goroutine 122:
  runtime.mapaccess1_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:172 +0x0
  ./mvcc/backend.(*txReadBuffer).Range()
      ./mvcc/backend/tx_buffer.go:78 +0xbf
  ./mvcc/backend.(*readTx).UnsafeRange()
      ./mvcc/backend/read_tx.go:63 +0x105
  ./mvcc.(*storeTxnRead).rangeKeys()
      ./mvcc/kvstore_txn.go:140 +0x4ba
  ./mvcc.(*storeTxnRead).Range()
      ./mvcc/kvstore_txn.go:45 +0xe2
  ./mvcc.(*txnReadWrite).Range()
      <autogenerated>:1 +0xea
  ./mvcc.(*metricsTxnWrite).Range()
      ./mvcc/metrics_txn.go:36 +0x128
  ./etcdserver.(*applierV3backend).Range()
      ./etcdserver/apply.go:268 +0x2da
  ./etcdserver.(*EtcdServer).Range.func2()
      ./etcdserver/v3_server.go:101 +0x9b
  ./etcdserver.(*EtcdServer).doSerialize()
      ./etcdserver/v3_server.go:537 +0x13c
  ./etcdserver.(*EtcdServer).Range()
      ./etcdserver/v3_server.go:102 +0x263
  ./etcdserver/api/v3rpc.(*kvServer).Range()
      ./etcdserver/api/v3rpc/key.go:52 +0xae
  ./etcdserver/api/v3rpc.(*quotaKVServer).Range()
      <autogenerated>:1 +0x7d
  ./etcdserver/etcdserverpb._KV_Range_Handler.func1()
      ./etcdserver/etcdserverpb/rpc.pb.go:3349 +0xa1
  ./vendor/github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      ./vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server_metrics.go:112 +0x120
  ./etcdserver/api/v3rpc.newUnaryInterceptor.func1()
      ./etcdserver/api/v3rpc/interceptor.go:57 +0x117
  ./etcdserver/etcdserverpb._KV_Range_Handler()
      ./etcdserver/etcdserverpb/rpc.pb.go:3351 +0x1e3
  ./vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      ./vendor/google.golang.org/grpc/server.go:843 +0xf88
  ./vendor/google.golang.org/grpc.(*Server).handleStream()
      ./vendor/google.golang.org/grpc/server.go:1040 +0x1364
  ./vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      ./vendor/google.golang.org/grpc/server.go:589 +0xac

Goroutine 121 (running) created at:
  ./vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      ./vendor/google.golang.org/grpc/server.go:587 +0xb8
  ./vendor/google.golang.org/grpc/transport.(*http2Server).operateHeaders()
      ./vendor/google.golang.org/grpc/transport/http2_server.go:374 +0x1433
  ./vendor/google.golang.org/grpc/transport.(*http2Server).HandleStreams()
      ./vendor/google.golang.org/grpc/transport/http2_server.go:406 +0x648
  ./vendor/google.golang.org/grpc.(*Server).serveStreams()
      ./vendor/google.golang.org/grpc/server.go:585 +0x1bc
  ./vendor/google.golang.org/grpc.(*Server).handleRawConn()
      ./vendor/google.golang.org/grpc/server.go:546 +0x708

Goroutine 122 (finished) created at:
  ./vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      ./vendor/google.golang.org/grpc/server.go:587 +0xb8
  ./vendor/google.golang.org/grpc/transport.(*http2Server).operateHeaders()
      ./vendor/google.golang.org/grpc/transport/http2_server.go:374 +0x1433
  ./vendor/google.golang.org/grpc/transport.(*http2Server).HandleStreams()
      ./vendor/google.golang.org/grpc/transport/http2_server.go:406 +0x648
  ./vendor/google.golang.org/grpc.(*Server).serveStreams()
      ./vendor/google.golang.org/grpc/server.go:585 +0x1bc
  ./vendor/google.golang.org/grpc.(*Server).handleRawConn()
      ./vendor/google.golang.org/grpc/server.go:546 +0x708
==================
==================
WARNING: DATA RACE
Write at 0x00c420134ed8 by goroutine 121:
  ./mvcc/backend.(*txBuffer).reset()
      ./mvcc/backend/tx_buffer.go:33 +0xa9
  ./mvcc/backend.(*readTx).reset()
      ./mvcc/backend/read_tx.go:117 +0x42
  ./mvcc/backend.(*backend).defrag()
      ./mvcc/backend/backend.go:348 +0x95f
  ./mvcc/backend.(*backend).Defrag()
      ./mvcc/backend/backend.go:293 +0x38
  ./etcdserver/api/v3rpc.(*maintenanceServer).Defragment()
      ./etcdserver/api/v3rpc/maintenance.go:72 +0xb1
  ./etcdserver/api/v3rpc.(*authMaintenanceServer).Defragment()
      ./etcdserver/api/v3rpc/maintenance.go:205 +0xe4
  ./etcdserver/etcdserverpb._Maintenance_Defragment_Handler.func1()
      ./etcdserver/etcdserverpb/rpc.pb.go:4166 +0xa1
  ./vendor/github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      ./vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server_metrics.go:112 +0x120
  ./etcdserver/api/v3rpc.newUnaryInterceptor.func1()
      ./etcdserver/api/v3rpc/interceptor.go:57 +0x117
  ./etcdserver/etcdserverpb._Maintenance_Defragment_Handler()
      ./etcdserver/etcdserverpb/rpc.pb.go:4168 +0x1e3
  ./vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      ./vendor/google.golang.org/grpc/server.go:843 +0xf88
  ./vendor/google.golang.org/grpc.(*Server).handleStream()
      ./vendor/google.golang.org/grpc/server.go:1040 +0x1364
  ./vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      ./vendor/google.golang.org/grpc/server.go:589 +0xac

Previous read at 0x00c420134ed8 by goroutine 122:
  ./mvcc/backend.(*bucketBuffer).Range()
      ./mvcc/backend/tx_buffer.go:109 +0xfd
  ./mvcc/backend.(*txReadBuffer).Range()
      ./mvcc/backend/tx_buffer.go:79 +0x14d
  ./mvcc/backend.(*readTx).UnsafeRange()
      ./mvcc/backend/read_tx.go:63 +0x105
  ./mvcc.(*storeTxnRead).rangeKeys()
      ./mvcc/kvstore_txn.go:140 +0x4ba
  ./mvcc.(*storeTxnRead).Range()
      ./mvcc/kvstore_txn.go:45 +0xe2
  ./mvcc.(*txnReadWrite).Range()
      <autogenerated>:1 +0xea
  ./mvcc.(*metricsTxnWrite).Range()
      ./mvcc/metrics_txn.go:36 +0x128
  ./etcdserver.(*applierV3backend).Range()
      ./etcdserver/apply.go:268 +0x2da
  ./etcdserver.(*EtcdServer).Range.func2()
      ./etcdserver/v3_server.go:101 +0x9b
  ./etcdserver.(*EtcdServer).doSerialize()
      ./etcdserver/v3_server.go:537 +0x13c
  ./etcdserver.(*EtcdServer).Range()
      ./etcdserver/v3_server.go:102 +0x263
  ./etcdserver/api/v3rpc.(*kvServer).Range()
      ./etcdserver/api/v3rpc/key.go:52 +0xae
  ./etcdserver/api/v3rpc.(*quotaKVServer).Range()
      <autogenerated>:1 +0x7d
  ./etcdserver/etcdserverpb._KV_Range_Handler.func1()
      ./etcdserver/etcdserverpb/rpc.pb.go:3349 +0xa1
  ./vendor/github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1()
      ./vendor/github.com/grpc-ecosystem/go-grpc-prometheus/server_metrics.go:112 +0x120
  ./etcdserver/api/v3rpc.newUnaryInterceptor.func1()
      ./etcdserver/api/v3rpc/interceptor.go:57 +0x117
  ./etcdserver/etcdserverpb._KV_Range_Handler()
      ./etcdserver/etcdserverpb/rpc.pb.go:3351 +0x1e3
  ./vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      ./vendor/google.golang.org/grpc/server.go:843 +0xf88
  ./vendor/google.golang.org/grpc.(*Server).handleStream()
      ./vendor/google.golang.org/grpc/server.go:1040 +0x1364
  ./vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      ./vendor/google.golang.org/grpc/server.go:589 +0xac

Goroutine 121 (running) created at:
  ./vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      ./vendor/google.golang.org/grpc/server.go:587 +0xb8
  ./vendor/google.golang.org/grpc/transport.(*http2Server).operateHeaders()
      ./vendor/google.golang.org/grpc/transport/http2_server.go:374 +0x1433
  ./vendor/google.golang.org/grpc/transport.(*http2Server).HandleStreams()
      ./vendor/google.golang.org/grpc/transport/http2_server.go:406 +0x648
  ./vendor/google.golang.org/grpc.(*Server).serveStreams()
      ./vendor/google.golang.org/grpc/server.go:585 +0x1bc
  ./vendor/google.golang.org/grpc.(*Server).handleRawConn()
      ./vendor/google.golang.org/grpc/server.go:546 +0x708

Goroutine 122 (finished) created at:
  ./vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      ./vendor/google.golang.org/grpc/server.go:587 +0xb8
  ./vendor/google.golang.org/grpc/transport.(*http2Server).operateHeaders()
      ./vendor/google.golang.org/grpc/transport/http2_server.go:374 +0x1433
  ./vendor/google.golang.org/grpc/transport.(*http2Server).HandleStreams()
      ./vendor/google.golang.org/grpc/transport/http2_server.go:406 +0x648
  ./vendor/google.golang.org/grpc.(*Server).serveStreams()
      ./vendor/google.golang.org/grpc/server.go:585 +0x1bc
  ./vendor/google.golang.org/grpc.(*Server).handleRawConn()
      ./vendor/google.golang.org/grpc/server.go:546 +0x708
==================
WARNING: 2018/03/16 03:30:34 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: Error while dialing context canceled"; Reconnecting to {localhost:45091831074893469940 0  <nil>}
WARNING: 2018/03/16 03:30:34 grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing
--- FAIL: TestV3MaintenanceDefragmentInflightRange (0.05s)
	testing.go:730: race detected during execution of test
FAIL
exit status 1
FAIL	./integration	0.069s
```