### PR TITLE
etcdserver: add is_leader prometheus metric that is 1 on the leader.

### DIFF
--- a/etcdserver/metrics.go
+++ b/etcdserver/metrics.go
@@ -30,6 +30,12 @@ var (
 		Name:      "has_leader",
 		Help:      "Whether or not a leader exists. 1 is existence, 0 is not.",
 	})
+	isLeader = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "is_leader",
+		Help:      "Whether or not this member is a leader. 1 if is, 0 otherwise.",
+	})
 	leaderChanges = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "etcd",
 		Subsystem: "server",
@@ -77,6 +83,7 @@ var (
 
 func init() {
 	prometheus.MustRegister(hasLeader)
+	prometheus.MustRegister(isLeader)
 	prometheus.MustRegister(leaderChanges)
 	prometheus.MustRegister(proposalsCommitted)
 	prometheus.MustRegister(proposalsApplied)

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -182,6 +182,11 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 
 					rh.updateLead(rd.SoftState.Lead)
 					islead = rd.RaftState == raft.StateLeader
+					if islead {
+						isLeader.Set(1)
+					} else {
+						isLeader.Set(0)
+					}
 					rh.updateLeadership(newLeader)
 					r.td.Reset()
 				}


### PR DESCRIPTION
Before this change, we had now way to find a leader using /metrics endpoint. This commit adds a metric to do that.