### PR TITLE
raft: fix logger Panic variadic parameter

### DIFF
--- a/raft/logger.go
+++ b/raft/logger.go
@@ -114,7 +114,7 @@ func (l *DefaultLogger) Fatalf(format string, v ...interface{}) {
 }
 
 func (l *DefaultLogger) Panic(v ...interface{}) {
-	l.Logger.Panic(v)
+	l.Logger.Panic(v..)
 }
 
 func (l *DefaultLogger) Panicf(format string, v ...interface{}) {


### PR DESCRIPTION
etcd/raft is failing in building with below error message

```
"# github.com/coreos/etcd/raft
raft/logger.go:117: missing ... in args forwarded to print-like function"
```

New parameter check got added the golang to check the function parameter
https://github.com/golang/go/commit/c00603607511701ecc9f56fd82ac528ecf6b8fc6#diff-8fa5b0d6191706747ef5773f895781c9


Please read https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
