### PR TITLE
test: fix "markdown_you_pass"

### DIFF
--- a/test
+++ b/test
@@ -368,7 +368,7 @@ function shellcheck_pass {
 
 function markdown_you_pass {
 	# eschew you
-	yous=$(find . -name \*.md -exec grep -E --color "[Yy]ou[r]?[ '.,;]" {} + | grep -v /v2/ || true)
+	yous=$(find . -name \*.md ! -path './vendor/*' ! -path './gopath.proto/*' -exec grep -E --color "[Yy]ou[r]?[ '.,;]" {} + | grep -v /v2/ || true)
 	if [ ! -z "$yous" ]; then
 		echo -e "found 'you' in documentation:\\n${yous}"
 		exit 255


### PR DESCRIPTION
"find" command was matching "vendor" directory in
my local machine.
