### PR TITLE
contrib/recipes: use clientv3.NoLease instead of 0

### DIFF
--- a/contrib/recipes/barrier.go
+++ b/contrib/recipes/barrier.go
@@ -36,7 +36,7 @@ func NewBarrier(client *v3.Client, key string) *Barrier {
 
 // Hold creates the barrier key causing processes to block on Wait.
 func (b *Barrier) Hold() error {
-	_, err := newKey(b.client, b.key, 0)
+	_, err := newKey(b.client, b.key, v3.NoLease)
 	return err
 }
 

--- a/contrib/recipes/key.go
+++ b/contrib/recipes/key.go
@@ -47,7 +47,7 @@ func newKV(kv v3.KV, key, val string, leaseID v3.LeaseID) (*RemoteKV, error) {
 func newUniqueKV(kv v3.KV, prefix string, val string) (*RemoteKV, error) {
 	for {
 		newKey := fmt.Sprintf("%s/%v", prefix, time.Now().UnixNano())
-		rev, err := putNewKV(kv, newKey, val, 0)
+		rev, err := putNewKV(kv, newKey, val, v3.NoLease)
 		if err == nil {
 			return &RemoteKV{kv, newKey, rev, val}, nil
 		}


### PR DESCRIPTION
If we have a named const, it's more readable to use that.

Found using https://go-critic.github.io/overview#namedConst-ref
