### PR TITLE
tests/e2e: do not run cipher suite tests for gRPC proxy

### DIFF
--- a/tests/e2e/v3_cipher_suite_test.go
+++ b/tests/e2e/v3_cipher_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !cov
+// +build !cov,!cluster_proxy
 
 package e2e
 


### PR DESCRIPTION
```
../../bin/etcd-30074: 2018-06-19 11:49:12.052662 I | etcdmain: v2 proxy started listening on client requests on "https://localhost:20002"
../../bin/etcd-30083: Error: unknown flag: --cipher-suites
../../bin/etcd-30083: Usage:
../../bin/etcd-30083:   etcd grpc-proxy start [flags]
```

Keep fixing gRPC proxy tests...