### PR TITLE
clientv3/integration: do not run fragmentation tests with gRPC Proxy

### DIFF
--- a/clientv3/integration/watch_fragment_test.go
+++ b/clientv3/integration/watch_fragment_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !cluster_proxy
+
 package integration
 
 import (


### PR DESCRIPTION
Client receive limit is not yet supported in gRPC proxy. Fixes test failures.