### PR TITLE
etcdserver/stats: fix stats data race.

### DIFF
--- a/etcdserver/stats/server.go
+++ b/etcdserver/stats/server.go
@@ -74,10 +74,10 @@ type serverStats struct {
 func (ss *ServerStats) JSON() []byte {
 	ss.Lock()
 	stats := ss.serverStats
-	ss.Unlock()
-	stats.LeaderInfo.Uptime = time.Since(stats.LeaderInfo.StartTime).String()
 	stats.SendingPkgRate, stats.SendingBandwidthRate = stats.sendRateQueue.Rate()
 	stats.RecvingPkgRate, stats.RecvingBandwidthRate = stats.recvRateQueue.Rate()
+	ss.Unlock()
+	stats.LeaderInfo.Uptime = time.Since(stats.LeaderInfo.StartTime).String()
 	b, err := json.Marshal(stats)
 	// TODO(jonboulle): appropriate error handling?
 	if err != nil {


### PR DESCRIPTION
Hi, the data race is recently reported from our CI. We are using etcd v3.2.14 as embed library.

```
WARNING: DATA RACE
Write at 0x00c425a78640 by goroutine 13:
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/stats.(*statsQueue).Insert()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/stats/queue.go:72 +0x3e3
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/stats.(*ServerStats).SendAppendReq()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/stats/server.go:120 +0x153
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/rafthttp.(*Transport).Send()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/rafthttp/transport.go:174 +0x343
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver.(*raftNode).start.func1()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/raft.go:214 +0xf4b
Previous read at 0x00c425a78640 by goroutine 99:
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/stats.(*statsQueue).Rate()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/stats/queue.go:43 +0x184
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/stats.(*ServerStats).JSON()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/stats/server.go:79 +0x122
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver.(*EtcdServer).SelfStats()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/server.go:1015 +0x58
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/api/v2http.(*statsHandler).serveSelf()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/api/v2http/client.go:301 +0x13b
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/api/v2http.(*statsHandler).(github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/api/v2http.serveSelf)-fm()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/api/v2http/client.go:95 +0x5f
  net/http.HandlerFunc.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.4.linux.amd64/src/net/http/server.go:1918 +0x51
  net/http.(*ServeMux).ServeHTTP()
      /home/travis/.gimme/versions/go1.9.4.linux.amd64/src/net/http/server.go:2254 +0xa2
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/api/v2http.requestLogger.func1()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/api/v2http/http.go:72 +0x20f
  net/http.HandlerFunc.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.4.linux.amd64/src/net/http/server.go:1918 +0x51
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/pkg/cors.(*CORSHandler).ServeHTTP()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/pkg/cors/cors.go:89 +0x16d
  net/http.(*ServeMux).ServeHTTP()
      /home/travis/.gimme/versions/go1.9.4.linux.amd64/src/net/http/server.go:2254 +0xa2
  net/http.serverHandler.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.4.linux.amd64/src/net/http/server.go:2619 +0xbc
  net/http.(*conn).serve()
      /home/travis/.gimme/versions/go1.9.4.linux.amd64/src/net/http/server.go:1801 +0x83b
Goroutine 13 (running) created at:
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver.(*raftNode).start()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/raft.go:157 +0x5f
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver.(*EtcdServer).run()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/etcdserver/server.go:678 +0x58b
Goroutine 99 (finished) created at:
  net/http.(*Server).Serve()
      /home/travis/.gimme/versions/go1.9.4.linux.amd64/src/net/http/server.go:2720 +0x37c
  github.com/pingcap/pd/vendor/github.com/coreos/etcd/embed.(*serveCtx).serve.func2()
      /home/travis/gopath/src/github.com/pingcap/pd/vendor/github.com/coreos/etcd/embed/serve.go:116 +0x4c
```