### PR TITLE
clientv3: fix dialer for maintenance API

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -247,10 +247,10 @@ func (c *Client) dialSetupOpts(target string, dopts ...grpc.DialOption) (opts []
 
 	f := func(dialEp string, t time.Duration) (net.Conn, error) {
 		proto, host, _ := endpoint.ParseEndpoint(dialEp)
-		if host == "" && ep != "" {
+		if host != ep {
 			// dialing an endpoint not in the balancer; use
 			// endpoint passed into dial
-			proto, host, _ = endpoint.ParseEndpoint(ep)
+			host = ep
 		}
 		if proto == "" {
 			return nil, fmt.Errorf("unknown scheme for %q", host)


### PR DESCRIPTION
Without patch

```
=== RUN   TestMaintenanceStatus
dial proto "unix" host "localhost:39491187763008498080" | dialEp "unix://localhost:39491187763008498080" | target "endpoint://client-bmdwzcpdjwn8/localhost:39491187763008498080" | ep "localhost:39491187763008498080"
dial proto "unix" host "localhost:57863826249668888540" | dialEp "unix://localhost:57863826249668888540" | target "endpoint://client-bmdwzcpe4ao8/localhost:57863826249668888540" | ep "localhost:57863826249668888540"
dial proto "unix" host "localhost:33033510950554123550" | dialEp "unix://localhost:33033510950554123550" | target "endpoint://client-bmdwzcpeiijr/localhost:33033510950554123550" | ep "localhost:33033510950554123550"
dial proto "unix" host "localhost:57863826249668888540" | dialEp "unix://localhost:57863826249668888540" | target "endpoint://client-bmdwzcpg64tf/localhost:39491187763008498080" | ep "localhost:39491187763008498080"
dial proto "unix" host "localhost:33033510950554123550" | dialEp "unix://localhost:33033510950554123550" | target "endpoint://client-bmdwzcpg64tf/localhost:39491187763008498080" | ep "localhost:39491187763008498080"
dial proto "unix" host "localhost:39491187763008498080" | dialEp "unix://localhost:39491187763008498080" | target "endpoint://client-bmdwzcpg64tf/localhost:39491187763008498080" | ep "localhost:39491187763008498080"
dial proto "unix" host "localhost:39491187763008498080" | dialEp "unix://localhost:39491187763008498080" | target "endpoint://client-bmdwzcpg64tf/localhost:39491187763008498080" | ep "localhost:39491187763008498080"
dial proto "unix" host "localhost:39491187763008498080" | dialEp "unix://localhost:39491187763008498080" | target "endpoint://client-bmdwzcpg64tf/localhost:57863826249668888540" | ep "localhost:57863826249668888540"
dial proto "unix" host "localhost:39491187763008498080" | dialEp "unix://localhost:39491187763008498080" | target "endpoint://client-bmdwzcpg64tf/localhost:33033510950554123550" | ep "localhost:33033510950554123550"
--- FAIL: TestMaintenanceStatus (0.17s)
	maintenance_test.go:102: #1: status returned duplicate member ID with 0eb083ea01d9b6c4
	maintenance_test.go:102: #2: status returned duplicate member ID with 0eb083ea01d9b6c4
	maintenance_test.go:112: no leader found
```

So gRPC is passing the endpoint used for initial client connection to the custom dialer, not the endpoint target that client passes to the dial method. So, we need special handling when two given hosts are different.

/cc @jpbetz 