### PR TITLE
*: highlight "--log-package-levels" deprecation in v3.5

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -14,6 +14,7 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.4.0...v3.5.0) and [
   - `curl -L http://localhost:2379/v3beta/kv/put -X POST -d '{"key": "Zm9v", "value": "YmFy"}'` does work in v3.5. Use `curl -L http://localhost:2379/v3/kv/put -X POST -d '{"key": "Zm9v", "value": "YmFy"}'` instead.
 - **`etcd --log-output` has been deprecated**. Use **`etcd --log-outputs`** instead.
 - **`etcd --logger=capnslog` has been deprecated**. Now, **`etcd --logger=zap`** is the default.
+- **`etcd --log-package-levels` for `capnslog` has been deprecated**. Now, **`etcd --logger=zap`** is the default.
 
 ### gRPC gateway
 

--- a/Documentation/upgrades/upgrade_3_5.md
+++ b/Documentation/upgrades/upgrade_3_5.md
@@ -34,6 +34,17 @@ v3.4 renamed [`etcd --log-output` to `--log-outputs`](https://github.com/coreos/
 +etcd --log-outputs stderr,a.log
 ```
 
+#### Deprecated in `etcd --log-package-levels`
+
+**`etcd --log-package-levels` for `capnslog` has been deprecated**.
+
+Now, **`etcd --logger=zap`** is the default.
+
+```diff
+-etcd --log-package-levels 'etcdmain=CRITICAL,etcdserver=DEBUG'
++etcd --logger=zap
+```
+
 #### Changed gRPC gateway HTTP endpoints (deprecated `/v3beta`)
 
 Before

--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -128,8 +128,7 @@ peer-transport-security:
 # Enable debug-level logging for etcd.
 debug: false
 
-# Specify a particular log level for each etcd package (eg: 'etcdmain=CRITICAL,etcdserver=DEBUG'.
-log-package-levels:
+logger: zap
 
 # Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.
 log-outputs: [default]


### PR DESCRIPTION
v3.4 still keeps capnslog and everything else.
v3.5 starts deprecating capnslog and capnslog specific config `--log-package-levels` flag.