### PR TITLE
tests/e2e: investigating TestCtlV3AuthAndWatch failure in coverage tests

### DIFF
--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -187,6 +187,8 @@ func TestKVPutWithIgnoreLease(t *testing.T) {
 }
 
 func TestKVPutWithRequireLeader(t *testing.T) {
+	t.Skip()
+
 	defer testutil.AfterTest(t)
 
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})

--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -127,6 +127,7 @@ func watchInteractiveFunc(cmd *cobra.Command, osArgs []string, envKey, envRange 
 
 func getWatchChan(c *clientv3.Client, args []string) (clientv3.WatchChan, error) {
 	if len(args) < 1 {
+		fmt.Println("1 args before errBadArgsNum:", args)
 		return nil, errBadArgsNum
 	}
 
@@ -236,6 +237,7 @@ func parseWatchArgs(osArgs, commandArgs []string, envKey, envRange string, inter
 		return nil, nil, errBadArgsInteractiveWatch
 	}
 	if len(watchArgs) < 1 && envKey == "" {
+		fmt.Println("1 watchArgs before errBadArgsNum:", watchArgs, "/", envKey)
 		return nil, nil, errBadArgsNum
 	}
 
@@ -248,6 +250,7 @@ func parseWatchArgs(osArgs, commandArgs []string, envKey, envRange string, inter
 	if idx < len(osArgs)-1 {
 		osArgs = osArgs[idx+1:]
 	} else if envKey == "" {
+		fmt.Println("2 watchArgs before errBadArgsNum:", watchArgs, "/", osArgs, "/", envKey)
 		return nil, nil, errBadArgsNum
 	}
 

--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -249,7 +249,7 @@ func parseWatchArgs(osArgs, commandArgs []string, envKey, envRange string, inter
 	}
 	if idx < len(osArgs)-1 {
 		osArgs = osArgs[idx+1:]
-	} else if envKey == "" {
+	} else if len(watchArgs) < 1 && envKey == "" {
 		fmt.Println(
 			"idx:", idx,
 			"/ watchArgs before errBadArgsNum:", watchArgs,

--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -250,7 +250,12 @@ func parseWatchArgs(osArgs, commandArgs []string, envKey, envRange string, inter
 	if idx < len(osArgs)-1 {
 		osArgs = osArgs[idx+1:]
 	} else if envKey == "" {
-		fmt.Println("2 watchArgs before errBadArgsNum:", watchArgs, "/", osArgs, "/", envKey)
+		fmt.Println(
+			"idx:", idx,
+			"/ watchArgs before errBadArgsNum:", watchArgs,
+			"/ osArgs:", osArgs,
+			"/ envKey:", envKey,
+		)
 		return nil, nil, errBadArgsNum
 	}
 

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -853,9 +853,13 @@ func authTestWatch(cx ctlCtx) {
 
 		var err error
 		if tt.want {
+			fmt.Println("ctlV3Watch 1")
 			err = ctlV3Watch(cx, tt.args, tt.wkv...)
+			fmt.Println("ctlV3Watch 2", err)
 		} else {
+			fmt.Println("ctlV3WatchFailPerm 1")
 			err = ctlV3WatchFailPerm(cx, tt.args)
+			fmt.Println("ctlV3WatchFailPerm 2", err)
 		}
 
 		if err != nil {

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -40,7 +40,14 @@ func TestCtlV3AuthCertCN(t *testing.T)           { testCtl(t, authTestCertCN, wi
 func TestCtlV3AuthRevokeWithDelete(t *testing.T) { testCtl(t, authTestRevokeWithDelete) }
 func TestCtlV3AuthInvalidMgmt(t *testing.T)      { testCtl(t, authTestInvalidMgmt) }
 func TestCtlV3AuthFromKeyPerm(t *testing.T)      { testCtl(t, authTestFromKeyPerm) }
-func TestCtlV3AuthAndWatch(t *testing.T)         { testCtl(t, authTestWatch) }
+
+func TestCtlV3AuthAndWatch(t *testing.T) {
+	oldenv := os.Getenv("EXPECT_DEBUG")
+	defer os.Setenv("EXPECT_DEBUG", oldenv)
+	os.Setenv("EXPECT_DEBUG", "1")
+
+	testCtl(t, authTestWatch)
+}
 
 func TestCtlV3AuthLeaseTestKeepAlive(t *testing.T)         { testCtl(t, authLeaseTestKeepAlive) }
 func TestCtlV3AuthLeaseTestTimeToLiveExpired(t *testing.T) { testCtl(t, authLeaseTestTimeToLiveExpired) }

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -857,9 +857,9 @@ func authTestWatch(cx ctlCtx) {
 			err = ctlV3Watch(cx, tt.args, tt.wkv...)
 			fmt.Println("ctlV3Watch 2", err)
 		} else {
-			fmt.Println("ctlV3WatchFailPerm 1")
+			fmt.Println("ctlV3WatchFailPerm 1", tt.args)
 			err = ctlV3WatchFailPerm(cx, tt.args)
-			fmt.Println("ctlV3WatchFailPerm 2", err)
+			fmt.Println("ctlV3WatchFailPerm 2", tt.args, "/", err)
 		}
 
 		if err != nil {

--- a/tests/e2e/ctl_v3_watch_test.go
+++ b/tests/e2e/ctl_v3_watch_test.go
@@ -21,11 +21,25 @@ import (
 	"testing"
 )
 
-func TestCtlV3Watch(t *testing.T)          { testCtl(t, watchTest) }
-func TestCtlV3WatchNoTLS(t *testing.T)     { testCtl(t, watchTest, withCfg(configNoTLS)) }
+func TestCtlV3Watch(t *testing.T) { testCtl(t, watchTest) }
+
+func TestCtlV3WatchNoTLS(t *testing.T) {
+	oldenv := os.Getenv("EXPECT_DEBUG")
+	defer os.Setenv("EXPECT_DEBUG", oldenv)
+	os.Setenv("EXPECT_DEBUG", "1")
+
+	testCtl(t, watchTest, withCfg(configNoTLS))
+}
+
 func TestCtlV3WatchClientTLS(t *testing.T) { testCtl(t, watchTest, withCfg(configClientTLS)) }
 func TestCtlV3WatchPeerTLS(t *testing.T)   { testCtl(t, watchTest, withCfg(configPeerTLS)) }
-func TestCtlV3WatchTimeout(t *testing.T)   { testCtl(t, watchTest, withDialTimeout(0)) }
+func TestCtlV3WatchTimeout(t *testing.T) {
+	oldenv := os.Getenv("EXPECT_DEBUG")
+	defer os.Setenv("EXPECT_DEBUG", oldenv)
+	os.Setenv("EXPECT_DEBUG", "1")
+
+	testCtl(t, watchTest, withDialTimeout(0))
+}
 
 func TestCtlV3WatchInteractive(t *testing.T) {
 	testCtl(t, watchTest, withInteractive())

--- a/tests/e2e/ctl_v3_watch_test.go
+++ b/tests/e2e/ctl_v3_watch_test.go
@@ -180,11 +180,14 @@ func watchTest(cx ctlCtx) {
 				}
 			}
 		}
+		fmt.Printf("#%d-1 ctlV3Watch: %+v\n", i, tt)
 		if err := ctlV3Watch(cx, tt.args, tt.wkv...); err != nil {
+			fmt.Printf("#%d-2 ctlV3Watch: %+v (error %v)\n", i, tt, err)
 			if cx.dialTimeout > 0 && !isGRPCTimedout(err) {
 				cx.t.Errorf("watchTest #%d: ctlV3Watch error (%v)", i, err)
 			}
 		}
+		fmt.Printf("#%d-3 ctlV3Watch: %+v\n", i, tt)
 		unsetEnv()
 		<-donec
 	}
@@ -204,6 +207,12 @@ func setupWatchArgs(cx ctlCtx, args []string) []string {
 func ctlV3Watch(cx ctlCtx, args []string, kvs ...kvExec) error {
 	cmdArgs := setupWatchArgs(cx, args)
 
+	println()
+	fmt.Println("ctlV3Watch os.Args:", os.Args)
+	fmt.Println("ctlV3Watch kvs:", kvs)
+	fmt.Println("ctlV3Watch args:", args)
+	fmt.Println("ctlV3Watch cmdArgs:", cmdArgs)
+	println()
 	proc, err := spawnCmd(cmdArgs)
 	if err != nil {
 		return err

--- a/tests/e2e/ctl_v3_watch_test.go
+++ b/tests/e2e/ctl_v3_watch_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -220,6 +221,7 @@ func ctlV3Watch(cx ctlCtx, args []string, kvs ...kvExec) error {
 func ctlV3WatchFailPerm(cx ctlCtx, args []string) error {
 	cmdArgs := setupWatchArgs(cx, args)
 
+	fmt.Println("ctlV3WatchFailPerm cmdArgs:", cmdArgs)
 	proc, err := spawnCmd(cmdArgs)
 	if err != nil {
 		return err


### PR DESCRIPTION
```
=== RUN   TestCtlV3AuthAndWatch
--- FAIL: TestCtlV3AuthAndWatch (2.11s)
	ctl_v3_auth_test.go:856: watchTest #0: ctlV3Watch error (read /dev/ptmx: input/output error)
	ctl_v3_auth_test.go:856: watchTest #1: ctlV3Watch error (read /dev/ptmx: input/output error)
	ctl_v3_auth_test.go:856: watchTest #2: ctlV3Watch error (read /dev/ptmx: input/output error)
	ctl_v3_auth_test.go:856: watchTest #3: ctlV3Watch error (read /dev/ptmx: input/output error)
```