### PR TITLE
raft: describe the purpose of lockedRand

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -72,8 +72,8 @@ const (
 var ErrProposalDropped = errors.New("raft proposal dropped")
 
 // lockedRand is a small wrapper around rand.Rand to provide
-// synchronization. Only the methods needed by the code are exposed
-// (e.g. Intn).
+// synchronization among multiple raft groups. Only the methods needed
+// by the code are exposed (e.g. Intn).
 type lockedRand struct {
 	mu   sync.Mutex
 	rand *rand.Rand


### PR DESCRIPTION
At the beginning, I found `raft.resetRandomizedElectionTimeout` is called in single goroutine of `raft.node.run`. So I thought there's no need to use mutex lock to protect `rand.Rand` variable.

After searching commit history and finding related issue #6347, I noticed that static varitable `globalRand` could be accessed by multi raft groups.

This commit adds comment of the reason why `globalRand(lockedRand)` needs synchronization, which may save time of the newcomers.
