### PR TITLE
compactor: adjust interval for period <1-hour

### DIFF
--- a/compactor/periodic_test.go
+++ b/compactor/periodic_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
-func TestPeriodic(t *testing.T) {
+func TestPeriodicHourly(t *testing.T) {
 	retentionHours := 2
 	retentionDuration := time.Duration(retentionHours) * time.Hour
 
@@ -36,31 +36,59 @@ func TestPeriodic(t *testing.T) {
 
 	tb.Run()
 	defer tb.Stop()
-	checkCompactInterval := retentionDuration / time.Duration(periodDivisor)
-	n := periodDivisor
-	// simulate 5 hours worth of intervals.
-	for i := 0; i < n/retentionHours*5; i++ {
+	// simulate 5 hours
+
+	for i := 0; i < 5; i++ {
 		rg.Wait(1)
-		fc.Advance(checkCompactInterval)
+		fc.Advance(time.Hour)
 		// compaction doesn't happen til 2 hours elapses.
-		if i < n {
+		if i < retentionHours {
 			continue
 		}
-		// after 2 hours, compaction happens at every checkCompactInterval.
+		// after 2 hours, compaction happens at every interval.
+		// at i = 3, t.revs = [1(2h-ago,T=0h), 2(1h-ago,T=1h), 3(now,T=2h)] (len=3) (rev starts from 1)
 		a, err := compactable.Wait(1)
 		if err != nil {
 			t.Fatal(err)
 		}
-		expectedRevision := int64(i + 1 - n)
+		expectedRevision := int64(i - 1)
 		if !reflect.DeepEqual(a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision}) {
 			t.Errorf("compact request = %v, want %v", a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision})
 		}
 	}
+}
 
-	// unblock the rev getter, so we can stop the compactor routine.
-	_, err := rg.Wait(1)
-	if err != nil {
-		t.Fatal(err)
+func TestPeriodicMinutes(t *testing.T) {
+	retentionMinutes := 23
+	retentionDuration := time.Duration(retentionMinutes) * time.Minute
+
+	fc := clockwork.NewFakeClock()
+	rg := &fakeRevGetter{testutil.NewRecorderStream(), 0}
+	compactable := &fakeCompactable{testutil.NewRecorderStream()}
+	tb := newPeriodic(fc, retentionDuration, rg, compactable)
+
+	tb.Run()
+	defer tb.Stop()
+
+	// simulate 115 (23 * 5) minutes
+	for i := 0; i < 5; i++ {
+		rg.Wait(1)
+		fc.Advance(retentionDuration)
+
+		// notting happens at T=0
+		if i == 0 {
+			continue
+		}
+		// from T=23m (i=1), compaction happens at every interval
+		a, err := compactable.Wait(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedRevision := int64(i)
+		if !reflect.DeepEqual(a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision}) {
+			t.Errorf("compact request = %v, want %v", a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision})
+		}
+
 	}
 }
 
@@ -75,13 +103,17 @@ func TestPeriodicPause(t *testing.T) {
 	tb.Pause()
 
 	// tb will collect 3 hours of revisions but not compact since paused
-	checkCompactInterval := retentionDuration / time.Duration(periodDivisor)
-	n := periodDivisor
-	for i := 0; i < 3*n; i++ {
-		rg.Wait(1)
-		fc.Advance(checkCompactInterval)
-	}
-	// tb ends up waiting for the clock
+	// T=0
+	rg.Wait(1) // t.revs = [1]
+	fc.Advance(time.Hour)
+	// T=1h
+	rg.Wait(1) // t.revs = [1, 2]
+	fc.Advance(time.Hour)
+	// T=2h
+	rg.Wait(1) // t.revs = [2, 3]
+	fc.Advance(time.Hour)
+	// T=3h
+	rg.Wait(1) // t.revs = [3, 4]
 
 	select {
 	case a := <-compactable.Chan():
@@ -92,15 +124,15 @@ func TestPeriodicPause(t *testing.T) {
 	// tb resumes to being blocked on the clock
 	tb.Resume()
 
-	// unblock clock, will kick off a compaction at hour 3:06
-	rg.Wait(1)
-	fc.Advance(checkCompactInterval)
+	// unblock clock, will kick off a compaction at T=3h6m by retry
+	fc.Advance(time.Minute * 6)
+	// T=3h6m
 	a, err := compactable.Wait(1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// compact the revision from hour 2:06
-	wreq := &pb.CompactionRequest{Revision: int64(1 + 2*n + 1)}
+	// compact the revision from T=3h
+	wreq := &pb.CompactionRequest{Revision: int64(3)}
 	if !reflect.DeepEqual(a[0].Params[0], wreq) {
 		t.Errorf("compact request = %v, want %v", a[0].Params[0], wreq.Revision)
 	}


### PR DESCRIPTION
Simplified version of https://github.com/coreos/etcd/pull/9482.
Similar to how v3.2 works while handling compaction period <1-hour.

Address https://github.com/coreos/etcd/pull/9443.