### PR TITLE
etcdserver: add "etcd_server_id" metric

### DIFF
--- a/etcdserver/metrics.go
+++ b/etcdserver/metrics.go
@@ -112,6 +112,13 @@ var (
 		Help:      "Which Go version server is running with. 1 for 'server_go_version' label with current version.",
 	},
 		[]string{"server_go_version"})
+	serverID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "id",
+		Help:      "Server or member ID in hexadecimal format. 1 for 'server_id' label with current ID.",
+	},
+		[]string{"server_id"})
 )
 
 func init() {
@@ -129,6 +136,7 @@ func init() {
 	prometheus.MustRegister(quotaBackendBytes)
 	prometheus.MustRegister(currentVersion)
 	prometheus.MustRegister(currentGoVersion)
+	prometheus.MustRegister(serverID)
 
 	currentVersion.With(prometheus.Labels{
 		"server_version": version.Version,

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/pkg/capnslog"
 	humanize "github.com/dustin/go-humanize"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
@@ -511,6 +512,7 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		forceVersionC:    make(chan struct{}),
 		AccessController: &AccessController{CORS: cfg.CORS, HostWhitelist: cfg.HostWhitelist},
 	}
+	serverID.With(prometheus.Labels{"server_id": id.String()}).Set(1)
 
 	srv.applyV2 = &applierV2store{store: srv.v2store, cluster: srv.cluster}
 


### PR DESCRIPTION
```
etcd_server_id{server_id="8e9e05c52164694d"} 1
```

Useful for automating membership change operations,
no need to run "endpoint status" or "member list"
command to get member IDs.

Also, useful for "etcd_network" metrics with "To/From" labels.

Will update http://etcd.readthedocs.io/en/latest and operation docs in following PRs.

ref. https://github.com/coreos/etcd/issues/9438
