### PR TITLE
etcdctl/ctlv3: remove ETCDCTL_API warning, fix e2e coverage tests

### DIFF
--- a/etcdctl/ctlv3/ctl_cov.go
+++ b/etcdctl/ctlv3/ctl_cov.go
@@ -23,16 +23,9 @@ import (
 	"github.com/coreos/etcd/etcdctl/ctlv3/command"
 )
 
-func Start(apiv string) {
+func Start() {
 	// ETCDCTL_ARGS=etcdctl_test arg1 arg2...
 	// SetArgs() takes arg1 arg2...
-	if apiv == "" {
-		rootCmd.Short += "\n\n" +
-			"WARNING:\n" +
-			"        Environment variable ETCDCTL_API is not set; defaults to etcdctl v3.\n" +
-			"        Set environment variable ETCDCTL_API=2 to use v2 API or ETCDCTL_API=3 to use v3 API."
-
-	}
 	rootCmd.SetArgs(strings.Split(os.Getenv("ETCDCTL_ARGS"), "\xe7\xcd")[1:])
 	os.Unsetenv("ETCDCTL_ARGS")
 	if err := rootCmd.Execute(); err != nil {

--- a/etcdctl/ctlv3/ctl_nocov.go
+++ b/etcdctl/ctlv3/ctl_nocov.go
@@ -18,14 +18,7 @@ package ctlv3
 
 import "github.com/coreos/etcd/etcdctl/ctlv3/command"
 
-func Start(apiv string) {
-	if apiv == "" {
-		rootCmd.Short += "\n\n" +
-			"WARNING:\n" +
-			"        Environment variable ETCDCTL_API is not set; defaults to etcdctl v3.\n" +
-			"        Set environment variable ETCDCTL_API=2 to use v2 API or ETCDCTL_API=3 to use v3 API."
-
-	}
+func Start() {
 	rootCmd.SetUsageFunc(usageFunc)
 	// Make help just show the usage
 	rootCmd.SetHelpTemplate(`{{.UsageString}}`)

--- a/etcdctl/main.go
+++ b/etcdctl/main.go
@@ -32,7 +32,7 @@ func main() {
 	// unset apiEnv to avoid side-effect for future env and flag parsing.
 	os.Unsetenv(apiEnv)
 	if len(apiv) == 0 || apiv == "3" {
-		ctlv3.Start(apiv)
+		ctlv3.Start()
 		return
 	}
 

--- a/tests/e2e/ctl_v2_test.go
+++ b/tests/e2e/ctl_v2_test.go
@@ -265,9 +265,11 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 
 	// v3 put before v2 set so snapshot happens after v3 operations to confirm
 	// v3 data is preserved after snapshot.
+	os.Setenv("ETCDCTL_API", "3")
 	if err := ctlV3Put(ctlCtx{t: t, epc: epc1}, "v3key", "123", ""); err != nil {
 		t.Fatal(err)
 	}
+	os.Setenv("ETCDCTL_API", "2")
 
 	if err := etcdctlSet(epc1, "foo1", "bar1"); err != nil {
 		t.Fatal(err)
@@ -298,6 +300,7 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 		t.Fatal(err)
 	}
 
+	os.Setenv("ETCDCTL_API", "3")
 	ctx2 := ctlCtx{t: t, epc: epc2}
 	if v3 {
 		if err := ctlV3Get(ctx2, []string{"v3key"}, kv{"v3key", "123"}); err != nil {
@@ -308,6 +311,7 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 			t.Fatal(err)
 		}
 	}
+	os.Setenv("ETCDCTL_API", "2")
 
 	// check if it can serve client requests
 	if err := etcdctlSet(epc2, "foo2", "bar2"); err != nil {


### PR DESCRIPTION
To make coverage stats happy https://codecov.io/gh/coreos/etcd/commit/25bc65794f6802cb24b40c3a46de9ab3fa5f9e6b.
