### PR TITLE
*: use Go 1.10.2 and Go 1.9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 services: docker
 
 go:
-- 1.10.1
+- 1.10.2
 - tip
 
 notifications:
@@ -65,7 +65,7 @@ matrix:
     env: TARGET=linux-arm64-build
   - go: tip
     env: TARGET=linux-ppc64le-build
-  - go: 1.10.1
+  - go: 1.10.2
     env: TARGET=linux-amd64-fmt-unit-go-tip
 
 before_install:

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -255,7 +255,7 @@ See [security doc](https://github.com/coreos/etcd/blob/master/Documentation/op-g
 ### Go
 
 - Require *Go 1.10+*.
-- Compile with [*Go 1.10.1*](https://golang.org/doc/devel/release.html#go1.10).
+- Compile with [*Go 1.10.2*](https://golang.org/doc/devel/release.html#go1.10).
 
 ### Tooling
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ docker-remove:
 
 
 
-GO_VERSION ?= 1.10.1
+GO_VERSION ?= 1.10.2
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)
@@ -62,16 +62,16 @@ endif
 
 # Example:
 #   GO_VERSION=1.8.7 make build-docker-test
-#   GO_VERSION=1.9.5 make build-docker-test
+#   GO_VERSION=1.9.6 make build-docker-test
 #   make build-docker-test
 #
 #   gcloud docker -- login -u _json_key -p "$(cat /etc/gcp-key-etcd-development.json)" https://gcr.io
 #   GO_VERSION=1.8.7 make push-docker-test
-#   GO_VERSION=1.9.5 make push-docker-test
+#   GO_VERSION=1.9.6 make push-docker-test
 #   make push-docker-test
 #
 #   gsutil -m acl ch -u allUsers:R -r gs://artifacts.etcd-development.appspot.com
-#   GO_VERSION=1.9.5 make pull-docker-test
+#   GO_VERSION=1.9.6 make pull-docker-test
 #   make pull-docker-test
 
 build-docker-test:

--- a/test
+++ b/test
@@ -82,8 +82,10 @@ fi
 
 # shellcheck disable=SC2206
 FMT=($FMT)
-# shellcheck disable=SC2128
-echo "Running with FMT:" "${FMT}"
+if [ "${VERBOSE}" == "1" ]; then
+	# shellcheck disable=SC2128
+	echo "Running with FMT:" "${FMT[@]}"
+fi
 
 # prepend REPO_PATH to each local package
 split=$TEST
@@ -92,16 +94,20 @@ for a in $split; do TEST="$TEST ${REPO_PATH}/${a}"; done
 
 # shellcheck disable=SC2206
 TEST=($TEST)
-# shellcheck disable=SC2128
-echo "Running with TEST:" "${TEST}"
+if [ "${VERBOSE}" == "1" ]; then
+	# shellcheck disable=SC2128
+	echo "Running with TEST:" "${TEST[@]}"
+fi
 
 # TODO: 'client' pkg fails with gosimple from generated files
 # TODO: 'rafttest' is failing with unused
 STATIC_ANALYSIS_PATHS=$(find . -name \*.go ! -path './vendor/*' ! -path './gopath.proto/*' ! -path '*pb/*' | while read -r a; do dirname "$a"; done | sort | uniq | grep -vE "$IGNORE_PKGS" | grep -v 'client')
 # shellcheck disable=SC2206
 STATIC_ANALYSIS_PATHS=($STATIC_ANALYSIS_PATHS)
-# shellcheck disable=SC2128
-echo "Running with STATIC_ANALYSIS_PATHS:" "${STATIC_ANALYSIS_PATHS}"
+if [ "${VERBOSE}" == "1" ]; then
+	# shellcheck disable=SC2128
+	echo "Running with STATIC_ANALYSIS_PATHS:" "${STATIC_ANALYSIS_PATHS[@]}"
+fi
 
 if [ -z "$GOARCH" ]; then
 	GOARCH=$(go env GOARCH);

--- a/tests/semaphore.test.bash
+++ b/tests/semaphore.test.bash
@@ -15,7 +15,7 @@ fi
 docker run \
   --rm \
   --volume=`pwd`:/go/src/github.com/coreos/etcd \
-  gcr.io/etcd-development/etcd-test:go1.10.1 \
+  gcr.io/etcd-development/etcd-test:go1.10.2 \
   /bin/bash -c "${TEST_OPTS} ./test 2>&1 | tee test-${TEST_SUFFIX}.log"
 
 ! egrep "(--- FAIL:|panic: test timed out|appears to have leaked)" -B50 -A10 test-${TEST_SUFFIX}.log


### PR DESCRIPTION
Already pushed test images to gcr. Will update 3.3 branch as well.

https://golang.org/doc/devel/release.html#go1.10