### PR TITLE
pkg/logutil: do not print error message on journaldWriter

### DIFF
--- a/pkg/logutil/zap_journald.go
+++ b/pkg/logutil/zap_journald.go
@@ -82,7 +82,6 @@ func (w *journaldWriter) Write(p []byte) (int, error) {
 		"SYSLOG_IDENTIFIER": filepath.Base(os.Args[0]),
 	})
 	if err != nil {
-		fmt.Println("FAILED TO WRITE TO JOURNALD", err, string(p))
 		return w.Writer.Write(p)
 	}
 	return 0, nil


### PR DESCRIPTION
Found that it was detecting as journald when run with container

```
FAILED TO WRITE TO JOURNALD journal error: could not connect to journald socket {"level":"info","ts":1526495490.4501956,"caller":"rafthttp/peer.go:340","msg":"stopped remote peer","remote-peer-id":"5a8f1f42fc365b65"}
{"level":"info","ts":1526495490.4501956,"caller":"rafthttp/peer.go:340","msg":"stopped remote peer","remote-peer-id":"5a8f1f42fc365b65"}
```

Which means capnslog will also keep error for every single log write.

After this PR, will disable PPID = 1 checks on journald logging.

Should only be configured manually.