### PR TITLE
etcdserver: Replace value contents with value_size in request took too long warning

### DIFF
--- a/etcdserver/etcdserverpb/raft_internal_stringer.go
+++ b/etcdserver/etcdserverpb/raft_internal_stringer.go
@@ -14,10 +14,15 @@
 
 package etcdserverpb
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	proto "github.com/golang/protobuf/proto"
+)
 
 // InternalRaftStringer implements custom proto Stringer:
-// redact password, shorten output(TODO).
+// redact password, replace value fields with value_size fields.
 type InternalRaftStringer struct {
 	Request *InternalRaftRequest
 }
@@ -51,8 +56,128 @@ func (as *InternalRaftStringer) String() string {
 			as.Request.Header.String(),
 			as.Request.AuthUserChangePassword.Name,
 		)
+	case as.Request.Put != nil:
+		return fmt.Sprintf("header:<%s> put:<%s>",
+			as.Request.Header.String(),
+			newLoggablePutRequest(as.Request.Put).String(),
+		)
+	case as.Request.Txn != nil:
+		return fmt.Sprintf("header:<%s> txn:<%s>",
+			as.Request.Header.String(),
+			newLoggableTxnRequest(as.Request.Txn).String(),
+		)
 	default:
 		// nothing to redact
 	}
 	return as.Request.String()
 }
+
+// txnRequestStringer implements a custom proto String to replace value bytes fields with value size
+// fields in any nested txn and put operations.
+type txnRequestStringer struct {
+	Request *TxnRequest
+}
+
+func newLoggableTxnRequest(request *TxnRequest) *txnRequestStringer {
+	return &txnRequestStringer{request}
+}
+
+func (as *txnRequestStringer) String() string {
+	var compare []string
+	for _, c := range as.Request.Compare {
+		switch cv := c.TargetUnion.(type) {
+		case *Compare_Value:
+			compare = append(compare, newLoggableValueCompare(c, cv).String())
+		default:
+			// nothing to redact
+			compare = append(compare, c.String())
+		}
+	}
+	var success []string
+	for _, s := range as.Request.Success {
+		success = append(success, newLoggableRequestOp(s).String())
+	}
+	var failure []string
+	for _, f := range as.Request.Failure {
+		failure = append(failure, newLoggableRequestOp(f).String())
+	}
+	return fmt.Sprintf("compare:<%s> success:<%s> failure:<%s>",
+		strings.Join(compare, " "),
+		strings.Join(success, " "),
+		strings.Join(failure, " "),
+	)
+}
+
+// requestOpStringer implements a custom proto String to replace value bytes fields with value
+// size fields in any nested txn and put operations.
+type requestOpStringer struct {
+	Op *RequestOp
+}
+
+func newLoggableRequestOp(op *RequestOp) *requestOpStringer {
+	return &requestOpStringer{op}
+}
+
+func (as *requestOpStringer) String() string {
+	switch op := as.Op.Request.(type) {
+	case *RequestOp_RequestPut:
+		return fmt.Sprintf("request_put:<%s>", newLoggablePutRequest(op.RequestPut).String())
+	case *RequestOp_RequestTxn:
+		return fmt.Sprintf("request_txn:<%s>", newLoggableTxnRequest(op.RequestTxn).String())
+	default:
+		// nothing to redact
+	}
+	return as.Op.String()
+}
+
+// loggableValueCompare implements a custom proto String for Compare.Value union member types to
+// replace the value bytes field with a value size field.
+// To preserve proto encoding of the key and range_end bytes, a faked out proto type is used here.
+type loggableValueCompare struct {
+	Result    Compare_CompareResult `protobuf:"varint,1,opt,name=result,proto3,enum=etcdserverpb.Compare_CompareResult"`
+	Target    Compare_CompareTarget `protobuf:"varint,2,opt,name=target,proto3,enum=etcdserverpb.Compare_CompareTarget"`
+	Key       []byte                `protobuf:"bytes,3,opt,name=key,proto3"`
+	ValueSize int                   `protobuf:"bytes,7,opt,name=value_size,proto3"`
+	RangeEnd  []byte                `protobuf:"bytes,64,opt,name=range_end,proto3"`
+}
+
+func newLoggableValueCompare(c *Compare, cv *Compare_Value) *loggableValueCompare {
+	return &loggableValueCompare{
+		c.Result,
+		c.Target,
+		c.Key,
+		len(cv.Value),
+		c.RangeEnd,
+	}
+}
+
+func (m *loggableValueCompare) Reset()         { *m = loggableValueCompare{} }
+func (m *loggableValueCompare) String() string { return proto.CompactTextString(m) }
+func (*loggableValueCompare) ProtoMessage()    {}
+
+// loggablePutRequest implements a custom proto String to replace value bytes field with a value
+// size field.
+// To preserve proto encoding of the key bytes, a faked out proto type is used here.
+type loggablePutRequest struct {
+	Key         []byte `protobuf:"bytes,1,opt,name=key,proto3"`
+	ValueSize   int    `protobuf:"varint,2,opt,name=value_size,proto3"`
+	Lease       int64  `protobuf:"varint,3,opt,name=lease,proto3"`
+	PrevKv      bool   `protobuf:"varint,4,opt,name=prev_kv,proto3"`
+	IgnoreValue bool   `protobuf:"varint,5,opt,name=ignore_value,proto3"`
+	IgnoreLease bool   `protobuf:"varint,6,opt,name=ignore_lease,proto3"`
+}
+
+func newLoggablePutRequest(request *PutRequest) *loggablePutRequest {
+	return &loggablePutRequest{
+		request.Key,
+		len(request.Value),
+		request.Lease,
+		request.PrevKv,
+		request.IgnoreValue,
+		request.IgnoreLease,
+	}
+}
+
+func (m *loggablePutRequest) Reset()         { *m = loggablePutRequest{} }
+func (m *loggablePutRequest) String() string { return proto.CompactTextString(m) }
+func (*loggablePutRequest) ProtoMessage()    {}


