### PR TITLE
travis: combine all build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,32 +15,24 @@ notifications:
 
 env:
   matrix:
-  - TARGET=linux-amd64-build
-  - TARGET=linux-amd64-unit
   - TARGET=linux-amd64-fmt
   - TARGET=linux-amd64-integration-1-cpu
   - TARGET=linux-amd64-integration-2-cpu
   - TARGET=linux-amd64-integration-4-cpu
   - TARGET=linux-amd64-functional
-  - TARGET=linux-386-build
-  - TARGET=linux-386-unit
-  - TARGET=darwin-amd64-build
-  - TARGET=windows-amd64-build
-  - TARGET=linux-arm-build
-  - TARGET=linux-arm64-build
-  - TARGET=linux-ppc64le-build
+  - TARGET=linux-amd64-unit
+  - TARGET=all-build
   - TARGET=linux-amd64-fmt-unit-go-tip
+  - TARGET=linux-386-unit
 
 matrix:
   fast_finish: true
   allow_failures:
   - go: tip
     env: TARGET=linux-amd64-fmt-unit-go-tip
+  - go: 1.10.3
+    env: TARGET=linux-386-unit
   exclude:
-  - go: tip
-    env: TARGET=linux-amd64-build
-  - go: tip
-    env: TARGET=linux-amd64-unit
   - go: tip
     env: TARGET=linux-amd64-fmt
   - go: tip
@@ -52,21 +44,13 @@ matrix:
   - go: tip
     env: TARGET=linux-amd64-functional
   - go: tip
-    env: TARGET=linux-386-build
+    env: TARGET=linux-amd64-unit
   - go: tip
-    env: TARGET=linux-386-unit
-  - go: tip
-    env: TARGET=darwin-amd64-build
-  - go: tip
-    env: TARGET=windows-amd64-build
-  - go: tip
-    env: TARGET=linux-arm-build
-  - go: tip
-    env: TARGET=linux-arm64-build
-  - go: tip
-    env: TARGET=linux-ppc64le-build
+    env: TARGET=all-build
   - go: 1.10.3
     env: TARGET=linux-amd64-fmt-unit-go-tip
+  - go: tip
+    env: TARGET=linux-386-unit
 
 before_install:
 - if [[ $TRAVIS_GO_VERSION == 1.* ]]; then docker pull gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION}; fi
@@ -78,16 +62,6 @@ script:
  - echo "TRAVIS_GO_VERSION=${TRAVIS_GO_VERSION}"
  - >
     case "${TARGET}" in
-      linux-amd64-build)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='build' ./test"
-        ;;
-      linux-amd64-unit)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='unit' ./test"
-        ;;
       linux-amd64-fmt)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
@@ -113,42 +87,28 @@ script:
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "./build && GOARCH=amd64 PASSES='functional' ./test"
         ;;
-      linux-386-build)
+      linux-amd64-unit)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=386 PASSES='build' ./test"
+          /bin/bash -c "GOARCH=amd64 PASSES='unit' ./test"
+        ;;
+      all-build)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GOARCH=amd64 PASSES='build' ./test \
+            && GOARCH=386 PASSES='build' ./test \
+            && GO_BUILD_FLAGS='-v' GOOS=darwin GOARCH=amd64 ./build \
+            && GO_BUILD_FLAGS='-v' GOOS=windows GOARCH=amd64 ./build \
+            && GO_BUILD_FLAGS='-v' GOARCH=arm ./build \
+            && GO_BUILD_FLAGS='-v' GOARCH=arm64 ./build \
+            && GO_BUILD_FLAGS='-v' GOARCH=ppc64le ./build"
+        ;;
+      linux-amd64-fmt-unit-go-tip)
+        GOARCH=amd64 PASSES='fmt unit' ./test
         ;;
       linux-386-unit)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "GOARCH=386 PASSES='unit' ./test"
-        ;;
-      darwin-amd64-build)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-v' GOOS=darwin GOARCH=amd64 ./build"
-        ;;
-      windows-amd64-build)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-v' GOOS=windows GOARCH=amd64 ./build"
-        ;;
-      linux-arm-build)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-v' GOARCH=arm ./build"
-        ;;
-      linux-arm64-build)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-v' GOARCH=arm64 ./build"
-        ;;
-      linux-ppc64le-build)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-v' GOARCH=ppc64le ./build"
-        ;;
-      linux-amd64-fmt-unit-go-tip)
-        GOARCH=amd64 PASSES='fmt unit' ./test
         ;;
     esac


### PR DESCRIPTION
We only get 5 concurrent workers in Travis.
Save time by fetching test image only once
for all build tests.

Keep working for https://github.com/coreos/etcd/issues/8862.