### PR TITLE
Do not recover db snapshot if index is 0

### DIFF
--- a/etcdserver/backend.go
+++ b/etcdserver/backend.go
@@ -73,7 +73,7 @@ func recoverSnapshotBackend(cfg *ServerConfig, oldbe backend.Backend, snapshot r
 	var cIndex consistentIndex
 	kv := mvcc.New(oldbe, &lease.FakeLessor{}, &cIndex)
 	defer kv.Close()
-	if snapshot.Metadata.Index <= kv.ConsistentIndex() {
+	if kv.ConsistentIndex() == 0 || snapshot.Metadata.Index <= kv.ConsistentIndex() {
 		return oldbe, nil
 	}
 	oldbe.Close()


### PR DESCRIPTION
... as that would indicate that the backend is a newly initialized
store rather than an outdated snapshot.

Fixes #9480 

cc @gyuho 