### PR TITLE
contrib/raftexample: remove useless check

### DIFF
--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -70,7 +70,7 @@ func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {
 			if err == raftsnap.ErrNoSnapshot {
 				return
 			}
-			if err != nil && err != raftsnap.ErrNoSnapshot {
+			if err != nil {
 				log.Panic(err)
 			}
 			log.Printf("loading snapshot at term %d and index %d", snapshot.Metadata.Term, snapshot.Metadata.Index)


### PR DESCRIPTION
`err == raftsnap.ErrNoSnapshot` being false implies that
`err != raftsnap.ErrNoSnapshot` is true.


Please read https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
