### PR TITLE
contrib/raftexample: fix typo

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -130,7 +130,7 @@ func (rc *raftNode) entriesToApply(ents []raftpb.Entry) (nents []raftpb.Entry) {
 	}
 	firstIdx := ents[0].Index
 	if firstIdx > rc.appliedIndex+1 {
-		log.Fatalf("first index of committed entry[%d] should <= progress.appliedIndex[%d] 1", firstIdx, rc.appliedIndex)
+		log.Fatalf("first index of committed entry[%d] should <= progress.appliedIndex[%d]+1", firstIdx, rc.appliedIndex)
 	}
 	if rc.appliedIndex-firstIdx+1 < uint64(len(ents)) {
 		nents = ents[rc.appliedIndex-firstIdx+1:]


### PR DESCRIPTION
`progress.appliedIndex[%d] 1` should be `progress.appliedIndex[%d]+1`.
