### PR TITLE
*: document auto-compaction logic

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -236,6 +236,13 @@ See [security doc](https://github.com/coreos/etcd/blob/master/Documentation/op-g
 - Cluster rejects removing members if quorum will be lost.
 - Discovery now has upper limit for waiting on retries.
 - Warn on binding listeners through domain names; to be deprecated.
+- v3.0 and v3.1 with `--auto-compaction-retention=10` run periodic compaction on v3 key-value store for every 10-hour.
+  - Compactor only supports periodic compaction.
+  - Compactor records latest revisions every 5-minute, until it reaches the first compaction period (e.g. 10-hour).
+  - In order to retain key-value history of last compaction period, it uses the last revision that was fetched before compaction period, from the revision records that were collected every 5-minute.
+  - When `--auto-compaction-retention=10`, compactor uses revision 100 for compact revision where revision 100 is the latest revision fetched from 10 hours ago.
+  - If compaction succeeds or requested revision has already been compacted, it resets period timer and starts over with new historical revision records (e.g. restart revision collect and compact for the next 10-hour period).
+  - If compaction fails, it retries in 5 minutes.
 
 ### Go
 

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -428,6 +428,15 @@ See [security doc](https://github.com/coreos/etcd/blob/master/Documentation/op-g
 - Add `--enable-v2` flag to enable v2 API server.
   - `--enable-v2=true` by default.
 - Add `--auth-token` flag.
+- v3.2 compactor runs [every hour](https://github.com/coreos/etcd/pull/7875).
+  - Compactor only supports periodic compaction.
+  - Compactor continues to record latest revisions every 5-minute.
+  - For every hour, it uses the last revision that was fetched before compaction period, from the revision records that were collected every 5-minute.
+  - That is, for every hour, compactor discards historical data created before compaction period.
+  - The retention window of compaction period moves to next hour.
+  - For instance, when hourly writes are about 100 and `--auto-compaction-retention=10`, v3.1 compacts revision 1000, 2000, and 3000 for every 10-hour, while v3.2 compacts revision 1000, 1100, and 1200 for every 1-hour.
+  - If compaction succeeds or requested revision has already been compacted, it resets period timer and removes used compacted revision from historical revision records (e.g. start next revision collect and compaction from previously collected revisions).
+  - If compaction fails, it retries in 5 minutes.
 
 ### Added: `clientv3`
 


### PR DESCRIPTION
Related to https://github.com/coreos/etcd/pull/9443.

This summarizes how our auto-compaction logic has been changed.

/cc @fanminshi @yudai 