### PR TITLE
Added support for s390x

### DIFF
--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,0 +1,18 @@
+FROM s390x/alpine:3.6
+
+ADD bin/etcd /usr/local/bin/
+ADD bin/etcdctl /usr/local/bin/
+ENV ETCD_UNSUPPORTED_ARCH=s390x
+RUN mkdir -p /var/etcd/
+RUN mkdir -p /var/lib/etcd/
+
+# Alpine Linux doesn't use pam, which means that there is no /etc/nsswitch.conf,
+# but Golang relies on /etc/nsswitch.conf to check the order of DNS resolving
+# (see https://github.com/golang/go/commit/9dee7771f561cf6aee081c0af6658cc81fac3918)
+# To fix this we just create /etc/nsswitch.conf and add the following line:
+RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
+EXPOSE 2379 2380
+
+# Define default command.
+CMD ["/usr/local/bin/etcd"]


### PR DESCRIPTION
Added support for s390x by creating the s390x specific `dockerfile-release` file which uses `s390x/alpine:3.6` as BASEIMAGE.
