### PR TITLE
leases: Add metrics to etcd leases

### DIFF
--- a/lease/lessor.go
+++ b/lease/lessor.go
@@ -233,6 +233,8 @@ func (le *lessor) Grant(id LeaseID, ttl int64) (*Lease, error) {
 	heap.Push(&le.leaseHeap, item)
 	l.persistTo(le.b)
 
+	leaseTotalTTLs.Observe(float64(l.ttl))
+	leaseGranted.Inc()
 	return l, nil
 }
 
@@ -271,6 +273,8 @@ func (le *lessor) Revoke(id LeaseID) error {
 	le.b.BatchTx().UnsafeDelete(leaseBucketName, int64ToBytes(int64(l.ID)))
 
 	txn.End()
+
+	leaseRevoked.Inc()
 	return nil
 }
 
@@ -315,6 +319,8 @@ func (le *lessor) Renew(id LeaseID) (int64, error) {
 	l.refresh(0)
 	item := &LeaseWithTime{id: l.ID, expiration: l.expiry.UnixNano()}
 	heap.Push(&le.leaseHeap, item)
+
+	leaseRenewed.Inc()
 	return l.ttl, nil
 }
 

--- a/lease/metrics.go
+++ b/lease/metrics.go
@@ -1,0 +1,59 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lease
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	leaseGranted = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "granted_total",
+		Help:      "The total number of granted leases.",
+	})
+
+	leaseRevoked = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "revoked_total",
+		Help:      "The total number of revoked leases.",
+	})
+
+	leaseRenewed = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "renewed_total",
+		Help:      "The number of renewed leases seen by the leader.",
+	})
+
+	leaseTotalTTLs = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "etcd_debugging",
+			Subsystem: "lease",
+			Name:      "ttl_total",
+			Help:      "Bucketed histogram of lease TTLs.",
+			// 1 second -> 3 months
+			Buckets: prometheus.ExponentialBuckets(1, 2, 24),
+		})
+)
+
+func init() {
+	prometheus.MustRegister(leaseGranted)
+	prometheus.MustRegister(leaseRevoked)
+	prometheus.MustRegister(leaseRenewed)
+	prometheus.MustRegister(leaseTotalTTLs)
+}


### PR DESCRIPTION
This patch adds four metrics (leases granted, leases revoked, leases renewed, and the average TTL of leases) to the `leases` package for easier debugging and visibility into outstanding leases. 

There's not currently a way to monitor the number of leases that are granted or revoked within etcd.  It's currently possible to see the number of leases expired via `server_lease_expired_total`, but not the number initially granted nor those being renewed.

This makes it tough to determine the current number of leases held, and determine why leases are not being cleaned up. This patch makes the behavior described in, for example, https://github.com/coreos/etcd/issues/9395 easier to debug and understand as it makes it clear that leases are never being revoked, rather than renewed forever.

Please read https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
