### PR TITLE
tests/e2e: fix v2 proxy tests

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -549,9 +549,9 @@ func startProxy(cfg *config) error {
 		host := u.String()
 		go func() {
 			if lg != nil {
-				lg.Info("proxy started listening on client requests", zap.String("host", host))
+				lg.Info("v2 proxy started listening on client requests", zap.String("host", host))
 			} else {
-				plog.Info("proxy: listening for client requests on ", host)
+				plog.Infof("v2 proxy started listening on client requests on %q", host)
 			}
 			mux := http.NewServeMux()
 			etcdhttp.HandlePrometheus(mux) // v2 proxy just uses the same port

--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -158,6 +158,9 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 		},
 		Encoding:      "json",
 		EncoderConfig: zap.NewProductionEncoderConfig(),
+
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
 	}
 	if grpcProxyDebug {
 		lcfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)

--- a/tests/e2e/cluster_proxy_test.go
+++ b/tests/e2e/cluster_proxy_test.go
@@ -284,5 +284,5 @@ func (v3p *proxyV3Proc) Start() error {
 	if err := v3p.start(); err != nil {
 		return err
 	}
-	return v3p.waitReady("listening for grpc-proxy client requests")
+	return v3p.waitReady("started gRPC proxy")
 }


### PR DESCRIPTION
https://jenkins-etcd.prod.coreos.systems/job/etcd-coverage/4144/console

Coverage tests should be fixed with this.