### PR TITLE
Documentation/upgrades: update upgrade doc indexes

### DIFF
--- a/Documentation/upgrades/upgrading-etcd.md
+++ b/Documentation/upgrades/upgrading-etcd.md
@@ -8,6 +8,8 @@ This section contains documents specific to upgrading etcd clusters and applicat
 ## Upgrading an etcd v3.x cluster
 * [Upgrade etcd from 3.0 to 3.1][upgrade-3-1]
 * [Upgrade etcd from 3.1 to 3.2][upgrade-3-2]
+* [Upgrade etcd from 3.2 to 3.3][upgrade-3-3]
+* [Upgrade etcd from 3.3 to 3.4][upgrade-3-4]
 
 ## Upgrading from etcd v2.3
 * [Upgrade a v2.3 cluster to v3.0][upgrade-cluster]
@@ -17,3 +19,5 @@ This section contains documents specific to upgrading etcd clusters and applicat
 [upgrade-cluster]: upgrade_3_0.md
 [upgrade-3-1]: upgrade_3_1.md
 [upgrade-3-2]: upgrade_3_2.md
+[upgrade-3-3]: upgrade_3_3.md
+[upgrade-3-4]: upgrade_3_4.md


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/9909.

Will backport and request for coreos.com doc sync.

v3.4 has not been released but we are starting tracking changes in https://github.com/coreos/etcd/blob/master/Documentation/upgrades/upgrade_3_4.md.

@philips 