### PR TITLE
docs: automate metrics list documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ clean:
 	rm -rf ./gopath.proto
 	rm -rf ./release
 	rm -f ./snapshot/localhost:*
+	rm -f ./tools/etcd-dump-metrics/localhost:*
 	rm -f ./integration/127.0.0.1:* ./integration/localhost:*
 	rm -f ./clientv3/integration/127.0.0.1:* ./clientv3/integration/localhost:*
 	rm -f ./clientv3/ordering/127.0.0.1:* ./clientv3/ordering/localhost:*

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,45 +1,41 @@
 .. _faq:
 
 
-FAQs
-####
-
-
 General
-=======
+#######
 
 
 What is etcd?
--------------
+=============
 
 etcd is a consistent distributed key-value store. Mainly used as a separate coordination service, in distributed systems. And designed to hold small amounts of data that can fit entirely in memory.
 
 
 How to pronounce etcd?
-----------------------
+======================
 
 etcd is pronounced ``/etˈ-sē-dē/`` or ``/etˈ-see-dee/``, and means distributed ``etc`` directory.
 
 
 Do clients have to send requests to the etcd leader?
-----------------------------------------------------
+====================================================
 
 `Raft <https://raft.github.io/raft.pdf>`_ is leader-based; the leader handles all client requests which need cluster consensus. However, the client does not need to know which node is the leader. Any request that requires consensus sent to a follower is automatically forwarded to the leader. Requests that do not require consensus (e.g., serialized reads) can be processed by any cluster member.
 
 
 Configuration
-=============
+#############
 
 
 Difference between listen-<client,peer>-urls, advertise-client-urls or initial-advertise-peer-urls?
----------------------------------------------------------------------------------------------------
+===================================================================================================
 
-``listen-client-urls`` and ``listen-peer-urls`` specify the local addresses etcd server binds to for accepting incoming connections. To listen on a port for all interfaces, specify ``0.0.0.0`` as the listen IP address.
+``--listen-client-urls`` and ``--listen-peer-urls`` specify the local addresses etcd server binds to for accepting incoming connections. To listen on a port for all interfaces, specify ``0.0.0.0`` as the listen IP address.
 
-``advertise-client-urls`` and ``initial-advertise-peer-urls`` specify the addresses etcd clients or other etcd members should use to contact the etcd server. The advertise addresses must be reachable from the remote machines. Do not advertise addresses like ``localhost`` or ``0.0.0.0`` for a production setup since these addresses are unreachable from remote machines.
+``--advertise-client-urls`` and ``--initial-advertise-peer-urls`` specify the addresses etcd clients or other etcd members should use to contact the etcd server. The advertise addresses must be reachable from the remote machines. Do not advertise addresses like ``localhost`` or ``0.0.0.0`` for a production setup since these addresses are unreachable from remote machines.
 
 
 Changing "listen-peer-urls" or "initial-advertise-peer-urls" does not update advertised peer URLs in member list output?
-------------------------------------------------------------------------------------------------------------------------
+========================================================================================================================
 
 A member's advertised peer URLs come from ``--initial-advertise-peer-urls`` on initial cluster boot. Changing the listen peer URLs or the initial advertise peers after booting the member won't affect the exported advertise peer URLs (e.g. ``etcdctl member list`` output remains the same), since changes must go through quorum to avoid membership configuration split brain. Use `etcdctl member update` to update a member's peer URLs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,20 +7,18 @@ This is official etcd documentation.
 Still working in progress...
 
 * :ref:`set-up`: setting up an etcd cluster.
-* :ref:`operate`: operating an etcd cluster.
 * :ref:`monitor`: monitoring an etcd cluster.
-* :ref:`faq`: frequently asked questions.
 * :ref:`client-architecture`: describes etcd client components.
 
 .. toctree::
    :maxdepth: 3
-   :caption: Set up
+   :caption: Get started
 
    set-up
 
 .. toctree::
    :maxdepth: 3
-   :caption: Operate
+   :caption: Operations
 
    operate
 

