### PR TITLE
watcher.Watch() should return WatchResponse on context error

### DIFF
--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -331,6 +331,9 @@ func (w *watcher) Watch(ctx context.Context, key string, opts ...OpOption) Watch
 	case reqc <- wr:
 		ok = true
 	case <-wr.ctx.Done():
+		if wr.ctx.Err() != nil {
+			closeCh <- WatchResponse{Canceled: true, closeErr: wr.ctx.Err()}
+		}
 	case <-donec:
 		if wgs.closeErr != nil {
 			closeCh <- WatchResponse{closeErr: wgs.closeErr}
@@ -346,6 +349,9 @@ func (w *watcher) Watch(ctx context.Context, key string, opts ...OpOption) Watch
 		case ret := <-wr.retc:
 			return ret
 		case <-ctx.Done():
+			if wr.ctx.Err() != nil {
+				closeCh <- WatchResponse{Canceled: true, closeErr: wr.ctx.Err()}
+			}
 		case <-donec:
 			if wgs.closeErr != nil {
 				closeCh <- WatchResponse{closeErr: wgs.closeErr}

--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 
@@ -150,7 +151,10 @@ func getWatchChan(c *clientv3.Client, args []string) (clientv3.WatchChan, error)
 	if watchPrevKey {
 		opts = append(opts, clientv3.WithPrevKV())
 	}
-	return c.Watch(clientv3.WithRequireLeader(context.Background()), key, opts...), nil
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	return c.Watch(clientv3.WithRequireLeader(ctx), key, opts...), nil
 }
 
 func printWatchCh(c *clientv3.Client, ch clientv3.WatchChan, execArgs []string) {


### PR DESCRIPTION
## Rational
This change allows users of watcher.Watch() to retrieve the context
error if the user passes in a context.WithTimeout(), etc..

## Example
```go
ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
defer cancel()
ch := c.Watch(clientv3.WithRequireLeader(ctx), key, opts...)
for wr := range ch {
     if wr.Canceled {
         if wr.Err() == context.DeadlineExceeded {
             // Watch failed to start because of a timeout. 
             // Preform some mitigation or inform the president.
         }
     }
}
```

## Resolution
```
$ etcdctl watch foo --prefix
watch was canceled (context deadline exceeded)
Error: watch is canceled by the server
```

## Notes
Not sure about the accuracy of specifying `Canceled: true` as technically the server didn't cancel the request. However setting `Canceled: true` is consistent with what users expect to see when a watch has an error. For example, without it etcdctl would not have displayed the error after the timeout.