### PR TITLE
clientv3: fix custom dialer endpoint

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -245,8 +245,8 @@ func (c *Client) dialSetupOpts(target string, dopts ...grpc.DialOption) (opts []
 	}
 	opts = append(opts, dopts...)
 
-	f := func(dialEp string, t time.Duration) (net.Conn, error) {
-		proto, host, _ := endpoint.ParseEndpoint(dialEp)
+	f := func(_ string, t time.Duration) (net.Conn, error) {
+		proto, host, _ := endpoint.ParseEndpoint(ep)
 		if host == "" && ep != "" {
 			// dialing an endpoint not in the balancer; use
 			// endpoint passed into dial


### PR DESCRIPTION
When given multiple resolved addresses, gRPC uses a fixed address
that's used for initial gRPC connection (not the other ones that
are resolved together).

Fix `Status` API and others that specify endpoints as a parameter (snapshot, defragment, maintenance APIs):

```
$ ./bin/etcdctl endpoint status --write-out table --cluster

+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+
|        ENDPOINT        |        ID        |  VERSION  | DB SIZE | IS LEADER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+
|  http://127.0.0.1:2379 | 8211f1d0f64f3269 | 3.3.0+git |   20 kB |      true |         2 |          8 |                  8 |        |
| http://127.0.0.1:22379 | 8211f1d0f64f3269 | 3.3.0+git |   20 kB |      true |         2 |          8 |                  8 |        |
| http://127.0.0.1:32379 | 8211f1d0f64f3269 | 3.3.0+git |   20 kB |      true |         2 |          8 |                  8 |        |
+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+
```

@jpbetz If this looks correct, I will add test cases. Also, need to dig in more, how gRPC consumes dialer.