### PR TITLE
sample: correct directive name

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -117,7 +117,7 @@ peer-transport-security:
   key-file:
 
   # Enable peer client cert authentication.
-  peer-client-cert-auth: false
+  client-cert-auth: false
 
   # Path to the peer server TLS trusted CA cert file.
   trusted-ca-file:


### PR DESCRIPTION
Both "client-transport-security" and "peer-transport-security"
is mapped to Go struct embed.securityConfig.

https://github.com/coreos/etcd/blob/master/embed/config.go#L345

Field for client certificate authentication is tagged as
"client-cert-auth", but it is misspelled in "peer-transport-security"
section.