### PR TITLE
etcdctl: fix small inconsistency with RPC ref

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -685,7 +685,7 @@ Prints the member ID of the removed member and the cluster ID.
 
 MEMBER LIST prints the member details for all members associated with an etcd cluster.
 
-RPC: [MemberList][member_list_rpc].
+RPC: MemberList
 
 #### Output
 
@@ -1655,4 +1655,3 @@ backward compatibility for `JSON` format and the format in non-interactive mode.
 [v3key]: ../mvcc/mvccpb/kv.proto#L12-L29
 [etcdrpc]: ../etcdserver/etcdserverpb/rpc.proto
 [storagerpc]: ../mvcc/mvccpb/kv.proto
-[member_list_rpc]: ../etcdserver/etcdserverpb/rpc.proto#L493-L497


### PR DESCRIPTION
Several RPC references in readme with memberlist only hyperlinked,
and since it's linked with line numbers it's not pointing to a
desired ref now. Remove the link to make it consistent and correct.
