### PR TITLE
scripts: Fix a few etcd release script bugs and make it reenterant.

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -16,6 +16,10 @@ help() {
   echo ""
   echo "  args:"
   echo "    version: version of etcd to release, e.g. '3.2.18'"
+  echo "  flags:"
+  echo "    --no-upload: skip gs://etcd binary artifact uploads."
+  echo "    --no-docker-push: skip docker image pushes."
+  echo ""
 }
 
 main() {
@@ -28,6 +32,38 @@ main() {
   MINOR_VERSION=$(echo "${VERSION}" | cut -d. -f 1-2)
   BRANCH="release-${MINOR_VERSION}"
 
+  if ! command -v acbuild >/dev/null; then
+    echo "cannot find acbuild"
+    exit 1
+  fi
+
+  if ! command -v docker >/dev/null; then
+    echo "cannot find docker"
+    exit 1
+  fi
+
+  KEYID=$(gpg --list-keys --with-colons| awk -F: '/^pub:/ { print $5 }')
+  if [[ -z "${KEYID}" ]]; then
+    echo "Failed to load gpg key. Is gpg set up correctly for etcd releases?"
+    exit 1
+  fi
+
+  # Set up release directory.
+  local reldir="/tmp/etcd-release-${VERSION}"
+  if [ ! -d "${reldir}/etcd" ]; then
+    mkdir -p "${reldir}"
+    cd "${reldir}"
+    git clone git@github.com:coreos/etcd.git --branch "${BRANCH}"
+  fi
+  cd "${reldir}/etcd"
+
+  # If a release version tag already exists, use it.
+  local remote_tag_exists=$(git ls-remote origin "refs/tags/${RELEASE_VERSION}" | grep -q "${RELEASE_VERSION}")
+  if ${remote_tag_exists}; then
+    echo "Release version tag exists on remote. Checking out refs/tags/${RELEASE_VERSION}"
+    git checkout -q "tags/${RELEASE_VERSION}"
+  fi
+
   # Check go version.
   local go_version="go$(yq -r ".go[0]" .travis.yml)"
   local current_go_version=$(go version | awk '{ print $3 }')
@@ -36,84 +72,110 @@ main() {
     exit 1
   fi
 
-  # Make a temp directory
-  cd $(mktemp -d)
-  git clone git@github.com:coreos/etcd.git --branch "${BRANCH}"
-  cd etcd
+  # If the release tag does not already exist remotely, create it.
+  if ! ${remote_tag_exists}; then
+    # Bump version/version.go to release version.
+    local source_version=$(egrep "\s+Version\s*=" version/version.go | sed -e "s/.*\"\(.*\)\".*/\1/g")
+    if [[ "${source_version}" != "${VERSION}" ]]; then
+      source_minor_version=$(echo "${source_version}" | cut -d. -f 1-2)
+      if [[ "${source_minor_version}" != "${MINOR_VERSION}" ]]; then
+        echo "Wrong etcd minor version in version/version.go. Expected ${MINOR_VERSION} but got ${source_minor_version}. Aborting."
+        exit 1
+      fi
+      echo "Updating version from ${source_version} to ${VERSION} in version/version.go"
+      sed -i "s/${source_version}/${VERSION}/g" version/version.go
+      echo "Building etcd with updated version"
+      ./build
+    fi
 
-  KEYID=$(gpg --list-keys --with-colons| awk -F: '/^pub:/ { print $5 }')
-
-  if [[ -z "${KEYID}" ]]; then
-    echo "Failed to load gpg key. Is gpg set up correctly for etcd releases?"
-    exit 1
-  fi
-
-  # Bump version/version.go to release version.
-  local source_version=$(egrep "\s+Version\s*=" version/version.go | sed -e "s/.*\"\(.*\)\".*/\1/g")
-  if [[ "${source_version}" != "${VERSION}" ]]; then
-    source_minor_version=$(echo "${source_version}" | cut -d. -f 1-2)
-    if [[ "${source_minor_version}" != "${MINOR_VERSION}" ]]; then
-      echo "Wrong etcd minor version in version/version.go. Expected ${MINOR_VERSION} but got ${source_minor_version}. Aborting."
+    local etcd_version=$(bin/etcd --version | grep "etcd Version" | awk '{ print $3 }')
+    if [[ "${etcd_version}" != "${VERSION}" ]]; then
+      echo "Wrong etcd version in version/version.go. Expected ${etcd_version} but got ${VERSION}. Aborting."
       exit 1
     fi
+
+    if [[ ! -z $(git status -s) ]]; then
+      echo "Committing version/version.go update."
+      git add version/version.go
+      git commit -m "version: bump up to ${VERSION}"
+      git diff --staged
+    fi
+
+    # Push the version change if it's not already been pushed.
+    if [ $(git rev-list --count "origin/${BRANCH}..${BRANCH}") -gt 0 ]; then
+      read -p "Push version bump up to ${VERSION} to github.com/coreos/etcd [y/N]? " confirm
+      [[ "${confirm,,}" == "y" ]] || exit 1
+      git push
+    fi
+
+    # Tag release.
+    if $(git tag --list | grep -q "${RELEASE_VERSION}"); then
+      echo "Skipping tag step. git tag ${RELEASE_VERSION} already exists."
+    else
+      echo "Tagging release..."
+      git tag --local-user "${KEYID}" --sign "${RELEASE_VERSION}" --message "${RELEASE_VERSION}"
+    fi
+
+    # Push the tag change if it's not already been pushed.
+    read -p "Push etcd ${RELEASE_VERSION} tag [y/N]? " confirm
+    [[ "${confirm,,}" == "y" ]] || exit 1
+    git push origin "tags/${RELEASE_VERSION}"
+  fi
+
+  # Build release.
+  # TODO: check the release directory for all required build artifacts.
+  if [ -d release ]; then
+    echo "Skpping release build step. /release directory already exists."
+  else
+    echo "Building release..."
+    # Check for old and new names of the release build script.
+    # TODO: Move the release script into this on as a function?
+    if [ -f ./scripts/release.sh ]; then
+      ./scripts/release.sh "${RELEASE_VERSION}"
+    else
+      ./scripts/build-release.sh "${RELEASE_VERSION}"
+    fi
+  fi
+
+  # Sanity checks.
+  ./release/etcd-${RELEASE_VERSION}-linux-amd64/etcd --version | grep -q "etcd Version: ${VERSION}"
+  ETCDCTL_API=3 ./release/etcd-${RELEASE_VERSION}-linux-amd64/etcdctl version | grep -q "etcdctl version: ${VERSION}"
+
+  # Upload artifacts.
+  if [ "${NO_UPLOAD}" == 1 ]; then
+    echo "Skipping artifact upload to gs://etcd. --no-upload flat is set."
+  else
+    read -p "Upload etcd ${RELEASE_VERSION} release artifacts to gs://etcd [y/N]? " confirm
+    [[ "${confirm,,}" == "y" ]] || exit 1
+    gsutil -m cp ./release/*.zip gs://etcd/${RELEASE_VERSION}/
+    gsutil -m cp ./release/*.tar.gz gs://etcd/${RELEASE_VERSION}/
+    gsutil -m cp ./release/*.aci gs://etcd/${RELEASE_VERSION}/
+    gsutil -m acl ch -u allUsers:R -r gs://etcd/${RELEASE_VERSION}/
+  fi
+  
+    # Push images.
+  if [ "${NO_DOCKER_PUSH}" == 1 ]; then
+    echo "Skipping docker push. --no-docker-push flat is set."
+  else    
+    read -p "Publish etcd ${RELEASE_VERSION} docker images to quay.io [y/N]? " confirm
+    [[ "${confirm,,}" == "y" ]] || exit 1
+    until $(docker login quay.io); do
+      echo "Docker login failed, retrying."
+    done
+    gcloud docker -- login -u _json_key -p "$(cat /etc/gcp-key-etcd-development.json)" https://gcr.io
     
-    echo "Updating version from ${source_version} to ${VERSION} in version/version.go"
-    sed -i.bak "s/${source_version}/${VERSION}/g" version/version.go
-    echo "Building etcd with updated version"
-    ./build
+    for TARGET_ARCH in "-arm64" "-ppc64le" ""; do
+      docker push quay.io/coreos/etcd:${RELEASE_VERSION}${TARGET_ARCH}
+      gcloud docker -- push gcr.io/etcd-development/etcd:${RELEASE_VERSION}${TARGET_ARCH}
+    done
+    gsutil -m acl ch -u allUsers:R -r gs://artifacts.etcd-development.appspot.com
+
+    docker tag quay.io/coreos/etcd:${RELEASE_VERSION} quay.io/coreos/etcd:v${MINOR_VERSION}
+    docker push quay.io/coreos/etcd:v${MINOR_VERSION}
+    
+    gcloud docker -- tag gcr.io/etcd-development/etcd:${RELEASE_VERSION} gcr.io/etcd-development/etcd:v${MINOR_VERSION}
+    gcloud docker -- push gcr.io/etcd-development/etcd:v${MINOR_VERSION}
   fi
-
-  local etcd_version=$(bin/etcd --version | grep "etcd Version" | awk '{ print $3 }')
-  if [[ "${etcd_version}" != "${VERSION}" ]]; then
-    echo "Wrong etcd version in version/version.go. Expected ${etcd_version} but got ${VERSION}. Aborting."
-    exit 1
-  fi
-
-  git add version/version.go
-  git commit -m "version: bump up to ${VERSION}"
-  git diff --staged
-  read -p "Push version bump up to ${VERSION} to github.com/coreos/etcd [y/N]? " confirm
-  [[ "${confirm,,}" == "y" ]] || exit 1
-  git push
-
-  echo "Tagging release..."
-  git tag --local-user "${KEYID}" --sign "${RELEASE_VERSION}" --message "${RELEASE_VERSION}"
-  git tag --list | grep "{VERSION}"
-  read -p "Push etcd ${RELEASE_VERSION} tag [y/N]? " confirm
-  [[ "${confirm,,}" == "y" ]] || exit 1
-  git push origin "tags/${RELEASE_VERSION}"
-
-  echo "Building release..."
-  ./scripts/release.sh "${RELEASE_VERSION}"
-
-  # TODO: validate output of checks
-  ./release/etcd-${RELEASE_VERSION}-linux-amd64/etcd --version
-  ETCDCTL_API=3 ./release/etcd-${RELEASE_VERSION}-linux-amd64/etcdctl version
-  
-  read -p "Upload etcd ${RELEASE_VERSION} release artifacts to gs://etcd [y/N]? " confirm
-  [[ "${confirm,,}" == "y" ]] || exit 1
-
-  gsutil -m cp ./release/*.zip gs://etcd/${RELEASE_VERSION}/
-  gsutil -m cp ./release/*.tar.gz gs://etcd/${RELEASE_VERSION}/
-  gsutil -m cp ./release/*.aci gs://etcd/${RELEASE_VERSION}/
-  gsutil -m acl ch -u allUsers:R -r gs://etcd/${RELEASE_VERSION}/
-
-  read -p "Publish etcd ${RELEASE_VERSION} docker images to quay.io [y/N]? " confirm
-  [[ "${confirm,,}" == "y" ]] || exit 1
-  docker login quay.io
-  gcloud docker -- login -u _json_key -p "$(cat /etc/gcp-key-etcd-development.json)" https://gcr.io
- 
-  for TARGET_ARCH in "-arm64" "-ppc64le" ""; do
-    docker push quay.io/coreos/etcd:${RELEASE_VERSION}${TARGET_ARCH}
-    gcloud docker -- push gcr.io/etcd-development/etcd:${RELEASE_VERSION}${TARGET_ARCH}
-  done
-  gsutil -m acl ch -u allUsers:R -r gs://artifacts.etcd-development.appspot.com
-
-  docker tag quay.io/coreos/etcd:${RELEASE_VERSION} quay.io/coreos/etcd:${MINOR_VERSION}
-  docker push quay.io/coreos/etcd:${MINOR_VERSION}
-  
-  gcloud docker -- tag gcr.io/etcd-development/etcd:${RELEASE_VERSION} gcr.io/etcd-development/etcd:${MINOR_VERSION}
-  gcloud docker -- push gcr.io/etcd-development/etcd:${MINOR_VERSION}
 
   # TODO: test
   # docker run --rm --name etcd-gcr-${RELEASE_VERSION} gcr.io/etcd-development/etcd:${RELEASE_VERSION};
@@ -122,31 +184,48 @@ main() {
   # docker exec etcd-gcr-${RELEASE_VERSION} /bin/sh -c "ETCDCTL_API=3 /usr/local/bin/etcdctl put foo bar"
   # docker exec etcd-gcr-${RELEASE_VERSION} /bin/sh -c "ETCDCTL_API=3 /usr/local/bin/etcdctl get foo"
 
-  echo "Updating version from ${VERSION} to ${VERSION}+git in version/version.go"
-  sed -i.bak "s/${VERSION}/${VERSION}+git/g" version/version.go
-  echo "Building etcd with ${VERSION}+git in version/version.go"
-  git add version/version.go
-  git commit -m "version: bump up to ${VERSION}+git"
-  git diff --staged
-  read -p "Push version bump up to ${VERSION}+git to github.com/coreos/etcd [y/N]? " confirm
-  [[ "${confirm,,}" == "y" ]] || exit 1
-  git push
-
+  # Bump version to next development version.
+  git checkout -q "${BRANCH}" # Since we might be on a checkout of the remote version tag.
+  local source_version=$(egrep "\s+Version\s*=" version/version.go | sed -e "s/.*\"\(.*\)\".*/\1/g")
+  if [[ "${source_version}" != "${VERSION}+git" ]]; then
+    echo "Updating version from ${source_version} to ${VERSION}+git in version/version.go"
+    sed -i "s/${source_version}/${VERSION}+git/g" version/version.go
+    echo "Building etcd with ${VERSION}+git in version/version.go"
+    git add version/version.go
+    git commit -m "version: bump up to ${VERSION}+git"
+    git diff --staged
+    read -p "Push version bump up to ${VERSION}+git to github.com/coreos/etcd [y/N]? " confirm
+    [[ "${confirm,,}" == "y" ]] || exit 1
+    git push
+  fi
+  
   # TODO: signing process
+  echo ""
   echo "WARNING: The release has not been signed and published to github. This must be done manually."
-
   echo "WARNING: version/version.go has not been updated to ${RELEASE_VERSION}+git. This must be done manually."
+  echo ""
   echo "Success."
   exit 0
 }
 
 POSITIONAL=()
+NO_UPLOAD=0
+NO_DOCKER_PUSH=0
+
 while test $# -gt 0; do
         case "$1" in
           -h|--help)
             shift
             help
             exit 0
+            ;;
+          --no-upload)
+            NO_UPLOAD=1
+            shift
+            ;;
+          --no-docker-push)
+            NO_DOCKER_PUSH=1
+            shift
             ;;
           *)
             POSITIONAL+=("$1") # save it in an array for later


### PR DESCRIPTION
We found a couple obvious bugs when attempting to use the release script for the first time.  This fixes those:
- Docker tags should be of the form "v<etcd-semver>".
- The git tag validation check was always failing causing the script to terminate early.
- The build script was assumed to be `./scripts/release.sh` but the previous PR move that script to `./scripts/build-release.sh`.  For now this script will check for both and use whichever exists so we can release 3.1..3.3 from this script.
- When entering docker registry passwords, don't exit the script if the login fails, instead keep retrying.

We should be able to safely re-run the script if it fails for any reason.  To make this possible:
- Instead of creating a new tempdir for each run, reuse the same temp dir using the naming scheme (e.g. `/tmp/etcd-release-3.2.19`)
- Check if the release version tag (e.g. refs/tags/v3.2.19) exists, and if so, check it out and build/release from that exact git commit
- Check if the `/release` directory exists already, if so, skip the build step
- Added `--no-upload` and `--no-docker-push` flags so we can optionally skip those release publication steps 

