### PR TITLE
lease: remove unnecessary O(log N) heap operation when nothing is expiry

### DIFF
--- a/lease/lease_queue.go
+++ b/lease/lease_queue.go
@@ -14,8 +14,9 @@
 
 package lease
 
+// LeaseWithTime contains lease object with expire information.
 type LeaseWithTime struct {
-	leaseId    LeaseID
+	id         LeaseID
 	expiration int64
 	index      int
 }

--- a/lease/lease_queue_test.go
+++ b/lease/lease_queue_test.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lease
+
+import (
+	"container/heap"
+	"testing"
+	"time"
+)
+
+func TestLeaseQueue(t *testing.T) {
+	le := &lessor{
+		leaseHeap: make(LeaseQueue, 0),
+		leaseMap:  make(map[LeaseID]*Lease),
+	}
+	heap.Init(&le.leaseHeap)
+
+	// insert in reverse order of expiration time
+	for i := 50; i >= 1; i-- {
+		exp := time.Now().Add(time.Hour).UnixNano()
+		if i == 1 {
+			exp = time.Now().UnixNano()
+		}
+		le.leaseMap[LeaseID(i)] = &Lease{ID: LeaseID(i)}
+		heap.Push(&le.leaseHeap, &LeaseWithTime{id: LeaseID(i), expiration: exp})
+	}
+
+	// first element must be front
+	if le.leaseHeap[0].id != LeaseID(1) {
+		t.Fatalf("first item expected lease ID %d, got %d", LeaseID(1), le.leaseHeap[0].id)
+	}
+}

--- a/lease/lease_queue_test.go
+++ b/lease/lease_queue_test.go
@@ -52,4 +52,8 @@ func TestLeaseQueue(t *testing.T) {
 	if more {
 		t.Fatal("expect no more expiry lease")
 	}
+
+	if le.leaseHeap.Len() != 49 {
+		t.Fatalf("expected lease heap pop, got %d", le.leaseHeap.Len())
+	}
 }

--- a/lease/lease_queue_test.go
+++ b/lease/lease_queue_test.go
@@ -41,4 +41,15 @@ func TestLeaseQueue(t *testing.T) {
 	if le.leaseHeap[0].id != LeaseID(1) {
 		t.Fatalf("first item expected lease ID %d, got %d", LeaseID(1), le.leaseHeap[0].id)
 	}
+
+	l, ok, more := le.expireExists()
+	if l.ID != 1 {
+		t.Fatalf("first item expected lease ID %d, got %d", 1, l.ID)
+	}
+	if !ok {
+		t.Fatal("expect expiry lease exists")
+	}
+	if more {
+		t.Fatal("expect no more expiry lease")
+	}
 }

--- a/lease/lessor.go
+++ b/lease/lessor.go
@@ -235,7 +235,7 @@ func (le *lessor) Grant(id LeaseID, ttl int64) (*Lease, error) {
 	}
 
 	le.leaseMap[id] = l
-	item := &LeaseWithTime{leaseId: l.ID, expiration: l.expiry.UnixNano()}
+	item := &LeaseWithTime{id: l.ID, expiration: l.expiry.UnixNano()}
 	heap.Push(&le.leaseHeap, item)
 	l.persistTo(le.b)
 
@@ -319,7 +319,7 @@ func (le *lessor) Renew(id LeaseID) (int64, error) {
 	}
 
 	l.refresh(0)
-	item := &LeaseWithTime{leaseId: l.ID, expiration: l.expiry.UnixNano()}
+	item := &LeaseWithTime{id: l.ID, expiration: l.expiry.UnixNano()}
 	heap.Push(&le.leaseHeap, item)
 	return l.ttl, nil
 }
@@ -355,7 +355,7 @@ func (le *lessor) Promote(extend time.Duration) {
 	// refresh the expiries of all leases.
 	for _, l := range le.leaseMap {
 		l.refresh(extend)
-		item := &LeaseWithTime{leaseId: l.ID, expiration: l.expiry.UnixNano()}
+		item := &LeaseWithTime{id: l.ID, expiration: l.expiry.UnixNano()}
 		heap.Push(&le.leaseHeap, item)
 	}
 
@@ -392,7 +392,7 @@ func (le *lessor) Promote(extend time.Duration) {
 		delay := time.Duration(rateDelay)
 		nextWindow = baseWindow + delay
 		l.refresh(delay + extend)
-		item := &LeaseWithTime{leaseId: l.ID, expiration: l.expiry.UnixNano()}
+		item := &LeaseWithTime{id: l.ID, expiration: l.expiry.UnixNano()}
 		heap.Push(&le.leaseHeap, item)
 	}
 }
@@ -532,7 +532,7 @@ func (le *lessor) findExpiredLeases(limit int) []*Lease {
 		}
 
 		item := heap.Pop(&le.leaseHeap).(*LeaseWithTime)
-		l := le.leaseMap[item.leaseId]
+		l := le.leaseMap[item.id]
 		if l == nil {
 			// lease has expired or been revoked, continue
 			continue


### PR DESCRIPTION
Since heap is already sorted, we can just check first element
to see if anything is expiry, rather than popping and pushing
it back. If nothing is expiry, pop operation O(log N) is unnecessary.

/cc @xiang90 @mgates @jcalvert

ref. https://github.com/coreos/etcd/pull/9418.