### PR TITLE
Update CHANGELOG-3.2 to include changes from #9894

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -2,8 +2,15 @@
 
 Previous change logs can be found at [CHANGELOG-3.1](https://github.com/coreos/etcd/blob/master/CHANGELOG-3.1.md).
 
+## [v3.2.24](https://github.com/coreos/etcd/releases/tag/v3.2.24) (TBD 2018-07)
 
-## [v3.2.23](https://github.com/coreos/etcd/releases/tag/v3.2.23) (TBD 2018-06)
+### gRPC Proxy
+
+* Add [flags for specifying TLS for connecting to proxy](https://github.com/coreos/etcd/pull/9894/files):
+  - Add `cert-file` and `key-file` and `trusted-ca-file` flags.
+* Add [`--metrics-addr` flag for specifying metrics listen address](https://github.com/coreos/etcd/pull/9894/files).
+
+## [v3.2.23](https://github.com/coreos/etcd/releases/tag/v3.2.23) (2018-06-15)
 
 See [code changes](https://github.com/coreos/etcd/compare/v3.2.22...v3.2.23) and [v3.2 upgrade guide](https://github.com/coreos/etcd/blob/master/Documentation/upgrades/upgrade_3_2.md) for any breaking changes. **Again, before running upgrades from any previous release, please make sure to read change logs below and [v3.2 upgrade guide](https://github.com/coreos/etcd/blob/master/Documentation/upgrades/upgrade_3_2.md).**
 


### PR DESCRIPTION
This PR updates the CHANGELOG for version 3.2 to include changes from #9894.

The Changelog seems out-of-loop, as 3.2.23 has already been released. I added a new 3.2.24 entry, however I didn't know release date and Go version.

Let me know should I add or improve something.

/cc @gyuho 