### PR TITLE
rafthttp: add "RaftDropHeartbeat" failpoint

### DIFF
--- a/etcdserver/api/rafthttp/stream.go
+++ b/etcdserver/api/rafthttp/stream.go
@@ -510,6 +510,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 	}
 	cr.mu.Unlock()
 
+	// gofail: labelRaftDropHeartbeat:
 	for {
 		m, err := dec.decode()
 		if err != nil {
@@ -519,6 +520,8 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 			return err
 		}
 
+		// gofail-go: var raftDropHeartbeat struct{}
+		// continue labelRaftDropHeartbeat
 		receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(m.Size()))
 
 		cr.mu.Lock()


### PR DESCRIPTION
To simulate network partition locally.

Will try this with https://github.com/coreos/gofail/pull/15.