--- a/docs/metrics-latest
+++ b/docs/metrics-latest
@@ -1,0 +1,896 @@
+# server version: etcd_server_version{server_version="3.3.0+git"}
+
+# name: "etcd_debugging_disk_backend_commit_rebalance_duration_seconds"
+# description: "The latency distributions of commit.rebalance called by bboltdb backend."
+# type: "histogram"
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.001"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.002"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.004"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.008"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.016"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.032"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.064"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.128"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.256"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.512"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="1.024"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="2.048"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="4.096"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="8.192"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_sum
+etcd_debugging_disk_backend_commit_rebalance_duration_seconds_count
+
+# name: "etcd_debugging_disk_backend_commit_spill_duration_seconds"
+# description: "The latency distributions of commit.spill called by bboltdb backend."
+# type: "histogram"
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.001"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.002"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.004"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.008"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.016"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.032"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.064"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.128"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.256"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="0.512"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="1.024"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="2.048"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="4.096"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="8.192"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_disk_backend_commit_spill_duration_seconds_sum
+etcd_debugging_disk_backend_commit_spill_duration_seconds_count
+
+# name: "etcd_debugging_disk_backend_commit_write_duration_seconds"
+# description: "The latency distributions of commit.write called by bboltdb backend."
+# type: "histogram"
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.001"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.002"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.004"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.008"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.016"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.032"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.064"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.128"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.256"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="0.512"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="1.024"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="2.048"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="4.096"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="8.192"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_disk_backend_commit_write_duration_seconds_sum
+etcd_debugging_disk_backend_commit_write_duration_seconds_count
+
+# name: "etcd_debugging_lease_granted_total"
+# description: "The total number of granted leases."
+# type: "counter"
+etcd_debugging_lease_granted_total
+
+# name: "etcd_debugging_lease_renewed_total"
+# description: "The number of renewed leases seen by the leader."
+# type: "counter"
+etcd_debugging_lease_renewed_total
+
+# name: "etcd_debugging_lease_revoked_total"
+# description: "The total number of revoked leases."
+# type: "counter"
+etcd_debugging_lease_revoked_total
+
+# name: "etcd_debugging_lease_ttl_total"
+# description: "Bucketed histogram of lease TTLs."
+# type: "histogram"
+etcd_debugging_lease_ttl_total_bucket{le="1"}
+etcd_debugging_lease_ttl_total_bucket{le="2"}
+etcd_debugging_lease_ttl_total_bucket{le="4"}
+etcd_debugging_lease_ttl_total_bucket{le="8"}
+etcd_debugging_lease_ttl_total_bucket{le="16"}
+etcd_debugging_lease_ttl_total_bucket{le="32"}
+etcd_debugging_lease_ttl_total_bucket{le="64"}
+etcd_debugging_lease_ttl_total_bucket{le="128"}
+etcd_debugging_lease_ttl_total_bucket{le="256"}
+etcd_debugging_lease_ttl_total_bucket{le="512"}
+etcd_debugging_lease_ttl_total_bucket{le="1024"}
+etcd_debugging_lease_ttl_total_bucket{le="2048"}
+etcd_debugging_lease_ttl_total_bucket{le="4096"}
+etcd_debugging_lease_ttl_total_bucket{le="8192"}
+etcd_debugging_lease_ttl_total_bucket{le="16384"}
+etcd_debugging_lease_ttl_total_bucket{le="32768"}
+etcd_debugging_lease_ttl_total_bucket{le="65536"}
+etcd_debugging_lease_ttl_total_bucket{le="131072"}
+etcd_debugging_lease_ttl_total_bucket{le="262144"}
+etcd_debugging_lease_ttl_total_bucket{le="524288"}
+etcd_debugging_lease_ttl_total_bucket{le="1.048576e+06"}
+etcd_debugging_lease_ttl_total_bucket{le="2.097152e+06"}
+etcd_debugging_lease_ttl_total_bucket{le="4.194304e+06"}
+etcd_debugging_lease_ttl_total_bucket{le="8.388608e+06"}
+etcd_debugging_lease_ttl_total_bucket{le="+Inf"}
+etcd_debugging_lease_ttl_total_sum
+etcd_debugging_lease_ttl_total_count
+
+# name: "etcd_debugging_mvcc_db_compaction_keys_total"
+# description: "Total number of db keys compacted."
+# type: "counter"
+etcd_debugging_mvcc_db_compaction_keys_total
+
+# name: "etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds"
+# description: "Bucketed histogram of db compaction pause duration."
+# type: "histogram"
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="1"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="2"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="4"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="8"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="16"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="32"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="64"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="128"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="256"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="512"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="1024"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="2048"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="4096"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_sum
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_db_compaction_total_duration_milliseconds"
+# description: "Bucketed histogram of db compaction total duration."
+# type: "histogram"
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="100"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="1600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="3200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="6400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="12800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="25600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="51200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="102400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="204800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="409600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="819200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_db_total_size_in_bytes"
+# description: "Total size of the underlying database physically allocated in bytes."
+# type: "gauge"
+etcd_debugging_mvcc_db_total_size_in_bytes
+
+# name: "etcd_debugging_mvcc_delete_total"
+# description: "Total number of deletes seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_delete_total
+
+# name: "etcd_debugging_mvcc_events_total"
+# description: "Total number of events sent by this member."
+# type: "counter"
+etcd_debugging_mvcc_events_total
+
+# name: "etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds"
+# description: "Bucketed histogram of index compaction pause duration."
+# type: "histogram"
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="0.5"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="1"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="2"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="4"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="8"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="16"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="32"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="64"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="128"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="256"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="512"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="1024"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="2048"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="4096"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_sum
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_keys_total"
+# description: "Total number of keys."
+# type: "gauge"
+etcd_debugging_mvcc_keys_total
+
+# name: "etcd_debugging_mvcc_pending_events_total"
+# description: "Total number of pending events to be sent."
+# type: "gauge"
+etcd_debugging_mvcc_pending_events_total
+
+# name: "etcd_debugging_mvcc_put_total"
+# description: "Total number of puts seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_put_total
+
+# name: "etcd_debugging_mvcc_range_total"
+# description: "Total number of ranges seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_range_total
+
+# name: "etcd_debugging_mvcc_slow_watcher_total"
+# description: "Total number of unsynced slow watchers."
+# type: "gauge"
+etcd_debugging_mvcc_slow_watcher_total
+
+# name: "etcd_debugging_mvcc_txn_total"
+# description: "Total number of txns seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_txn_total
+
+# name: "etcd_debugging_mvcc_watch_stream_total"
+# description: "Total number of watch streams."
+# type: "gauge"
+etcd_debugging_mvcc_watch_stream_total
+
+# name: "etcd_debugging_mvcc_watcher_total"
+# description: "Total number of watchers."
+# type: "gauge"
+etcd_debugging_mvcc_watcher_total
+
+# name: "etcd_debugging_server_lease_expired_total"
+# description: "The total number of expired leases."
+# type: "counter"
+etcd_debugging_server_lease_expired_total
+
+# name: "etcd_debugging_snap_save_marshalling_duration_seconds"
+# description: "The marshalling cost distributions of save called by snapshot."
+# type: "histogram"
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.001"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.002"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.004"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.008"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.016"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.032"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.064"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.128"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.256"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.512"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="1.024"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="2.048"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="4.096"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="8.192"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_snap_save_marshalling_duration_seconds_sum
+etcd_debugging_snap_save_marshalling_duration_seconds_count
+
+# name: "etcd_debugging_snap_save_total_duration_seconds"
+# description: "The total latency distributions of save called by snapshot."
+# type: "histogram"
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.001"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.002"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.004"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.008"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.016"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.032"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.064"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.128"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.256"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.512"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="1.024"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="2.048"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="4.096"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="8.192"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_snap_save_total_duration_seconds_sum
+etcd_debugging_snap_save_total_duration_seconds_count
+
+# name: "etcd_debugging_store_expires_total"
+# description: "Total number of expired keys."
+# type: "counter"
+etcd_debugging_store_expires_total
+
+# name: "etcd_debugging_store_reads_total"
+# description: "Total number of reads action by (get/getRecursive), local to this member."
+# type: "counter"
+etcd_debugging_store_reads_total{action="getRecursive"}
+
+# name: "etcd_debugging_store_watch_requests_total"
+# description: "Total number of incoming watch requests (new or reestablished)."
+# type: "counter"
+etcd_debugging_store_watch_requests_total
+
+# name: "etcd_debugging_store_watchers"
+# description: "Count of currently active watchers."
+# type: "gauge"
+etcd_debugging_store_watchers
+
+# name: "etcd_debugging_store_writes_total"
+# description: "Total number of writes (e.g. set/compareAndDelete) seen by this member."
+# type: "counter"
+etcd_debugging_store_writes_total{action="create"}
+etcd_debugging_store_writes_total{action="set"}
+
+# name: "etcd_disk_backend_commit_duration_seconds"
+# description: "The latency distributions of commit called by backend."
+# type: "histogram"
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.001"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.002"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.004"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.008"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.016"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.032"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.064"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.128"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.256"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.512"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="1.024"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="2.048"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="4.096"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="8.192"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="+Inf"}
+etcd_disk_backend_commit_duration_seconds_sum
+etcd_disk_backend_commit_duration_seconds_count
+
+# name: "etcd_disk_backend_defrag_duration_seconds"
+# description: "The latency distribution of backend defragmentation."
+# type: "histogram"
+etcd_disk_backend_defrag_duration_seconds_bucket{le="0.1"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="0.2"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="0.4"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="0.8"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="1.6"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="3.2"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="6.4"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="12.8"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="25.6"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="51.2"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="102.4"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="204.8"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="409.6"}
+etcd_disk_backend_defrag_duration_seconds_bucket{le="+Inf"}
+etcd_disk_backend_defrag_duration_seconds_sum
+etcd_disk_backend_defrag_duration_seconds_count
+
+# name: "etcd_disk_backend_snapshot_duration_seconds"
+# description: "The latency distribution of backend snapshots."
+# type: "histogram"
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.01"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.02"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.04"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.08"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.16"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.32"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.64"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="1.28"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="2.56"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="5.12"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="10.24"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="20.48"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="40.96"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="81.92"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="163.84"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="327.68"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="655.36"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="+Inf"}
+etcd_disk_backend_snapshot_duration_seconds_sum
+etcd_disk_backend_snapshot_duration_seconds_count
+
+# name: "etcd_disk_wal_fsync_duration_seconds"
+# description: "The latency distributions of fsync called by WAL."
+# type: "histogram"
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.001"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.002"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.004"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.008"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.016"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.032"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.064"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.128"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.256"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.512"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="1.024"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="2.048"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="4.096"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="8.192"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="+Inf"}
+etcd_disk_wal_fsync_duration_seconds_sum
+etcd_disk_wal_fsync_duration_seconds_count
+
+# name: "etcd_mvcc_db_total_size_in_bytes"
+# description: "Total size of the underlying database physically allocated in bytes."
+# type: "gauge"
+etcd_mvcc_db_total_size_in_bytes
+
+# name: "etcd_mvcc_db_total_size_in_use_in_bytes"
+# description: "Total size of the underlying database logically in use in bytes."
+# type: "gauge"
+etcd_mvcc_db_total_size_in_use_in_bytes
+
+# name: "etcd_mvcc_hash_duration_seconds"
+# description: "The latency distribution of storage hash operation."
+# type: "histogram"
+etcd_mvcc_hash_duration_seconds_bucket{le="0.01"}
+etcd_mvcc_hash_duration_seconds_bucket{le="0.02"}
+etcd_mvcc_hash_duration_seconds_bucket{le="0.04"}
+etcd_mvcc_hash_duration_seconds_bucket{le="0.08"}
+etcd_mvcc_hash_duration_seconds_bucket{le="0.16"}
+etcd_mvcc_hash_duration_seconds_bucket{le="0.32"}
+etcd_mvcc_hash_duration_seconds_bucket{le="0.64"}
+etcd_mvcc_hash_duration_seconds_bucket{le="1.28"}
+etcd_mvcc_hash_duration_seconds_bucket{le="2.56"}
+etcd_mvcc_hash_duration_seconds_bucket{le="5.12"}
+etcd_mvcc_hash_duration_seconds_bucket{le="10.24"}
+etcd_mvcc_hash_duration_seconds_bucket{le="20.48"}
+etcd_mvcc_hash_duration_seconds_bucket{le="40.96"}
+etcd_mvcc_hash_duration_seconds_bucket{le="81.92"}
+etcd_mvcc_hash_duration_seconds_bucket{le="163.84"}
+etcd_mvcc_hash_duration_seconds_bucket{le="+Inf"}
+etcd_mvcc_hash_duration_seconds_sum
+etcd_mvcc_hash_duration_seconds_count
+
+# name: "etcd_mvcc_hash_rev_duration_seconds"
+# description: "The latency distribution of storage hash by revision operation."
+# type: "histogram"
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="0.01"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="0.02"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="0.04"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="0.08"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="0.16"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="0.32"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="0.64"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="1.28"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="2.56"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="5.12"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="10.24"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="20.48"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="40.96"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="81.92"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="163.84"}
+etcd_mvcc_hash_rev_duration_seconds_bucket{le="+Inf"}
+etcd_mvcc_hash_rev_duration_seconds_sum
+etcd_mvcc_hash_rev_duration_seconds_count
+
+# name: "etcd_network_active_peers"
+# description: "The current number of active peer connections."
+# type: "gauge"
+etcd_network_active_peers{Local="LOCAL_NODE_ID",Remote="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_client_grpc_received_bytes_total"
+# description: "The total number of bytes received from grpc clients."
+# type: "counter"
+etcd_network_client_grpc_received_bytes_total
+
+# name: "etcd_network_client_grpc_sent_bytes_total"
+# description: "The total number of bytes sent to grpc clients."
+# type: "counter"
+etcd_network_client_grpc_sent_bytes_total
+
+# name: "etcd_network_peer_received_bytes_total"
+# description: "The total number of bytes received from peers."
+# type: "counter"
+etcd_network_peer_received_bytes_total{From="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_peer_round_trip_time_seconds"
+# description: "Round-Trip-Time histogram between peers."
+# type: "histogram"
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="+Inf"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0001"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0002"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0004"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0008"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0016"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0032"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0064"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0128"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0256"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0512"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.1024"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.2048"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.4096"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.8192"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="1.6384"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="3.2768"}
+etcd_network_peer_round_trip_time_seconds_count{To="REMOTE_PEER_NODE_ID"}
+etcd_network_peer_round_trip_time_seconds_sum{To="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_peer_sent_bytes_total"
+# description: "The total number of bytes sent to peers."
+# type: "counter"
+etcd_network_peer_sent_bytes_total{To="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_server_has_leader"
+# description: "Whether or not a leader exists. 1 is existence, 0 is not."
+# type: "gauge"
+etcd_server_has_leader
+
+# name: "etcd_server_heartbeat_send_failures_total"
+# description: "The total number of leader heartbeat send failures (likely overloaded from slow disk)."
+# type: "counter"
+etcd_server_heartbeat_send_failures_total
+
+# name: "etcd_server_is_leader"
+# description: "Whether or not this member is a leader. 1 if is, 0 otherwise."
+# type: "gauge"
+etcd_server_is_leader
+
+# name: "etcd_server_leader_changes_seen_total"
+# description: "The number of leader changes seen."
+# type: "counter"
+etcd_server_leader_changes_seen_total
+
+# name: "etcd_server_proposals_applied_total"
+# description: "The total number of consensus proposals applied."
+# type: "gauge"
+etcd_server_proposals_applied_total
+
+# name: "etcd_server_proposals_committed_total"
+# description: "The total number of consensus proposals committed."
+# type: "gauge"
+etcd_server_proposals_committed_total
+
+# name: "etcd_server_proposals_failed_total"
+# description: "The total number of failed proposals seen."
+# type: "counter"
+etcd_server_proposals_failed_total
+
+# name: "etcd_server_proposals_pending"
+# description: "The current number of pending proposals to commit."
+# type: "gauge"
+etcd_server_proposals_pending
+
+# name: "etcd_server_quota_backend_bytes"
+# description: "Current backend storage quota size in bytes."
+# type: "gauge"
+etcd_server_quota_backend_bytes
+
+# name: "etcd_server_slow_apply_total"
+# description: "The total number of slow apply requests (likely overloaded from slow disk)."
+# type: "counter"
+etcd_server_slow_apply_total
+
+# name: "etcd_server_slow_read_indexes_total"
+# description: "The total number of pending read indexes not in sync with leader's or timed out read index requests."
+# type: "counter"
+etcd_server_slow_read_indexes_total
+
+# name: "etcd_server_version"
+# description: "Which version is running. 1 for 'server_version' label with current version."
+# type: "gauge"
+etcd_server_version{server_version="3.3.0+git"}
+
+# name: "etcd_snap_fsync_duration_seconds"
+# description: "The latency distributions of fsync called by snap."
+# type: "histogram"
+etcd_snap_fsync_duration_seconds_bucket{le="0.001"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.002"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.004"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.008"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.016"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.032"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.064"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.128"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.256"}
+etcd_snap_fsync_duration_seconds_bucket{le="0.512"}
+etcd_snap_fsync_duration_seconds_bucket{le="1.024"}
+etcd_snap_fsync_duration_seconds_bucket{le="2.048"}
+etcd_snap_fsync_duration_seconds_bucket{le="4.096"}
+etcd_snap_fsync_duration_seconds_bucket{le="8.192"}
+etcd_snap_fsync_duration_seconds_bucket{le="+Inf"}
+etcd_snap_fsync_duration_seconds_sum
+etcd_snap_fsync_duration_seconds_count
+
+# name: "go_gc_duration_seconds"
+# description: "A summary of the GC invocation durations."
+# type: "summary"
+go_gc_duration_seconds{quantile="0"}
+go_gc_duration_seconds{quantile="0.25"}
+go_gc_duration_seconds{quantile="0.5"}
+go_gc_duration_seconds{quantile="0.75"}
+go_gc_duration_seconds{quantile="1"}
+go_gc_duration_seconds_sum
+go_gc_duration_seconds_count
+
+# name: "go_goroutines"
+# description: "Number of goroutines that currently exist."
+# type: "gauge"
+go_goroutines
+
+# name: "go_memstats_alloc_bytes"
+# description: "Number of bytes allocated and still in use."
+# type: "gauge"
+go_memstats_alloc_bytes
+
+# name: "go_memstats_alloc_bytes_total"
+# description: "Total number of bytes allocated, even if freed."
+# type: "counter"
+go_memstats_alloc_bytes_total
+
+# name: "go_memstats_buck_hash_sys_bytes"
+# description: "Number of bytes used by the profiling bucket hash table."
+# type: "gauge"
+go_memstats_buck_hash_sys_bytes
+
+# name: "go_memstats_frees_total"
+# description: "Total number of frees."
+# type: "counter"
+go_memstats_frees_total
+
+# name: "go_memstats_gc_sys_bytes"
+# description: "Number of bytes used for garbage collection system metadata."
+# type: "gauge"
+go_memstats_gc_sys_bytes
+
+# name: "go_memstats_heap_alloc_bytes"
+# description: "Number of heap bytes allocated and still in use."
+# type: "gauge"
+go_memstats_heap_alloc_bytes
+
+# name: "go_memstats_heap_idle_bytes"
+# description: "Number of heap bytes waiting to be used."
+# type: "gauge"
+go_memstats_heap_idle_bytes
+
+# name: "go_memstats_heap_inuse_bytes"
+# description: "Number of heap bytes that are in use."
+# type: "gauge"
+go_memstats_heap_inuse_bytes
+
+# name: "go_memstats_heap_objects"
+# description: "Number of allocated objects."
+# type: "gauge"
+go_memstats_heap_objects
+
+# name: "go_memstats_heap_released_bytes_total"
+# description: "Total number of heap bytes released to OS."
+# type: "counter"
+go_memstats_heap_released_bytes_total
+
+# name: "go_memstats_heap_sys_bytes"
+# description: "Number of heap bytes obtained from system."
+# type: "gauge"
+go_memstats_heap_sys_bytes
+
+# name: "go_memstats_last_gc_time_seconds"
+# description: "Number of seconds since 1970 of last garbage collection."
+# type: "gauge"
+go_memstats_last_gc_time_seconds
+
+# name: "go_memstats_lookups_total"
+# description: "Total number of pointer lookups."
+# type: "counter"
+go_memstats_lookups_total
+
+# name: "go_memstats_mallocs_total"
+# description: "Total number of mallocs."
+# type: "counter"
+go_memstats_mallocs_total
+
+# name: "go_memstats_mcache_inuse_bytes"
+# description: "Number of bytes in use by mcache structures."
+# type: "gauge"
+go_memstats_mcache_inuse_bytes
+
+# name: "go_memstats_mcache_sys_bytes"
+# description: "Number of bytes used for mcache structures obtained from system."
+# type: "gauge"
+go_memstats_mcache_sys_bytes
+
+# name: "go_memstats_mspan_inuse_bytes"
+# description: "Number of bytes in use by mspan structures."
+# type: "gauge"
+go_memstats_mspan_inuse_bytes
+
+# name: "go_memstats_mspan_sys_bytes"
+# description: "Number of bytes used for mspan structures obtained from system."
+# type: "gauge"
+go_memstats_mspan_sys_bytes
+
+# name: "go_memstats_next_gc_bytes"
+# description: "Number of heap bytes when next garbage collection will take place."
+# type: "gauge"
+go_memstats_next_gc_bytes
+
+# name: "go_memstats_other_sys_bytes"
+# description: "Number of bytes used for other system allocations."
+# type: "gauge"
+go_memstats_other_sys_bytes
+
+# name: "go_memstats_stack_inuse_bytes"
+# description: "Number of bytes in use by the stack allocator."
+# type: "gauge"
+go_memstats_stack_inuse_bytes
+
+# name: "go_memstats_stack_sys_bytes"
+# description: "Number of bytes obtained from system for stack allocator."
+# type: "gauge"
+go_memstats_stack_sys_bytes
+
+# name: "go_memstats_sys_bytes"
+# description: "Number of bytes obtained by system. Sum of all system allocations."
+# type: "gauge"
+go_memstats_sys_bytes
+
+# name: "grpc_server_handled_total"
+# description: "Total number of RPCs completed on the server, regardless of success or failure."
+# type: "counter"
+# gRPC codes: 
+#  - "Aborted"
+#  - "AlreadyExists"
+#  - "Canceled"
+#  - "DataLoss"
+#  - "DeadlineExceeded"
+#  - "FailedPrecondition"
+#  - "Internal"
+#  - "InvalidArgument"
+#  - "NotFound"
+#  - "OK"
+#  - "OutOfRange"
+#  - "PermissionDenied"
+#  - "ResourceExhausted"
+#  - "Unauthenticated"
+#  - "Unavailable"
+#  - "Unimplemented"
+#  - "Unknown"
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Alarm",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="AuthDisable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="AuthEnable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Authenticate",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Compact",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Defragment",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Hash",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="HashKV",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseGrant",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseKeepAlive",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseLeases",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseRevoke",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseTimeToLive",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MemberAdd",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MemberList",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MemberRemove",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MemberUpdate",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MoveLeader",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleGrantPermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleRevokePermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Snapshot",grpc_service="etcdserverpb.Maintenance",grpc_type="server_stream"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Status",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Txn",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserChangePassword",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserGrantRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserRevokeRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_msg_received_total"
+# description: "Total number of RPC stream messages received on the server."
+# type: "counter"
+grpc_server_msg_received_total{grpc_method="Alarm",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="AuthDisable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="AuthEnable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Authenticate",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Compact",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Defragment",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Hash",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="HashKV",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="LeaseGrant",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="LeaseKeepAlive",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+grpc_server_msg_received_total{grpc_method="LeaseLeases",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="LeaseRevoke",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="LeaseTimeToLive",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MemberAdd",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MemberList",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MemberRemove",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MemberUpdate",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MoveLeader",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleGrantPermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleRevokePermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Snapshot",grpc_service="etcdserverpb.Maintenance",grpc_type="server_stream"}
+grpc_server_msg_received_total{grpc_method="Status",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Txn",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserChangePassword",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserGrantRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserRevokeRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_msg_sent_total"
+# description: "Total number of gRPC stream messages sent by the server."
+# type: "counter"
+grpc_server_msg_sent_total{grpc_method="Alarm",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="AuthDisable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="AuthEnable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Authenticate",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Compact",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Defragment",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Hash",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="HashKV",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="LeaseGrant",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="LeaseKeepAlive",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+grpc_server_msg_sent_total{grpc_method="LeaseLeases",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="LeaseRevoke",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="LeaseTimeToLive",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MemberAdd",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MemberList",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MemberRemove",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MemberUpdate",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MoveLeader",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleGrantPermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleRevokePermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Snapshot",grpc_service="etcdserverpb.Maintenance",grpc_type="server_stream"}
+grpc_server_msg_sent_total{grpc_method="Status",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Txn",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserChangePassword",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserGrantRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserRevokeRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_started_total"
+# description: "Total number of RPCs started on the server."
+# type: "counter"
+grpc_server_started_total{grpc_method="Alarm",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="AuthDisable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="AuthEnable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Authenticate",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Compact",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Defragment",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Hash",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="HashKV",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="LeaseGrant",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_started_total{grpc_method="LeaseKeepAlive",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+grpc_server_started_total{grpc_method="LeaseLeases",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_started_total{grpc_method="LeaseRevoke",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_started_total{grpc_method="LeaseTimeToLive",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MemberAdd",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MemberList",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MemberRemove",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MemberUpdate",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MoveLeader",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleGrantPermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleRevokePermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Snapshot",grpc_service="etcdserverpb.Maintenance",grpc_type="server_stream"}
+grpc_server_started_total{grpc_method="Status",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Txn",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserChangePassword",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserGrantRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserRevokeRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+

--- a/docs/metrics-v3.1
+++ b/docs/metrics-v3.1
@@ -1,0 +1,519 @@
+# server version: etcd_server_version{server_version="3.1.18"}
+
+# name: "etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds"
+# description: "Bucketed histogram of db compaction pause duration."
+# type: "histogram"
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="1"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="2"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="4"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="8"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="16"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="32"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="64"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="128"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="256"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="512"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="1024"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="2048"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="4096"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_sum
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_db_compaction_total_duration_milliseconds"
+# description: "Bucketed histogram of db compaction total duration."
+# type: "histogram"
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="100"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="1600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="3200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="6400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="12800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="25600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="51200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="102400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="204800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="409600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="819200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_db_total_size_in_bytes"
+# description: "Total size of the underlying database in bytes."
+# type: "gauge"
+etcd_debugging_mvcc_db_total_size_in_bytes
+
+# name: "etcd_debugging_mvcc_delete_total"
+# description: "Total number of deletes seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_delete_total
+
+# name: "etcd_debugging_mvcc_events_total"
+# description: "Total number of events sent by this member."
+# type: "counter"
+etcd_debugging_mvcc_events_total
+
+# name: "etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds"
+# description: "Bucketed histogram of index compaction pause duration."
+# type: "histogram"
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="0.5"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="1"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="2"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="4"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="8"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="16"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="32"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="64"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="128"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="256"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="512"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="1024"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_sum
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_keys_total"
+# description: "Total number of keys."
+# type: "gauge"
+etcd_debugging_mvcc_keys_total
+
+# name: "etcd_debugging_mvcc_pending_events_total"
+# description: "Total number of pending events to be sent."
+# type: "gauge"
+etcd_debugging_mvcc_pending_events_total
+
+# name: "etcd_debugging_mvcc_put_total"
+# description: "Total number of puts seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_put_total
+
+# name: "etcd_debugging_mvcc_range_total"
+# description: "Total number of ranges seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_range_total
+
+# name: "etcd_debugging_mvcc_slow_watcher_total"
+# description: "Total number of unsynced slow watchers."
+# type: "gauge"
+etcd_debugging_mvcc_slow_watcher_total
+
+# name: "etcd_debugging_mvcc_txn_total"
+# description: "Total number of txns seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_txn_total
+
+# name: "etcd_debugging_mvcc_watch_stream_total"
+# description: "Total number of watch streams."
+# type: "gauge"
+etcd_debugging_mvcc_watch_stream_total
+
+# name: "etcd_debugging_mvcc_watcher_total"
+# description: "Total number of watchers."
+# type: "gauge"
+etcd_debugging_mvcc_watcher_total
+
+# name: "etcd_debugging_snap_save_marshalling_duration_seconds"
+# description: "The marshalling cost distributions of save called by snapshot."
+# type: "histogram"
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.001"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.002"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.004"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.008"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.016"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.032"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.064"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.128"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.256"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.512"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="1.024"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="2.048"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="4.096"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="8.192"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_snap_save_marshalling_duration_seconds_sum
+etcd_debugging_snap_save_marshalling_duration_seconds_count
+
+# name: "etcd_debugging_snap_save_total_duration_seconds"
+# description: "The total latency distributions of save called by snapshot."
+# type: "histogram"
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.001"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.002"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.004"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.008"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.016"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.032"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.064"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.128"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.256"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.512"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="1.024"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="2.048"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="4.096"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="8.192"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_snap_save_total_duration_seconds_sum
+etcd_debugging_snap_save_total_duration_seconds_count
+
+# name: "etcd_debugging_store_expires_total"
+# description: "Total number of expired keys."
+# type: "counter"
+etcd_debugging_store_expires_total
+
+# name: "etcd_debugging_store_reads_total"
+# description: "Total number of reads action by (get/getRecursive), local to this member."
+# type: "counter"
+etcd_debugging_store_reads_total{action="getRecursive"}
+
+# name: "etcd_debugging_store_watch_requests_total"
+# description: "Total number of incoming watch requests (new or reestablished)."
+# type: "counter"
+etcd_debugging_store_watch_requests_total
+
+# name: "etcd_debugging_store_watchers"
+# description: "Count of currently active watchers."
+# type: "gauge"
+etcd_debugging_store_watchers
+
+# name: "etcd_debugging_store_writes_total"
+# description: "Total number of writes (e.g. set/compareAndDelete) seen by this member."
+# type: "counter"
+etcd_debugging_store_writes_total{action="create"}
+etcd_debugging_store_writes_total{action="set"}
+
+# name: "etcd_disk_backend_commit_duration_seconds"
+# description: "The latency distributions of commit called by backend."
+# type: "histogram"
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.001"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.002"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.004"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.008"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.016"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.032"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.064"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.128"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.256"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.512"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="1.024"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="2.048"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="4.096"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="8.192"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="+Inf"}
+etcd_disk_backend_commit_duration_seconds_sum
+etcd_disk_backend_commit_duration_seconds_count
+
+# name: "etcd_disk_wal_fsync_duration_seconds"
+# description: "The latency distributions of fsync called by wal."
+# type: "histogram"
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.001"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.002"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.004"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.008"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.016"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.032"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.064"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.128"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.256"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.512"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="1.024"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="2.048"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="4.096"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="8.192"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="+Inf"}
+etcd_disk_wal_fsync_duration_seconds_sum
+etcd_disk_wal_fsync_duration_seconds_count
+
+# name: "etcd_grpc_proxy_cache_hits_total"
+# description: "Total number of cache hits"
+# type: "gauge"
+etcd_grpc_proxy_cache_hits_total
+
+# name: "etcd_grpc_proxy_cache_misses_total"
+# description: "Total number of cache misses"
+# type: "gauge"
+etcd_grpc_proxy_cache_misses_total
+
+# name: "etcd_grpc_proxy_events_coalescing_total"
+# description: "Total number of events coalescing"
+# type: "counter"
+etcd_grpc_proxy_events_coalescing_total
+
+# name: "etcd_grpc_proxy_watchers_coalescing_total"
+# description: "Total number of current watchers coalescing"
+# type: "gauge"
+etcd_grpc_proxy_watchers_coalescing_total
+
+# name: "etcd_network_client_grpc_received_bytes_total"
+# description: "The total number of bytes received from grpc clients."
+# type: "counter"
+etcd_network_client_grpc_received_bytes_total
+
+# name: "etcd_network_client_grpc_sent_bytes_total"
+# description: "The total number of bytes sent to grpc clients."
+# type: "counter"
+etcd_network_client_grpc_sent_bytes_total
+
+# name: "etcd_network_peer_received_bytes_total"
+# description: "The total number of bytes received from peers."
+# type: "counter"
+etcd_network_peer_received_bytes_total{From="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_peer_round_trip_time_seconds"
+# description: "Round-Trip-Time histogram between peers."
+# type: "histogram"
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="+Inf"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0001"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0002"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0004"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0008"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0016"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0032"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0064"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0128"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0256"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0512"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.1024"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.2048"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.4096"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.8192"}
+etcd_network_peer_round_trip_time_seconds_count{To="REMOTE_PEER_NODE_ID"}
+etcd_network_peer_round_trip_time_seconds_sum{To="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_peer_sent_bytes_total"
+# description: "The total number of bytes sent to peers."
+# type: "counter"
+etcd_network_peer_sent_bytes_total{To="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_server_has_leader"
+# description: "Whether or not a leader exists. 1 is existence, 0 is not."
+# type: "gauge"
+etcd_server_has_leader
+
+# name: "etcd_server_is_leader"
+# description: "Whether or not this member is a leader. 1 if is, 0 otherwise."
+# type: "gauge"
+etcd_server_is_leader
+
+# name: "etcd_server_leader_changes_seen_total"
+# description: "The number of leader changes seen."
+# type: "counter"
+etcd_server_leader_changes_seen_total
+
+# name: "etcd_server_proposals_applied_total"
+# description: "The total number of consensus proposals applied."
+# type: "gauge"
+etcd_server_proposals_applied_total
+
+# name: "etcd_server_proposals_committed_total"
+# description: "The total number of consensus proposals committed."
+# type: "gauge"
+etcd_server_proposals_committed_total
+
+# name: "etcd_server_proposals_failed_total"
+# description: "The total number of failed proposals seen."
+# type: "counter"
+etcd_server_proposals_failed_total
+
+# name: "etcd_server_proposals_pending"
+# description: "The current number of pending proposals to commit."
+# type: "gauge"
+etcd_server_proposals_pending
+
+# name: "etcd_server_version"
+# description: "Which version is running. 1 for 'server_version' label with current version."
+# type: "gauge"
+etcd_server_version{server_version="3.1.18"}
+
+# name: "go_gc_duration_seconds"
+# description: "A summary of the GC invocation durations."
+# type: "summary"
+go_gc_duration_seconds{quantile="0"}
+go_gc_duration_seconds{quantile="0.25"}
+go_gc_duration_seconds{quantile="0.5"}
+go_gc_duration_seconds{quantile="0.75"}
+go_gc_duration_seconds{quantile="1"}
+go_gc_duration_seconds_sum
+go_gc_duration_seconds_count
+
+# name: "go_goroutines"
+# description: "Number of goroutines that currently exist."
+# type: "gauge"
+go_goroutines
+
+# name: "go_memstats_alloc_bytes"
+# description: "Number of bytes allocated and still in use."
+# type: "gauge"
+go_memstats_alloc_bytes
+
+# name: "go_memstats_alloc_bytes_total"
+# description: "Total number of bytes allocated, even if freed."
+# type: "counter"
+go_memstats_alloc_bytes_total
+
+# name: "go_memstats_buck_hash_sys_bytes"
+# description: "Number of bytes used by the profiling bucket hash table."
+# type: "gauge"
+go_memstats_buck_hash_sys_bytes
+
+# name: "go_memstats_frees_total"
+# description: "Total number of frees."
+# type: "counter"
+go_memstats_frees_total
+
+# name: "go_memstats_gc_sys_bytes"
+# description: "Number of bytes used for garbage collection system metadata."
+# type: "gauge"
+go_memstats_gc_sys_bytes
+
+# name: "go_memstats_heap_alloc_bytes"
+# description: "Number of heap bytes allocated and still in use."
+# type: "gauge"
+go_memstats_heap_alloc_bytes
+
+# name: "go_memstats_heap_idle_bytes"
+# description: "Number of heap bytes waiting to be used."
+# type: "gauge"
+go_memstats_heap_idle_bytes
+
+# name: "go_memstats_heap_inuse_bytes"
+# description: "Number of heap bytes that are in use."
+# type: "gauge"
+go_memstats_heap_inuse_bytes
+
+# name: "go_memstats_heap_objects"
+# description: "Number of allocated objects."
+# type: "gauge"
+go_memstats_heap_objects
+
+# name: "go_memstats_heap_released_bytes_total"
+# description: "Total number of heap bytes released to OS."
+# type: "counter"
+go_memstats_heap_released_bytes_total
+
+# name: "go_memstats_heap_sys_bytes"
+# description: "Number of heap bytes obtained from system."
+# type: "gauge"
+go_memstats_heap_sys_bytes
+
+# name: "go_memstats_last_gc_time_seconds"
+# description: "Number of seconds since 1970 of last garbage collection."
+# type: "gauge"
+go_memstats_last_gc_time_seconds
+
+# name: "go_memstats_lookups_total"
+# description: "Total number of pointer lookups."
+# type: "counter"
+go_memstats_lookups_total
+
+# name: "go_memstats_mallocs_total"
+# description: "Total number of mallocs."
+# type: "counter"
+go_memstats_mallocs_total
+
+# name: "go_memstats_mcache_inuse_bytes"
+# description: "Number of bytes in use by mcache structures."
+# type: "gauge"
+go_memstats_mcache_inuse_bytes
+
+# name: "go_memstats_mcache_sys_bytes"
+# description: "Number of bytes used for mcache structures obtained from system."
+# type: "gauge"
+go_memstats_mcache_sys_bytes
+
+# name: "go_memstats_mspan_inuse_bytes"
+# description: "Number of bytes in use by mspan structures."
+# type: "gauge"
+go_memstats_mspan_inuse_bytes
+
+# name: "go_memstats_mspan_sys_bytes"
+# description: "Number of bytes used for mspan structures obtained from system."
+# type: "gauge"
+go_memstats_mspan_sys_bytes
+
+# name: "go_memstats_next_gc_bytes"
+# description: "Number of heap bytes when next garbage collection will take place."
+# type: "gauge"
+go_memstats_next_gc_bytes
+
+# name: "go_memstats_other_sys_bytes"
+# description: "Number of bytes used for other system allocations."
+# type: "gauge"
+go_memstats_other_sys_bytes
+
+# name: "go_memstats_stack_inuse_bytes"
+# description: "Number of bytes in use by the stack allocator."
+# type: "gauge"
+go_memstats_stack_inuse_bytes
+
+# name: "go_memstats_stack_sys_bytes"
+# description: "Number of bytes obtained from system for stack allocator."
+# type: "gauge"
+go_memstats_stack_sys_bytes
+
+# name: "go_memstats_sys_bytes"
+# description: "Number of bytes obtained by system. Sum of all system allocations."
+# type: "gauge"
+go_memstats_sys_bytes
+
+# name: "grpc_server_handled_total"
+# description: "Total number of RPCs completed on the server, regardless of success or failure."
+# type: "counter"
+# gRPC codes: 
+#  - "OK"
+grpc_server_handled_total{grpc_code="CODE",grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+
+# name: "grpc_server_msg_received_total"
+# description: "Total number of RPC stream messages received on the server."
+# type: "counter"
+grpc_server_msg_received_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_msg_sent_total"
+# description: "Total number of gRPC stream messages sent by the server."
+# type: "counter"
+grpc_server_msg_sent_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_started_total"
+# description: "Total number of RPCs started on the server."
+# type: "counter"
+grpc_server_started_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "http_request_duration_microseconds"
+# description: "The HTTP request latencies in microseconds."
+# type: "summary"
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"}
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"}
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"}
+http_request_duration_microseconds_sum{handler="prometheus"}
+http_request_duration_microseconds_count{handler="prometheus"}
+
+# name: "http_request_size_bytes"
+# description: "The HTTP request sizes in bytes."
+# type: "summary"
+http_request_size_bytes{handler="prometheus",quantile="0.5"}
+http_request_size_bytes{handler="prometheus",quantile="0.9"}
+http_request_size_bytes{handler="prometheus",quantile="0.99"}
+http_request_size_bytes_sum{handler="prometheus"}
+http_request_size_bytes_count{handler="prometheus"}
+
+# name: "http_response_size_bytes"
+# description: "The HTTP response sizes in bytes."
+# type: "summary"
+http_response_size_bytes{handler="prometheus",quantile="0.5"}
+http_response_size_bytes{handler="prometheus",quantile="0.9"}
+http_response_size_bytes{handler="prometheus",quantile="0.99"}
+http_response_size_bytes_sum{handler="prometheus"}
+http_response_size_bytes_count{handler="prometheus"}
+

--- a/docs/metrics-v3.2
+++ b/docs/metrics-v3.2
@@ -1,0 +1,560 @@
+# server version: etcd_server_version{server_version="3.2.23"}
+
+# name: "etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds"
+# description: "Bucketed histogram of db compaction pause duration."
+# type: "histogram"
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="1"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="2"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="4"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="8"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="16"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="32"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="64"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="128"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="256"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="512"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="1024"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="2048"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="4096"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_sum
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_db_compaction_total_duration_milliseconds"
+# description: "Bucketed histogram of db compaction total duration."
+# type: "histogram"
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="100"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="1600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="3200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="6400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="12800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="25600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="51200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="102400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="204800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="409600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="819200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_db_total_size_in_bytes"
+# description: "Total size of the underlying database in bytes."
+# type: "gauge"
+etcd_debugging_mvcc_db_total_size_in_bytes
+
+# name: "etcd_debugging_mvcc_delete_total"
+# description: "Total number of deletes seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_delete_total
+
+# name: "etcd_debugging_mvcc_events_total"
+# description: "Total number of events sent by this member."
+# type: "counter"
+etcd_debugging_mvcc_events_total
+
+# name: "etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds"
+# description: "Bucketed histogram of index compaction pause duration."
+# type: "histogram"
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="0.5"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="1"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="2"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="4"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="8"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="16"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="32"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="64"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="128"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="256"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="512"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="1024"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_sum
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_keys_total"
+# description: "Total number of keys."
+# type: "gauge"
+etcd_debugging_mvcc_keys_total
+
+# name: "etcd_debugging_mvcc_pending_events_total"
+# description: "Total number of pending events to be sent."
+# type: "gauge"
+etcd_debugging_mvcc_pending_events_total
+
+# name: "etcd_debugging_mvcc_put_total"
+# description: "Total number of puts seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_put_total
+
+# name: "etcd_debugging_mvcc_range_total"
+# description: "Total number of ranges seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_range_total
+
+# name: "etcd_debugging_mvcc_slow_watcher_total"
+# description: "Total number of unsynced slow watchers."
+# type: "gauge"
+etcd_debugging_mvcc_slow_watcher_total
+
+# name: "etcd_debugging_mvcc_txn_total"
+# description: "Total number of txns seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_txn_total
+
+# name: "etcd_debugging_mvcc_watch_stream_total"
+# description: "Total number of watch streams."
+# type: "gauge"
+etcd_debugging_mvcc_watch_stream_total
+
+# name: "etcd_debugging_mvcc_watcher_total"
+# description: "Total number of watchers."
+# type: "gauge"
+etcd_debugging_mvcc_watcher_total
+
+# name: "etcd_debugging_server_lease_expired_total"
+# description: "The total number of expired leases."
+# type: "counter"
+etcd_debugging_server_lease_expired_total
+
+# name: "etcd_debugging_snap_save_marshalling_duration_seconds"
+# description: "The marshalling cost distributions of save called by snapshot."
+# type: "histogram"
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.001"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.002"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.004"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.008"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.016"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.032"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.064"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.128"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.256"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.512"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="1.024"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="2.048"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="4.096"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="8.192"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_snap_save_marshalling_duration_seconds_sum
+etcd_debugging_snap_save_marshalling_duration_seconds_count
+
+# name: "etcd_debugging_snap_save_total_duration_seconds"
+# description: "The total latency distributions of save called by snapshot."
+# type: "histogram"
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.001"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.002"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.004"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.008"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.016"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.032"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.064"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.128"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.256"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.512"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="1.024"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="2.048"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="4.096"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="8.192"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_snap_save_total_duration_seconds_sum
+etcd_debugging_snap_save_total_duration_seconds_count
+
+# name: "etcd_debugging_store_expires_total"
+# description: "Total number of expired keys."
+# type: "counter"
+etcd_debugging_store_expires_total
+
+# name: "etcd_debugging_store_reads_total"
+# description: "Total number of reads action by (get/getRecursive), local to this member."
+# type: "counter"
+etcd_debugging_store_reads_total{action="getRecursive"}
+
+# name: "etcd_debugging_store_watch_requests_total"
+# description: "Total number of incoming watch requests (new or reestablished)."
+# type: "counter"
+etcd_debugging_store_watch_requests_total
+
+# name: "etcd_debugging_store_watchers"
+# description: "Count of currently active watchers."
+# type: "gauge"
+etcd_debugging_store_watchers
+
+# name: "etcd_debugging_store_writes_total"
+# description: "Total number of writes (e.g. set/compareAndDelete) seen by this member."
+# type: "counter"
+etcd_debugging_store_writes_total{action="create"}
+etcd_debugging_store_writes_total{action="set"}
+
+# name: "etcd_disk_backend_commit_duration_seconds"
+# description: "The latency distributions of commit called by backend."
+# type: "histogram"
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.001"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.002"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.004"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.008"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.016"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.032"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.064"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.128"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.256"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.512"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="1.024"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="2.048"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="4.096"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="8.192"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="+Inf"}
+etcd_disk_backend_commit_duration_seconds_sum
+etcd_disk_backend_commit_duration_seconds_count
+
+# name: "etcd_disk_backend_snapshot_duration_seconds"
+# description: "The latency distribution of backend snapshots."
+# type: "histogram"
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.01"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.02"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.04"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.08"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.16"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.32"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.64"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="1.28"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="2.56"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="5.12"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="10.24"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="20.48"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="40.96"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="81.92"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="163.84"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="327.68"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="655.36"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="+Inf"}
+etcd_disk_backend_snapshot_duration_seconds_sum
+etcd_disk_backend_snapshot_duration_seconds_count
+
+# name: "etcd_disk_wal_fsync_duration_seconds"
+# description: "The latency distributions of fsync called by wal."
+# type: "histogram"
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.001"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.002"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.004"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.008"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.016"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.032"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.064"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.128"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.256"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.512"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="1.024"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="2.048"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="4.096"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="8.192"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="+Inf"}
+etcd_disk_wal_fsync_duration_seconds_sum
+etcd_disk_wal_fsync_duration_seconds_count
+
+# name: "etcd_grpc_proxy_cache_hits_total"
+# description: "Total number of cache hits"
+# type: "gauge"
+etcd_grpc_proxy_cache_hits_total
+
+# name: "etcd_grpc_proxy_cache_keys_total"
+# description: "Total number of keys/ranges cached"
+# type: "gauge"
+etcd_grpc_proxy_cache_keys_total
+
+# name: "etcd_grpc_proxy_cache_misses_total"
+# description: "Total number of cache misses"
+# type: "gauge"
+etcd_grpc_proxy_cache_misses_total
+
+# name: "etcd_grpc_proxy_events_coalescing_total"
+# description: "Total number of events coalescing"
+# type: "counter"
+etcd_grpc_proxy_events_coalescing_total
+
+# name: "etcd_grpc_proxy_watchers_coalescing_total"
+# description: "Total number of current watchers coalescing"
+# type: "gauge"
+etcd_grpc_proxy_watchers_coalescing_total
+
+# name: "etcd_network_client_grpc_received_bytes_total"
+# description: "The total number of bytes received from grpc clients."
+# type: "counter"
+etcd_network_client_grpc_received_bytes_total
+
+# name: "etcd_network_client_grpc_sent_bytes_total"
+# description: "The total number of bytes sent to grpc clients."
+# type: "counter"
+etcd_network_client_grpc_sent_bytes_total
+
+# name: "etcd_network_peer_received_bytes_total"
+# description: "The total number of bytes received from peers."
+# type: "counter"
+etcd_network_peer_received_bytes_total{From="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_peer_round_trip_time_seconds"
+# description: "Round-Trip-Time histogram between peers."
+# type: "histogram"
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="+Inf"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0001"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0002"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0004"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0008"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0016"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0032"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0064"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0128"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0256"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0512"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.1024"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.2048"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.4096"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.8192"}
+etcd_network_peer_round_trip_time_seconds_count{To="REMOTE_PEER_NODE_ID"}
+etcd_network_peer_round_trip_time_seconds_sum{To="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_peer_sent_bytes_total"
+# description: "The total number of bytes sent to peers."
+# type: "counter"
+etcd_network_peer_sent_bytes_total{To="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_server_has_leader"
+# description: "Whether or not a leader exists. 1 is existence, 0 is not."
+# type: "gauge"
+etcd_server_has_leader
+
+# name: "etcd_server_is_leader"
+# description: "Whether or not this member is a leader. 1 if is, 0 otherwise."
+# type: "gauge"
+etcd_server_is_leader
+
+# name: "etcd_server_leader_changes_seen_total"
+# description: "The number of leader changes seen."
+# type: "counter"
+etcd_server_leader_changes_seen_total
+
+# name: "etcd_server_proposals_applied_total"
+# description: "The total number of consensus proposals applied."
+# type: "gauge"
+etcd_server_proposals_applied_total
+
+# name: "etcd_server_proposals_committed_total"
+# description: "The total number of consensus proposals committed."
+# type: "gauge"
+etcd_server_proposals_committed_total
+
+# name: "etcd_server_proposals_failed_total"
+# description: "The total number of failed proposals seen."
+# type: "counter"
+etcd_server_proposals_failed_total
+
+# name: "etcd_server_proposals_pending"
+# description: "The current number of pending proposals to commit."
+# type: "gauge"
+etcd_server_proposals_pending
+
+# name: "etcd_server_version"
+# description: "Which version is running. 1 for 'server_version' label with current version."
+# type: "gauge"
+etcd_server_version{server_version="3.2.23"}
+
+# name: "go_gc_duration_seconds"
+# description: "A summary of the GC invocation durations."
+# type: "summary"
+go_gc_duration_seconds{quantile="0"}
+go_gc_duration_seconds{quantile="0.25"}
+go_gc_duration_seconds{quantile="0.5"}
+go_gc_duration_seconds{quantile="0.75"}
+go_gc_duration_seconds{quantile="1"}
+go_gc_duration_seconds_sum
+go_gc_duration_seconds_count
+
+# name: "go_goroutines"
+# description: "Number of goroutines that currently exist."
+# type: "gauge"
+go_goroutines
+
+# name: "go_memstats_alloc_bytes"
+# description: "Number of bytes allocated and still in use."
+# type: "gauge"
+go_memstats_alloc_bytes
+
+# name: "go_memstats_alloc_bytes_total"
+# description: "Total number of bytes allocated, even if freed."
+# type: "counter"
+go_memstats_alloc_bytes_total
+
+# name: "go_memstats_buck_hash_sys_bytes"
+# description: "Number of bytes used by the profiling bucket hash table."
+# type: "gauge"
+go_memstats_buck_hash_sys_bytes
+
+# name: "go_memstats_frees_total"
+# description: "Total number of frees."
+# type: "counter"
+go_memstats_frees_total
+
+# name: "go_memstats_gc_sys_bytes"
+# description: "Number of bytes used for garbage collection system metadata."
+# type: "gauge"
+go_memstats_gc_sys_bytes
+
+# name: "go_memstats_heap_alloc_bytes"
+# description: "Number of heap bytes allocated and still in use."
+# type: "gauge"
+go_memstats_heap_alloc_bytes
+
+# name: "go_memstats_heap_idle_bytes"
+# description: "Number of heap bytes waiting to be used."
+# type: "gauge"
+go_memstats_heap_idle_bytes
+
+# name: "go_memstats_heap_inuse_bytes"
+# description: "Number of heap bytes that are in use."
+# type: "gauge"
+go_memstats_heap_inuse_bytes
+
+# name: "go_memstats_heap_objects"
+# description: "Number of allocated objects."
+# type: "gauge"
+go_memstats_heap_objects
+
+# name: "go_memstats_heap_released_bytes_total"
+# description: "Total number of heap bytes released to OS."
+# type: "counter"
+go_memstats_heap_released_bytes_total
+
+# name: "go_memstats_heap_sys_bytes"
+# description: "Number of heap bytes obtained from system."
+# type: "gauge"
+go_memstats_heap_sys_bytes
+
+# name: "go_memstats_last_gc_time_seconds"
+# description: "Number of seconds since 1970 of last garbage collection."
+# type: "gauge"
+go_memstats_last_gc_time_seconds
+
+# name: "go_memstats_lookups_total"
+# description: "Total number of pointer lookups."
+# type: "counter"
+go_memstats_lookups_total
+
+# name: "go_memstats_mallocs_total"
+# description: "Total number of mallocs."
+# type: "counter"
+go_memstats_mallocs_total
+
+# name: "go_memstats_mcache_inuse_bytes"
+# description: "Number of bytes in use by mcache structures."
+# type: "gauge"
+go_memstats_mcache_inuse_bytes
+
+# name: "go_memstats_mcache_sys_bytes"
+# description: "Number of bytes used for mcache structures obtained from system."
+# type: "gauge"
+go_memstats_mcache_sys_bytes
+
+# name: "go_memstats_mspan_inuse_bytes"
+# description: "Number of bytes in use by mspan structures."
+# type: "gauge"
+go_memstats_mspan_inuse_bytes
+
+# name: "go_memstats_mspan_sys_bytes"
+# description: "Number of bytes used for mspan structures obtained from system."
+# type: "gauge"
+go_memstats_mspan_sys_bytes
+
+# name: "go_memstats_next_gc_bytes"
+# description: "Number of heap bytes when next garbage collection will take place."
+# type: "gauge"
+go_memstats_next_gc_bytes
+
+# name: "go_memstats_other_sys_bytes"
+# description: "Number of bytes used for other system allocations."
+# type: "gauge"
+go_memstats_other_sys_bytes
+
+# name: "go_memstats_stack_inuse_bytes"
+# description: "Number of bytes in use by the stack allocator."
+# type: "gauge"
+go_memstats_stack_inuse_bytes
+
+# name: "go_memstats_stack_sys_bytes"
+# description: "Number of bytes obtained from system for stack allocator."
+# type: "gauge"
+go_memstats_stack_sys_bytes
+
+# name: "go_memstats_sys_bytes"
+# description: "Number of bytes obtained by system. Sum of all system allocations."
+# type: "gauge"
+go_memstats_sys_bytes
+
+# name: "grpc_server_handled_total"
+# description: "Total number of RPCs completed on the server, regardless of success or failure."
+# type: "counter"
+# gRPC codes: 
+#  - "OK"
+#  - "Unavailable"
+grpc_server_handled_total{grpc_code="CODE",grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_msg_received_total"
+# description: "Total number of RPC stream messages received on the server."
+# type: "counter"
+grpc_server_msg_received_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_msg_sent_total"
+# description: "Total number of gRPC stream messages sent by the server."
+# type: "counter"
+grpc_server_msg_sent_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_started_total"
+# description: "Total number of RPCs started on the server."
+# type: "counter"
+grpc_server_started_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "http_request_duration_microseconds"
+# description: "The HTTP request latencies in microseconds."
+# type: "summary"
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"}
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"}
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"}
+http_request_duration_microseconds_sum{handler="prometheus"}
+http_request_duration_microseconds_count{handler="prometheus"}
+
+# name: "http_request_size_bytes"
+# description: "The HTTP request sizes in bytes."
+# type: "summary"
+http_request_size_bytes{handler="prometheus",quantile="0.5"}
+http_request_size_bytes{handler="prometheus",quantile="0.9"}
+http_request_size_bytes{handler="prometheus",quantile="0.99"}
+http_request_size_bytes_sum{handler="prometheus"}
+http_request_size_bytes_count{handler="prometheus"}
+
+# name: "http_requests_total"
+# description: "Total number of HTTP requests made."
+# type: "counter"
+http_requests_total{code="200",handler="prometheus",method="get"}
+
+# name: "http_response_size_bytes"
+# description: "The HTTP response sizes in bytes."
+# type: "summary"
+http_response_size_bytes{handler="prometheus",quantile="0.5"}
+http_response_size_bytes{handler="prometheus",quantile="0.9"}
+http_response_size_bytes{handler="prometheus",quantile="0.99"}
+http_response_size_bytes_sum{handler="prometheus"}
+http_response_size_bytes_count{handler="prometheus"}
+

--- a/docs/metrics-v3.3
+++ b/docs/metrics-v3.3
@@ -1,0 +1,703 @@
+# server version: etcd_server_version{server_version="3.3.8"}
+
+# name: "etcd_debugging_mvcc_db_compaction_keys_total"
+# description: "Total number of db keys compacted."
+# type: "counter"
+etcd_debugging_mvcc_db_compaction_keys_total
+
+# name: "etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds"
+# description: "Bucketed histogram of db compaction pause duration."
+# type: "histogram"
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="1"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="2"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="4"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="8"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="16"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="32"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="64"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="128"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="256"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="512"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="1024"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="2048"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="4096"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_sum
+etcd_debugging_mvcc_db_compaction_pause_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_db_compaction_total_duration_milliseconds"
+# description: "Bucketed histogram of db compaction total duration."
+# type: "histogram"
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="100"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="1600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="3200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="6400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="12800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="25600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="51200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="102400"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="204800"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="409600"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="819200"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum
+etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_db_total_size_in_bytes"
+# description: "Total size of the underlying database in bytes."
+# type: "gauge"
+etcd_debugging_mvcc_db_total_size_in_bytes
+
+# name: "etcd_debugging_mvcc_delete_total"
+# description: "Total number of deletes seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_delete_total
+
+# name: "etcd_debugging_mvcc_events_total"
+# description: "Total number of events sent by this member."
+# type: "counter"
+etcd_debugging_mvcc_events_total
+
+# name: "etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds"
+# description: "Bucketed histogram of index compaction pause duration."
+# type: "histogram"
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="0.5"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="1"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="2"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="4"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="8"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="16"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="32"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="64"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="128"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="256"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="512"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="1024"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_bucket{le="+Inf"}
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_sum
+etcd_debugging_mvcc_index_compaction_pause_duration_milliseconds_count
+
+# name: "etcd_debugging_mvcc_keys_total"
+# description: "Total number of keys."
+# type: "gauge"
+etcd_debugging_mvcc_keys_total
+
+# name: "etcd_debugging_mvcc_pending_events_total"
+# description: "Total number of pending events to be sent."
+# type: "gauge"
+etcd_debugging_mvcc_pending_events_total
+
+# name: "etcd_debugging_mvcc_put_total"
+# description: "Total number of puts seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_put_total
+
+# name: "etcd_debugging_mvcc_range_total"
+# description: "Total number of ranges seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_range_total
+
+# name: "etcd_debugging_mvcc_slow_watcher_total"
+# description: "Total number of unsynced slow watchers."
+# type: "gauge"
+etcd_debugging_mvcc_slow_watcher_total
+
+# name: "etcd_debugging_mvcc_txn_total"
+# description: "Total number of txns seen by this member."
+# type: "counter"
+etcd_debugging_mvcc_txn_total
+
+# name: "etcd_debugging_mvcc_watch_stream_total"
+# description: "Total number of watch streams."
+# type: "gauge"
+etcd_debugging_mvcc_watch_stream_total
+
+# name: "etcd_debugging_mvcc_watcher_total"
+# description: "Total number of watchers."
+# type: "gauge"
+etcd_debugging_mvcc_watcher_total
+
+# name: "etcd_debugging_server_lease_expired_total"
+# description: "The total number of expired leases."
+# type: "counter"
+etcd_debugging_server_lease_expired_total
+
+# name: "etcd_debugging_snap_save_marshalling_duration_seconds"
+# description: "The marshalling cost distributions of save called by snapshot."
+# type: "histogram"
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.001"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.002"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.004"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.008"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.016"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.032"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.064"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.128"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.256"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="0.512"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="1.024"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="2.048"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="4.096"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="8.192"}
+etcd_debugging_snap_save_marshalling_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_snap_save_marshalling_duration_seconds_sum
+etcd_debugging_snap_save_marshalling_duration_seconds_count
+
+# name: "etcd_debugging_snap_save_total_duration_seconds"
+# description: "The total latency distributions of save called by snapshot."
+# type: "histogram"
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.001"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.002"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.004"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.008"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.016"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.032"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.064"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.128"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.256"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="0.512"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="1.024"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="2.048"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="4.096"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="8.192"}
+etcd_debugging_snap_save_total_duration_seconds_bucket{le="+Inf"}
+etcd_debugging_snap_save_total_duration_seconds_sum
+etcd_debugging_snap_save_total_duration_seconds_count
+
+# name: "etcd_debugging_store_expires_total"
+# description: "Total number of expired keys."
+# type: "counter"
+etcd_debugging_store_expires_total
+
+# name: "etcd_debugging_store_reads_total"
+# description: "Total number of reads action by (get/getRecursive), local to this member."
+# type: "counter"
+etcd_debugging_store_reads_total{action="getRecursive"}
+
+# name: "etcd_debugging_store_watch_requests_total"
+# description: "Total number of incoming watch requests (new or reestablished)."
+# type: "counter"
+etcd_debugging_store_watch_requests_total
+
+# name: "etcd_debugging_store_watchers"
+# description: "Count of currently active watchers."
+# type: "gauge"
+etcd_debugging_store_watchers
+
+# name: "etcd_debugging_store_writes_total"
+# description: "Total number of writes (e.g. set/compareAndDelete) seen by this member."
+# type: "counter"
+etcd_debugging_store_writes_total{action="create"}
+etcd_debugging_store_writes_total{action="set"}
+
+# name: "etcd_disk_backend_commit_duration_seconds"
+# description: "The latency distributions of commit called by backend."
+# type: "histogram"
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.001"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.002"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.004"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.008"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.016"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.032"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.064"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.128"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.256"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="0.512"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="1.024"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="2.048"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="4.096"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="8.192"}
+etcd_disk_backend_commit_duration_seconds_bucket{le="+Inf"}
+etcd_disk_backend_commit_duration_seconds_sum
+etcd_disk_backend_commit_duration_seconds_count
+
+# name: "etcd_disk_backend_snapshot_duration_seconds"
+# description: "The latency distribution of backend snapshots."
+# type: "histogram"
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.01"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.02"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.04"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.08"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.16"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.32"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="0.64"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="1.28"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="2.56"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="5.12"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="10.24"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="20.48"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="40.96"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="81.92"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="163.84"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="327.68"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="655.36"}
+etcd_disk_backend_snapshot_duration_seconds_bucket{le="+Inf"}
+etcd_disk_backend_snapshot_duration_seconds_sum
+etcd_disk_backend_snapshot_duration_seconds_count
+
+# name: "etcd_disk_wal_fsync_duration_seconds"
+# description: "The latency distributions of fsync called by wal."
+# type: "histogram"
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.001"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.002"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.004"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.008"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.016"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.032"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.064"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.128"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.256"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="0.512"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="1.024"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="2.048"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="4.096"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="8.192"}
+etcd_disk_wal_fsync_duration_seconds_bucket{le="+Inf"}
+etcd_disk_wal_fsync_duration_seconds_sum
+etcd_disk_wal_fsync_duration_seconds_count
+
+# name: "etcd_grpc_proxy_cache_hits_total"
+# description: "Total number of cache hits"
+# type: "gauge"
+etcd_grpc_proxy_cache_hits_total
+
+# name: "etcd_grpc_proxy_cache_keys_total"
+# description: "Total number of keys/ranges cached"
+# type: "gauge"
+etcd_grpc_proxy_cache_keys_total
+
+# name: "etcd_grpc_proxy_cache_misses_total"
+# description: "Total number of cache misses"
+# type: "gauge"
+etcd_grpc_proxy_cache_misses_total
+
+# name: "etcd_grpc_proxy_events_coalescing_total"
+# description: "Total number of events coalescing"
+# type: "counter"
+etcd_grpc_proxy_events_coalescing_total
+
+# name: "etcd_grpc_proxy_watchers_coalescing_total"
+# description: "Total number of current watchers coalescing"
+# type: "gauge"
+etcd_grpc_proxy_watchers_coalescing_total
+
+# name: "etcd_network_client_grpc_received_bytes_total"
+# description: "The total number of bytes received from grpc clients."
+# type: "counter"
+etcd_network_client_grpc_received_bytes_total
+
+# name: "etcd_network_client_grpc_sent_bytes_total"
+# description: "The total number of bytes sent to grpc clients."
+# type: "counter"
+etcd_network_client_grpc_sent_bytes_total
+
+# name: "etcd_network_peer_received_bytes_total"
+# description: "The total number of bytes received from peers."
+# type: "counter"
+etcd_network_peer_received_bytes_total{From="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_peer_round_trip_time_seconds"
+# description: "Round-Trip-Time histogram between peers."
+# type: "histogram"
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="+Inf"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0001"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0002"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0004"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0008"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0016"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0032"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0064"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0128"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0256"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.0512"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.1024"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.2048"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.4096"}
+etcd_network_peer_round_trip_time_seconds_bucket{To="REMOTE_PEER_NODE_ID",le="0.8192"}
+etcd_network_peer_round_trip_time_seconds_count{To="REMOTE_PEER_NODE_ID"}
+etcd_network_peer_round_trip_time_seconds_sum{To="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_network_peer_sent_bytes_total"
+# description: "The total number of bytes sent to peers."
+# type: "counter"
+etcd_network_peer_sent_bytes_total{To="REMOTE_PEER_NODE_ID"}
+
+# name: "etcd_server_has_leader"
+# description: "Whether or not a leader exists. 1 is existence, 0 is not."
+# type: "gauge"
+etcd_server_has_leader
+
+# name: "etcd_server_is_leader"
+# description: "Whether or not this member is a leader. 1 if is, 0 otherwise."
+# type: "gauge"
+etcd_server_is_leader
+
+# name: "etcd_server_leader_changes_seen_total"
+# description: "The number of leader changes seen."
+# type: "counter"
+etcd_server_leader_changes_seen_total
+
+# name: "etcd_server_proposals_applied_total"
+# description: "The total number of consensus proposals applied."
+# type: "gauge"
+etcd_server_proposals_applied_total
+
+# name: "etcd_server_proposals_committed_total"
+# description: "The total number of consensus proposals committed."
+# type: "gauge"
+etcd_server_proposals_committed_total
+
+# name: "etcd_server_proposals_failed_total"
+# description: "The total number of failed proposals seen."
+# type: "counter"
+etcd_server_proposals_failed_total
+
+# name: "etcd_server_proposals_pending"
+# description: "The current number of pending proposals to commit."
+# type: "gauge"
+etcd_server_proposals_pending
+
+# name: "etcd_server_version"
+# description: "Which version is running. 1 for 'server_version' label with current version."
+# type: "gauge"
+etcd_server_version{server_version="3.3.8"}
+
+# name: "go_gc_duration_seconds"
+# description: "A summary of the GC invocation durations."
+# type: "summary"
+go_gc_duration_seconds{quantile="0"}
+go_gc_duration_seconds{quantile="0.25"}
+go_gc_duration_seconds{quantile="0.5"}
+go_gc_duration_seconds{quantile="0.75"}
+go_gc_duration_seconds{quantile="1"}
+go_gc_duration_seconds_sum
+go_gc_duration_seconds_count
+
+# name: "go_goroutines"
+# description: "Number of goroutines that currently exist."
+# type: "gauge"
+go_goroutines
+
+# name: "go_info"
+# description: "Information about the Go environment."
+# type: "gauge"
+go_info{version="go1.9.7"}
+
+# name: "go_memstats_alloc_bytes"
+# description: "Number of bytes allocated and still in use."
+# type: "gauge"
+go_memstats_alloc_bytes
+
+# name: "go_memstats_alloc_bytes_total"
+# description: "Total number of bytes allocated, even if freed."
+# type: "counter"
+go_memstats_alloc_bytes_total
+
+# name: "go_memstats_buck_hash_sys_bytes"
+# description: "Number of bytes used by the profiling bucket hash table."
+# type: "gauge"
+go_memstats_buck_hash_sys_bytes
+
+# name: "go_memstats_frees_total"
+# description: "Total number of frees."
+# type: "counter"
+go_memstats_frees_total
+
+# name: "go_memstats_gc_cpu_fraction"
+# description: "The fraction of this program's available CPU time used by the GC since the program started."
+# type: "gauge"
+go_memstats_gc_cpu_fraction
+
+# name: "go_memstats_gc_sys_bytes"
+# description: "Number of bytes used for garbage collection system metadata."
+# type: "gauge"
+go_memstats_gc_sys_bytes
+
+# name: "go_memstats_heap_alloc_bytes"
+# description: "Number of heap bytes allocated and still in use."
+# type: "gauge"
+go_memstats_heap_alloc_bytes
+
+# name: "go_memstats_heap_idle_bytes"
+# description: "Number of heap bytes waiting to be used."
+# type: "gauge"
+go_memstats_heap_idle_bytes
+
+# name: "go_memstats_heap_inuse_bytes"
+# description: "Number of heap bytes that are in use."
+# type: "gauge"
+go_memstats_heap_inuse_bytes
+
+# name: "go_memstats_heap_objects"
+# description: "Number of allocated objects."
+# type: "gauge"
+go_memstats_heap_objects
+
+# name: "go_memstats_heap_released_bytes"
+# description: "Number of heap bytes released to OS."
+# type: "gauge"
+go_memstats_heap_released_bytes
+
+# name: "go_memstats_heap_sys_bytes"
+# description: "Number of heap bytes obtained from system."
+# type: "gauge"
+go_memstats_heap_sys_bytes
+
+# name: "go_memstats_last_gc_time_seconds"
+# description: "Number of seconds since 1970 of last garbage collection."
+# type: "gauge"
+go_memstats_last_gc_time_seconds
+
+# name: "go_memstats_lookups_total"
+# description: "Total number of pointer lookups."
+# type: "counter"
+go_memstats_lookups_total
+
+# name: "go_memstats_mallocs_total"
+# description: "Total number of mallocs."
+# type: "counter"
+go_memstats_mallocs_total
+
+# name: "go_memstats_mcache_inuse_bytes"
+# description: "Number of bytes in use by mcache structures."
+# type: "gauge"
+go_memstats_mcache_inuse_bytes
+
+# name: "go_memstats_mcache_sys_bytes"
+# description: "Number of bytes used for mcache structures obtained from system."
+# type: "gauge"
+go_memstats_mcache_sys_bytes
+
+# name: "go_memstats_mspan_inuse_bytes"
+# description: "Number of bytes in use by mspan structures."
+# type: "gauge"
+go_memstats_mspan_inuse_bytes
+
+# name: "go_memstats_mspan_sys_bytes"
+# description: "Number of bytes used for mspan structures obtained from system."
+# type: "gauge"
+go_memstats_mspan_sys_bytes
+
+# name: "go_memstats_next_gc_bytes"
+# description: "Number of heap bytes when next garbage collection will take place."
+# type: "gauge"
+go_memstats_next_gc_bytes
+
+# name: "go_memstats_other_sys_bytes"
+# description: "Number of bytes used for other system allocations."
+# type: "gauge"
+go_memstats_other_sys_bytes
+
+# name: "go_memstats_stack_inuse_bytes"
+# description: "Number of bytes in use by the stack allocator."
+# type: "gauge"
+go_memstats_stack_inuse_bytes
+
+# name: "go_memstats_stack_sys_bytes"
+# description: "Number of bytes obtained from system for stack allocator."
+# type: "gauge"
+go_memstats_stack_sys_bytes
+
+# name: "go_memstats_sys_bytes"
+# description: "Number of bytes obtained from system."
+# type: "gauge"
+go_memstats_sys_bytes
+
+# name: "go_threads"
+# description: "Number of OS threads created."
+# type: "gauge"
+go_threads
+
+# name: "grpc_server_handled_total"
+# description: "Total number of RPCs completed on the server, regardless of success or failure."
+# type: "counter"
+# gRPC codes: 
+#  - "Aborted"
+#  - "AlreadyExists"
+#  - "Canceled"
+#  - "DataLoss"
+#  - "DeadlineExceeded"
+#  - "FailedPrecondition"
+#  - "Internal"
+#  - "InvalidArgument"
+#  - "NotFound"
+#  - "OK"
+#  - "OutOfRange"
+#  - "PermissionDenied"
+#  - "ResourceExhausted"
+#  - "Unauthenticated"
+#  - "Unavailable"
+#  - "Unimplemented"
+#  - "Unknown"
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Alarm",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="AuthDisable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="AuthEnable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Authenticate",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Compact",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Defragment",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Hash",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="HashKV",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseGrant",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseKeepAlive",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseLeases",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseRevoke",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="LeaseTimeToLive",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MemberAdd",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MemberList",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MemberRemove",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MemberUpdate",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="MoveLeader",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleGrantPermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="RoleRevokePermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Snapshot",grpc_service="etcdserverpb.Maintenance",grpc_type="server_stream"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Status",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Txn",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserChangePassword",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserGrantRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="UserRevokeRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_handled_total{grpc_code="CODE",grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_msg_received_total"
+# description: "Total number of RPC stream messages received on the server."
+# type: "counter"
+grpc_server_msg_received_total{grpc_method="Alarm",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="AuthDisable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="AuthEnable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Authenticate",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Compact",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Defragment",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Hash",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="HashKV",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="LeaseGrant",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="LeaseKeepAlive",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+grpc_server_msg_received_total{grpc_method="LeaseLeases",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="LeaseRevoke",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="LeaseTimeToLive",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MemberAdd",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MemberList",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MemberRemove",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MemberUpdate",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="MoveLeader",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleGrantPermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="RoleRevokePermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Snapshot",grpc_service="etcdserverpb.Maintenance",grpc_type="server_stream"}
+grpc_server_msg_received_total{grpc_method="Status",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Txn",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserChangePassword",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserGrantRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="UserRevokeRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_received_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_msg_sent_total"
+# description: "Total number of gRPC stream messages sent by the server."
+# type: "counter"
+grpc_server_msg_sent_total{grpc_method="Alarm",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="AuthDisable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="AuthEnable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Authenticate",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Compact",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Defragment",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Hash",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="HashKV",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="LeaseGrant",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="LeaseKeepAlive",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+grpc_server_msg_sent_total{grpc_method="LeaseLeases",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="LeaseRevoke",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="LeaseTimeToLive",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MemberAdd",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MemberList",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MemberRemove",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MemberUpdate",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="MoveLeader",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleGrantPermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="RoleRevokePermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Snapshot",grpc_service="etcdserverpb.Maintenance",grpc_type="server_stream"}
+grpc_server_msg_sent_total{grpc_method="Status",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Txn",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserChangePassword",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserGrantRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="UserRevokeRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_msg_sent_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+
+# name: "grpc_server_started_total"
+# description: "Total number of RPCs started on the server."
+# type: "counter"
+grpc_server_started_total{grpc_method="Alarm",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="AuthDisable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="AuthEnable",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Authenticate",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Check",grpc_service="grpc.health.v1.Health",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Compact",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Defragment",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="DeleteRange",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Hash",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="HashKV",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="LeaseGrant",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_started_total{grpc_method="LeaseKeepAlive",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+grpc_server_started_total{grpc_method="LeaseLeases",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_started_total{grpc_method="LeaseRevoke",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_started_total{grpc_method="LeaseTimeToLive",grpc_service="etcdserverpb.Lease",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MemberAdd",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MemberList",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MemberRemove",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MemberUpdate",grpc_service="etcdserverpb.Cluster",grpc_type="unary"}
+grpc_server_started_total{grpc_method="MoveLeader",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Put",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Range",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleGrantPermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="RoleRevokePermission",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Snapshot",grpc_service="etcdserverpb.Maintenance",grpc_type="server_stream"}
+grpc_server_started_total{grpc_method="Status",grpc_service="etcdserverpb.Maintenance",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Txn",grpc_service="etcdserverpb.KV",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserAdd",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserChangePassword",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserDelete",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserGet",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserGrantRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserList",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="UserRevokeRole",grpc_service="etcdserverpb.Auth",grpc_type="unary"}
+grpc_server_started_total{grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+

--- a/docs/operate.rst
+++ b/docs/operate.rst
@@ -1,18 +1,3 @@
-.. _operate:
-
-
-Operate
-#######
-
-TODO
-
-
-Introduction
-============
-
-TODO
-
-
 .. _monitor:
 
 
@@ -20,3 +5,31 @@ Monitor
 #######
 
 TODO
+
+
+List of metrics
+###############
+
+Latest
+======
+
+.. literalinclude:: metrics-latest
+  :language: BASH
+
+v3.3
+====
+
+.. literalinclude:: metrics-v3.3
+  :language: BASH
+
+v3.2
+====
+
+.. literalinclude:: metrics-v3.2
+  :language: BASH
+
+v3.1
+====
+
+.. literalinclude:: metrics-v3.1
+  :language: BASH

--- a/tools/etcd-dump-metrics/README
+++ b/tools/etcd-dump-metrics/README
@@ -1,0 +1,18 @@
+
+go install -v ./tools/etcd-dump-metrics
+
+# for latest master branch
+etcd-dump-metrics > docs/metrics-latest
+
+# download etcd v3.3 to ./bin
+goreman start
+etcd-dump-metrics -addr http://localhost:2379/metrics > docs/metrics-v3.3
+
+# download etcd v3.2 to ./bin
+goreman start
+etcd-dump-metrics -addr http://localhost:2379/metrics > docs/metrics-v3.2
+
+# download etcd v3.1 to ./bin
+goreman start
+etcd-dump-metrics -addr http://localhost:2379/metrics > docs/metrics-v3.1
+

--- a/tools/etcd-dump-metrics/main.go
+++ b/tools/etcd-dump-metrics/main.go
@@ -1,0 +1,363 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/embed"
+	"github.com/coreos/etcd/pkg/transport"
+
+	"go.uber.org/zap"
+)
+
+var lg *zap.Logger
+
+func init() {
+	var err error
+	lg, err = zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	addr := flag.String("addr", "", "etcd metrics URL to fetch from (empty to use current git branch)")
+	enableLog := flag.Bool("server-log", false, "true to enable embedded etcd server logs")
+	debug := flag.Bool("debug", false, "true to enable debug logging")
+	flag.Parse()
+
+	if *debug {
+		lg = zap.NewExample()
+	}
+
+	ep := *addr
+	if ep == "" {
+		uss := newEmbedURLs(4)
+		ep = uss[0].String() + "/metrics"
+
+		cfgs := []*embed.Config{embed.NewConfig(), embed.NewConfig()}
+		cfgs[0].Name, cfgs[1].Name = "0", "1"
+		setupEmbedCfg(cfgs[0], *enableLog, []url.URL{uss[0]}, []url.URL{uss[1]}, []url.URL{uss[1], uss[3]})
+		setupEmbedCfg(cfgs[1], *enableLog, []url.URL{uss[2]}, []url.URL{uss[3]}, []url.URL{uss[1], uss[3]})
+		type embedAndError struct {
+			ec  *embed.Etcd
+			err error
+		}
+		ech := make(chan embedAndError)
+		for _, cfg := range cfgs {
+			go func(c *embed.Config) {
+				e, err := embed.StartEtcd(c)
+				if err != nil {
+					ech <- embedAndError{err: err}
+					return
+				}
+				<-e.Server.ReadyNotify()
+				ech <- embedAndError{ec: e}
+			}(cfg)
+		}
+		for range cfgs {
+			ev := <-ech
+			if ev.err != nil {
+				lg.Panic("failed to start embedded etcd", zap.Error(ev.err))
+			}
+			defer ev.ec.Close()
+		}
+
+		// give enough time for peer-to-peer metrics
+		time.Sleep(7 * time.Second)
+
+		lg.Debug("started 2-node embedded etcd cluster")
+	}
+
+	lg.Debug("starting etcd-dump-metrics", zap.String("endpoint", ep))
+
+	// send client requests to populate gRPC client-side metrics
+	// TODO: enable default metrics initialization in v3.1 and v3.2
+	cli, err := clientv3.New(clientv3.Config{Endpoints: []string{strings.Replace(ep, "/metrics", "", 1)}})
+	if err != nil {
+		lg.Panic("failed to create client", zap.Error(err))
+	}
+	defer cli.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = cli.Put(ctx, "____test", "")
+	if err != nil {
+		lg.Panic("failed to write test key", zap.Error(err))
+	}
+	_, err = cli.Get(ctx, "____test")
+	if err != nil {
+		lg.Panic("failed to read test key", zap.Error(err))
+	}
+	_, err = cli.Delete(ctx, "____test")
+	if err != nil {
+		lg.Panic("failed to delete test key", zap.Error(err))
+	}
+	cli.Watch(ctx, "____test", clientv3.WithCreatedNotify())
+
+	fmt.Println(getMetrics(ep))
+}
+
+func getMetrics(ep string) (m metricSlice) {
+	lines, err := fetchMetrics(ep)
+	if err != nil {
+		lg.Panic("failed to fetch metrics", zap.Error(err))
+	}
+	mss := parse(lines)
+	sort.Sort(metricSlice(mss))
+	return mss
+}
+
+func (mss metricSlice) String() (s string) {
+	ver := "unknown"
+	for i, v := range mss {
+		if strings.HasPrefix(v.name, "etcd_server_version") {
+			ver = v.metrics[0]
+		}
+		s += v.String()
+		if i != len(mss)-1 {
+			s += "\n\n"
+		}
+	}
+	return "# server version: " + ver + "\n\n" + s
+}
+
+type metricSlice []metric
+
+func (mss metricSlice) Len() int {
+	return len(mss)
+}
+
+func (mss metricSlice) Less(i, j int) bool {
+	return mss[i].name < mss[j].name
+}
+
+func (mss metricSlice) Swap(i, j int) {
+	mss[i], mss[j] = mss[j], mss[i]
+}
+
+type metric struct {
+	// raw data for debugging purposes
+	raw []string
+
+	// metrics name
+	name string
+
+	// metrics description
+	desc string
+
+	// metrics type
+	tp string
+
+	// aggregates of "grpc_server_handled_total"
+	grpcCodes []string
+
+	// keep fist 1 and last 4 if histogram or summary
+	// otherwise, keep only 1
+	metrics []string
+}
+
+func (m metric) String() (s string) {
+	s += fmt.Sprintf("# name: %q\n", m.name)
+	s += fmt.Sprintf("# description: %q\n", m.desc)
+	s += fmt.Sprintf("# type: %q\n", m.tp)
+	if len(m.grpcCodes) > 0 {
+		s += "# gRPC codes: \n"
+		for _, c := range m.grpcCodes {
+			s += fmt.Sprintf("#  - %q\n", c)
+		}
+	}
+	s += strings.Join(m.metrics, "\n")
+	return s
+}
+
+func parse(lines []string) (mss []metric) {
+	m := metric{raw: make([]string, 0), metrics: make([]string, 0)}
+	for _, line := range lines {
+		if strings.HasPrefix(line, "# HELP ") {
+			// add previous metric and initialize
+			if m.name != "" {
+				mss = append(mss, m)
+			}
+			m = metric{raw: make([]string, 0), metrics: make([]string, 0)}
+
+			m.raw = append(m.raw, line)
+			ss := strings.Split(strings.Replace(line, "# HELP ", "", 1), " ")
+			m.name, m.desc = ss[0], strings.Join(ss[1:], " ")
+			continue
+		}
+
+		if strings.HasPrefix(line, "# TYPE ") {
+			m.raw = append(m.raw, line)
+			m.tp = strings.Split(strings.Replace(line, "# TYPE "+m.tp, "", 1), " ")[1]
+			continue
+		}
+
+		m.raw = append(m.raw, line)
+		m.metrics = append(m.metrics, strings.Split(line, " ")[0])
+	}
+	if m.name != "" {
+		mss = append(mss, m)
+	}
+
+	// aggregate
+	for i := range mss {
+		/*
+			munge data for:
+				etcd_network_active_peers{Local="c6c9b5143b47d146",Remote="fbdddd08d7e1608b"}
+				etcd_network_peer_sent_bytes_total{To="c6c9b5143b47d146"}
+				etcd_network_peer_received_bytes_total{From="0"}
+				etcd_network_peer_received_bytes_total{From="fd422379fda50e48"}
+				etcd_network_peer_round_trip_time_seconds_bucket{To="91bc3c398fb3c146",le="0.0001"}
+				etcd_network_peer_round_trip_time_seconds_bucket{To="fd422379fda50e48",le="0.8192"}
+				etcd_network_peer_round_trip_time_seconds_bucket{To="fd422379fda50e48",le="+Inf"}
+				etcd_network_peer_round_trip_time_seconds_sum{To="fd422379fda50e48"}
+				etcd_network_peer_round_trip_time_seconds_count{To="fd422379fda50e48"}
+		*/
+		if mss[i].name == "etcd_network_active_peers" {
+			mss[i].metrics = []string{`etcd_network_active_peers{Local="LOCAL_NODE_ID",Remote="REMOTE_PEER_NODE_ID"}`}
+		}
+		if mss[i].name == "etcd_network_peer_sent_bytes_total" {
+			mss[i].metrics = []string{`etcd_network_peer_sent_bytes_total{To="REMOTE_PEER_NODE_ID"}`}
+		}
+		if mss[i].name == "etcd_network_peer_received_bytes_total" {
+			mss[i].metrics = []string{`etcd_network_peer_received_bytes_total{From="REMOTE_PEER_NODE_ID"}`}
+		}
+		if mss[i].tp == "histogram" || mss[i].tp == "summary" {
+			if mss[i].name == "etcd_network_peer_round_trip_time_seconds" {
+				for j := range mss[i].metrics {
+					l := mss[i].metrics[j]
+					if strings.Contains(l, `To="`) && strings.Contains(l, `le="`) {
+						k1 := strings.Index(l, `To="`)
+						k2 := strings.Index(l, `",le="`)
+						mss[i].metrics[j] = l[:k1+4] + "REMOTE_PEER_NODE_ID" + l[k2:]
+					}
+					if strings.HasPrefix(l, "etcd_network_peer_round_trip_time_seconds_sum") {
+						mss[i].metrics[j] = `etcd_network_peer_round_trip_time_seconds_sum{To="REMOTE_PEER_NODE_ID"}`
+					}
+					if strings.HasPrefix(l, "etcd_network_peer_round_trip_time_seconds_count") {
+						mss[i].metrics[j] = `etcd_network_peer_round_trip_time_seconds_count{To="REMOTE_PEER_NODE_ID"}`
+					}
+				}
+				mss[i].metrics = aggSort(mss[i].metrics)
+			}
+		}
+
+		// aggregate gRPC RPC metrics
+		if mss[i].name == "grpc_server_handled_total" {
+			pfx := `grpc_server_handled_total{grpc_code="`
+			codes, metrics := make(map[string]struct{}), make(map[string]struct{})
+			for _, v := range mss[i].metrics {
+				v2 := strings.Replace(v, pfx, "", 1)
+				idx := strings.Index(v2, `",grpc_method="`)
+				code := v2[:idx]
+				v2 = v2[idx:]
+				codes[code] = struct{}{}
+				v2 = pfx + "CODE" + v2
+				metrics[v2] = struct{}{}
+			}
+			mss[i].grpcCodes = sortMap(codes)
+			mss[i].metrics = sortMap(metrics)
+		}
+
+	}
+	return mss
+}
+
+func fetchMetrics(ep string) (lines []string, err error) {
+	tr, err := transport.NewTimeoutTransport(transport.TLSInfo{}, time.Second, time.Second, time.Second)
+	if err != nil {
+		return nil, err
+	}
+	cli := &http.Client{Transport: tr}
+	resp, err := cli.Get(ep)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, rerr := ioutil.ReadAll(resp.Body)
+	if rerr != nil {
+		return nil, rerr
+	}
+	lines = strings.Split(string(b), "\n")
+	return lines, nil
+}
+
+func newEmbedURLs(n int) (urls []url.URL) {
+	urls = make([]url.URL, n)
+	for i := 0; i < n; i++ {
+		u, _ := url.Parse(fmt.Sprintf("unix://localhost:%d%06d", os.Getpid(), i))
+		urls[i] = *u
+	}
+	return urls
+}
+
+func setupEmbedCfg(cfg *embed.Config, enableLog bool, curls, purls, ics []url.URL) {
+	cfg.Logger = "zap"
+	cfg.LogOutputs = []string{"/dev/null"}
+	if enableLog {
+		cfg.LogOutputs = []string{"stderr"}
+	}
+	cfg.Debug = false
+
+	var err error
+	cfg.Dir, err = ioutil.TempDir(os.TempDir(), fmt.Sprintf("%016X", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+	os.RemoveAll(cfg.Dir)
+
+	cfg.ClusterState = "new"
+	cfg.LCUrls, cfg.ACUrls = curls, curls
+	cfg.LPUrls, cfg.APUrls = purls, purls
+
+	cfg.InitialCluster = ""
+	for i := range ics {
+		cfg.InitialCluster += fmt.Sprintf(",%d=%s", i, ics[i].String())
+	}
+	cfg.InitialCluster = cfg.InitialCluster[1:]
+}
+
+func aggSort(ss []string) (sorted []string) {
+	set := make(map[string]struct{})
+	for _, s := range ss {
+		set[s] = struct{}{}
+	}
+	sorted = make([]string, 0, len(set))
+	for k := range set {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+	return sorted
+}
+
+func sortMap(set map[string]struct{}) (sorted []string) {
+	sorted = make([]string, 0, len(set))
+	for k := range set {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+	return sorted
+}


### PR DESCRIPTION
Currently, need manual cluster set-up to find all available metrics, thus cannot be documented. Automatically document all available metrics, with embedded etcd for master branch or specified endpoints. This will make tracking metrics changes much easier.

Following PR should initialize `grpc_server_msg_sent_total` for all available RPCs (https://github.com/coreos/etcd/pull/8878). Right now, v3.1 and v3.2 only show the ones that have been requested.

```
# for latest master branch
etcd-dump-metrics > docs/metrics-latest

# download etcd v3.3 to ./bin
goreman start
etcd-dump-metrics -addr http://localhost:2379/metrics > docs/metrics-v3.3

# download etcd v3.2 to ./bin
goreman start
etcd-dump-metrics -addr http://localhost:2379/metrics > docs/metrics-v3.2

# download etcd v3.1 to ./bin
goreman start
etcd-dump-metrics -addr http://localhost:2379/metrics > docs/metrics-v3.1
```

<br>

Sample rendering (will be served via https://etcd.readthedocs.io/en/latest once merged)

<img width="1008" alt="screen shot 2018-07-22 at 12 39 51 am" src="https://user-images.githubusercontent.com/6799218/43043396-cd294744-8d47-11e8-83a7-8ab96c053f38.png">


For https://github.com/coreos/etcd/issues/9438.