### PR TITLE
Documentation: 2379 port mistake

### DIFF
--- a/Documentation/tuning.md
+++ b/Documentation/tuning.md
@@ -75,8 +75,8 @@ These errors may be resolved by prioritizing etcd's peer traffic over its client
 tc qdisc add dev eth0 root handle 1: prio bands 3
 tc filter add dev eth0 parent 1: protocol ip prio 1 u32 match ip sport 2380 0xffff flowid 1:1
 tc filter add dev eth0 parent 1: protocol ip prio 1 u32 match ip dport 2380 0xffff flowid 1:1
-tc filter add dev eth0 parent 1: protocol ip prio 2 u32 match ip sport 2739 0xffff flowid 1:1
-tc filter add dev eth0 parent 1: protocol ip prio 2 u32 match ip dport 2739 0xffff flowid 1:1
+tc filter add dev eth0 parent 1: protocol ip prio 2 u32 match ip sport 2379 0xffff flowid 1:1
+tc filter add dev eth0 parent 1: protocol ip prio 2 u32 match ip dport 2379 0xffff flowid 1:1
 ```
 
 [ping]: https://en.wikipedia.org/wiki/Ping_(networking_utility)


### PR DESCRIPTION
Tunning: Network
The higher priority of port is 2379 instead of 2739 
