### PR TITLE
*: parallelize tests, remove redundant tests, Phase 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,75 +15,124 @@ notifications:
 
 env:
   matrix:
-  - TARGET=amd64
-  - TARGET=amd64-go-tip
-  - TARGET=darwin-amd64
-  - TARGET=windows-amd64
-  - TARGET=arm64
-  - TARGET=arm
-  - TARGET=386
-  - TARGET=ppc64le
+  - TARGET=linux-amd64-build
+  - TARGET=linux-amd64-unit
+  - TARGET=linux-amd64-fmt
+  - TARGET=linux-amd64-integration
+  - TARGET=linux-amd64-functional
+  - TARGET=linux-386-build
+  - TARGET=linux-386-unit
+  - TARGET=darwin-amd64-build
+  - TARGET=windows-amd64-build
+  - TARGET=linux-arm-build
+  - TARGET=linux-arm64-build
+  - TARGET=linux-ppc64le-build
+  - TARGET=linux-amd64-fmt-unit-go-tip
 
 matrix:
   fast_finish: true
   allow_failures:
   - go: tip
-    env: TARGET=amd64-go-tip
+    env: TARGET=linux-amd64-fmt-unit-go-tip
   exclude:
+  - go: tip
+    env: TARGET=linux-amd64-build
+  - go: tip
+    env: TARGET=linux-amd64-unit
+  - go: tip
+    env: TARGET=linux-amd64-fmt
+  - go: tip
+    env: TARGET=linux-amd64-integration
+  - go: tip
+    env: TARGET=linux-amd64-functional
+  - go: tip
+    env: TARGET=linux-386-build
+  - go: tip
+    env: TARGET=linux-386-unit
+  - go: tip
+    env: TARGET=darwin-amd64-build
+  - go: tip
+    env: TARGET=windows-amd64-build
+  - go: tip
+    env: TARGET=linux-arm-build
+  - go: tip
+    env: TARGET=linux-arm64-build
+  - go: tip
+    env: TARGET=linux-ppc64le-build
   - go: 1.10.1
-    env: TARGET=amd64-go-tip
-  - go: tip
-    env: TARGET=amd64
-  - go: tip
-    env: TARGET=darwin-amd64
-  - go: tip
-    env: TARGET=windows-amd64
-  - go: tip
-    env: TARGET=arm
-  - go: tip
-    env: TARGET=arm64
-  - go: tip
-    env: TARGET=386
-  - go: tip
-    env: TARGET=ppc64le
+    env: TARGET=linux-amd64-fmt-unit-go-tip
 
 before_install:
 - if [[ $TRAVIS_GO_VERSION == 1.* ]]; then docker pull gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION}; fi
 
 install:
-- go get -t -v ./...
+- go get -t -d ./...
 
 script:
  - echo "TRAVIS_GO_VERSION=${TRAVIS_GO_VERSION}"
  - >
     case "${TARGET}" in
-      amd64)
+      linux-amd64-build)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 ./test"
+          /bin/bash -c "GOARCH=amd64 PASSES='build' ./test"
         ;;
-      amd64-go-tip)
-        GOARCH=amd64 ./test
-        ;;
-      darwin-amd64)
+      linux-amd64-unit)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-a -v' GOOS=darwin GOARCH=amd64 ./build"
+          /bin/bash -c "GOARCH=amd64 PASSES='unit' ./test"
         ;;
-      windows-amd64)
+      linux-amd64-fmt)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-a -v' GOOS=windows GOARCH=amd64 ./build"
+          /bin/bash -c "GOARCH=amd64 PASSES='fmt bom dep' ./test"
         ;;
-      386)
+      linux-amd64-integration)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=386 PASSES='build unit' ./test"
+          /bin/bash -c "GOARCH=amd64 PASSES='integration' ./test"
         ;;
-      *)
-        # test building out of gopath
+      linux-amd64-functional)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-a -v' GOARCH='${TARGET}' ./build"
+          /bin/bash -c "./build && GOARCH=amd64 PASSES='functional' ./test"
+        ;;
+      linux-386-build)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GOARCH=386 PASSES='build' ./test"
+        ;;
+      linux-386-unit)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GOARCH=386 PASSES='unit' ./test"
+        ;;
+      darwin-amd64-build)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GO_BUILD_FLAGS='-v' GOOS=darwin GOARCH=amd64 ./build"
+        ;;
+      windows-amd64-build)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GO_BUILD_FLAGS='-v' GOOS=windows GOARCH=amd64 ./build"
+        ;;
+      linux-arm-build)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GO_BUILD_FLAGS='-v' GOARCH=arm ./build"
+        ;;
+      linux-arm64-build)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GO_BUILD_FLAGS='-v' GOARCH=arm64 ./build"
+        ;;
+      linux-ppc64le-build)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GO_BUILD_FLAGS='-v' GOARCH=ppc64le ./build"
+        ;;
+      linux-amd64-fmt-unit-go-tip)
+        GOARCH=amd64 PASSES='fmt unit' ./test
         ;;
     esac

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ compile-setup-gopath-with-docker-test:
 #
 # Local machine:
 #   TEST_OPTS="PASSES='fmt'" make test
-#   TEST_OPTS="PASSES='fmt bom dep compile build unit'" make test
+#   TEST_OPTS="PASSES='fmt bom dep build unit'" make test
 #   TEST_OPTS="PASSES='build unit release integration_e2e functional'" make test
 #   TEST_OPTS="PASSES='build grpcproxy'" make test
 #
@@ -128,7 +128,7 @@ compile-setup-gopath-with-docker-test:
 #   TEST_OPTS="VERBOSE=2 PASSES='unit'" make docker-test
 #
 # Travis CI (test with docker):