### PR DESCRIPTION
This removes the logging of values for "request took too long warnings" that was introduced in etcd 3.2.  We shouldn't log values. Value fields are likely contain sensitive data, make the logs difficult to scan, and have the potential to "flood" the logs exhausting disk space and/or starving the system disk IO.

This replaces all occurrences of value fields with a value_size field. Fortunately there are only two occurrences: (1) put requests and (2) txns that do a value compare.

Example output:

txn:
```
BEFORE:
2018-06-07 16:54:52.146394 W | etcdserver: request "header:<ID:7587830746628055043 > txn:<compare:<target:VALUE key:\"a\" value:\"1\" > success:<request_put:<key:\"b\" value:\"foo\" > > failure:<request_put:<key:\"c\" value:\"goo\\\"\" > > > " took too long (106.821µs) to execute

AFTER:
2018-06-07 16:37:42.945095 W | etcdserver: request "header:<ID:7587830746365689091 > txn:<compare:<target:VALUE key:\"a\" value_size:1 > success:<request_put:<key:\"b\" value_size:3 >> failure:<request_put:<key:\"c\" value_size:4 >>>" took too long (71.196µs) to execute
```

put:
```
BEFORE:
2018-06-07 16:54:58.694712 W | etcdserver: request "header:<ID:7587830746628055044 > put:<key:\"a\" value:\"this is a test\" > " took too long (106.008µs) to execute

AFTER:
2018-06-07 16:37:58.844290 W | etcdserver: request "header:<ID:7587830746365689092 > put:<key:\"a\" value_size:14 >" took too long (59.798µs) to execute
```

In order to preserve proto encoding of `[]byte` fields, this introduces some private structs mirroring the request proto structs, but with `value` replaced with `value_size`.

cc @gyuho @wenjiaswe @mml