### PR TITLE
Automated cherry pick of #9437

### DIFF
--- a/rafthttp/peer.go
+++ b/rafthttp/peer.go
@@ -225,6 +225,7 @@ func (p *peer) send(m raftpb.Message) {
 			plog.MergeWarningf("dropped internal raft message to %s since %s's sending buffer is full (bad/overloaded network)", p.id, name)
 		}
 		plog.Debugf("dropped %s to %s since %s's sending buffer is full", m.Type, p.id, name)
+		sentFailures.WithLabelValues(types.ID(m.To).String()).Inc()
 	}
 }
 

--- a/rafthttp/remote.go
+++ b/rafthttp/remote.go
@@ -53,6 +53,7 @@ func (g *remote) send(m raftpb.Message) {
 			plog.MergeWarningf("dropped internal raft message to %s since sending buffer is full (bad/overloaded network)", g.id)
 		}
 		plog.Debugf("dropped %s to %s since sending buffer is full", m.Type, g.id)
+		sentFailures.WithLabelValues(types.ID(m.To).String()).Inc()
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #9437 on release-3.2.

#9437: rafthttp: add missing "peer_sent_failures_total" metrics call