### PR TITLE
compactor: clean up, adjust retention window in periodic compaction

### DIFF
--- a/compactor/compactor.go
+++ b/compactor/compactor.go
@@ -29,8 +29,6 @@ var (
 )
 
 const (
-	checkCompactionInterval = 5 * time.Minute
-
 	ModePeriodic = "periodic"
 	ModeRevision = "revision"
 )

--- a/compactor/revision_test.go
+++ b/compactor/revision_test.go
@@ -38,13 +38,13 @@ func TestRevision(t *testing.T) {
 	tb.Run()
 	defer tb.Stop()
 
-	fc.Advance(checkCompactionInterval)
+	fc.Advance(revInterval)
 	rg.Wait(1)
 	// nothing happens
 
 	rg.SetRev(99) // will be 100
 	expectedRevision := int64(90)
-	fc.Advance(checkCompactionInterval)
+	fc.Advance(revInterval)
 	rg.Wait(1)
 	a, err := compactable.Wait(1)
 	if err != nil {
@@ -61,7 +61,7 @@ func TestRevision(t *testing.T) {
 
 	rg.SetRev(199) // will be 200
 	expectedRevision = int64(190)
-	fc.Advance(checkCompactionInterval)
+	fc.Advance(revInterval)
 	rg.Wait(1)
 	a, err = compactable.Wait(1)
 	if err != nil {
@@ -87,9 +87,9 @@ func TestRevisionPause(t *testing.T) {
 	tb.Pause()
 
 	// tb will collect 3 hours of revisions but not compact since paused
-	n := int(time.Hour / checkCompactionInterval)
+	n := int(time.Hour / revInterval)
 	for i := 0; i < 3*n; i++ {
-		fc.Advance(checkCompactionInterval)
+		fc.Advance(revInterval)
 	}
 	// tb ends up waiting for the clock
 
@@ -103,7 +103,7 @@ func TestRevisionPause(t *testing.T) {
 	tb.Resume()
 
 	// unblock clock, will kick off a compaction at hour 3:05
-	fc.Advance(checkCompactionInterval)
+	fc.Advance(revInterval)
 	rg.Wait(1)
 	a, err := compactable.Wait(1)
 	if err != nil {


### PR DESCRIPTION
If given compaction period is < 1h, compaction interval will be the same given compaction period (e.g. `--auto-compaction-retention=10m` will compact every 10-minute, rather than 1-minute as in v3.3.0).

If given compaction period is > 1h, compaction interval will be reset to 1h (e.g. `--auto-compaction-retention=2h` will compact every 1-hour, rather than 12-minute as in v3.3.0).

Replace https://github.com/coreos/etcd/pull/9443.