### PR TITLE
clientv3: Fix maintenance APIs to directly dial grpc endpoints directly

### DIFF
--- a/.words
+++ b/.words
@@ -30,6 +30,7 @@ gRPC
 goroutine
 goroutines
 healthcheck
+hostname
 iff
 inflight
 keepalive

--- a/clientv3/balancer/resolver/endpoint/endpoint.go
+++ b/clientv3/balancer/resolver/endpoint/endpoint.go
@@ -99,6 +99,15 @@ func Target(id, endpoint string) string {
 	return fmt.Sprintf("%s://%s/%s", scheme, id, endpoint)
 }
 
+// DirectTarget constructs a direct resolver target to a single endpoint.
+// TODO: It should be possible to use the 'passthrough' resolver instead
+// of a custom resolver for this use case, but TLS connections fail for
+// a reason we haven't been able to determine.
+func DirectTarget(endpoint string) string {
+	_, host, scheme := ParseEndpoint(endpoint)
+	return Target(fmt.Sprintf("direct:%s", scheme), host)
+}
+
 // IsTarget checks if a given target string in an endpoint resolver target.
 func IsTarget(target string) bool {
 	return strings.HasPrefix(target, "endpoint://")
@@ -114,6 +123,11 @@ func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, opts res
 		return nil, fmt.Errorf("'etcd' target scheme requires non-empty authority identifying etcd cluster being routed to")
 	}
 	id := target.Authority
+
+	if isDirectEndpoint(target) {
+		return buildDirectEndpointResolver(target, cc, opts)
+	}
+
 	es, err := b.getResolverGroup(id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build resolver: %v", err)
@@ -123,6 +137,25 @@ func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, opts res
 		cc:         cc,
 	}
 	es.addResolver(r)
+	return r, nil
+}
+
+func isDirectEndpoint(target resolver.Target) bool {
+	return strings.HasPrefix(target.Authority, "direct:")
+}
+
+func buildDirectEndpointResolver(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+	parts := strings.SplitN(target.Authority, ":", 2)
+	if len(parts) != 2 || parts[0] != "direct" {
+		return nil, fmt.Errorf("'endpoint' resolver authority must be of form 'direct:<scheme>', but got %s", target.Authority)
+	}
+	scheme := parts[1]
+	ep := scheme + "://" + target.Endpoint
+	r := &DirectResolver{
+		endpoint: ep,
+		cc:       cc,
+	}
+	r.cc.NewAddress(epsToAddrs(ep))
 	return r, nil
 }
 
@@ -187,6 +220,15 @@ func (r *Resolver) Close() {
 	es.removeResolver(r)
 }
 
+// DirectResolver provides a resolver for a single etcd endpoint.
+type DirectResolver struct {
+	endpoint string
+	cc       resolver.ClientConn
+}
+
+func (*DirectResolver) ResolveNow(o resolver.ResolveNowOption) {}
+func (*DirectResolver) Close()                                 {}
+
 // ParseEndpoint endpoint parses an endpoint of the form
 // (http|https)://<host>*|(unix|unixs)://<path>)
 // and returns a protocol ('tcp' or 'unix'),
@@ -212,18 +254,4 @@ func ParseEndpoint(endpoint string) (proto string, host string, scheme string) {
 		proto, host = "", ""
 	}
 	return proto, host, scheme
-}
-
-// ParseTarget parses a endpoint://<id>/<endpoint> string and returns the parsed id and endpoint.
-// If the target is malformed, an error is returned.
-func ParseTarget(target string) (string, string, error) {
-	noPrefix := strings.TrimPrefix(target, targetPrefix)
-	if noPrefix == target {
-		return "", "", fmt.Errorf("malformed target, %s prefix is required: %s", targetPrefix, target)
-	}
-	parts := strings.SplitN(noPrefix, "/", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("malformed target, expected %s://<id>/<endpoint>, but got %s", scheme, target)
-	}
-	return parts[0], parts[1], nil
 }

--- a/clientv3/integration/dial_test.go
+++ b/clientv3/integration/dial_test.go
@@ -79,20 +79,15 @@ func TestDialTLSNoConfig(t *testing.T) {
 		DialTimeout: time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer c.Close()
-
-	// TODO: this should not be required when we set grpc.WithBlock()
-	if c != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		_, err = c.KV.Get(ctx, "/")
-		cancel()
-	}
+	defer func() {
+		if c != nil {
+			c.Close()
+		}
+	}()
 	if !isClientTimeout(err) {
 		t.Fatalf("expected dial timeout error, got %v", err)
 	}
