### PR TITLE
*: make bcrypt-cost configurable

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -375,6 +375,10 @@ Follow the instructions when using these flags.
 + Example option of JWT: '--auth-token jwt,pub-key=app.rsa.pub,priv-key=app.rsa,sign-method=RS512,ttl=10m'
 + default: "simple"
 
+### --bcrypt-cost
++ Specify the cost / strength of the bcrypt algorithm for hashing auth passwords. Valid values are between 4 and 31.
++ default: 10
+
 ## Experimental flags
 
 ### --experimental-corrupt-check-time

--- a/clientv3/main_test.go
+++ b/clientv3/main_test.go
@@ -22,14 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd/auth"
 	"github.com/coreos/etcd/integration"
 	"github.com/coreos/etcd/pkg/testutil"
-
-	"golang.org/x/crypto/bcrypt"
 )
-
-func init() { auth.BcryptCost = bcrypt.MinCost }
 
 // TestMain sets up an etcd cluster if running the examples.
 func TestMain(m *testing.M) {

--- a/embed/config.go
+++ b/embed/config.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ghodss/yaml"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 )
 
@@ -242,7 +243,8 @@ type Config struct {
 	//	embed.StartEtcd(cfg)
 	ServiceRegister func(*grpc.Server) `json:"-"`
 
-	AuthToken string `json:"auth-token"`
+	AuthToken  string `json:"auth-token"`
+	BcryptCost uint   `json:"bcrypt-cost"`
 
 	ExperimentalInitialCorruptCheck bool          `json:"experimental-initial-corrupt-check"`
 	ExperimentalCorruptCheckTime    time.Duration `json:"experimental-corrupt-check-time"`
@@ -364,7 +366,8 @@ func NewConfig() *Config {
 		CORS:          map[string]struct{}{"*": {}},
 		HostWhitelist: map[string]struct{}{"*": {}},
 
-		AuthToken: "simple",
+		AuthToken:  "simple",
+		BcryptCost: uint(bcrypt.DefaultCost),
 
 		PreVote: false, // TODO: enable by default in v3.5
 

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -183,6 +183,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		StrictReconfigCheck:        cfg.StrictReconfigCheck,
 		ClientCertAuthEnabled:      cfg.ClientTLSInfo.ClientCertAuth,
 		AuthToken:                  cfg.AuthToken,
+		BcryptCost:                 cfg.BcryptCost,
 		CORS:                       cfg.CORS,
 		HostWhitelist:              cfg.HostWhitelist,
 		InitialCorruptCheck:        cfg.ExperimentalInitialCorruptCheck,

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -237,6 +237,7 @@ func newConfig() *config {
 
 	// auth
 	fs.StringVar(&cfg.ec.AuthToken, "auth-token", cfg.ec.AuthToken, "Specify auth token specific options.")
+	fs.UintVar(&cfg.ec.BcryptCost, "bcrypt-cost", cfg.ec.BcryptCost, "Specify bcrypt algorithm cost factor for auth password hashing.")
 
 	// experimental
 	fs.BoolVar(&cfg.ec.ExperimentalInitialCorruptCheck, "experimental-initial-corrupt-check", cfg.ec.ExperimentalInitialCorruptCheck, "Enable to check data corruption before serving any client/peer traffic.")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -15,9 +15,11 @@
 package etcdmain
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/coreos/etcd/embed"
+	"golang.org/x/crypto/bcrypt"
 )
 
 var (
@@ -148,6 +150,8 @@ Security:
 Auth:
   --auth-token 'simple'
     Specify a v3 authentication token type and its options ('simple' or 'jwt').
+  --bcrypt-cost ` + fmt.Sprintf("%d", bcrypt.DefaultCost) + `
+    Specify the cost / strength of the bcrypt algorithm for hashing auth passwords. Valid values are between ` + fmt.Sprintf("%d", bcrypt.MinCost) + ` and ` + fmt.Sprintf("%d", bcrypt.MaxCost) + `.
 
 Profiling and Monitoring:
   --enable-pprof 'false'

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -103,7 +103,8 @@ type ServerConfig struct {
 	// ClientCertAuthEnabled is true when cert has been signed by the client CA.
 	ClientCertAuthEnabled bool
 
-	AuthToken string
+	AuthToken  string
+	BcryptCost uint
 
 	// InitialCorruptCheck is true to check data corruption on boot
 	// before serving any peer/client traffic.

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -559,7 +559,7 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		}
 		return nil, err
 	}
-	srv.authStore = auth.NewAuthStore(srv.getLogger(), srv.be, tp)
+	srv.authStore = auth.NewAuthStore(srv.getLogger(), srv.be, tp, int(cfg.BcryptCost))
 	if num := cfg.AutoCompactionRetention; num != 0 {
 		srv.compactor, err = compactor.New(cfg.Logger, cfg.AutoCompactionMode, num, srv.kv, srv)
 		if err != nil {

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -54,6 +54,7 @@ import (
 
 	"github.com/soheilhy/cmux"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
@@ -611,7 +612,8 @@ func mustNewMember(t *testing.T, mcfg memberConfig) *member {
 	if m.MaxRequestBytes == 0 {
 		m.MaxRequestBytes = embed.DefaultMaxRequestBytes
 	}
-	m.AuthToken = "simple" // for the purpose of integration testing, simple token is enough
+	m.AuthToken = "simple"              // for the purpose of integration testing, simple token is enough
+	m.BcryptCost = uint(bcrypt.MinCost) // use min bcrypt cost to speedy up integration testing
 
 	m.grpcServerOpts = []grpc.ServerOption{}
 	if mcfg.grpcKeepAliveMinTime > time.Duration(0) {


### PR DESCRIPTION
This change implements the feature request in #9615. It replaces https://github.com/coreos/etcd/pull/9633