### PR TITLE
*: add "etcd_server_quota_backend_bytes" metric

### DIFF
--- a/etcdserver/metrics.go
+++ b/etcdserver/metrics.go
@@ -84,6 +84,12 @@ var (
 		Name:      "lease_expired_total",
 		Help:      "The total number of expired leases.",
 	})
+	quotaBackendBytes = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "quota_backend_bytes",
+		Help:      "Current backend storage quota size in bytes.",
+	})
 	currentVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "etcd",
 		Subsystem: "server",
@@ -104,6 +110,7 @@ func init() {
 	prometheus.MustRegister(proposalsPending)
 	prometheus.MustRegister(proposalsFailed)
 	prometheus.MustRegister(leaseExpired)
+	prometheus.MustRegister(quotaBackendBytes)
 	prometheus.MustRegister(currentVersion)
 
 	currentVersion.With(prometheus.Labels{

--- a/etcdserver/quota.go
+++ b/etcdserver/quota.go
@@ -62,6 +62,7 @@ const (
 
 func NewBackendQuota(s *EtcdServer, name string) Quota {
 	lg := s.getLogger()
+	quotaBackendBytes.Set(float64(s.Cfg.QuotaBackendBytes))
 
 	if s.Cfg.QuotaBackendBytes < 0 {
 		// disable quotas if negative
@@ -87,6 +88,7 @@ func NewBackendQuota(s *EtcdServer, name string) Quota {
 				zap.String("quota-size", humanize.Bytes(uint64(DefaultQuotaBytes))),
 			)
 		}
+		quotaBackendBytes.Set(float64(DefaultQuotaBytes))
 		return &backendQuota{s, DefaultQuotaBytes}
 	}
 

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/etcd/etcdserver"
+
 	pb "github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/pkg/testutil"
 )
@@ -135,5 +137,23 @@ func TestMetricDbSizeDefrag(t *testing.T) {
 	}
 	if adiu > av {
 		t.Fatalf("db size in use (%d) is expected less than db size (%d) after defrag", adiu, av)
+	}
+}
+
+func TestMetricQuotaBackendBytes(t *testing.T) {
+	defer testutil.AfterTest(t)
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	qs, err := clus.Members[0].Metric("etcd_server_quota_backend_bytes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	qv, err := strconv.ParseFloat(qs, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(qv) != etcdserver.DefaultQuotaBytes {
+		t.Fatalf("expected %d, got %f", etcdserver.DefaultQuotaBytes, qv)
 	}
 }


### PR DESCRIPTION
Currently, there's no way to programmatically fetch the current quota size and use it for alert. One manually needs to look at the server configuration flag, or look at the server logs.

Add `etcd_server_quota_backend_bytes` metrics. It will be useful for writing alert rules combining with `etcd_mvcc_db_total_size_in_bytes` and `etcd_mvcc_db_total_size_in_use_in_bytes`, before the alarm is raised.

/cc @saranbalaji90 @xiang90 @jpbetz 