### PR TITLE
etcdctl/ctlv2/command: fix type switch case order

### DIFF
--- a/etcdctl/ctlv2/command/util.go
+++ b/etcdctl/ctlv2/command/util.go
@@ -270,12 +270,12 @@ func isConnectionError(err error) bool {
 			return true
 		}
 		return isConnectionError(t.Err)
-	case net.Error:
-		if t.Timeout() {
-			return true
-		}
 	case syscall.Errno:
 		if t == syscall.ECONNREFUSED {
+			return true
+		}
+	case net.Error:
+		if t.Timeout() {
 			return true
 		}
 	}


### PR DESCRIPTION
Since syscall.Errno implements net.Error and all cases
are matched sequentially, it's a mistake to put syscall.Errno
case after net.Error since it will never be executed.

This change swaps syscall.Errno case with net.Error
to give that clause chance to execute.

Found using https://go-critic.github.io/overview#caseOrder-ref
