### PR TITLE
ctlv3: support TLS endpoints for move-leader command

### DIFF
--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -112,11 +112,12 @@ func (*discardValue) Type() string     { return "" }
 
 func clientConfigFromCmd(cmd *cobra.Command) *clientConfig {
 	fs := cmd.InheritedFlags()
-
-	// silence "pkg/flags: unrecognized environment variable ETCDCTL_WATCH_KEY=foo" warnings
-	// silence "pkg/flags: unrecognized environment variable ETCDCTL_WATCH_RANGE_END=bar" warnings
-	fs.AddFlag(&pflag.Flag{Name: "watch-key", Value: &discardValue{}})
-	fs.AddFlag(&pflag.Flag{Name: "watch-range-end", Value: &discardValue{}})
+	if strings.HasPrefix(cmd.Use, "watch") {
+		// silence "pkg/flags: unrecognized environment variable ETCDCTL_WATCH_KEY=foo" warnings
+		// silence "pkg/flags: unrecognized environment variable ETCDCTL_WATCH_RANGE_END=bar" warnings
+		fs.AddFlag(&pflag.Flag{Name: "watch-key", Value: &discardValue{}})
+		fs.AddFlag(&pflag.Flag{Name: "watch-range-end", Value: &discardValue{}})
+	}
 	flags.SetPflagsFromEnv("ETCDCTL", fs)
 
 	debug, err := cmd.Flags().GetBool("debug")

--- a/etcdctl/ctlv3/command/move_leader_command.go
+++ b/etcdctl/ctlv3/command/move_leader_command.go
@@ -17,7 +17,6 @@ package command
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/spf13/cobra"
@@ -53,13 +52,9 @@ func transferLeadershipCommandFunc(cmd *cobra.Command, args []string) {
 	var leaderCli *clientv3.Client
 	var leaderID uint64
 	for _, ep := range eps {
-		cli, cerr := clientv3.New(clientv3.Config{
-			Endpoints:   []string{ep},
-			DialTimeout: 3 * time.Second,
-		})
-		if cerr != nil {
-			ExitWithError(ExitError, cerr)
-		}
+		cfg := clientConfigFromCmd(cmd)
+		cfg.endpoints = []string{ep}
+		cli := cfg.mustClient()
 		resp, serr := cli.Status(ctx, ep)
 		if serr != nil {
 			ExitWithError(ExitError, serr)

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"testing"
@@ -23,18 +24,41 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/testutil"
+	"github.com/coreos/etcd/pkg/transport"
 	"github.com/coreos/etcd/pkg/types"
 )
 
-func TestCtlV3MoveLeader(t *testing.T) {
+func TestCtlV3MoveLeaderSecure(t *testing.T) {
+	testCtlV3MoveLeader(t, configTLS)
+}
+
+func TestCtlV3MoveLeaderInsecure(t *testing.T) {
+	testCtlV3MoveLeader(t, configNoTLS)
+}
+
+func testCtlV3MoveLeader(t *testing.T, cfg etcdProcessClusterConfig) {
 	defer testutil.AfterTest(t)
 
-	epc := setupEtcdctlTest(t, &configNoTLS, true)
+	epc := setupEtcdctlTest(t, &cfg, true)
 	defer func() {
 		if errC := epc.Close(); errC != nil {
 			t.Fatalf("error closing etcd processes (%v)", errC)
 		}
 	}()
+
+	var tcfg *tls.Config
+	if cfg.clientTLS == clientTLS {
+		tinfo := transport.TLSInfo{
+			CertFile:      certPath,
+			KeyFile:       privateKeyPath,
+			TrustedCAFile: caPath,
+		}
+		var err error
+		tcfg, err = tinfo.ClientConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	var leadIdx int
 	var leaderID uint64
@@ -43,6 +67,7 @@ func TestCtlV3MoveLeader(t *testing.T) {
 		cli, err := clientv3.New(clientv3.Config{
 			Endpoints:   []string{ep},
 			DialTimeout: 3 * time.Second,
+			TLS:         tcfg,
 		})
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/9805.