### PR TITLE
etcdserver: Fix txn request 'took too long' warnings to use loggable request stringer

### DIFF
--- a/etcdserver/etcdserverpb/raft_internal_stringer.go
+++ b/etcdserver/etcdserverpb/raft_internal_stringer.go
@@ -64,7 +64,7 @@ func (as *InternalRaftStringer) String() string {
 	case as.Request.Txn != nil:
 		return fmt.Sprintf("header:<%s> txn:<%s>",
 			as.Request.Header.String(),
-			newLoggableTxnRequest(as.Request.Txn).String(),
+			NewLoggableTxnRequest(as.Request.Txn).String(),
 		)
 	default:
 		// nothing to redact
@@ -78,7 +78,7 @@ type txnRequestStringer struct {
 	Request *TxnRequest
 }
 
-func newLoggableTxnRequest(request *TxnRequest) *txnRequestStringer {
+func NewLoggableTxnRequest(request *TxnRequest) *txnRequestStringer {
 	return &txnRequestStringer{request}
 }
 
@@ -123,7 +123,7 @@ func (as *requestOpStringer) String() string {
 	case *RequestOp_RequestPut:
 		return fmt.Sprintf("request_put:<%s>", newLoggablePutRequest(op.RequestPut).String())
 	case *RequestOp_RequestTxn:
-		return fmt.Sprintf("request_txn:<%s>", newLoggableTxnRequest(op.RequestTxn).String())
+		return fmt.Sprintf("request_txn:<%s>", NewLoggableTxnRequest(op.RequestTxn).String())
 	default:
 		// nothing to redact
 	}

--- a/etcdserver/util.go
+++ b/etcdserver/util.go
@@ -111,7 +111,8 @@ func warnOfExpensiveRequest(lg *zap.Logger, now time.Time, reqStringer fmt.Strin
 	warnOfExpensiveGenericRequest(lg, now, reqStringer, "", resp, err)
 }
 
-func warnOfExpensiveReadOnlyTxnRequest(lg *zap.Logger, now time.Time, reqStringer fmt.Stringer, txnResponse *pb.TxnResponse, err error) {
+func warnOfExpensiveReadOnlyTxnRequest(lg *zap.Logger, now time.Time, r *pb.TxnRequest, txnResponse *pb.TxnResponse, err error) {
+	reqStringer := pb.NewLoggableTxnRequest(r)
 	var resp string
 	if !isNil(txnResponse) {
 		var resps []string


### PR DESCRIPTION
#9822 fixed log entries starting with "etcdserver: request", but not those starting with. "etcdserver: read-only range request":

```
etcdserver: read-only range request "compare:<target:VALUE key:\"a\" value:\"1\" > success:<request_range:<key:\"/a\" range_end:\"/b\" > > failure:<request_range:<key:\"/a\" range_end:\"/b\" > > " with result "responses:<range_response_count:0> size:12" took too long (48.373µs) to execute
```

This fixes the logger to handle the "read-only range" warnings correctly:

```
etcdserver: read-only range request "compare:<target:VALUE key:\"a\" value_size:1 > success:<request_range:<key:\"/a\" range_end:\"/b\" > > failure:<request_range:<key:\"/a\" range_end:\"/b\" > >" with result "responses:<range_response_count:0> size:12" took too long (37.32µs) to execute
```