### PR TITLE
Documentation: Fix etcdctl tx eBNF

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -256,7 +256,7 @@ RPC: Txn
 <Txn> ::= <CMP>* "\n" <THEN> "\n" <ELSE> "\n"
 <CMP> ::= (<CMPCREATE>|<CMPMOD>|<CMPVAL>|<CMPVER>|<CMPLEASE>) "\n"
 <CMPOP> ::= "<" | "=" | ">"
-<CMPCREATE> := ("c"|"create")"("<KEY>")" <REVISION>
+<CMPCREATE> := ("c"|"create")"("<KEY>")" <CMPOP> <REVISION>
 <CMPMOD> ::= ("m"|"mod")"("<KEY>")" <CMPOP> <REVISION>
 <CMPVAL> ::= ("val"|"value")"("<KEY>")" <CMPOP> <VALUE>
 <CMPVER> ::= ("ver"|"version")"("<KEY>")" <CMPOP> <VERSION>


### PR DESCRIPTION
In `etcdctl txn`, the`create` target also expects operand or error is printed.

```
$ etcdctl txn -i
compares:
create("mykey") "1"
Error:  malformed comparison: create("mykey") "1"; got create("mykey") "1" ""
```