### PR TITLE
etcdctl/ctlv3 : fixes 9583. trim spaces in ETCDCTL_ENDPOINTS env variable

### DIFF
--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -394,6 +394,11 @@ func endpointsFromCmd(cmd *cobra.Command) ([]string, error) {
 	// If domain discovery returns no endpoints, check endpoints flag
 	if len(eps) == 0 {
 		eps, err = cmd.Flags().GetStringSlice("endpoints")
+		if err == nil {
+			for i, ip := range eps {
+				eps[i] = strings.TrimSpace(ip)
+			}
+		}
 	}
 	return eps, err
 }


### PR DESCRIPTION
fixes #9583 