### PR TITLE
tests: switch between Travis and Semaphore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,20 @@ env:
   - TARGET=linux-amd64-integration-2-cpu
   - TARGET=linux-amd64-integration-4-cpu
   - TARGET=linux-amd64-functional
-  - TARGET=linux-amd64-unit
   - TARGET=all-build
+  - TARGET=linux-amd64-grpcproxy
+  - TARGET=linux-amd64-coverage
   - TARGET=linux-amd64-fmt-unit-go-tip
-  - TARGET=linux-386-unit
 
 matrix:
   fast_finish: true
   allow_failures:
+  - go: 1.10.3
+    env: TARGET=linux-amd64-grpcproxy
+  - go: 1.10.3
+    env: TARGET=linux-amd64-coverage
   - go: tip
     env: TARGET=linux-amd64-fmt-unit-go-tip
-  - go: 1.10.3
-    env: TARGET=linux-386-unit
   exclude:
   - go: tip
     env: TARGET=linux-amd64-fmt
@@ -47,10 +49,12 @@ matrix:
     env: TARGET=linux-amd64-unit
   - go: tip
     env: TARGET=all-build
+  - go: tip
+    env: TARGET=linux-amd64-grpcproxy
+  - go: tip
+    env: TARGET=linux-amd64-coverage
   - go: 1.10.3
     env: TARGET=linux-amd64-fmt-unit-go-tip
-  - go: tip
-    env: TARGET=linux-386-unit
 
 before_install:
 - if [[ $TRAVIS_GO_VERSION == 1.* ]]; then docker pull gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION}; fi
@@ -87,11 +91,6 @@ script:
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "./build && GOARCH=amd64 PASSES='functional' ./test"
         ;;
-      linux-amd64-unit)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='unit' ./test"
-        ;;
       all-build)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
@@ -103,12 +102,13 @@ script:
             && GO_BUILD_FLAGS='-v' GOARCH=arm64 ./build \
             && GO_BUILD_FLAGS='-v' GOARCH=ppc64le ./build"
         ;;
+      linux-amd64-grpcproxy)
+        sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build grpcproxy'" make docker-test
+        ;;
+      linux-amd64-coverage)
+        sudo HOST_TMP_DIR=/tmp make docker-test-coverage
+        ;;
       linux-amd64-fmt-unit-go-tip)
         GOARCH=amd64 PASSES='fmt unit' ./test
-        ;;
-      linux-386-unit)
-        docker run --rm \
-          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=386 PASSES='unit' ./test"
         ;;
     esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,12 @@ env:
   - TARGET=linux-amd64-integration-2-cpu
   - TARGET=linux-amd64-integration-4-cpu
   - TARGET=linux-amd64-functional
+  - TARGET=linux-amd64-unit
   - TARGET=all-build
   - TARGET=linux-amd64-grpcproxy
   - TARGET=linux-amd64-coverage
   - TARGET=linux-amd64-fmt-unit-go-tip
+  - TARGET=linux-386-unit
 
 matrix:
   fast_finish: true
@@ -34,6 +36,8 @@ matrix:
     env: TARGET=linux-amd64-coverage
   - go: tip
     env: TARGET=linux-amd64-fmt-unit-go-tip
+  - go: 1.10.3
+    env: TARGET=linux-386-unit
   exclude:
   - go: tip
     env: TARGET=linux-amd64-fmt
@@ -55,6 +59,8 @@ matrix:
     env: TARGET=linux-amd64-coverage
   - go: 1.10.3
     env: TARGET=linux-amd64-fmt-unit-go-tip
+  - go: tip
+    env: TARGET=linux-386-unit
 
 before_install:
 - if [[ $TRAVIS_GO_VERSION == 1.* ]]; then docker pull gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION}; fi
@@ -91,6 +97,11 @@ script:
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "./build && GOARCH=amd64 PASSES='functional' ./test"
         ;;
+      linux-amd64-unit)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GOARCH=amd64 PASSES='unit' ./test"
+        ;;
       all-build)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
@@ -110,5 +121,10 @@ script:
         ;;
       linux-amd64-fmt-unit-go-tip)
         GOARCH=amd64 PASSES='fmt unit' ./test
+        ;;
+      linux-386-unit)
+        docker run --rm \
+          --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
+          /bin/bash -c "GOARCH=386 PASSES='unit' ./test"
         ;;
     esac

--- a/tests/semaphore.test.bash
+++ b/tests/semaphore.test.bash
@@ -12,12 +12,6 @@ sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.3.7" 
 
 # 386-e2e
 sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='build e2e'" make docker-test
-
-# amd64-unit
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=amd64 PASSES='unit'" make docker-test
-
-# 386-unit
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='unit'" make docker-test
 COMMENT
 
 sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.3.7" make docker-test

--- a/tests/semaphore.test.bash
+++ b/tests/semaphore.test.bash
@@ -7,28 +7,17 @@ fi
 
 <<COMMENT
 # amd64-e2e
-bash tests/semaphore.test.bash
+tests/semaphore.test.bash
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.3.7" make docker-test
 
 # 386-e2e
-TEST_ARCH=386 bash tests/semaphore.test.bash
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='build e2e'" make docker-test
 
-# grpc-proxy
-TEST_OPTS="PASSES='build grpcproxy'" bash tests/semaphore.test.bash
+# amd64-unit
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=amd64 PASSES='unit'" make docker-test
 
-# coverage
-TEST_OPTS="coverage" bash tests/semaphore.test.bash
+# 386-unit
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='unit'" make docker-test
 COMMENT
 
-if [ -z "${TEST_OPTS}" ]; then
-	TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.3.7"
-fi
-if [ "${TEST_ARCH}" == "386" ]; then
-  TEST_OPTS="GOARCH=386 PASSES='build e2e'"
-fi
-
-echo "Running tests with" ${TEST_OPTS}
-if [ "${TEST_OPTS}" == "coverage" ]; then
-  sudo HOST_TMP_DIR=/tmp make docker-test-coverage
-else
-  sudo HOST_TMP_DIR=/tmp TEST_OPTS="${TEST_OPTS}" make docker-test
-fi
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.3.7" make docker-test


### PR DESCRIPTION
Run e2e and unit tests in Semaphore.
Run rest in Travis.

gRPC proxy tests are failing for no reason, only in Semaphore.
Testing it in Travis, to see if it fixes.