### PR TITLE
etcdctl/ctlv3/command: enable gRPC WARNING logs by default

### DIFF
--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -128,7 +128,9 @@ func clientConfigFromCmd(cmd *cobra.Command) *clientConfig {
 			fmt.Fprintf(os.Stderr, "%s=%v\n", flags.FlagToEnv("ETCDCTL", f.Name), f.Value)
 		})
 	} else {
-		clientv3.SetLogger(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+		// Enable logging for WARNING and ERROR logs since these levels include fatal error
+		// such as TLS misconfiguration
+		clientv3.SetLogger(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
 	}
 
 	cfg := &clientConfig{}


### PR DESCRIPTION
Fixes https://github.com/coreos/etcd/issues/9619

Before

```
$ ETCDCTL_API=3 etcdctl --cert tls/etcd-client.crt --key tls/etcd-client.key get keys --endpoints=https://etcd-1.local:12379 get keys                                                                                                                            
Error: context deadline exceeded
```

After

```
$ ETCDCTL_API=3 etcdctl --cert tls/etcd-client.crt --key tls/etcd-client.key get keys --endpoints=https://etcd-1.local:12379 get keys                                                                                                                          
WARNING: 2018/04/24 15:34:04 Failed to dial etcd-1.local:12379: connection error: desc = "transport: authentication handshake failed: x509: certificate signed by unknown authority"; please retry.
Error: context deadline exceeded
```

Way down in the depths of the gRPC package, their global logger swallows TLS errors unless you enable at least WARNING errors.

https://github.com/coreos/etcd/blob/f1b3b327459810465c712beb5d7859e7198d0dd8/vendor/google.golang.org/grpc/clientconn.go#L696

By default, etcdctl silences these log messages, and it seems like others have hit this with things other than TLS configuration:

https://github.com/coreos/etcd/issues/9610
https://github.com/coreos/etcd/issues/8793

INFO would definitely be too high by default, but if we hit a warning or an error, this seems worth displaying to the user.

cc @gyuho @xiang90 