### PR TITLE
*: combine all configuration print logs to embed.StartEtcd

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -78,27 +78,17 @@ func startEtcdOrProxyV2() {
 		os.Exit(1)
 	}
 
-	maxProcs, cpus := runtime.GOMAXPROCS(0), runtime.NumCPU()
-
 	lg := cfg.ec.GetLogger()
-	if lg != nil {
-		lg.Info(
-			"starting etcd",
-			zap.String("etcd-version", version.Version),
-			zap.String("git-sha", version.GitSHA),
-			zap.String("go-version", runtime.Version()),
-			zap.String("go-os", runtime.GOOS),
-			zap.String("go-arch", runtime.GOARCH),
-			zap.Int("max-cpu-set", maxProcs),
-			zap.Int("max-cpu-available", cpus),
-		)
-	} else {
+
+	if lg == nil {
+		// TODO: remove in 3.5
 		plog.Infof("etcd Version: %s\n", version.Version)
 		plog.Infof("Git SHA: %s\n", version.GitSHA)
 		plog.Infof("Go Version: %s\n", runtime.Version())
 		plog.Infof("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-		plog.Infof("setting maximum number of CPUs to %d, total number of available CPUs is %d", maxProcs, cpus)
+		plog.Infof("setting maximum number of CPUs to %d, total number of available CPUs is %d", runtime.GOMAXPROCS(0), runtime.NumCPU())
 	}
+
 	defer func() {
 		logger := cfg.ec.GetLogger()
 		if logger != nil {

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -266,71 +266,6 @@ func (c *ServerConfig) peerDialTimeout() time.Duration {
 	return time.Second + time.Duration(c.ElectionTicks*int(c.TickMs))*time.Millisecond
 }
 
-func (c *ServerConfig) PrintWithInitial() { c.print(true) }
-
-func (c *ServerConfig) Print() { c.print(false) }
-
-func (c *ServerConfig) print(initial bool) {
-	// TODO: remove this after dropping "capnslog"
-	if c.Logger == nil {
-		plog.Infof("name = %s", c.Name)
-		if c.ForceNewCluster {
-			plog.Infof("force new cluster")
-		}
-		plog.Infof("data dir = %s", c.DataDir)
-		plog.Infof("member dir = %s", c.MemberDir())
-		if c.DedicatedWALDir != "" {
-			plog.Infof("dedicated WAL dir = %s", c.DedicatedWALDir)
-		}
-		plog.Infof("heartbeat = %dms", c.TickMs)
-		plog.Infof("election = %dms", c.ElectionTicks*int(c.TickMs))
-		plog.Infof("snapshot count = %d", c.SnapshotCount)
-		if len(c.DiscoveryURL) != 0 {
-			plog.Infof("discovery URL= %s", c.DiscoveryURL)
-			if len(c.DiscoveryProxy) != 0 {
-				plog.Infof("discovery proxy = %s", c.DiscoveryProxy)
-			}
-		}
-		plog.Infof("advertise client URLs = %s", c.ClientURLs)
-		if initial {
-			plog.Infof("initial advertise peer URLs = %s", c.PeerURLs)
-			plog.Infof("initial cluster = %s", c.InitialPeerURLsMap)
-		}
-	} else {
-		state := "new"
-		if !c.NewCluster {
-			state = "existing"
-		}
-		c.Logger.Info(
-			"server configuration",
-			zap.String("name", c.Name),
-			zap.String("data-dir", c.DataDir),
-			zap.String("member-dir", c.MemberDir()),
-			zap.String("dedicated-wal-dir", c.DedicatedWALDir),
-			zap.Bool("force-new-cluster", c.ForceNewCluster),
-			zap.String("heartbeat-interval", fmt.Sprintf("%v", time.Duration(c.TickMs)*time.Millisecond)),
-			zap.String("election-timeout", fmt.Sprintf("%v", time.Duration(c.ElectionTicks*int(c.TickMs))*time.Millisecond)),
-			zap.Bool("initial-election-tick-advance", c.InitialElectionTickAdvance),
-			zap.Uint64("snapshot-count", c.SnapshotCount),
-			zap.Uint64("snapshot-catchup-entries", c.SnapshotCatchUpEntries),
-			zap.Strings("advertise-client-urls", c.getACURLs()),
-			zap.Strings("initial-advertise-peer-urls", c.getAPURLs()),
-			zap.Bool("initial", initial),
-			zap.String("initial-cluster", c.InitialPeerURLsMap.String()),
-			zap.String("initial-cluster-state", state),
-			zap.String("initial-cluster-token", c.InitialClusterToken),
-			zap.Bool("pre-vote", c.PreVote),
-			zap.Bool("initial-corrupt-check", c.InitialCorruptCheck),
-			zap.String("corrupt-check-time-interval", c.CorruptCheckTime.String()),
-			zap.String("auto-compaction-mode", c.AutoCompactionMode),
-			zap.Duration("auto-compaction-retention", c.AutoCompactionRetention),
-			zap.String("auto-compaction-interval", c.AutoCompactionRetention.String()),
-			zap.String("discovery-url", c.DiscoveryURL),
-			zap.String("discovery-proxy", c.DiscoveryProxy),
-		)
-	}
-}
-
 func checkDuplicateURL(urlsmap types.URLsMap) bool {
 	um := make(map[string]bool)
 	for _, urls := range urlsmap {
@@ -353,19 +288,3 @@ func (c *ServerConfig) bootstrapTimeout() time.Duration {
 }
 
 func (c *ServerConfig) backendPath() string { return filepath.Join(c.SnapDir(), "db") }
-
-func (c *ServerConfig) getAPURLs() (ss []string) {
-	ss = make([]string, len(c.PeerURLs))
-	for i := range c.PeerURLs {
-		ss[i] = c.PeerURLs[i].String()
-	}
-	return ss
-}
-
-func (c *ServerConfig) getACURLs() (ss []string) {
-	ss = make([]string, len(c.ClientURLs))
-	for i := range c.ClientURLs {
-		ss[i] = c.ClientURLs[i].String()
-	}
-	return ss
-}

--- a/etcdserver/quota.go
+++ b/etcdserver/quota.go
@@ -66,7 +66,7 @@ var (
 	// only log once
 	quotaLogOnce sync.Once
 
-	defaultQuotaSize = humanize.Bytes(uint64(DefaultQuotaBytes))
+	DefaultQuotaSize = humanize.Bytes(uint64(DefaultQuotaBytes))
 	maxQuotaSize     = humanize.Bytes(uint64(MaxQuotaBytes))
 )
 
@@ -99,7 +99,7 @@ func NewBackendQuota(s *EtcdServer, name string) Quota {
 					"enabled backend quota with default value",
 					zap.String("quota-name", name),
 					zap.Int64("quota-size-bytes", DefaultQuotaBytes),
-					zap.String("quota-size", defaultQuotaSize),
+					zap.String("quota-size", DefaultQuotaSize),
 				)
 			}
 		})

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -357,7 +357,6 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		cl.SetID(types.ID(0), existingCluster.ID())
 		cl.SetStore(st)
 		cl.SetBackend(be)
-		cfg.Print()
 		id, n, s, w = startNode(cfg, cl, nil)
 		cl.SetID(id, existingCluster.ID())
 
@@ -393,7 +392,6 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		}
 		cl.SetStore(st)
 		cl.SetBackend(be)
-		cfg.PrintWithInitial()
 		id, n, s, w = startNode(cfg, cl, cl.MemberIDs())
 		cl.SetID(id, cl.ID())
 
@@ -457,8 +455,6 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 				)
 			}
 		}
