### PR TITLE
etcdserver: clarify read index wait timeout warnings

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -693,9 +693,9 @@ func (s *EtcdServer) linearizableReadLoop() {
 				}
 			case <-time.After(s.Cfg.ReqTimeout()):
 				if lg != nil {
-					lg.Warn("timed out waiting for read index response", zap.Duration("timeout", s.Cfg.ReqTimeout()))
+					lg.Warn("timed out waiting for read index response (local node might have slow network)", zap.Duration("timeout", s.Cfg.ReqTimeout()))
 				} else {
-					plog.Warningf("timed out waiting for read index response")
+					plog.Warningf("timed out waiting for read index response (local node might have slow network)")
 				}
 				nr.notify(ErrTimeout)
 				timeout = true


### PR DESCRIPTION
"read index" doesn't tell much about the root cause.
Most likely, the local follower node is having slow
network, thus timing out waiting to receive read
index response from leader.