-#   TEST_OPTS="PASSES='fmt bom dep compile build unit'" make docker-test
+#   TEST_OPTS="PASSES='fmt bom dep build unit'" make docker-test
 #
 # Semaphore CI (test with docker):
 #   TEST_OPTS="PASSES='build unit release integration_e2e functional'" make docker-test

--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -1,18 +1,5 @@
 [
 	{
-		"project": "bitbucket.org/ww/goautoneg",
-		"licenses": [
-			{
-				"type": "Apache License 2.0",
-				"confidence": 1
-			},
-			{
-				"type": "BSD 3-clause \"New\" or \"Revised\" License",
-				"confidence": 1
-			}
-		]
-	},
-	{
 		"project": "github.com/beorn7/perks/quantile",
 		"licenses": [
 			{

--- a/bill-of-materials.override.json
+++ b/bill-of-materials.override.json
@@ -1,13 +1,5 @@
 [
 	{
-		"project": "bitbucket.org/ww/goautoneg",
-		"licenses": [
-			{
-				"type": "BSD 3-clause \"New\" or \"Revised\" License"
-			}
-		]
-	},
-	{
 		"project": "github.com/ghodss/yaml",
 		"licenses": [
 			{

--- a/etcdserver/v2_server.go
+++ b/etcdserver/v2_server.go
@@ -101,12 +101,7 @@ func (a *reqV2HandlerEtcdServer) processRaftRequest(ctx context.Context, r *Requ
 	ch := a.s.w.Register(r.ID)
 
 	start := time.Now()
-	err = a.s.r.Propose(ctx, data)
-	if err != nil {
-		proposalsFailed.Inc()
-		a.s.w.Trigger(r.ID, nil)
-		return Response{}, err
-	}
+	a.s.r.Propose(ctx, data)
 	proposalsPending.Inc()
 	defer proposalsPending.Dec()
 

--- a/test
+++ b/test
@@ -41,7 +41,7 @@ if [[ "${PASSES}" == *"functional"* ]]; then
 fi
 
 if [ -z "$PASSES" ]; then
-	PASSES="fmt bom dep compile build unit"
+	PASSES="fmt bom dep build unit"
 fi
 
 USERPKG=${PKG:-}
@@ -619,14 +619,11 @@ function build_cov_pass {
 	go test -tags cov -c -covermode=set -coverpkg="$PKGS_COMMA" -o "${out}/etcdctl_test" "${REPO_PATH}/etcdctl"
 }
 
-function compile_pass {
-	echo "Checking build..."
-	GO_BUILD_FLAGS="-a -v" tools_build
-}
-
 # fail fast on static tests
 function build_pass {
+	echo "Checking build..."
 	GO_BUILD_FLAGS="-a -v" etcd_build
+	GO_BUILD_FLAGS="-a -v" tools_build
 }
 
 for pass in $PASSES; do

--- a/test
+++ b/test
@@ -195,21 +195,20 @@ function functional_pass {
 		done
 	done
 
-	echo "Starting 'etcd-tester'"
+	echo "functional test START!"
 	./bin/etcd-tester --config ./functional.yaml && echo "'etcd-tester' succeeded"
 	ETCD_TESTER_EXIT_CODE=$?
 	echo "ETCD_TESTER_EXIT_CODE:" ${ETCD_TESTER_EXIT_CODE}
 
-	echo "Waiting for processes to exit"
 	# shellcheck disable=SC2206
 	agent_pids=($agent_pids)
-	kill -s TERM "${agent_pids[@]}"
-	for a in "${agent_pids[@]}"; do wait "$a" || true; done
+	kill -s TERM "${agent_pids[@]}" || true
 
 	if [[ "${ETCD_TESTER_EXIT_CODE}" -ne "0" ]]; then
 		echo "--- FAIL: exit code" ${ETCD_TESTER_EXIT_CODE}
 		exit ${ETCD_TESTER_EXIT_CODE}
 	fi
+	echo "functional test PASS!"
 }
 
 function cov_pass {
@@ -551,7 +550,7 @@ function commit_title_pass {
 		spaceCommas=$(echo "$commitMsg" | sed 's/ /\n/g' | grep -c ',$' || echo 0)
 		commaSpaces=$(echo "$commitMsg" | sed 's/,/\n/g' | grep -c '^ ' || echo 0)
 		if [[ $(echo "$commitMsg" | grep -c ":..*") == 0 || "$commitMsg" == "$pkgPrefix" || "$spaceCommas" != "$commaSpaces" ]]; then
-    			echo "$l"...
+			echo "$l"...
 			echo "Expected commit title format '<package>{\", \"<package>}: <description>'"
 			echo "Got: $l"
 			exit 255

--- a/tests/semaphore.test.bash
+++ b/tests/semaphore.test.bash
@@ -7,9 +7,9 @@ fi
 
 TEST_SUFFIX=$(date +%s | base64 | head -c 15)
 
-TEST_OPTS="PASSES='build unit release integration_e2e functional' MANUAL_VER=v3.3.3"
+TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.3.3"
 if [ "$TEST_ARCH" == "386" ]; then
-  TEST_OPTS="GOARCH=386 PASSES='build unit integration_e2e'"
+  TEST_OPTS="GOARCH=386 PASSES='build e2e'"
 fi
 
 docker run \


### PR DESCRIPTION
Address https://github.com/coreos/etcd/issues/8862.

Currently, semaphore runs almost >50min. We have 5 workers in travis (vs. 2 workers in semaphore), so move `functional` and `integraion` tests to Travis, and only run `e2e` tests in semaphore. This should reduce test runtime from 50-min to 35-min.

Later, split more over to Jenkins.