### PR TITLE
functional-tester: use "clientv3" for stressers

### DIFF
--- a/tools/functional-tester/rpcpb/member.go
+++ b/tools/functional-tester/rpcpb/member.go
@@ -41,15 +41,17 @@ func (m *Member) DialEtcdGRPCServer(opts ...grpc.DialOption) (*grpc.ClientConn, 
 }
 
 // CreateEtcdClient creates a client from member.
-func (m *Member) CreateEtcdClient() (*clientv3.Client, error) {
+func (m *Member) CreateEtcdClient(opts ...grpc.DialOption) (*clientv3.Client, error) {
+	cfg := clientv3.Config{
+		Endpoints:   []string{m.EtcdClientEndpoint},
+		DialTimeout: 5 * time.Second,
+		DialOptions: opts,
+	}
 	if m.EtcdClientTLS {
 		// TODO: support TLS
 		panic("client TLS not supported yet")
 	}
-	return clientv3.New(clientv3.Config{
-		Endpoints:   []string{m.EtcdClientEndpoint},
-		DialTimeout: 5 * time.Second,
-	})
+	return clientv3.New(cfg)
 }
 
 // CheckCompact ensures that historical data before given revision has been compacted.

--- a/tools/functional-tester/tester/checks.go
+++ b/tools/functional-tester/tester/checks.go
@@ -113,6 +113,7 @@ func (lc *leaseChecker) Check() error {
 			cli.Close()
 		}
 	}()
+	lc.cli = cli
 	if err := lc.check(true, lc.ls.revokedLeases.leases); err != nil {
 		return err
 	}

--- a/tools/functional-tester/tester/stress_key.go
+++ b/tools/functional-tester/tester/stress_key.go
@@ -259,8 +259,8 @@ func writeTxn(cli *clientv3.Client, keys []string, txnOps int) stressFunc {
 		}
 		_, err := cli.Txn(ctx).
 			If(com).
-			Else(elseOps...).
 			Then(thenOps...).
+			Else(elseOps...).
 			Commit()
 		return err, int64(txnOps)
 	}


### PR DESCRIPTION
We already use `clientv3` in some functional-tester code. As long as we configure clients with only one endpoint, the stressing client should behave the same, except now it defaults to `grpc.FailFast(true)` (e.g. clientv3 retry logic vs. gRPC internal retry logic with `grpc.FailFast(false)`).

I ran this for a few rounds, but so far it works. I will address any other issues from this change later.
More important to run tests with TLS https://github.com/coreos/etcd/issues/8943.
Need to use `clientv3` for easier TLS client set up.