+
 }
 
 // TestDialSetEndpointsBeforeFail ensures SetEndpoints can replace unavailable

--- a/clientv3/integration/dial_test.go
+++ b/clientv3/integration/dial_test.go
@@ -87,7 +87,6 @@ func TestDialTLSNoConfig(t *testing.T) {
 	if !isClientTimeout(err) {
 		t.Fatalf("expected dial timeout error, got %v", err)
 	}
-
 }
 
 // TestDialSetEndpointsBeforeFail ensures SetEndpoints can replace unavailable

--- a/clientv3/integration/maintenance_test.go
+++ b/clientv3/integration/maintenance_test.go
@@ -25,7 +25,9 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 
+	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/coreos/etcd/integration"
 	"github.com/coreos/etcd/lease"
@@ -191,5 +193,49 @@ func TestMaintenanceSnapshotErrorInflight(t *testing.T) {
 	_, err = io.Copy(ioutil.Discard, rc2)
 	if err != nil && !isClientTimeout(err) {
 		t.Errorf("expected client timeout, got %v", err)
+	}
+}
+
+func TestMaintenanceStatus(t *testing.T) {
+	defer testutil.AfterTest(t)
+
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	defer clus.Terminate(t)
+
+	clus.WaitLeader(t)
+
+	eps := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		eps[i] = clus.Members[i].GRPCAddr()
+	}
+
+	cli, err := clientv3.New(clientv3.Config{Endpoints: eps, DialOptions: []grpc.DialOption{grpc.WithBlock()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	prevID, leaderFound := uint64(0), false
+	for i := 0; i < 3; i++ {
+		resp, err := cli.Status(context.TODO(), eps[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if prevID == 0 {
+			prevID, leaderFound = resp.Header.MemberId, resp.Header.MemberId == resp.Leader
+			continue
+		}
+		if prevID == resp.Header.MemberId {
+			t.Errorf("#%d: status returned duplicate member ID with %016x", i, prevID)
+		}
+		if leaderFound && resp.Header.MemberId == resp.Leader {
+			t.Errorf("#%d: leader already found, but found another %016x", i, resp.Header.MemberId)
+		}
+		if !leaderFound {
+			leaderFound = resp.Header.MemberId == resp.Leader
+		}
+	}
+	if !leaderFound {
+		t.Fatal("no leader found")
 	}
 }

--- a/clientv3/maintenance.go
+++ b/clientv3/maintenance.go
@@ -76,7 +76,7 @@ type maintenance struct {
 func NewMaintenance(c *Client) Maintenance {
 	api := &maintenance{
 		dial: func(endpoint string) (pb.MaintenanceClient, func(), error) {
-			conn, err := c.dial(endpoint)
+			conn, err := c.Dial(endpoint)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to dial endpoint %s with maintenance client: %v", endpoint, err)
 			}

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -72,10 +72,12 @@ func testCtlV3MoveLeader(t *testing.T, cfg etcdProcessClusterConfig) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, err := cli.Status(context.Background(), ep)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		resp, err := cli.Status(ctx, ep)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("failed to get status from endpoint %s: %v", ep, err)
 		}
+		cancel()
 		cli.Close()
 
 		if resp.Header.GetMemberId() == resp.Leader {


### PR DESCRIPTION
This fixes `clientv3.Dial` function to directly dial a single endpoint. 

Conveniently, it seems this can be fixed by removing special casing logic from clientv3. Previously clientv3 had code in `dialSetupOpts` that would attempt to circumvent the endpoint the balancer had selected when performing a `net.Dial`, but we had accidentally disabled this code path in the grpc new load balancer upgrade (with a condition that always returned false), and attempts to fix it to properly handle all use cases error prone, attempts to fix it could easily be applied it too broadly such that the balancer became unintentionally disabled when it should not. Instead of using that approach, this PR simply dials with a non-load balanced grpc target for all connections established via `clientv3.Dial`.

Fixes https://github.com/coreos/etcd/issues/9919

Example etcdctl status call after applying this to master:

```
bin/etcdctl endpoint status --cluster
http://127.0.0.1:2379, 8211f1d0f64f3269, 3.3.0+git, 422 MB, false, 14, 118988, 118988,                   
http://127.0.0.1:22379, 91bc3c398fb3c146, 3.3.0+git, 423 MB, false, 14, 118988, 118988,              
http://127.0.0.1:32379, fd422379fda50e48, 3.3.0+git, 423 MB, true, 14, 118988, 118988,
```

cc @gyuho @jingyih