### PR TITLE
clientv3/integration: fix "TestMaintenanceSnapshotErrorInflight"

### DIFF
--- a/clientv3/integration/maintenance_test.go
+++ b/clientv3/integration/maintenance_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -188,7 +189,7 @@ func TestMaintenanceSnapshotErrorInflight(t *testing.T) {
 	// 300ms left and expect timeout while snapshot reading is in progress
 	time.Sleep(700 * time.Millisecond)
 	_, err = io.Copy(ioutil.Discard, rc2)
-	if err != nil && err != context.DeadlineExceeded {
-		t.Errorf("expected %v, got %v", context.DeadlineExceeded, err)
+	if err != nil && !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Errorf("expected %v from gRPC, got %v", context.DeadlineExceeded, err)
 	}
 }


### PR DESCRIPTION
Errors from gRPC should be typed *status.statusError

```
=== RUN   TestMaintenanceSnapshotErrorInflight
WARNING: 2018/05/29 11:43:21 grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: Error while dialing dial unix localhost:55815860381826373260: connect: no such file or directory"; Reconnecting to {localhost:55815860381826373260 0  <nil>}
--- FAIL: TestMaintenanceSnapshotErrorInflight (2.42s)
	maintenance_test.go:192: expected context deadline exceeded, got rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

Fix https://jenkins-etcd-public.prod.coreos.systems/job/etcd-proxy/4840/console.