### PR TITLE
e2e: remove duplicate error check

### DIFF
--- a/e2e/v3_curl_test.go
+++ b/e2e/v3_curl_test.go
@@ -322,9 +322,6 @@ func testV3CurlProclaimMissiongLeaderKey(cx ctlCtx) {
 	if err != nil {
 		cx.t.Fatal(err)
 	}
-	if err != nil {
-		cx.t.Fatal(err)
-	}
 	if err = cURLPost(cx.epc, cURLReq{
 		endpoint: path.Join(cx.apiPrefix, "/election/proclaim"),
 		value:    string(pdata),


### PR DESCRIPTION
small cleanup while reviewing curl tests.