-
-		cfg.Print()
 
 		if !cfg.ForceNewCluster {
 			id, cl, n, s, w = restartNode(cfg, snapshot)


### PR DESCRIPTION
Previous server configuration logs were spread-out, thus hard to read. Move all info logs to `embed.StartEtcd`. This will make test debug easier once we move all integration tests  to use embed package. And just use `memberInitialized` in `embed` package.

Before

> {"level":"info","ts":1531157203.0864909,"caller":"etcdmain/etcd.go:85","msg":"starting etcd","etcd-version":"3.3.0+git","git-sha":"e23853a9e","go-version":"go1.10.3","go-os":"linux","go-arch":"amd64","max-cpu-set":4,"max-cpu-available":4}

> {"level":"info","ts":1531157203.098978,"caller":"etcdserver/config.go:304","msg":"server configuration","name":"default","data-dir":"default.etcd","member-dir":"default.etcd/member","dedicated-wal-dir":"","force-new-cluster":false,"heartbeat-interval":"100ms","election-timeout":"1s","initial-election-tick-advance":true,"snapshot-count":100000,"snapshot-catchup-entries":0,"advertise-client-urls":["http://localhost:2379"],"initial-advertise-peer-urls":["http://localhost:2380"],"initial":true,"initial-cluster":"default=http://localhost:2380","initial-cluster-state":"new","initial-cluster-token":"etcd-cluster","pre-vote":false,"initial-corrupt-check":false,"corrupt-check-time-interval":"0s","auto-compaction-mode":"periodic","auto-compaction-retention":0,"auto-compaction-interval":"0s","discovery-url":"","discovery-proxy":""}

> {"level":"info","ts":1531157203.1305707,"caller":"embed/etcd.go:210","msg":"configured CORS","cors":["*"]}

> {"level":"info","ts":1531157203.1306794,"caller":"embed/etcd.go:222","msg":"configured host whitelist","hosts":["*"]}


Now

> {"level":"info","ts":1531160645.0471747,"caller":"embed/etcd.go:292","msg":"starting an etcd server","etcd-version":"3.3.0+git","git-sha":"e23853a9e","go-version":"go1.10.3","go-os":"linux","go-arch":"amd64","max-cpu-set":4,"max-cpu-available":4,"member-initialized":false,"name":"default","data-dir":"default.etcd","wal-dir":"","wal-dir-dedicated":"","member-dir":"default.etcd/member","force-new-cluster":false,"heartbeat-interval":"100ms","election-timeout":"1s","initial-election-tick-advance":true,"snapshot-count":100000,"snapshot-catchup-entries":5000,"initial-advertise-peer-urls":["http://localhost:2380"],"listen-peer-urls":["http://localhost:2380"],"advertise-client-urls":["http://localhost:2379"],"listen-client-urls":["http://localhost:2379"],"listen-metrics-urls":[],"cors":["*"],"host-whitelist":["*"],"initial-cluster":"default=http://localhost:2380","initial-cluster-state":"new","initial-cluster-token":"etcd-cluster","quota-size-bytes":2147483648,"pre-vote":false,"initial-corrupt-check":false,"corrupt-check-time-interval":"0s","auto-compaction-mode":"periodic","auto-compaction-retention":0,"auto-compaction-interval":"0s","discovery-url":"","discovery-proxy":""}
