### PR TITLE
ctlv3: support "write-out" for "endpoint health" command

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -141,6 +141,8 @@ See [security doc](https://github.com/coreos/etcd/blob/master/Documentation/op-g
 - Add [`defrag --cluster`](https://github.com/coreos/etcd/pull/9390) flag.
 - Add ["raft applied index" field to `endpoint status`](https://github.com/coreos/etcd/pull/9176).
 - Add ["errors" field to `endpoint status`](https://github.com/coreos/etcd/pull/9206).
+- Add [`endpoint health --write-out` support](https://github.com/coreos/etcd/pull/9540).
+  - Previously, [`endpoint health --write-out json` did not work](https://github.com/coreos/etcd/issues/9532).
 
 ### Added: gRPC gateway
 

--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -44,6 +44,7 @@ type printer interface {
 	MemberUpdate(id uint64, r v3.MemberUpdateResponse)
 	MemberList(v3.MemberListResponse)
 
+	EndpointHealth([]epHealth)
 	EndpointStatus([]epStatus)
 	EndpointHashKV([]epHashKV)
 	MoveLeader(leader, target uint64, r v3.MoveLeaderResponse)
@@ -149,6 +150,7 @@ func newPrinterUnsupported(n string) printer {
 	return &printerUnsupported{printerRPC{nil, f}}
 }
 
+func (p *printerUnsupported) EndpointHealth([]epHealth) { p.p(nil) }
 func (p *printerUnsupported) EndpointStatus([]epStatus) { p.p(nil) }
 func (p *printerUnsupported) EndpointHashKV([]epHashKV) { p.p(nil) }
 func (p *printerUnsupported) DBStatus(snapshot.Status)  { p.p(nil) }
@@ -168,6 +170,19 @@ func makeMemberListTable(r v3.MemberListResponse) (hdr []string, rows [][]string
 			m.Name,
 			strings.Join(m.PeerURLs, ","),
 			strings.Join(m.ClientURLs, ","),
+		})
+	}
+	return hdr, rows
+}
+
+func makeEndpointHealthTable(healthList []epHealth) (hdr []string, rows [][]string) {
+	hdr = []string{"endpoint", "health", "took", "error"}
+	for _, h := range healthList {
+		rows = append(rows, []string{
+			h.Ep,
+			fmt.Sprintf("%v", h.Health),
+			h.Took,
+			h.Error,
 		})
 	}
 	return hdr, rows

--- a/etcdctl/ctlv3/command/printer_fields.go
+++ b/etcdctl/ctlv3/command/printer_fields.go
@@ -141,6 +141,16 @@ func (p *fieldsPrinter) MemberList(r v3.MemberListResponse) {
 	}
 }
 
+func (p *fieldsPrinter) EndpointHealth(hs []epHealth) {
+	for _, h := range hs {
+		fmt.Printf("\"Endpoint\" : %q\n", h.Ep)
+		fmt.Println(`"Health" :`, h.Health)
+		fmt.Println(`"Took" :`, h.Took)
+		fmt.Println(`"Error" :`, h.Error)
+		fmt.Println()
+	}
+}
+
 func (p *fieldsPrinter) EndpointStatus(eps []epStatus) {
 	for _, ep := range eps {
 		p.hdr(ep.Resp.Header)

--- a/etcdctl/ctlv3/command/printer_json.go
+++ b/etcdctl/ctlv3/command/printer_json.go
@@ -30,6 +30,7 @@ func newJSONPrinter() printer {
 	}
 }
 
+func (p *jsonPrinter) EndpointHealth(r []epHealth) { printJSON(r) }
 func (p *jsonPrinter) EndpointStatus(r []epStatus) { printJSON(r) }
 func (p *jsonPrinter) EndpointHashKV(r []epHashKV) { printJSON(r) }
 func (p *jsonPrinter) DBStatus(r snapshot.Status)  { printJSON(r) }

--- a/etcdctl/ctlv3/command/printer_simple.go
+++ b/etcdctl/ctlv3/command/printer_simple.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	v3 "github.com/coreos/etcd/clientv3"
@@ -139,6 +140,16 @@ func (s *simplePrinter) MemberList(resp v3.MemberListResponse) {
 	_, rows := makeMemberListTable(resp)
 	for _, row := range rows {
 		fmt.Println(strings.Join(row, ", "))
+	}
+}
+
+func (s *simplePrinter) EndpointHealth(hs []epHealth) {
+	for _, h := range hs {
+		if h.Error == "" {
+			fmt.Fprintf(os.Stderr, "%s is healthy: successfully committed proposal: took = %v\n", h.Ep, h.Took)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s is unhealthy: failed to commit proposal: %v", h.Ep, h.Error)
+		}
 	}
 }
 

--- a/etcdctl/ctlv3/command/printer_table.go
+++ b/etcdctl/ctlv3/command/printer_table.go
@@ -35,6 +35,16 @@ func (tp *tablePrinter) MemberList(r v3.MemberListResponse) {
 	table.SetAlignment(tablewriter.ALIGN_RIGHT)
 	table.Render()
 }
+func (tp *tablePrinter) EndpointHealth(r []epHealth) {
+	hdr, rows := makeEndpointHealthTable(r)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(hdr)
+	for _, row := range rows {
+		table.Append(row)
+	}
+	table.SetAlignment(tablewriter.ALIGN_RIGHT)
+	table.Render()
+}
 func (tp *tablePrinter) EndpointStatus(r []epStatus) {
 	hdr, rows := makeEndpointStatusTable(r)
 	table := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
```bash
$ ETCDCTL_API=3 ./bin/etcdctl endpoint --cluster health --write-out simple                                                    
http://127.0.0.1:2379 is healthy: successfully committed proposal: took = 474.51µs                                                                            
http://127.0.0.1:32379 is healthy: successfully committed proposal: took = 719.75µs                                                                           
http://127.0.0.1:22379 is healthy: successfully committed proposal: took = 459.323µs                                                                          

$ ETCDCTL_API=3 ./bin/etcdctl endpoint --cluster health --write-out table                                                     
+------------------------+--------+-----------+-------+                        
|        ENDPOINT        | HEALTH |   TOOK    | ERROR |                        
+------------------------+--------+-----------+-------+                        
|  http://127.0.0.1:2379 |   true | 520.835µs |       |                        
| http://127.0.0.1:32379 |   true | 518.894µs |       |                        
| http://127.0.0.1:22379 |   true | 751.764µs |       |                        
+------------------------+--------+-----------+-------+                        

$ ETCDCTL_API=3 ./bin/etcdctl endpoint --cluster health --write-out proto                                                     
Error: unsupported output format       

$ ETCDCTL_API=3 ./bin/etcdctl endpoint --cluster health --write-out json                                                      
[{"endpoint":"http://127.0.0.1:32379","health":true,"took":"749.662µs"},{"endpoint":"http://127.0.0.1:2379","health":true,"took":"456.438µs"},{"endpoint":"http://127.0.0.1:22379","health":true,"took":"772.233µs"}]
```

Fix https://github.com/coreos/etcd/issues/9532.

/cc @omkensey